### PR TITLE
Far manager Colorer syntax highlight for Ficus

### DIFF
--- a/misc/FarColorer/README.md
+++ b/misc/FarColorer/README.md
@@ -1,0 +1,7 @@
+# Far manager colorer syntax highlight for Ficus
+
+There is a syntax highlight definition for [Colorer](https://github.com/colorer/FarColorer/) library.
+
+Checked with [Far2l](https://github.com/elfmz/far2l), should work with Far manager as well.
+
+If you know what Colorer is, you'll be able to install it. Good luck!

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -21,6 +21,7 @@
       <region name="Directive" parent="def:Directive"/>
       <region name="Symbol" parent="def:Symbol"/>
       <region name="SymbolStrong" parent="def:SymbolStrong"/>
+      <region name="StringEdge" parent="def:StringEdge"/>
       <region name="Keyword" parent="def:Keyword"/>
       <region name="TypeKeyword" parent="def:TypeKeyword"/>
       <region name="Number" parent="def:Number"/>
@@ -44,32 +45,92 @@
         </block>
       </scheme>
 
+      <!-- @ccode {} highlight (inner block highlighted as plain C) -->
       <scheme name="CCode">
         <regexp match="/\/\/.*$/" region0="Comment"/>
          <block start="/\/\*/" end="/\*\//" scheme="def:Comment" region="Comment"
                 region00="def:PairStart" region10="def:PairEnd"/>
+
+      <!-- TODO may be replaced by C++ -->
         <inherit scheme="c:c"/>
       </scheme>
 
-      <scheme name="StringContent">
-       <regexp match="/\\\\$/" region="def:Error"/>
-       <regexp match="/\\x[\da-fA-F]{2}/" region="StringEscape"/>
-       <regexp match="/\\u[\da-fA-F]{4}/" region="StringEscape"/>
-       <regexp match="/\\U[\da-fA-F]{8}/" region="StringEscape"/>
-       <regexp match="/\\[0-7]{1,3}/" region="StringEscape"/>
-       <regexp match="/[^\\\&#34;]$/" region="def:Error"/>
-      </scheme>
-      <scheme name="String">
-       <block start="/&#34;/" end="/&#34;/" scheme="StringContent" region="String"/>
-      </scheme>
+      <!-- Strings (borrowed from Python) -->
+  <scheme name="RawStringContent">
+    <regexp match="/\\\\/" />
+    <regexp match="/\\[&apos;&quot;]/" />
+    <block start="/\\$/" end="/^/" scheme="def:empty" region="StringEscape" />
+  </scheme>
+
+  <scheme name="ContentCommon">
+    <regexp match="/\\[\n\\&apos;&quot;abfnrtv]/" region="StringEscape" />
+    <regexp match="/\\[0-7]{1,3}/" region="StringEscape" />
+    <regexp match="/\\x[0-9a-fA-F]{2}/" region="StringEscape" />
+    <regexp match="/\\x[0-9a-fA-F]{0,2}/" region="def:Error" />
+  </scheme>
+
+  <scheme name="StringContent">
+    <regexp match="/\\u[0-9a-fA-F]{4}/" region="StringEscape" />
+    <regexp match="/\\u[0-9a-fA-F]{0,4}/" region="def:Error" />
+    <regexp match="/\\U[0-9a-fA-F]{8}/" region="StringEscape" />
+    <regexp match="/\\U[0-9a-fA-F]{0,8}/" region="def:Error" />
+    <inherit scheme="ContentCommon" />
+    <inherit scheme="RawStringContent" />
+    <regexp match="/\\/" region="def:ErrorText" />
+  </scheme>
+
+  <scheme name="FormatSpec">
+    <regexp match="/[^\{\}]/" region="String" />
+    <inherit scheme="ReplacementField" />
+  </scheme>
+  <scheme name="FExpression">
+    <regexp match="/(!)([sra])?([^:\}]+)?/" priority="low"
+       region1="StringEdge" region2="String" region3="def:Error" />
+    <block start="/:/" end="/($|\}?=)/" scheme="FormatSpec" region00="StringEdge" />
+    <regexp match="/(=)\s*([^!:\}]+)?/" priority="low" region1="Symbol" region2="def:Error" />
+    <inherit scheme="ficus" />
+  </scheme>
+  <scheme name="ReplacementField">
+    <block start="/(\{)/" end="/($|\})/"
+       scheme="FExpression" region="def:Insertion"
+       region00="def:PairStart" region10="def:PairEnd" 
+       region01="StringEdge" region11="StringEdge" />
+  </scheme>
+  <scheme name="FStringCommon">
+    <regexp match="/\{{2}|\}{2}/" region="StringEscape" />
+    <inherit scheme="ReplacementField" />
+  </scheme>
+  <scheme name="FStringContent">
+    <inherit scheme="FStringCommon" />
+    <inherit scheme="StringContent" />
+  </scheme>
+  <scheme name="RawFStringContent">
+    <inherit scheme="FStringCommon" />
+    <inherit scheme="RawStringContent" />
+  </scheme>
+ 
+    <scheme name="StringAndLiterals">
+    <block start="/(u?(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
+       scheme="StringContent" region="String" inner-region="yes"
+       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
+    <block start="/(r(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
+       scheme="RawStringContent" region="String" inner-region="yes"
+       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
+    <block start="/(f(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
+       scheme="FStringContent" region="String" inner-region="yes"
+       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
+    <block start="/((?:fr|rf)(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
+       scheme="RawFStringContent" region="String" inner-region="yes"
+       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
+    </scheme>
 
       <scheme name="ficus">
-         <inherit scheme="String"/>
+         <inherit scheme="StringAndLiterals"/>
 <!-- Comments -->
          <block start="/\/\*/" end="/\*\//" scheme="NestedComment" region="Comment" region00="PairStart" region10="PairEnd"/>
          <regexp match="/(\/\/)(\s+)(\[TODO\]|TODO|ЗАДАЧА)(.*)$/" region="Comment" region3="TODO"/>
          <regexp match="/\/\/.*$/" region0="Comment"/>
-<!-- paired -->
+<!-- Paired -->
          <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
          <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
          <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
@@ -77,8 +138,7 @@
          <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode"
           region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
 
-
-         <!--block start="/\b(while|for)\b/" end="/\b(done)\b/" scheme="ficus"
+          <!--block start="/\b(while|for)\b/" end="/\b(done)\b/" scheme="ficus"
            region01="Keyword" region00="PairStart"
            region10="Keyword" region11="PairEnd"/>
          <block start="/\b(try)\b/" end="/\b(with)\b/" scheme="ficus"
@@ -89,14 +149,10 @@
            region10="Keyword" region11="PairEnd"/-->
 
 <!-- Integer literals   -->
-         <!--regexp match="/\b[\-]?(\d+ | 0x[\da-f_]+| 0o[0-7_]+ | 0b[01_]+)\b/ix" region0="Number"/>
-
-         <regexp match="/\d{1,3}(\%)/" region="def:Number" region1="def:NumberSuffix"/-->
-
          <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="Number" region2="NumberSuffix"/>
 
+<!-- Type parameter literals   -->
          <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>
-
 
 <!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
          <regexp match="/\b[\-]?(\d+\.\d*)([eE][\-+]?\d+)?([fh])?\b/x" region0="NumberFloat" region3="NumberSuffix"/>
@@ -113,8 +169,6 @@
            <symb name="="/>
            <symb name="&gt;"/>
            <symb name="||"/>
-
-
            <symb name="+"/>
            <symb name="−"/>
            <symb name="*"/>
@@ -129,6 +183,7 @@
            <symb name=":"/>
          </keywords>
 
+<!-- Special symbols -->
          <keywords region="SymbolStrong">
            <symb name="|"/>
            <symb name=".+"/>
@@ -136,7 +191,6 @@
            <symb name=".*"/>
            <symb name="./"/>
            <symb name=".**"/>
-
            <symb name=".=="/>
            <symb name=".!="/>
            <symb name=".&gt;"/>
@@ -151,12 +205,14 @@
            <symb name="..."/>
          </keywords>
 
+<!-- Special constants -->
          <keywords region="KeywordConstant">
            <word name="false"/>
            <word name="null"/>
            <word name="true"/>
          </keywords>
 
+<!-- Exceptions -->
          <keywords region="Exceptions">
            <word name="DateError"/>
            <word name="RBSetError"/>
@@ -202,9 +258,10 @@
            <word name="TestFailure"/>
          </keywords>
 
-<!-- reserved words -->
+<!-- Directives -->
          <keywords region="Directive">
-            <!--word name="@ccode"/-->
+            <!-- CCode processed separately
+            word name="@ccode"/-->
             <word name="@data"/>
             <word name="@inline"/>
             <word name="@nothrow"/>
@@ -240,12 +297,10 @@
            <word name="match"/>
            <word name="nan"/>
            <word name="nanf"/>
-
            <word name="operator"/>
            <word name="ref"/>
            <word name="return"/>
            <word name="throw"/>
-
            <word name="try"/>
            <word name="type"/>
            <word name="val"/>
@@ -253,6 +308,7 @@
            <word name="while"/>
          </keywords>
 
+<!-- Built-in types -->
          <keywords region="Var">
            <word name="var"/>
          </keywords>

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -118,7 +118,7 @@
       <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode" region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
 
       <!-- Integer literals   -->
-      <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="Number" region2="NumberSuffix"/>
+      <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))?\b/" region="Number" region2="NumberSuffix"/>
 
       <!-- Type parameter literals   -->
       <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -9,7 +9,7 @@
            Depends on Standard ML and C schemes
          ]]></documentation>
       <contributors>
-	   Dmitry Solomennikov https://github.com/dmitrys99
+	    Dmitry Solomennikov https://github.com/dmitrys99
       </contributors>
     </annotation>
 
@@ -26,6 +26,7 @@
     <region name="NumberFloat" parent="def:NumberFloat"/>
     <region name="PairStart" parent="def:PairStart"/>
     <region name="PairEnd" parent="def:PairEnd"/>
+    <region name="Character" parent="def:Character"/>
     <region name="StringEscape" parent="c:StringEscape"/>
     <region name="KeywordConstant" parent="def:Constant"/>
     <region name="Var" parent="def:VarStrong"/>
@@ -47,6 +48,17 @@
       <block start="/\/\*/" end="/\*\//" scheme="def:Comment" region="Comment" region00="def:PairStart" region10="def:PairEnd"/>
       <!-- TODO may be replaced by C++ -->
       <inherit scheme="c:c"/>
+    </scheme>
+
+    <scheme name="Character">
+      <!-- Character ('x') -->
+      <regexp match="/'(\\\D | \\[0-7]{1,3} | \\x[\da-fA-F]{2} | \\u[\da-fA-F]{4} | \\U[\da-fA-F]{8} | [^\\'])'/x" region="Character"/>
+      <!-- Type parameter literals ('t)  -->
+      <regexp match="/(')([a-z][a-zA-Z_\d]*)/" region="NumberSuffix"/>
+      <!-- Matrix transposition operator (A') -->
+      <regexp match="/\b([a-z][a-zA-Z_\d]*)(')/" region1="Var" region2="NumberSuffix"/>
+      <!-- Invalid character syntax -->
+      <regexp match="/'.*?'/" region="def:Error"/>
     </scheme>
 
     <!-- Strings (borrowed from Python) -->
@@ -121,8 +133,8 @@
       <!-- Integer literals   -->
       <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))?\b/" region="Number" region2="NumberSuffix"/>
 
-      <!-- Type parameter literals   -->
-      <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>
+      <!-- Character 'x', generic type 't and matrix transposition A' highlight -->
+      <inherit scheme="Character"/>
 
       <!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
       <regexp match="/\b[\-]?(\d+\.\d*)([eE][\-+]?\d+)?([fh])?\b/x" region0="NumberFloat" region3="NumberSuffix"/>

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hrc PUBLIC "-//Cail Lomecb//DTD Colorer HRC take5//EN"
+  "http://colorer.sf.net/2003/hrc.dtd">
+<hrc version="take5" xmlns="http://colorer.sf.net/2003/hrc"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hrc.xsd">
+   <type name="ficus">
+      <annotation>
+         <documentation><![CDATA[
+           Ficus syntax http://www.ficus-lang.org
+           <filename>/\.(fx)$/i</filename>
+           Depends on Standard ML and C schemes
+         ]]></documentation>
+         <contributors>
+	   Dmitry Solomennikov https://github.com/dmitrys99
+         </contributors>
+      </annotation>
+
+      <region name="String" parent="def:String"/>
+      <region name="Comment" parent="def:Comment"/>
+      <region name="Directive" parent="def:Directive"/>
+      <region name="Symbol" parent="def:Symbol"/>
+      <region name="SymbolStrong" parent="def:SymbolStrong"/>
+      <region name="Keyword" parent="def:Keyword"/>
+      <region name="TypeKeyword" parent="def:TypeKeyword"/>
+      <region name="Number" parent="def:Number"/>
+      <region name="PairStart" parent="def:PairStart"/>
+      <region name="PairEnd" parent="def:PairEnd"/>
+      <region name="StringEscape" parent="c:StringEscape"/>
+      <region name="CCode" parent="def:Directive"/>
+      <region name="KeywordConstant" parent="def:Constant"/>
+      <region name="Var" parent="def:VarStrong"/>
+      <region name="Directive" parent="def:Directive"/>
+      <region name="Exceptions" parent="def:KeywordStrong"/>
+
+      <scheme name="NestedComment">
+        <inherit scheme="def:Comment"/>
+        <block scheme="NestedComment" region="Comment">
+          <start region="PairStart">/\/\*/</start>
+          <end region="PairEnd">/\*\//</end>
+        </block>
+      </scheme>
+
+
+      <scheme name="StringContent">
+       <regexp match="/\\\\$/" region="def:Error"/>
+       <regexp match="/\\[^xX\d]/" region="StringEscape"/>
+       <regexp match="/\\$/" region="StringEscape"/>
+       <regexp match="/\\x[\da-fA-F]{1,8}/i" region="StringEscape"/>
+       <regexp match="/\\[0-9]{1,3}/" region="StringEscape"/>
+       <regexp match="/\%[\-\+\#0]*?[\d\*]*(\.[\d\*]+)?[Ll]?[SsCcsuidopxXnEefgG]/" region="StringEscape"/>
+       <regexp match="/[^\\\&#34;]$/" region="def:Error"/>
+      </scheme>
+      <scheme name="String">
+       <block start="/&#34;/" end="/&#34;/" scheme="StringContent" region="String"/>
+      </scheme>
+
+      <scheme name="ficus">
+         <inherit scheme="String"/>
+<!-- Comments -->
+         <block start="/\/\*/" end="/\*\//" scheme="NestedComment" region="Comment" region00="PairStart" region10="PairEnd"/>
+         <regexp match="/\/\/.*$/" region0="Comment"/>
+<!-- paired -->
+         <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+         <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+         <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+
+         <!--block start="/\b(while|for)\b/" end="/\b(done)\b/" scheme="ficus"
+           region01="Keyword" region00="PairStart"
+           region10="Keyword" region11="PairEnd"/>
+         <block start="/\b(try)\b/" end="/\b(with)\b/" scheme="ficus"
+           region01="Keyword" region00="PairStart"
+           region10="Keyword" region11="PairEnd"/>
+         <block start="/\b(declare|sig|object|struct|begin)\b/" end="/\b(end)\b/" scheme="ficus"
+           region01="Keyword" region00="PairStart"
+           region10="Keyword" region11="PairEnd"/-->
+
+<!-- Top level let-bindings are listed as functions -->
+         <regexp match="/^\M (let) (\s+rec)? \s+ (?{def:Function}[_\w]+)/ix"/>
+<!-- Directive -->
+         <regexp match='/^#[ ]*[0-9]+ [ ]*".*"[\s]*$/' region="Directive"/>
+         <regexp match="/^#[ ]*[0-9]+$/" region="Directive"/>
+<!-- Character constants  -->
+         <regexp match="/'((\\.)|[^\\']){0,8}'/" region0="String"/>
+<!-- Integer literals   -->
+         <!--regexp match="/\b[\-]?(\d+ | 0x[\da-f_]+| 0o[0-7_]+ | 0b[01_]+)\b/ix" region0="Number"/>
+
+         <regexp match="/\d{1,3}(\%)/" region="def:Number" region1="def:NumberSuffix"/-->
+
+         <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="def:Number" region2="def:NumberSuffix"/>
+
+         <regexp match="/&#39;[a-z][a-z0-9]+/" region="def:ParameterStrong"/>
+
+
+<!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
+         <regexp match="/\b([0-9_.]+(E|e[\-+]?\d+)?)\b/" region0="Number"/>
+<!-- Symbols -->
+         <keywords region="Symbol">
+           <symb name="!"/>
+           <symb name="%"/>
+           <symb name="&amp;&amp;"/>
+           <symb name="*"/>
+           <symb name="+"/>
+           <symb name="-"/>
+           <symb name="/"/>
+           <symb name="&lt;"/>
+           <symb name="="/>
+           <symb name="&gt;"/>
+           <symb name="||"/>
+
+
+           <symb name="+"/>
+           <symb name="−"/>
+           <symb name="*"/>
+           <symb name="/"/>
+           <symb name="**"/>
+           <symb name="=="/>
+           <symb name="!=="/>
+           <symb name="&lt;="/>
+           <symb name="&gt;="/>
+           <symb name="&lt;=&gt;"/>
+           <symb name="==="/>
+         </keywords>
+
+         <keywords region="SymbolStrong">
+           <symb name="|"/>
+           <symb name=".+"/>
+           <symb name=".-"/>
+           <symb name=".*"/>
+           <symb name="./"/>
+           <symb name=".**"/>
+
+           <symb name=".=="/>
+           <symb name=".!="/>
+           <symb name=".&gt;"/>
+           <symb name=".&lt;"/>
+           <symb name=".&lt;="/>
+           <symb name=".&gt;="/>
+           <symb name=".&lt;=&gt;"/>
+           <symb name="=&gt;"/>
+           <symb name="&lt;-"/>
+           <symb name="::"/>
+         </keywords>
+
+         <keywords region="KeywordConstant">
+           <word name="false"/>
+           <word name="null"/>
+           <word name="true"/>
+         </keywords>
+
+         <keywords region="Exceptions">
+           <word name="DateError"/>
+           <word name="RBSetError"/>
+           <word name="NullQueueError"/>
+           <word name="RBMapError"/>
+           <word name="PPStackOverflow"/>
+           <word name="PPEmptyStack"/>
+           <word name="PPQueueOverflow"/>
+           <word name="ASCIIError"/>
+           <word name="AssertError"/>
+           <word name="BadArgError"/>
+           <word name="Break"/>
+           <word name="DimError"/>
+           <word name="DivByZeroError"/>
+           <word name="Exit"/>
+           <word name="Fail"/>
+           <word name="FileOpenError"/>
+           <word name="IOError"/>
+           <word name="NoMatchError"/>
+           <word name="NotFoundError"/>
+           <word name="NotImplementedError"/>
+           <word name="NullFileError"/>
+           <word name="NullListError"/>
+           <word name="NullPtrError"/>
+           <word name="OptionError"/>
+           <word name="OutOfMemError"/>
+           <word name="OutOfRangeError"/>
+           <word name="OverflowError"/>
+           <word name="ParallelForError"/>
+           <word name="RangeError"/>
+           <word name="SizeError"/>
+           <word name="SizeMismatchError"/>
+           <word name="StackOverflowError"/>
+           <word name="TypeMismatchError"/>
+           <word name="ZeroStepError"/>
+           <word name="OnnxConvertError"/>
+           <word name="OpenCVError"/>
+           <word name="LexerError"/>
+           <word name="EmptyDynVector"/>
+           <word name="NNError"/>
+           <word name="BadRegexp"/>
+           <word name="TestAssertError"/>
+           <word name="TestFailure"/>
+           <word name="false"/>
+           <word name="null"/>
+           <word name="true"/>
+         </keywords>
+
+<!-- reserved words -->
+         <keywords region="Directive">
+            <word name="@ccode"/>
+            <word name="@data"/>
+            <word name="@inline"/>
+            <word name="@nothrow"/>
+            <word name="@pragma"/>
+            <word name="@parallel"/>
+            <word name="@private"/>
+            <word name="@pure"/>
+            <word name="@sync"/>
+            <word name="@text"/>
+            <word name="@unzip"/>
+         </keywords>
+
+         <keywords region="Keyword">
+<!-- reserved words -->
+           <word name="as"/>
+           <word name="break"/>
+           <word name="catch"/>
+           <word name="class"/>
+           <word name="continue"/>
+           <word name="do"/>
+           <word name="else"/>
+           <word name="exception"/>
+           <word name="finally"/>
+           <word name="fold"/>
+           <word name="for"/>
+           <word name="from"/>
+           <word name="fun"/>
+           <word name="if"/>
+           <word name="import"/>
+           <word name="inf"/>
+           <word name="inff"/>
+           <word name="interface"/>
+           <word name="match"/>
+           <word name="nan"/>
+           <word name="nanf"/>
+
+           <word name="operator"/>
+           <word name="ref"/>
+           <word name="return"/>
+           <word name="throw"/>
+
+           <word name="try"/>
+           <word name="type"/>
+           <word name="val"/>
+           <word name="when"/>
+           <word name="while"/>
+         </keywords>
+
+         <keywords region="Var">
+           <word name="var"/>
+         </keywords>
+
+<!-- Built-in types -->
+         <keywords region="TypeKeyword">
+           <word name="int8"/>
+           <word name="uint8"/>
+           <word name="int16"/>
+           <word name="uint16"/>
+           <word name="int32"/>
+           <word name="uint32"/>
+           <word name="int"/>
+           <word name="uint64"/>
+           <word name="int64"/>
+           <word name="half"/>
+           <word name="float"/>
+           <word name="double"/>
+           <word name="bool"/>
+           <word name="string"/>
+           <word name="char"/>
+           <word name="list"/>
+           <word name="vector"/>
+           <word name="cptr"/>
+           <word name="exn"/>
+         </keywords>
+      </scheme>
+   </type>
+</hrc>
+<!-- ***** BEGIN LICENSE BLOCK *****
+   - Copyright (C) 1999-2009 Cail Lomecb <irusskih at gmail dot com>.
+   - This program is free software; you can redistribute it and/or
+   - modify it under the terms of the GNU General Public License
+   - as published by the Free Software Foundation; either version 2
+   - of the License, or (at your option) any later version.
+   - This program is distributed in the hope that it will be useful,
+   - but WITHOUT ANY WARRANTY; without even the implied warranty of
+   - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   - GNU General Public License for more details.
+   - You should have received a copy of the GNU General Public License
+   - along with this program; If not, see <http://www.gnu.org/licenses/>.
+   - ***** END LICENSE BLOCK ***** -->

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -24,14 +24,17 @@
       <region name="Keyword" parent="def:Keyword"/>
       <region name="TypeKeyword" parent="def:TypeKeyword"/>
       <region name="Number" parent="def:Number"/>
+      <region name="NumberSuffix" parent="def:NumberSuffix"/>
+      <region name="NumberFloat" parent="def:NumberFloat"/>
       <region name="PairStart" parent="def:PairStart"/>
       <region name="PairEnd" parent="def:PairEnd"/>
       <region name="StringEscape" parent="c:StringEscape"/>
-      <region name="CCode" parent="def:Directive"/>
       <region name="KeywordConstant" parent="def:Constant"/>
       <region name="Var" parent="def:VarStrong"/>
       <region name="Directive" parent="def:Directive"/>
       <region name="Exceptions" parent="def:KeywordStrong"/>
+      <region name="TODO" parent="def:TODO"/>
+
 
       <scheme name="NestedComment">
         <inherit scheme="def:Comment"/>
@@ -41,14 +44,19 @@
         </block>
       </scheme>
 
+      <scheme name="CCode">
+        <regexp match="/\/\/.*$/" region0="Comment"/>
+         <block start="/\/\*/" end="/\*\//" scheme="def:Comment" region="Comment"
+                region00="def:PairStart" region10="def:PairEnd"/>
+        <inherit scheme="c:c"/>
+      </scheme>
 
       <scheme name="StringContent">
        <regexp match="/\\\\$/" region="def:Error"/>
-       <regexp match="/\\[^xX\d]/" region="StringEscape"/>
-       <regexp match="/\\$/" region="StringEscape"/>
-       <regexp match="/\\x[\da-fA-F]{1,8}/i" region="StringEscape"/>
-       <regexp match="/\\[0-9]{1,3}/" region="StringEscape"/>
-       <regexp match="/\%[\-\+\#0]*?[\d\*]*(\.[\d\*]+)?[Ll]?[SsCcsuidopxXnEefgG]/" region="StringEscape"/>
+       <regexp match="/\\x[\da-fA-F]{2}/" region="StringEscape"/>
+       <regexp match="/\\u[\da-fA-F]{4}/" region="StringEscape"/>
+       <regexp match="/\\U[\da-fA-F]{8}/" region="StringEscape"/>
+       <regexp match="/\\[0-7]{1,3}/" region="StringEscape"/>
        <regexp match="/[^\\\&#34;]$/" region="def:Error"/>
       </scheme>
       <scheme name="String">
@@ -59,11 +67,16 @@
          <inherit scheme="String"/>
 <!-- Comments -->
          <block start="/\/\*/" end="/\*\//" scheme="NestedComment" region="Comment" region00="PairStart" region10="PairEnd"/>
+         <regexp match="/(\/\/)(\s+)(\[TODO\]|TODO|ЗАДАЧА)(.*)$/" region="Comment" region3="TODO"/>
          <regexp match="/\/\/.*$/" region0="Comment"/>
 <!-- paired -->
          <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
          <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
          <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+
+         <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode"
+          region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
+
 
          <!--block start="/\b(while|for)\b/" end="/\b(done)\b/" scheme="ficus"
            region01="Keyword" region00="PairStart"
@@ -75,25 +88,18 @@
            region01="Keyword" region00="PairStart"
            region10="Keyword" region11="PairEnd"/-->
 
-<!-- Top level let-bindings are listed as functions -->
-         <regexp match="/^\M (let) (\s+rec)? \s+ (?{def:Function}[_\w]+)/ix"/>
-<!-- Directive -->
-         <regexp match='/^#[ ]*[0-9]+ [ ]*".*"[\s]*$/' region="Directive"/>
-         <regexp match="/^#[ ]*[0-9]+$/" region="Directive"/>
-<!-- Character constants  -->
-         <regexp match="/'((\\.)|[^\\']){0,8}'/" region0="String"/>
 <!-- Integer literals   -->
          <!--regexp match="/\b[\-]?(\d+ | 0x[\da-f_]+| 0o[0-7_]+ | 0b[01_]+)\b/ix" region0="Number"/>
 
          <regexp match="/\d{1,3}(\%)/" region="def:Number" region1="def:NumberSuffix"/-->
 
-         <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="def:Number" region2="def:NumberSuffix"/>
+         <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="Number" region2="NumberSuffix"/>
 
-         <regexp match="/&#39;[a-z][a-z0-9]+/" region="def:ParameterStrong"/>
+         <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>
 
 
 <!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
-         <regexp match="/\b([0-9_.]+(E|e[\-+]?\d+)?)\b/" region0="Number"/>
+         <regexp match="/\b[\-]?(\d+\.\d*)([eE][\-+]?\d+)?([fh])?\b/x" region0="NumberFloat" region3="NumberSuffix"/>
 <!-- Symbols -->
          <keywords region="Symbol">
            <symb name="!"/>
@@ -120,6 +126,7 @@
            <symb name="&gt;="/>
            <symb name="&lt;=&gt;"/>
            <symb name="==="/>
+           <symb name=":"/>
          </keywords>
 
          <keywords region="SymbolStrong">
@@ -138,8 +145,10 @@
            <symb name=".&gt;="/>
            <symb name=".&lt;=&gt;"/>
            <symb name="=&gt;"/>
+           <symb name=":&gt;"/>
            <symb name="&lt;-"/>
            <symb name="::"/>
+           <symb name="..."/>
          </keywords>
 
          <keywords region="KeywordConstant">
@@ -191,14 +200,11 @@
            <word name="BadRegexp"/>
            <word name="TestAssertError"/>
            <word name="TestFailure"/>
-           <word name="false"/>
-           <word name="null"/>
-           <word name="true"/>
          </keywords>
 
 <!-- reserved words -->
          <keywords region="Directive">
-            <word name="@ccode"/>
+            <!--word name="@ccode"/-->
             <word name="@data"/>
             <word name="@inline"/>
             <word name="@nothrow"/>
@@ -273,6 +279,96 @@
            <word name="cptr"/>
            <word name="exn"/>
          </keywords>
+         <keywords region="def:Identifier">
+<!-- Builtins -->
+           <word name="assert"/>
+           <word name="ignore"/>
+           <word name="always_use"/>
+           <word name="value_or"/>
+           <word name="value"/>
+           <word name="isnone"/>
+           <word name="issome"/>
+           <word name="__is_scalar__"/>
+           <word name="scalar_type"/>
+           <word name="elemsize"/>
+           <word name="__min__"/>
+           <word name="__max__"/>
+           <word name="length"/>
+           <word name="join"/>
+           <word name="join_embrace"/>
+           <word name="link2"/>
+           <word name="ord"/>
+           <word name="chr"/>
+           <word name="odd"/>
+           <word name="even"/>
+           <word name="repr"/>
+           <word name="parse_format"/>
+           <word name="format_"/>
+           <word name="size"/>
+           <word name="dot"/>
+           <word name="cross"/>
+           <word name="normInf"/>
+           <word name="normL1"/>
+           <word name="normL2sqr"/>
+           <word name="normL2"/>
+           <word name="normInf"/>
+           <word name="norm"/>
+           <word name="all"/>
+           <word name="exists"/>
+           <word name="__eq_variants__"/>
+           <word name="__fun_string__"/>
+           <word name="sat_uint8"/>
+           <word name="sat_int8"/>
+           <word name="sat_uint16"/>
+           <word name="sat_int16"/>
+           <word name="round"/>
+           <word name="min"/>
+           <word name="max"/>
+           <word name="abs"/>
+           <word name="sign"/>
+           <word name="clip"/>
+           <word name="print_string"/>
+           <word name="print"/>
+           <word name="print_repr"/>
+           <word name="println"/>
+           <word name="array"/>
+           <word name="reinterpret"/>
+           <word name="size"/>
+           <word name="hash"/>
+           <word name="_swap_"/>
+<!-- List -->
+           <word name="length"/>
+           <word name="hd"/>
+           <word name="tl"/>
+           <word name="empty"/>
+           <word name="last"/>
+           <word name="nth"/>
+           <word name="skip"/>
+           <word name="skip_nothrow"/>
+           <word name="rev"/>
+           <word name="foldl"/>
+           <word name="assoc"/>
+           <word name="assoc_opt"/>
+           <word name="app"/>
+           <word name="map"/>
+           <word name="all2"/>
+           <word name="mem"/>
+           <word name="find"/>
+           <word name="find_opt"/>
+           <word name="concat"/>
+           <word name="filter"/>
+           <word name="zip"/>
+           <word name="unzip"/>
+           <word name="sort"/>
+<!-- Char -->
+           <word name="isalpha"/>
+           <word name="isdigit"/>
+           <word name="tolower"/>
+           <word name="toupper"/>
+           <word name="isdecimal"/>
+           <word name="isspace"/>
+           <word name="isalnum"/>
+        </keywords>
       </scheme>
    </type>
 </hrc>

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -115,6 +115,7 @@
       <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
       <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
       <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+      <!-- TODO newline after @ccode breaks C highlight -->
       <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode" region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
 
       <!-- Integer literals   -->

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -1,432 +1,406 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE hrc PUBLIC "-//Cail Lomecb//DTD Colorer HRC take5//EN"
-  "http://colorer.sf.net/2003/hrc.dtd">
-<hrc version="take5" xmlns="http://colorer.sf.net/2003/hrc"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hrc.xsd">
-   <type name="ficus">
-      <annotation>
-         <documentation><![CDATA[
+<!DOCTYPE hrc PUBLIC "-//Cail Lomecb//DTD Colorer HRC take5//EN" "http://colorer.sf.net/2003/hrc.dtd">
+<hrc xmlns="http://colorer.sf.net/2003/hrc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="take5" xsi:schemaLocation="http://colorer.sf.net/2003/hrc http://colorer.sf.net/2003/hrc.xsd">
+  <type name="ficus">
+    <annotation>
+      <documentation><![CDATA[
            Ficus syntax http://www.ficus-lang.org
            <filename>/\.(fx)$/i</filename>
            Depends on Standard ML and C schemes
          ]]></documentation>
-         <contributors>
+      <contributors>
 	   Dmitry Solomennikov https://github.com/dmitrys99
          </contributors>
-      </annotation>
+    </annotation>
 
-      <region name="String" parent="def:String"/>
-      <region name="Comment" parent="def:Comment"/>
-      <region name="Directive" parent="def:Directive"/>
-      <region name="Symbol" parent="def:Symbol"/>
-      <region name="SymbolStrong" parent="def:SymbolStrong"/>
-      <region name="StringEdge" parent="def:StringEdge"/>
-      <region name="Keyword" parent="def:Keyword"/>
-      <region name="TypeKeyword" parent="def:TypeKeyword"/>
-      <region name="Number" parent="def:Number"/>
-      <region name="NumberSuffix" parent="def:NumberSuffix"/>
-      <region name="NumberFloat" parent="def:NumberFloat"/>
-      <region name="PairStart" parent="def:PairStart"/>
-      <region name="PairEnd" parent="def:PairEnd"/>
-      <region name="StringEscape" parent="c:StringEscape"/>
-      <region name="KeywordConstant" parent="def:Constant"/>
-      <region name="Var" parent="def:VarStrong"/>
-      <region name="Directive" parent="def:Directive"/>
-      <region name="Exceptions" parent="def:KeywordStrong"/>
-      <region name="TODO" parent="def:TODO"/>
+    <region name="String" parent="def:String"/>
+    <region name="Comment" parent="def:Comment"/>
+    <region name="Directive" parent="def:Directive"/>
+    <region name="Symbol" parent="def:Symbol"/>
+    <region name="SymbolStrong" parent="def:SymbolStrong"/>
+    <region name="StringEdge" parent="def:StringEdge"/>
+    <region name="Keyword" parent="def:Keyword"/>
+    <region name="TypeKeyword" parent="def:TypeKeyword"/>
+    <region name="Number" parent="def:Number"/>
+    <region name="NumberSuffix" parent="def:NumberSuffix"/>
+    <region name="NumberFloat" parent="def:NumberFloat"/>
+    <region name="PairStart" parent="def:PairStart"/>
+    <region name="PairEnd" parent="def:PairEnd"/>
+    <region name="StringEscape" parent="c:StringEscape"/>
+    <region name="KeywordConstant" parent="def:Constant"/>
+    <region name="Var" parent="def:VarStrong"/>
+    <region name="Directive" parent="def:Directive"/>
+    <region name="Exceptions" parent="def:KeywordStrong"/>
+    <region name="TODO" parent="def:TODO"/>
 
-
-      <scheme name="NestedComment">
-        <inherit scheme="def:Comment"/>
-        <block scheme="NestedComment" region="Comment">
-          <start region="PairStart">/\/\*/</start>
-          <end region="PairEnd">/\*\//</end>
-        </block>
-      </scheme>
-
-      <!-- @ccode {} highlight (inner block highlighted as plain C) -->
-      <scheme name="CCode">
-        <regexp match="/\/\/.*$/" region0="Comment"/>
-         <block start="/\/\*/" end="/\*\//" scheme="def:Comment" region="Comment"
-                region00="def:PairStart" region10="def:PairEnd"/>
-
-      <!-- TODO may be replaced by C++ -->
-        <inherit scheme="c:c"/>
-      </scheme>
-
-      <!-- Strings (borrowed from Python) -->
-  <scheme name="RawStringContent">
-    <regexp match="/\\\\/" />
-    <regexp match="/\\[&apos;&quot;]/" />
-    <block start="/\\$/" end="/^/" scheme="def:empty" region="StringEscape" />
-  </scheme>
-
-  <scheme name="ContentCommon">
-    <regexp match="/\\[\n\\&apos;&quot;abfnrtv]/" region="StringEscape" />
-    <regexp match="/\\[0-7]{1,3}/" region="StringEscape" />
-    <regexp match="/\\x[0-9a-fA-F]{2}/" region="StringEscape" />
-    <regexp match="/\\x[0-9a-fA-F]{0,2}/" region="def:Error" />
-  </scheme>
-
-  <scheme name="StringContent">
-    <regexp match="/\\u[0-9a-fA-F]{4}/" region="StringEscape" />
-    <regexp match="/\\u[0-9a-fA-F]{0,4}/" region="def:Error" />
-    <regexp match="/\\U[0-9a-fA-F]{8}/" region="StringEscape" />
-    <regexp match="/\\U[0-9a-fA-F]{0,8}/" region="def:Error" />
-    <inherit scheme="ContentCommon" />
-    <inherit scheme="RawStringContent" />
-    <regexp match="/\\/" region="def:ErrorText" />
-  </scheme>
-
-  <scheme name="FormatSpec">
-    <regexp match="/[^\{\}]/" region="String" />
-    <inherit scheme="ReplacementField" />
-  </scheme>
-  <scheme name="FExpression">
-    <regexp match="/(!)([sra])?([^:\}]+)?/" priority="low"
-       region1="StringEdge" region2="String" region3="def:Error" />
-    <block start="/:/" end="/($|\}?=)/" scheme="FormatSpec" region00="StringEdge" />
-    <regexp match="/(=)\s*([^!:\}]+)?/" priority="low" region1="Symbol" region2="def:Error" />
-    <inherit scheme="ficus" />
-  </scheme>
-  <scheme name="ReplacementField">
-    <block start="/(\{)/" end="/($|\})/"
-       scheme="FExpression" region="def:Insertion"
-       region00="def:PairStart" region10="def:PairEnd" 
-       region01="StringEdge" region11="StringEdge" />
-  </scheme>
-  <scheme name="FStringCommon">
-    <regexp match="/\{{2}|\}{2}/" region="StringEscape" />
-    <inherit scheme="ReplacementField" />
-  </scheme>
-  <scheme name="FStringContent">
-    <inherit scheme="FStringCommon" />
-    <inherit scheme="StringContent" />
-  </scheme>
-  <scheme name="RawFStringContent">
-    <inherit scheme="FStringCommon" />
-    <inherit scheme="RawStringContent" />
-  </scheme>
- 
-    <scheme name="StringAndLiterals">
-    <block start="/(u?(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
-       scheme="StringContent" region="String" inner-region="yes"
-       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
-    <block start="/(r(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
-       scheme="RawStringContent" region="String" inner-region="yes"
-       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
-    <block start="/(f(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
-       scheme="FStringContent" region="String" inner-region="yes"
-       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
-    <block start="/((?:fr|rf)(?{Delim}&quot;))/i" end="/($|\y{Delim})/"
-       scheme="RawFStringContent" region="String" inner-region="yes"
-       region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge" />
+    <scheme name="NestedComment">
+      <inherit scheme="def:Comment"/>
+      <block scheme="NestedComment" region="Comment">
+        <start region="PairStart">/\/\*/</start>
+        <end region="PairEnd">/\*\//</end>
+      </block>
     </scheme>
 
-      <scheme name="ficus">
-         <inherit scheme="StringAndLiterals"/>
-<!-- Comments -->
-         <block start="/\/\*/" end="/\*\//" scheme="NestedComment" region="Comment" region00="PairStart" region10="PairEnd"/>
-         <regexp match="/(\/\/)(\s+)(\[TODO\]|TODO|ЗАДАЧА)(.*)$/" region="Comment" region3="TODO"/>
-         <regexp match="/\/\/.*$/" region0="Comment"/>
-<!-- Paired -->
-         <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
-         <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
-         <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+    <!-- @ccode {} highlight (inner block highlighted as plain C) -->
+    <scheme name="CCode">
+      <regexp match="/\/\/.*$/" region0="Comment"/>
+      <block start="/\/\*/" end="/\*\//" scheme="def:Comment" region="Comment" region00="def:PairStart" region10="def:PairEnd"/>
+      <!-- TODO may be replaced by C++ -->
+      <inherit scheme="c:c"/>
+    </scheme>
 
-         <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode"
-          region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
+    <!-- Strings (borrowed from Python) -->
+    <scheme name="RawStringContent">
+      <regexp match="/\\\\/"/>
+      <regexp match="/\\['&quot;]/"/>
+      <block start="/\\$/" end="/^/" scheme="def:empty" region="StringEscape"/>
+    </scheme>
+    <scheme name="ContentCommon">
+      <regexp match="/\\[\n\\'&quot;abfnrtv]/" region="StringEscape"/>
+      <regexp match="/\\[0-7]{1,3}/" region="StringEscape"/>
+      <regexp match="/\\x[0-9a-fA-F]{2}/" region="StringEscape"/>
+      <regexp match="/\\x[0-9a-fA-F]{0,2}/" region="def:Error"/>
+    </scheme>
+    <scheme name="StringContent">
+      <regexp match="/\\u[0-9a-fA-F]{4}/" region="StringEscape"/>
+      <regexp match="/\\u[0-9a-fA-F]{0,4}/" region="def:Error"/>
+      <regexp match="/\\U[0-9a-fA-F]{8}/" region="StringEscape"/>
+      <regexp match="/\\U[0-9a-fA-F]{0,8}/" region="def:Error"/>
+      <inherit scheme="ContentCommon"/>
+      <inherit scheme="RawStringContent"/>
+      <regexp match="/\\/" region="def:ErrorText"/>
+    </scheme>
+    <scheme name="FormatSpec">
+      <regexp match="/[^\{\}]/" region="String"/>
+      <inherit scheme="ReplacementField"/>
+    </scheme>
+    <scheme name="FExpression">
+      <regexp match="/(!)([sra])?([^:\}]+)?/" priority="low" region1="StringEdge" region2="String" region3="def:Error"/>
+      <block start="/:/" end="/($|\}?=)/" scheme="FormatSpec" region00="StringEdge"/>
+      <regexp match="/(=)\s*([^!:\}]+)?/" priority="low" region1="Symbol" region2="def:Error"/>
+      <inherit scheme="ficus"/>
+    </scheme>
+    <scheme name="ReplacementField">
+      <block start="/(\{)/" end="/($|\})/" scheme="FExpression" region="def:Insertion" region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge"/>
+    </scheme>
+    <scheme name="FStringCommon">
+      <regexp match="/\{{2}|\}{2}/" region="StringEscape"/>
+      <inherit scheme="ReplacementField"/>
+    </scheme>
+    <scheme name="FStringContent">
+      <inherit scheme="FStringCommon"/>
+      <inherit scheme="StringContent"/>
+    </scheme>
+    <scheme name="RawFStringContent">
+      <inherit scheme="FStringCommon"/>
+      <inherit scheme="RawStringContent"/>
+    </scheme>
 
-          <!--block start="/\b(while|for)\b/" end="/\b(done)\b/" scheme="ficus"
-           region01="Keyword" region00="PairStart"
-           region10="Keyword" region11="PairEnd"/>
-         <block start="/\b(try)\b/" end="/\b(with)\b/" scheme="ficus"
-           region01="Keyword" region00="PairStart"
-           region10="Keyword" region11="PairEnd"/>
-         <block start="/\b(declare|sig|object|struct|begin)\b/" end="/\b(end)\b/" scheme="ficus"
-           region01="Keyword" region00="PairStart"
-           region10="Keyword" region11="PairEnd"/-->
+    <scheme name="StringAndLiterals">
+      <block start="/(u?(?{Delim}&quot;))/i" end="/($|\y{Delim})/" scheme="StringContent" region="String" inner-region="yes" region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge"/>
+      <block start="/(r(?{Delim}&quot;))/i" end="/($|\y{Delim})/" scheme="RawStringContent" region="String" inner-region="yes" region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge"/>
+      <block start="/(f(?{Delim}&quot;))/i" end="/($|\y{Delim})/" scheme="FStringContent" region="String" inner-region="yes" region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge"/>
+      <block start="/((?:fr|rf)(?{Delim}&quot;))/i" end="/($|\y{Delim})/" scheme="RawFStringContent" region="String" inner-region="yes" region00="def:PairStart" region10="def:PairEnd" region01="StringEdge" region11="StringEdge"/>
+    </scheme>
 
-<!-- Integer literals   -->
-         <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="Number" region2="NumberSuffix"/>
+    <scheme name="ficus">
+      <inherit scheme="StringAndLiterals"/>
 
-<!-- Type parameter literals   -->
-         <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>
+      <!-- Comments -->
+      <block start="/\/\*/" end="/\*\//" scheme="NestedComment" region="Comment" region00="PairStart" region10="PairEnd"/>
+      <regexp match="/(\/\/)(\s+)(\[TODO\]|TODO|ЗАДАЧА)(.*)$/" region="Comment" region3="TODO"/>
+      <regexp match="/\/\/.*$/" region0="Comment"/>
 
-<!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
-         <regexp match="/\b[\-]?(\d+\.\d*)([eE][\-+]?\d+)?([fh])?\b/x" region0="NumberFloat" region3="NumberSuffix"/>
-<!-- Symbols -->
-         <keywords region="Symbol">
-           <symb name="!"/>
-           <symb name="%"/>
-           <symb name="&amp;&amp;"/>
-           <symb name="*"/>
-           <symb name="+"/>
-           <symb name="-"/>
-           <symb name="/"/>
-           <symb name="&lt;"/>
-           <symb name="="/>
-           <symb name="&gt;"/>
-           <symb name="||"/>
-           <symb name="+"/>
-           <symb name="−"/>
-           <symb name="*"/>
-           <symb name="/"/>
-           <symb name="**"/>
-           <symb name="=="/>
-           <symb name="!=="/>
-           <symb name="&lt;="/>
-           <symb name="&gt;="/>
-           <symb name="&lt;=&gt;"/>
-           <symb name="==="/>
-           <symb name=":"/>
-         </keywords>
+      <!-- Paired -->
+      <block start="/(\()/" end="/(\))/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+      <block start="/(\[)/" end="/(\])/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+      <block start="/(\{)/" end="/(\})/" scheme="ficus" region00="Symbol" region01="PairStart" region10="Symbol" region11="PairEnd"/>
+      <block start="/(\@ccode)\s*?(\{)/x" end="/(\})/" scheme="CCode" region01="Directive" region02="StructureSymbol" region10="StructureSymbol" region00="def:PairStart" region11="def:PairEnd"/>
 
-<!-- Special symbols -->
-         <keywords region="SymbolStrong">
-           <symb name="|"/>
-           <symb name=".+"/>
-           <symb name=".-"/>
-           <symb name=".*"/>
-           <symb name="./"/>
-           <symb name=".**"/>
-           <symb name=".=="/>
-           <symb name=".!="/>
-           <symb name=".&gt;"/>
-           <symb name=".&lt;"/>
-           <symb name=".&lt;="/>
-           <symb name=".&gt;="/>
-           <symb name=".&lt;=&gt;"/>
-           <symb name="=&gt;"/>
-           <symb name=":&gt;"/>
-           <symb name="&lt;-"/>
-           <symb name="::"/>
-           <symb name="..."/>
-         </keywords>
+      <!-- Integer literals   -->
+      <regexp match="/\b[\-]?(\d+)((i|u)(8|16|32|64|128))\b/" region="Number" region2="NumberSuffix"/>
 
-<!-- Special constants -->
-         <keywords region="KeywordConstant">
-           <word name="false"/>
-           <word name="null"/>
-           <word name="true"/>
-         </keywords>
+      <!-- Type parameter literals   -->
+      <regexp match="/(')([a-z][a-zA-Z\d]*)/" region="NumberSuffix"/>
 
-<!-- Exceptions -->
-         <keywords region="Exceptions">
-           <word name="DateError"/>
-           <word name="RBSetError"/>
-           <word name="NullQueueError"/>
-           <word name="RBMapError"/>
-           <word name="PPStackOverflow"/>
-           <word name="PPEmptyStack"/>
-           <word name="PPQueueOverflow"/>
-           <word name="ASCIIError"/>
-           <word name="AssertError"/>
-           <word name="BadArgError"/>
-           <word name="Break"/>
-           <word name="DimError"/>
-           <word name="DivByZeroError"/>
-           <word name="Exit"/>
-           <word name="Fail"/>
-           <word name="FileOpenError"/>
-           <word name="IOError"/>
-           <word name="NoMatchError"/>
-           <word name="NotFoundError"/>
-           <word name="NotImplementedError"/>
-           <word name="NullFileError"/>
-           <word name="NullListError"/>
-           <word name="NullPtrError"/>
-           <word name="OptionError"/>
-           <word name="OutOfMemError"/>
-           <word name="OutOfRangeError"/>
-           <word name="OverflowError"/>
-           <word name="ParallelForError"/>
-           <word name="RangeError"/>
-           <word name="SizeError"/>
-           <word name="SizeMismatchError"/>
-           <word name="StackOverflowError"/>
-           <word name="TypeMismatchError"/>
-           <word name="ZeroStepError"/>
-           <word name="OnnxConvertError"/>
-           <word name="OpenCVError"/>
-           <word name="LexerError"/>
-           <word name="EmptyDynVector"/>
-           <word name="NNError"/>
-           <word name="BadRegexp"/>
-           <word name="TestAssertError"/>
-           <word name="TestFailure"/>
-         </keywords>
+      <!-- Floating-point literals [-]{0...9}+[.{0...9}][(e|E)[+|-] {0...9}+] -->
+      <regexp match="/\b[\-]?(\d+\.\d*)([eE][\-+]?\d+)?([fh])?\b/x" region0="NumberFloat" region3="NumberSuffix"/>
 
-<!-- Directives -->
-         <keywords region="Directive">
-            <!-- CCode processed separately
+      <!-- Symbols -->
+      <keywords region="Symbol">
+        <symb name="!"/>
+        <symb name="%"/>
+        <symb name="&amp;&amp;"/>
+        <symb name="*"/>
+        <symb name="+"/>
+        <symb name="-"/>
+        <symb name="/"/>
+        <symb name="&lt;"/>
+        <symb name="="/>
+        <symb name="&gt;"/>
+        <symb name="||"/>
+        <symb name="+"/>
+        <symb name="−"/>
+        <symb name="*"/>
+        <symb name="/"/>
+        <symb name="**"/>
+        <symb name="=="/>
+        <symb name="!=="/>
+        <symb name="&lt;="/>
+        <symb name="&gt;="/>
+        <symb name="&lt;=&gt;"/>
+        <symb name="==="/>
+        <symb name=":"/>
+      </keywords>
+
+      <!-- Special symbols -->
+      <keywords region="SymbolStrong">
+        <symb name="|"/>
+        <symb name=".+"/>
+        <symb name=".-"/>
+        <symb name=".*"/>
+        <symb name="./"/>
+        <symb name=".**"/>
+        <symb name=".=="/>
+        <symb name=".!="/>
+        <symb name=".&gt;"/>
+        <symb name=".&lt;"/>
+        <symb name=".&lt;="/>
+        <symb name=".&gt;="/>
+        <symb name=".&lt;=&gt;"/>
+        <symb name="=&gt;"/>
+        <symb name=":&gt;"/>
+        <symb name="&lt;-"/>
+        <symb name="::"/>
+        <symb name="..."/>
+      </keywords>
+
+      <!-- Special constants -->
+      <keywords region="KeywordConstant">
+        <word name="false"/>
+        <word name="null"/>
+        <word name="true"/>
+      </keywords>
+
+      <!-- Exceptions -->
+      <keywords region="Exceptions">
+        <word name="DateError"/>
+        <word name="RBSetError"/>
+        <word name="NullQueueError"/>
+        <word name="RBMapError"/>
+        <word name="PPStackOverflow"/>
+        <word name="PPEmptyStack"/>
+        <word name="PPQueueOverflow"/>
+        <word name="ASCIIError"/>
+        <word name="AssertError"/>
+        <word name="BadArgError"/>
+        <word name="Break"/>
+        <word name="DimError"/>
+        <word name="DivByZeroError"/>
+        <word name="Exit"/>
+        <word name="Fail"/>
+        <word name="FileOpenError"/>
+        <word name="IOError"/>
+        <word name="NoMatchError"/>
+        <word name="NotFoundError"/>
+        <word name="NotImplementedError"/>
+        <word name="NullFileError"/>
+        <word name="NullListError"/>
+        <word name="NullPtrError"/>
+        <word name="OptionError"/>
+        <word name="OutOfMemError"/>
+        <word name="OutOfRangeError"/>
+        <word name="OverflowError"/>
+        <word name="ParallelForError"/>
+        <word name="RangeError"/>
+        <word name="SizeError"/>
+        <word name="SizeMismatchError"/>
+        <word name="StackOverflowError"/>
+        <word name="TypeMismatchError"/>
+        <word name="ZeroStepError"/>
+        <word name="OnnxConvertError"/>
+        <word name="OpenCVError"/>
+        <word name="LexerError"/>
+        <word name="EmptyDynVector"/>
+        <word name="NNError"/>
+        <word name="BadRegexp"/>
+        <word name="TestAssertError"/>
+        <word name="TestFailure"/>
+      </keywords>
+
+      <!-- Directives -->
+      <keywords region="Directive">
+        <!-- CCode processed separately
             word name="@ccode"/-->
-            <word name="@data"/>
-            <word name="@inline"/>
-            <word name="@nothrow"/>
-            <word name="@pragma"/>
-            <word name="@parallel"/>
-            <word name="@private"/>
-            <word name="@pure"/>
-            <word name="@sync"/>
-            <word name="@text"/>
-            <word name="@unzip"/>
-         </keywords>
+        <word name="@data"/>
+        <word name="@inline"/>
+        <word name="@nothrow"/>
+        <word name="@pragma"/>
+        <word name="@parallel"/>
+        <word name="@private"/>
+        <word name="@pure"/>
+        <word name="@sync"/>
+        <word name="@text"/>
+        <word name="@unzip"/>
+      </keywords>
 
-         <keywords region="Keyword">
-<!-- reserved words -->
-           <word name="as"/>
-           <word name="break"/>
-           <word name="catch"/>
-           <word name="class"/>
-           <word name="continue"/>
-           <word name="do"/>
-           <word name="else"/>
-           <word name="exception"/>
-           <word name="finally"/>
-           <word name="fold"/>
-           <word name="for"/>
-           <word name="from"/>
-           <word name="fun"/>
-           <word name="if"/>
-           <word name="import"/>
-           <word name="inf"/>
-           <word name="inff"/>
-           <word name="interface"/>
-           <word name="match"/>
-           <word name="nan"/>
-           <word name="nanf"/>
-           <word name="operator"/>
-           <word name="ref"/>
-           <word name="return"/>
-           <word name="throw"/>
-           <word name="try"/>
-           <word name="type"/>
-           <word name="val"/>
-           <word name="when"/>
-           <word name="while"/>
-         </keywords>
+      <!-- Reserved words -->
+      <keywords region="Keyword">
+        <word name="as"/>
+        <word name="break"/>
+        <word name="catch"/>
+        <word name="class"/>
+        <word name="continue"/>
+        <word name="do"/>
+        <word name="else"/>
+        <word name="exception"/>
+        <word name="finally"/>
+        <word name="fold"/>
+        <word name="for"/>
+        <word name="from"/>
+        <word name="fun"/>
+        <word name="if"/>
+        <word name="import"/>
+        <word name="inf"/>
+        <word name="inff"/>
+        <word name="interface"/>
+        <word name="match"/>
+        <word name="nan"/>
+        <word name="nanf"/>
+        <word name="operator"/>
+        <word name="ref"/>
+        <word name="return"/>
+        <word name="throw"/>
+        <word name="try"/>
+        <word name="type"/>
+        <word name="val"/>
+        <word name="when"/>
+        <word name="while"/>
+      </keywords>
 
-<!-- Built-in types -->
-         <keywords region="Var">
-           <word name="var"/>
-         </keywords>
+      <!-- Variable -->
+      <keywords region="Var">
+        <word name="var"/>
+      </keywords>
 
-<!-- Built-in types -->
-         <keywords region="TypeKeyword">
-           <word name="int8"/>
-           <word name="uint8"/>
-           <word name="int16"/>
-           <word name="uint16"/>
-           <word name="int32"/>
-           <word name="uint32"/>
-           <word name="int"/>
-           <word name="uint64"/>
-           <word name="int64"/>
-           <word name="half"/>
-           <word name="float"/>
-           <word name="double"/>
-           <word name="bool"/>
-           <word name="string"/>
-           <word name="char"/>
-           <word name="list"/>
-           <word name="vector"/>
-           <word name="cptr"/>
-           <word name="exn"/>
-         </keywords>
-         <keywords region="def:Identifier">
-<!-- Builtins -->
-           <word name="assert"/>
-           <word name="ignore"/>
-           <word name="always_use"/>
-           <word name="value_or"/>
-           <word name="value"/>
-           <word name="isnone"/>
-           <word name="issome"/>
-           <word name="__is_scalar__"/>
-           <word name="scalar_type"/>
-           <word name="elemsize"/>
-           <word name="__min__"/>
-           <word name="__max__"/>
-           <word name="length"/>
-           <word name="join"/>
-           <word name="join_embrace"/>
-           <word name="link2"/>
-           <word name="ord"/>
-           <word name="chr"/>
-           <word name="odd"/>
-           <word name="even"/>
-           <word name="repr"/>
-           <word name="parse_format"/>
-           <word name="format_"/>
-           <word name="size"/>
-           <word name="dot"/>
-           <word name="cross"/>
-           <word name="normInf"/>
-           <word name="normL1"/>
-           <word name="normL2sqr"/>
-           <word name="normL2"/>
-           <word name="normInf"/>
-           <word name="norm"/>
-           <word name="all"/>
-           <word name="exists"/>
-           <word name="__eq_variants__"/>
-           <word name="__fun_string__"/>
-           <word name="sat_uint8"/>
-           <word name="sat_int8"/>
-           <word name="sat_uint16"/>
-           <word name="sat_int16"/>
-           <word name="round"/>
-           <word name="min"/>
-           <word name="max"/>
-           <word name="abs"/>
-           <word name="sign"/>
-           <word name="clip"/>
-           <word name="print_string"/>
-           <word name="print"/>
-           <word name="print_repr"/>
-           <word name="println"/>
-           <word name="array"/>
-           <word name="reinterpret"/>
-           <word name="size"/>
-           <word name="hash"/>
-           <word name="_swap_"/>
-<!-- List -->
-           <word name="length"/>
-           <word name="hd"/>
-           <word name="tl"/>
-           <word name="empty"/>
-           <word name="last"/>
-           <word name="nth"/>
-           <word name="skip"/>
-           <word name="skip_nothrow"/>
-           <word name="rev"/>
-           <word name="foldl"/>
-           <word name="assoc"/>
-           <word name="assoc_opt"/>
-           <word name="app"/>
-           <word name="map"/>
-           <word name="all2"/>
-           <word name="mem"/>
-           <word name="find"/>
-           <word name="find_opt"/>
-           <word name="concat"/>
-           <word name="filter"/>
-           <word name="zip"/>
-           <word name="unzip"/>
-           <word name="sort"/>
-<!-- Char -->
-           <word name="isalpha"/>
-           <word name="isdigit"/>
-           <word name="tolower"/>
-           <word name="toupper"/>
-           <word name="isdecimal"/>
-           <word name="isspace"/>
-           <word name="isalnum"/>
-        </keywords>
-      </scheme>
-   </type>
+      <!-- Built-in types -->
+      <keywords region="TypeKeyword">
+        <word name="int8"/>
+        <word name="uint8"/>
+        <word name="int16"/>
+        <word name="uint16"/>
+        <word name="int32"/>
+        <word name="uint32"/>
+        <word name="int"/>
+        <word name="uint64"/>
+        <word name="int64"/>
+        <word name="half"/>
+        <word name="float"/>
+        <word name="double"/>
+        <word name="bool"/>
+        <word name="string"/>
+        <word name="char"/>
+        <word name="list"/>
+        <word name="vector"/>
+        <word name="cptr"/>
+        <word name="exn"/>
+      </keywords>
+
+      <keywords region="Identifier">
+
+        <!-- Builtins -->
+        <word name="assert"/>
+        <word name="ignore"/>
+        <word name="always_use"/>
+        <word name="value_or"/>
+        <word name="value"/>
+        <word name="isnone"/>
+        <word name="issome"/>
+        <word name="__is_scalar__"/>
+        <word name="scalar_type"/>
+        <word name="elemsize"/>
+        <word name="__min__"/>
+        <word name="__max__"/>
+        <word name="length"/>
+        <word name="join"/>
+        <word name="join_embrace"/>
+        <word name="link2"/>
+        <word name="ord"/>
+        <word name="chr"/>
+        <word name="odd"/>
+        <word name="even"/>
+        <word name="repr"/>
+        <word name="parse_format"/>
+        <word name="format_"/>
+        <word name="size"/>
+        <word name="dot"/>
+        <word name="cross"/>
+        <word name="normInf"/>
+        <word name="normL1"/>
+        <word name="normL2sqr"/>
+        <word name="normL2"/>
+        <word name="normInf"/>
+        <word name="norm"/>
+        <word name="all"/>
+        <word name="exists"/>
+        <word name="__eq_variants__"/>
+        <word name="__fun_string__"/>
+        <word name="sat_uint8"/>
+        <word name="sat_int8"/>
+        <word name="sat_uint16"/>
+        <word name="sat_int16"/>
+        <word name="round"/>
+        <word name="min"/>
+        <word name="max"/>
+        <word name="abs"/>
+        <word name="sign"/>
+        <word name="clip"/>
+        <word name="print_string"/>
+        <word name="print"/>
+        <word name="print_repr"/>
+        <word name="println"/>
+        <word name="array"/>
+        <word name="reinterpret"/>
+        <word name="size"/>
+        <word name="hash"/>
+        <word name="_swap_"/>
+
+        <!-- List -->
+        <word name="length"/>
+        <word name="hd"/>
+        <word name="tl"/>
+        <word name="empty"/>
+        <word name="last"/>
+        <word name="nth"/>
+        <word name="skip"/>
+        <word name="skip_nothrow"/>
+        <word name="rev"/>
+        <word name="foldl"/>
+        <word name="assoc"/>
+        <word name="assoc_opt"/>
+        <word name="app"/>
+        <word name="map"/>
+        <word name="all2"/>
+        <word name="mem"/>
+        <word name="find"/>
+        <word name="find_opt"/>
+        <word name="concat"/>
+        <word name="filter"/>
+        <word name="zip"/>
+        <word name="unzip"/>
+        <word name="sort"/>
+
+        <!-- Char -->
+        <word name="isalpha"/>
+        <word name="isdigit"/>
+        <word name="tolower"/>
+        <word name="toupper"/>
+        <word name="isdecimal"/>
+        <word name="isspace"/>
+        <word name="isalnum"/>
+      </keywords>
+    </scheme>
+  </type>
 </hrc>
 <!-- ***** BEGIN LICENSE BLOCK *****
    - Copyright (C) 1999-2009 Cail Lomecb <irusskih at gmail dot com>.

--- a/misc/FarColorer/ficus.hrc
+++ b/misc/FarColorer/ficus.hrc
@@ -10,7 +10,7 @@
          ]]></documentation>
       <contributors>
 	   Dmitry Solomennikov https://github.com/dmitrys99
-         </contributors>
+      </contributors>
     </annotation>
 
     <region name="String" parent="def:String"/>


### PR DESCRIPTION
Add syntax definition for Ficus to use with Far manager Colorer plugin.

Supported:
* keywords
* exceptions from library
* functions from library
* expressions `+`, `==`, `:>` and so on
* f-, r- and plain strings
* numbers (with optional suffixes)
* directives (including `@ccode` with `C` code highlight)
* types
* `var` keyword highlighted separately from `val`
* characters, type parameters and matrix transposition