### PR TITLE
lexer: reject bare positive 2^63 that aliased INT64_MIN (FB-014)

### DIFF
--- a/compiler/Lexer.fx
+++ b/compiler/Lexer.fx
@@ -270,6 +270,7 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
     var backquote_pos = -1
     var backquote_loc = (0, 0)
     var fmt: format_t? = None
+    var expect_neg_number = false
 
     fun getloc(pos: int) = (strm.lineno, max(pos - strm.bol, 0) + 1)
     fun addloc(loc: lloc_t, tokens: token_t list) = [:: for t <- tokens {(t, loc)} ]
@@ -375,6 +376,12 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
 
         if '0' <= c <= '9' {
             val (p, (t, c)) = getnumber(buf, pos, loc, prev_dot, !prev_dot)
+            match t {
+            | LITERAL(Ast.LitInt(i)) => if i < 0 && !expect_neg_number {throw Lxu.LexerError(getloc(pos), "the numeric literal is out of range for the specified type")}
+            | LITERAL(Ast.LitSInt(_, i)) => if i < 0 && !expect_neg_number {throw Lxu.LexerError(getloc(pos), "the numeric literal is out of range for the specified type")}
+            | LITERAL(Ast.LitUInt(_, i)) => if expect_neg_number {throw Lxu.LexerError(getloc(pos), "'-' in front of unsigned integer literal")}
+            | _ => {}
+            }
             new_exp = false
             prev_dot = false
             pos = p
@@ -612,7 +619,10 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                 if c1 == '=' {pos += 1; [:: (AUG_BINOP(Ast.OpSub), loc)]}
                 else if c1 == '>' {pos += 1; [:: (ARROW, loc)]}
                 else if !prev_ne {[:: (MINUS(false), loc)]} else {
-                    match nexttokens() {
+                    expect_neg_number = !expect_neg_number
+                    val ts = nexttokens()
+                    expect_neg_number = !expect_neg_number
+                    match ts {
                     | (LITERAL(Ast.LitInt(x)), _) :: rest => (LITERAL(Ast.LitInt(-x)), loc) :: rest
                     | (LITERAL(Ast.LitSInt(b, x)), _) :: rest => (LITERAL(Ast.LitSInt(b, -x)), loc) :: rest
                     | (LITERAL(Ast.LitFloat(b, x)), _) :: rest => (LITERAL(Ast.LitFloat(b, -x)), loc) :: rest

--- a/compiler/bootstrap/Lexer.c
+++ b/compiler/bootstrap/Lexer.c
@@ -952,9 +952,10 @@ FX_EXTERN_C void _fx_M3AstFM7LitBoolN10Ast__lit_t1B(bool, struct _fx_N10Ast__lit
 FX_EXTERN_C void _fx_M3AstFM7LitCharN10Ast__lit_t1C(char_, struct _fx_N10Ast__lit_t*);
 
 FX_EXTERN_C int
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i08rTa2irirNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
    struct _fx_rTa2i_data_t*,
    struct _fx_ri_data_t*,
+   struct _fx_rB_data_t*,
    struct _fx_rNt6option1R8format_t_data_t*,
    struct _fx_rB_data_t*,
    struct _fx_rLT2N14Lexer__token_tTa2i_data_t*,
@@ -1005,12 +1006,13 @@ typedef struct {
    fx_free_t free_f;
    struct _fx_rTa2i_data_t* t0;
    struct _fx_ri_data_t* t1;
-   struct _fx_rNt6option1R8format_t_data_t* t2;
-   struct _fx_rB_data_t* t3;
-   struct _fx_rLT2N14Lexer__token_tTa2i_data_t* t4;
-   struct _fx_ri_data_t* t5;
-   struct _fx_rB_data_t* t6;
-   struct _fx_N20LexerUtils__stream_t_data_t* t7;
+   struct _fx_rB_data_t* t2;
+   struct _fx_rNt6option1R8format_t_data_t* t3;
+   struct _fx_rB_data_t* t4;
+   struct _fx_rLT2N14Lexer__token_tTa2i_data_t* t5;
+   struct _fx_ri_data_t* t6;
+   struct _fx_rB_data_t* t7;
+   struct _fx_N20LexerUtils__stream_t_data_t* t8;
 } _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t;
 
 FX_EXTERN_C void _fx_free_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
@@ -1020,10 +1022,11 @@ FX_EXTERN_C void _fx_free_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
    FX_FREE_REF_SIMPLE(&dst->t1);
    FX_FREE_REF_SIMPLE(&dst->t2);
    FX_FREE_REF_SIMPLE(&dst->t3);
-   _fx_free_rLT2N14Lexer__token_tTa2i(&dst->t4);
-   FX_FREE_REF_SIMPLE(&dst->t5);
+   FX_FREE_REF_SIMPLE(&dst->t4);
+   _fx_free_rLT2N14Lexer__token_tTa2i(&dst->t5);
    FX_FREE_REF_SIMPLE(&dst->t6);
-   _fx_free_N20LexerUtils__stream_t(&dst->t7);
+   FX_FREE_REF_SIMPLE(&dst->t7);
+   _fx_free_N20LexerUtils__stream_t(&dst->t8);
    fx_free(dst);
 }
 
@@ -3352,6 +3355,7 @@ FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUti
    _fx_ri backquote_pos_ref_0 = 0;
    _fx_rTa2i backquote_loc_ref_0 = 0;
    _fx_rNt6option1R8format_t fmt_ref_0 = 0;
+   _fx_rB expect_neg_number_ref_0 = 0;
    int fx_status = 0;
    FX_CALL(_fx_make_rB(true, &new_exp_ref_0), _fx_cleanup);
    FX_CALL(_fx_make_rLT2N14Lexer__token_tTa2i(0, &paren_stack_ref_0), _fx_cleanup);
@@ -3361,9 +3365,10 @@ FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUti
    _fx_Ta2i backquote_loc_arg_0 = { 0, 0 };
    FX_CALL(_fx_make_rTa2i(&backquote_loc_arg_0, &backquote_loc_ref_0), _fx_cleanup);
    FX_CALL(_fx_make_rNt6option1R8format_t(&_fx_g13Lexer__None1_, &fmt_ref_0), _fx_cleanup);
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i08rTa2irirNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
-      backquote_loc_ref_0, backquote_pos_ref_0, fmt_ref_0, new_exp_ref_0, paren_stack_ref_0, pos_ref_0, prev_dot_ref_0, strm_0,
-      fx_result);
+   FX_CALL(_fx_make_rB(false, &expect_neg_number_ref_0), _fx_cleanup);
+   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+      backquote_loc_ref_0, backquote_pos_ref_0, expect_neg_number_ref_0, fmt_ref_0, new_exp_ref_0, paren_stack_ref_0, pos_ref_0,
+      prev_dot_ref_0, strm_0, fx_result);
 
 _fx_cleanup: ;
    FX_FREE_REF_SIMPLE(&new_exp_ref_0);
@@ -3375,6 +3380,7 @@ _fx_cleanup: ;
    FX_FREE_REF_SIMPLE(&backquote_pos_ref_0);
    FX_FREE_REF_SIMPLE(&backquote_loc_ref_0);
    FX_FREE_REF_SIMPLE(&fmt_ref_0);
+   FX_FREE_REF_SIMPLE(&expect_neg_number_ref_0);
    return fx_status;
 }
 
@@ -3546,14 +3552,15 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
    FX_CALL(fx_check_stack(), _fx_cleanup);
    _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t* cv_0 =
       (_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t*)fx_fv;
-   _fx_N20LexerUtils__stream_t strm_0 = cv_0->t7;
+   _fx_N20LexerUtils__stream_t strm_0 = cv_0->t8;
    _fx_Ta2i* backquote_loc_0 = &cv_0->t0->data;
    int_* backquote_pos_0 = &cv_0->t1->data;
-   _fx_Nt6option1R8format_t* fmt_0 = &cv_0->t2->data;
-   bool* new_exp_0 = &cv_0->t3->data;
-   _fx_LT2N14Lexer__token_tTa2i* paren_stack_0 = &cv_0->t4->data;
-   int_* pos_0 = &cv_0->t5->data;
-   bool* prev_dot_0 = &cv_0->t6->data;
+   bool* expect_neg_number_0 = &cv_0->t2->data;
+   _fx_Nt6option1R8format_t* fmt_0 = &cv_0->t3->data;
+   bool* new_exp_0 = &cv_0->t4->data;
+   _fx_LT2N14Lexer__token_tTa2i* paren_stack_0 = &cv_0->t5->data;
+   int_* pos_0 = &cv_0->t6->data;
+   bool* prev_dot_0 = &cv_0->t7->data;
    for (;;) {
       fx_str_t buf_0 = {0};
       _fx_LT2N14Lexer__token_tTa2i paren_stack_1 = 0;
@@ -3616,7 +3623,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
       _fx_Nt6option1T2N14Lexer__token_ti v_46 = {0};
       fx_copy_str(&strm_0->u.stream_t.t3, &buf_0);
       int_ len_0;
-      FX_CALL(_fx_M5LexerFM6lengthi1S(&buf_0, &len_0, 0), _fx_catch_63);
+      FX_CALL(_fx_M5LexerFM6lengthi1S(&buf_0, &len_0, 0), _fx_catch_66);
       char_ c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
       int_ v_47 = *pos_0 + 1;
       char_ c1_0 = FX_STR_ELEM_ZERO(buf_0, v_47);
@@ -3637,7 +3644,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
       }
       if (v_48) {
          _fx_T3CiB v_49;
-         FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_49, 0), _fx_catch_63);
+         FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_49, 0), _fx_catch_66);
          char_ c__0 = v_49.t0;
          int_ p_0 = v_49.t1;
          bool nl_0 = v_49.t2;
@@ -3658,51 +3665,119 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
             res_1 = false;
 
          _fx_endmatch_0: ;
-            FX_CHECK_EXN(_fx_catch_63);
+            FX_CHECK_EXN(_fx_catch_66);
             if (res_1) {
                goto _fx_endmatch_1;
             }
             *new_exp_0 = true;
 
          _fx_endmatch_1: ;
-            FX_CHECK_EXN(_fx_catch_63);
+            FX_CHECK_EXN(_fx_catch_66);
          }
          *pos_0 = p_0;
          int_ v_50 = *pos_0 + 1;
          c1_0 = FX_STR_ELEM_ZERO(buf_0, v_50);
       }
       _fx_Ta2i loc_0;
-      FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &loc_0, 0), _fx_catch_63);
+      FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &loc_0, 0), _fx_catch_66);
       if ((bool)(((char_)48 <= c_0) & (c_0 <= (char_)57))) {
          FX_CALL(
             _fx_M5LexerFM9getnumberT2iT2N14Lexer__token_tC5SiTa2iBB(&buf_0, *pos_0, &loc_0, *prev_dot_0, !*prev_dot_0, &v_0, 0),
-            _fx_catch_63);
+            _fx_catch_66);
          int_ p_1 = v_0.t0;
          _fx_T2N14Lexer__token_tC* v_51 = &v_0.t1;
          _fx_copy_N14Lexer__token_t(&v_51->t0, &t_0);
          char_ c_1 = v_51->t1;
+         int tag_0 = t_0.tag;
+         if (tag_0 == 1) {
+            _fx_N10Ast__lit_t* v_52 = &t_0.u.LITERAL;
+            if (v_52->tag == 1) {
+               fx_exn_t v_53 = {0};
+               bool t_1;
+               if (v_52->u.LitInt < 0LL) {
+                  t_1 = !*expect_neg_number_0;
+               }
+               else {
+                  t_1 = false;
+               }
+               if (t_1) {
+                  _fx_Ta2i v_54;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_54, 0), _fx_catch_0);
+                  fx_str_t slit_0 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_54, &slit_0, &v_53), _fx_catch_0);
+                  FX_THROW(&v_53, true, _fx_catch_0);
+               }
+
+            _fx_catch_0: ;
+               fx_free_exn(&v_53);
+               goto _fx_endmatch_2;
+            }
+         }
+         if (tag_0 == 1) {
+            _fx_N10Ast__lit_t* v_55 = &t_0.u.LITERAL;
+            if (v_55->tag == 2) {
+               fx_exn_t v_56 = {0};
+               bool t_2;
+               if (v_55->u.LitSInt.t1 < 0LL) {
+                  t_2 = !*expect_neg_number_0;
+               }
+               else {
+                  t_2 = false;
+               }
+               if (t_2) {
+                  _fx_Ta2i v_57;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_57, 0), _fx_catch_1);
+                  fx_str_t slit_1 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_57, &slit_1, &v_56), _fx_catch_1);
+                  FX_THROW(&v_56, true, _fx_catch_1);
+               }
+
+            _fx_catch_1: ;
+               fx_free_exn(&v_56);
+               goto _fx_endmatch_2;
+            }
+         }
+         if (tag_0 == 1) {
+            if (t_0.u.LITERAL.tag == 3) {
+               fx_exn_t v_58 = {0};
+               if (*expect_neg_number_0) {
+                  _fx_Ta2i v_59;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_59, 0), _fx_catch_2);
+                  fx_str_t slit_2 = FX_MAKE_STR("\'-\' in front of unsigned integer literal");
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_59, &slit_2, &v_58), _fx_catch_2);
+                  FX_THROW(&v_58, true, _fx_catch_2);
+               }
+
+            _fx_catch_2: ;
+               fx_free_exn(&v_58);
+               goto _fx_endmatch_2;
+            }
+         }
+
+      _fx_endmatch_2: ;
+         FX_CHECK_EXN(_fx_catch_66);
          *new_exp_0 = false;
          *prev_dot_0 = false;
          *pos_0 = p_1;
          if (c_1 == (char_)108) {
-            fx_str_t slit_0 = FX_MAKE_STR("long");
-            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_0, &v_1);
+            fx_str_t slit_3 = FX_MAKE_STR("long");
+            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_3, &v_1);
             _fx_make_T2N14Lexer__token_tTa2i(&v_1, &loc_0, &v_2);
             _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_3);
             _fx_make_T2N14Lexer__token_tTa2i(&v_3, &loc_0, &v_4);
             _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_5);
             _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_6);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_6, 0, true, &v_7), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_5, v_7, false, &v_7), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_4, v_7, false, &v_7), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_2, v_7, false, &v_7), _fx_catch_63);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_6, 0, true, &v_7), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_5, v_7, false, &v_7), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_4, v_7, false, &v_7), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_2, v_7, false, &v_7), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(v_7, &result_0);
-            FX_BREAK(_fx_catch_63);
+            FX_BREAK(_fx_catch_66);
          }
          else if (c_1 == (char_)99) {
-            fx_str_t slit_1 = FX_MAKE_STR("complex");
-            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_1, &v_8);
+            fx_str_t slit_4 = FX_MAKE_STR("complex");
+            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_4, &v_8);
             _fx_make_T2N14Lexer__token_tTa2i(&v_8, &loc_0, &v_9);
             _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_10);
             _fx_make_T2N14Lexer__token_tTa2i(&v_10, &loc_0, &v_11);
@@ -3712,138 +3787,138 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
             _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_15);
             _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_16);
             _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_17);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_17, 0, true, &v_18), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, v_18, false, &v_18), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_18, false, &v_18), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_18, false, &v_18), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_18, false, &v_18), _fx_catch_63);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_18, false, &v_18), _fx_catch_63);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_17, 0, true, &v_18), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, v_18, false, &v_18), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_18, false, &v_18), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_18, false, &v_18), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_18, false, &v_18), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_18, false, &v_18), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(v_18, &result_0);
-            FX_BREAK(_fx_catch_63);
+            FX_BREAK(_fx_catch_66);
          }
          else {
             _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_19);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &result_1), _fx_catch_63);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &result_1), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(result_1, &result_0);
-            FX_BREAK(_fx_catch_63);
+            FX_BREAK(_fx_catch_66);
          }
       }
       else {
-         bool t_1;
+         bool t_3;
          if (c_0 == (char_)39) {
-            t_1 = !*new_exp_0;
+            t_3 = !*new_exp_0;
          }
          else {
-            t_1 = false;
+            t_3 = false;
          }
-         if (t_1) {
+         if (t_3) {
             *prev_dot_0 = false;
             *pos_0 = *pos_0 + 1;
             _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__APOS, &loc_0, &v_20);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_20, 0, true, &result_2), _fx_catch_63);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_20, 0, true, &result_2), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(result_2, &result_0);
-            FX_BREAK(_fx_catch_63);
+            FX_BREAK(_fx_catch_66);
          }
          else {
-            bool v_52;
-            bool t_2;
+            bool v_60;
+            bool t_4;
             if (c_0 == (char_)39) {
-               t_2 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
+               t_4 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
             }
             else {
-               t_2 = false;
+               t_4 = false;
             }
-            if (t_2) {
-               int_ v_53 = *pos_0 + 2; v_52 = FX_STR_ELEM_ZERO(buf_0, v_53) != (char_)39;
+            if (t_4) {
+               int_ v_61 = *pos_0 + 2; v_60 = FX_STR_ELEM_ZERO(buf_0, v_61) != (char_)39;
             }
             else {
-               v_52 = false;
+               v_60 = false;
             }
-            if (v_52) {
+            if (v_60) {
                int_ p_2 = *pos_0 + 1;
                while (p_2 < len_0) {
-                  FX_STR_CHKIDX(buf_0, p_2, _fx_catch_0);
+                  FX_STR_CHKIDX(buf_0, p_2, _fx_catch_3);
                   char_ cp_0 = FX_STR_ELEM(buf_0, p_2);
-                  bool v_54 = _fx_M4CharFM7isalnumB1C(cp_0, 0);
-                  bool t_3;
-                  if (!v_54) {
-                     t_3 = cp_0 != (char_)95;
+                  bool v_62 = _fx_M4CharFM7isalnumB1C(cp_0, 0);
+                  bool t_5;
+                  if (!v_62) {
+                     t_5 = cp_0 != (char_)95;
                   }
                   else {
-                     t_3 = false;
+                     t_5 = false;
                   }
-                  if (t_3) {
-                     FX_BREAK(_fx_catch_0);
+                  if (t_5) {
+                     FX_BREAK(_fx_catch_3);
                   }
                   p_2 = p_2 + 1;
 
-               _fx_catch_0: ;
+               _fx_catch_3: ;
                   FX_CHECK_BREAK();
-                  FX_CHECK_EXN(_fx_catch_63);
+                  FX_CHECK_EXN(_fx_catch_66);
                }
-               FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_21), _fx_catch_63);
-               FX_CALL(_fx_M6StringFM4copyS1S(&v_21, &tyvar_0, 0), _fx_catch_63);
+               FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_21), _fx_catch_66);
+               FX_CALL(_fx_M6StringFM4copyS1S(&v_21, &tyvar_0, 0), _fx_catch_66);
                *pos_0 = p_2;
                *new_exp_0 = false;
                *prev_dot_0 = false;
                _fx_M5LexerFM5TYVARN14Lexer__token_t1S(&tyvar_0, &v_22);
                _fx_make_T2N14Lexer__token_tTa2i(&v_22, &loc_0, &v_23);
-               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_23, 0, true, &result_3), _fx_catch_63);
+               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_23, 0, true, &result_3), _fx_catch_66);
                _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                FX_COPY_PTR(result_3, &result_0);
-               FX_BREAK(_fx_catch_63);
+               FX_BREAK(_fx_catch_66);
             }
             else {
-               bool t_4;
+               bool t_6;
                if (c_0 == (char_)34) {
-                  t_4 = true;
+                  t_6 = true;
                }
                else {
-                  t_4 = c_0 == (char_)39;
+                  t_6 = c_0 == (char_)39;
                }
-               bool t_5;
-               if (t_4) {
-                  t_5 = true;
+               bool t_7;
+               if (t_6) {
+                  t_7 = true;
                }
                else {
-                  bool t_6;
+                  bool t_8;
                   if (c_0 == (char_)102) {
-                     t_6 = true;
+                     t_8 = true;
                   }
                   else {
-                     t_6 = c_0 == (char_)114;
+                     t_8 = c_0 == (char_)114;
                   }
-                  if (t_6) {
-                     t_5 = c1_0 == (char_)34;
+                  if (t_8) {
+                     t_7 = c1_0 == (char_)34;
                   }
                   else {
-                     t_5 = false;
+                     t_7 = false;
                   }
                }
-               if (t_5) {
-                  bool t_7;
+               if (t_7) {
+                  bool t_9;
                   if (c_0 == (char_)102) {
-                     t_7 = true;
+                     t_9 = true;
                   }
                   else {
-                     t_7 = c_0 == (char_)114;
+                     t_9 = c_0 == (char_)114;
                   }
                   int_ termpos_0;
-                  if (t_7) {
+                  if (t_9) {
                      termpos_0 = *pos_0 + 1;
                   }
                   else {
                      termpos_0 = *pos_0;
                   }
                   char_ term_0 = FX_STR_ELEM_ZERO(buf_0, termpos_0);
-                  _fx_Ta2i v_55;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(termpos_0 + 1, strm_0, &v_55, 0), _fx_catch_63);
+                  _fx_Ta2i v_63;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(termpos_0 + 1, strm_0, &v_63, 0), _fx_catch_66);
                   FX_CALL(
-                     _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, termpos_0 + 1, &v_55, term_0, c_0 == (char_)114,
-                        c_0 == (char_)102, &v_24, 0), _fx_catch_63);
+                     _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, termpos_0 + 1, &v_63, term_0, c_0 == (char_)114,
+                        c_0 == (char_)102, &v_24, 0), _fx_catch_66);
                   int_ p_3 = v_24.t0;
                   fx_copy_str(&v_24.t1, &res_0);
                   int_ dl_0 = v_24.t2;
@@ -3855,212 +3930,212 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                   *prev_dot_0 = false;
                   if (term_0 == (char_)39) {
                      int_ res_2;
-                     FX_CALL(_fx_M5LexerFM6lengthi1S(&res_0, &res_2, 0), _fx_catch_63);
+                     FX_CALL(_fx_M5LexerFM6lengthi1S(&res_0, &res_2, 0), _fx_catch_66);
                      if (res_2 != 1) {
-                        _fx_Ta2i v_56;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_56, 0), _fx_catch_63);
-                        fx_str_t slit_2 = FX_MAKE_STR("character literal should contain exactly one character");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_56, &slit_2, &v_25), _fx_catch_63);
-                        FX_THROW(&v_25, true, _fx_catch_63);
+                        _fx_Ta2i v_64;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_64, 0), _fx_catch_66);
+                        fx_str_t slit_5 = FX_MAKE_STR("character literal should contain exactly one character");
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_64, &slit_5, &v_25), _fx_catch_66);
+                        FX_THROW(&v_25, true, _fx_catch_66);
                      }
-                     FX_STR_CHKIDX(res_0, 0, _fx_catch_63);
+                     FX_STR_CHKIDX(res_0, 0, _fx_catch_66);
                      _fx_M3AstFM7LitCharN10Ast__lit_t1C(FX_STR_ELEM(res_0, 0), &v_26);
                      _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_26, &v_27);
                      _fx_make_T2N14Lexer__token_tTa2i(&v_27, &loc_0, &v_28);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, 0, true, &result_4), _fx_catch_63);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, 0, true, &result_4), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_4, &result_0);
-                     FX_BREAK(_fx_catch_63);
+                     FX_BREAK(_fx_catch_66);
                   }
                   else if (inline_exp_0) {
-                     _fx_Ta2i v_57;
-                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(prev_pos_0, strm_0, &v_57, 0), _fx_catch_63);
-                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_57, &v_29);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_29, *paren_stack_0, true, &v_30), _fx_catch_63);
+                     _fx_Ta2i v_65;
+                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(prev_pos_0, strm_0, &v_65, 0), _fx_catch_66);
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_65, &v_29);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_29, *paren_stack_0, true, &v_30), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                      FX_COPY_PTR(v_30, paren_stack_0);
                      *new_exp_0 = true;
                      *fmt_0 = _fx_g13Lexer__None1_;
                      if (FX_STR_LENGTH(res_0) == 0) {
                         _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_32);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, 0, true, &v_31), _fx_catch_63);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, 0, true, &v_31), _fx_catch_66);
                      }
                      else {
                         _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_33);
                         _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_34);
                         _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_34, &v_35);
                         _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_36);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_36, 0, true, &v_37), _fx_catch_63);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, v_37, false, &v_37), _fx_catch_63);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_33, v_37, true, &v_31), _fx_catch_63);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_36, 0, true, &v_37), _fx_catch_66);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, v_37, false, &v_37), _fx_catch_66);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_33, v_37, true, &v_31), _fx_catch_66);
                      }
-                     fx_str_t slit_3 = FX_MAKE_STR("string");
-                     _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_3, &v_38);
+                     fx_str_t slit_6 = FX_MAKE_STR("string");
+                     _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_6, &v_38);
                      _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_39);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_39, 0, true, &v_40), _fx_catch_63);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, v_40, false, &v_40), _fx_catch_63);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_39, 0, true, &v_40), _fx_catch_66);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, v_40, false, &v_40), _fx_catch_66);
                      FX_CALL(_fx_M5LexerFM7__add__LN14Lexer__token_t2LN14Lexer__token_tLN14Lexer__token_t(v_31, v_40, &v_41, 0),
-                        _fx_catch_63);
+                        _fx_catch_66);
                      FX_CALL(_fx_M5LexerFM6addlocLT2N14Lexer__token_tTa2i2Ta2iLN14Lexer__token_t(&loc_0, v_41, &result_5, 0),
-                        _fx_catch_63);
+                        _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_5, &result_0);
-                     FX_BREAK(_fx_catch_63);
+                     FX_BREAK(_fx_catch_66);
                   }
                   else {
                      _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_42);
                      _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_42, &v_43);
                      _fx_make_T2N14Lexer__token_tTa2i(&v_43, &loc_0, &v_44);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_44, 0, true, &result_6), _fx_catch_63);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_44, 0, true, &result_6), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_6, &result_0);
-                     FX_BREAK(_fx_catch_63);
+                     FX_BREAK(_fx_catch_66);
                   }
                }
                else {
-                  bool v_58;
-                  bool t_8;
+                  bool v_66;
+                  bool t_10;
                   if (_fx_M4CharFM7isalphaB1C(c_0, 0)) {
-                     t_8 = true;
+                     t_10 = true;
                   }
                   else {
-                     t_8 = c_0 == (char_)95;
+                     t_10 = c_0 == (char_)95;
                   }
-                  if (t_8) {
-                     v_58 = true;
+                  if (t_10) {
+                     v_66 = true;
                   }
                   else if (c_0 == (char_)64) {
-                     v_58 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
+                     v_66 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
                   }
                   else {
-                     v_58 = false;
+                     v_66 = false;
                   }
-                  if (v_58) {
+                  if (v_66) {
                      int_ p_4 = *pos_0 + 1;
                      while (p_4 < len_0) {
-                        FX_STR_CHKIDX(buf_0, p_4, _fx_catch_1);
+                        FX_STR_CHKIDX(buf_0, p_4, _fx_catch_4);
                         char_ cp_1 = FX_STR_ELEM(buf_0, p_4);
-                        bool v_59 = _fx_M4CharFM7isalnumB1C(cp_1, 0);
-                        bool t_9;
-                        if (!v_59) {
-                           t_9 = cp_1 != (char_)95;
+                        bool v_67 = _fx_M4CharFM7isalnumB1C(cp_1, 0);
+                        bool t_11;
+                        if (!v_67) {
+                           t_11 = cp_1 != (char_)95;
                         }
                         else {
-                           t_9 = false;
+                           t_11 = false;
                         }
-                        if (t_9) {
-                           FX_BREAK(_fx_catch_1);
+                        if (t_11) {
+                           FX_BREAK(_fx_catch_4);
                         }
                         p_4 = p_4 + 1;
 
-                     _fx_catch_1: ;
+                     _fx_catch_4: ;
                         FX_CHECK_BREAK();
-                        FX_CHECK_EXN(_fx_catch_63);
+                        FX_CHECK_EXN(_fx_catch_66);
                      }
-                     FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_45), _fx_catch_63);
-                     FX_CALL(_fx_M6StringFM4copyS1S(&v_45, &ident_0, 0), _fx_catch_63);
+                     FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_45), _fx_catch_66);
+                     FX_CALL(_fx_M6StringFM4copyS1S(&v_45, &ident_0, 0), _fx_catch_66);
                      *pos_0 = p_4;
                      *prev_dot_0 = false;
                      FX_CALL(
                         _fx_M5LexerFM8find_optNt6option1T2N14Lexer__token_ti2Nt10Hashmap__t2ST2N14Lexer__token_tiS(
-                           _fx_g21Lexer__ficus_keywords, &ident_0, &v_46, 0), _fx_catch_63);
+                           _fx_g21Lexer__ficus_keywords, &ident_0, &v_46, 0), _fx_catch_66);
                      if (v_46.tag == 2) {
-                        _fx_N14Lexer__token_t t_10 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_60 = {0};
+                        _fx_N14Lexer__token_t t_12 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_68 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_7 = 0;
-                        _fx_T2N14Lexer__token_ti* v_61 = &v_46.u.Some;
-                        int_ n_0 = v_61->t1;
-                        _fx_N14Lexer__token_t* t_11 = &v_61->t0;
-                        if (t_11->tag == 9) {
-                           _fx_T2N14Lexer__token_tTa2i v_62 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i v_63 = 0;
-                           fx_str_t slit_4 = FX_MAKE_STR("ccode");
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &slit_4, 0), _fx_catch_2);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__CCODE, &loc_0, &v_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_62, *paren_stack_0, true, &v_63), _fx_catch_2);
+                        _fx_T2N14Lexer__token_ti* v_69 = &v_46.u.Some;
+                        int_ n_0 = v_69->t1;
+                        _fx_N14Lexer__token_t* t_13 = &v_69->t0;
+                        if (t_13->tag == 9) {
+                           _fx_T2N14Lexer__token_tTa2i v_70 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_71 = 0;
+                           fx_str_t slit_7 = FX_MAKE_STR("ccode");
+                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &slit_7, 0), _fx_catch_5);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__CCODE, &loc_0, &v_70);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_70, *paren_stack_0, true, &v_71), _fx_catch_5);
                            _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_63, paren_stack_0);
+                           FX_COPY_PTR(v_71, paren_stack_0);
                            *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_11, &t_10);
+                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
 
-                        _fx_catch_2: ;
-                           if (v_63) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&v_63);
+                        _fx_catch_5: ;
+                           if (v_71) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_71);
                            }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_62);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_70);
                         }
-                        else if (t_11->tag == 19) {
-                           _fx_N14Lexer__token_t t_12 = {0};
-                           _fx_M5LexerFM3FORN14Lexer__token_t1B(*new_exp_0, &t_12);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_12, &t_10);
-                           _fx_free_N14Lexer__token_t(&t_12);
-                        }
-                        else if (t_11->tag == 23) {
-                           _fx_N14Lexer__token_t t_13 = {0};
-                           _fx_M5LexerFM6IMPORTN14Lexer__token_t1B(*new_exp_0, &t_13);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_13, &t_10);
-                           _fx_free_N14Lexer__token_t(&t_13);
-                        }
-                        else if (t_11->tag == 42) {
+                        else if (t_13->tag == 19) {
                            _fx_N14Lexer__token_t t_14 = {0};
-                           _fx_M5LexerFM5WHILEN14Lexer__token_t1B(*new_exp_0, &t_14);
+                           _fx_M5LexerFM3FORN14Lexer__token_t1B(*new_exp_0, &t_14);
                            *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_14, &t_10);
+                           _fx_copy_N14Lexer__token_t(&t_14, &t_12);
                            _fx_free_N14Lexer__token_t(&t_14);
                         }
-                        else if (t_11->tag == 26) {
-                           _fx_T2N14Lexer__token_tTa2i v_64 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i v_65 = 0;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__MATCH, &loc_0, &v_64);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_64, *paren_stack_0, true, &v_65), _fx_catch_3);
-                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_65, paren_stack_0);
+                        else if (t_13->tag == 23) {
+                           _fx_N14Lexer__token_t t_15 = {0};
+                           _fx_M5LexerFM6IMPORTN14Lexer__token_t1B(*new_exp_0, &t_15);
                            *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_11, &t_10);
+                           _fx_copy_N14Lexer__token_t(&t_15, &t_12);
+                           _fx_free_N14Lexer__token_t(&t_15);
+                        }
+                        else if (t_13->tag == 42) {
+                           _fx_N14Lexer__token_t t_16 = {0};
+                           _fx_M5LexerFM5WHILEN14Lexer__token_t1B(*new_exp_0, &t_16);
+                           *new_exp_0 = true;
+                           _fx_copy_N14Lexer__token_t(&t_16, &t_12);
+                           _fx_free_N14Lexer__token_t(&t_16);
+                        }
+                        else if (t_13->tag == 26) {
+                           _fx_T2N14Lexer__token_tTa2i v_72 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_73 = 0;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__MATCH, &loc_0, &v_72);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_72, *paren_stack_0, true, &v_73), _fx_catch_6);
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
+                           FX_COPY_PTR(v_73, paren_stack_0);
+                           *new_exp_0 = true;
+                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
 
-                        _fx_catch_3: ;
-                           if (v_65) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&v_65);
+                        _fx_catch_6: ;
+                           if (v_73) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_73);
                            }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_64);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_72);
                         }
-                        else if (t_11->tag == 33) {
-                           _fx_M5LexerFM3REFN14Lexer__token_t1B(*new_exp_0, &t_10);
+                        else if (t_13->tag == 33) {
+                           _fx_M5LexerFM3REFN14Lexer__token_t1B(*new_exp_0, &t_12);
                         }
-                        else if (t_11->tag == 100) {
-                           *new_exp_0 = false; _fx_copy_N14Lexer__token_t(t_11, &t_10);
+                        else if (t_13->tag == 100) {
+                           *new_exp_0 = false; _fx_copy_N14Lexer__token_t(t_13, &t_12);
                         }
-                        else if (t_11->tag == 34) {
+                        else if (t_13->tag == 34) {
                            _fx_LT2N14Lexer__token_tTa2i paren_stack_2 = 0;
                            c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
-                           int_ v_66 = *pos_0 + 1;
-                           c1_0 = FX_STR_ELEM_ZERO(buf_0, v_66);
-                           bool v_67;
+                           int_ v_74 = *pos_0 + 1;
+                           c1_0 = FX_STR_ELEM_ZERO(buf_0, v_74);
+                           bool v_75;
                            if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
-                              v_67 = true;
+                              v_75 = true;
                            }
                            else if (c_0 == (char_)47) {
                               if (c1_0 == (char_)47) {
-                                 v_67 = true;
+                                 v_75 = true;
                               }
                               else {
-                                 v_67 = c1_0 == (char_)42;
+                                 v_75 = c1_0 == (char_)42;
                               }
                            }
                            else {
-                              v_67 = false;
+                              v_75 = false;
                            }
                            bool may_have_arg_0;
-                           if (v_67) {
-                              _fx_T3CiB v_68;
+                           if (v_75) {
+                              _fx_T3CiB v_76;
                               FX_CALL(
-                                 _fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_68,
-                                    0), _fx_catch_4);
-                              char_ c__1 = v_68.t0;
-                              int_ p_5 = v_68.t1;
-                              bool nl_1 = v_68.t2;
+                                 _fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_76,
+                                    0), _fx_catch_7);
+                              char_ c__1 = v_76.t0;
+                              int_ p_5 = v_76.t1;
+                              bool nl_1 = v_76.t2;
                               c_0 = c__1;
                               *pos_0 = p_5;
                               if (nl_1) {
@@ -4068,25 +4143,25 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  bool res_3;
                                  if (paren_stack_2 != 0) {
                                     if (paren_stack_2->hd.t0.tag == 44) {
-                                       res_3 = true; goto _fx_endmatch_2;
+                                       res_3 = true; goto _fx_endmatch_3;
                                     }
                                  }
                                  if (paren_stack_2 != 0) {
                                     if (paren_stack_2->hd.t0.tag == 47) {
-                                       res_3 = true; goto _fx_endmatch_2;
+                                       res_3 = true; goto _fx_endmatch_3;
                                     }
                                  }
                                  res_3 = false;
 
-                              _fx_endmatch_2: ;
-                                 FX_CHECK_EXN(_fx_catch_4);
+                              _fx_endmatch_3: ;
+                                 FX_CHECK_EXN(_fx_catch_7);
                                  if (res_3) {
-                                    may_have_arg_0 = true; goto _fx_endmatch_3;
+                                    may_have_arg_0 = true; goto _fx_endmatch_4;
                                  }
                                  may_have_arg_0 = false;
 
-                              _fx_endmatch_3: ;
-                                 FX_CHECK_EXN(_fx_catch_4);
+                              _fx_endmatch_4: ;
+                                 FX_CHECK_EXN(_fx_catch_7);
                               }
                               else {
                                  may_have_arg_0 = true;
@@ -4096,183 +4171,183 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               may_have_arg_0 = true;
                            }
                            *new_exp_0 = true;
-                           bool t_15;
+                           bool t_17;
                            if (may_have_arg_0) {
-                              t_15 = c_0 != (char_)59;
+                              t_17 = c_0 != (char_)59;
                            }
                            else {
-                              t_15 = false;
+                              t_17 = false;
                            }
-                           _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_15, &t_10);
+                           _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_17, &t_12);
 
-                        _fx_catch_4: ;
+                        _fx_catch_7: ;
                            if (paren_stack_2) {
                               _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_2);
                            }
                         }
                         else if (n_0 == -1) {
-                           fx_str_t v_69 = {0};
-                           fx_str_t v_70 = {0};
-                           fx_exn_t v_71 = {0};
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_69, 0), _fx_catch_5);
-                           fx_str_t slit_5 = FX_MAKE_STR("Identifier \'");
-                           fx_str_t slit_6 = FX_MAKE_STR("\' is reserved and cannot be used");
+                           fx_str_t v_77 = {0};
+                           fx_str_t v_78 = {0};
+                           fx_exn_t v_79 = {0};
+                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_77, 0), _fx_catch_8);
+                           fx_str_t slit_8 = FX_MAKE_STR("Identifier \'");
+                           fx_str_t slit_9 = FX_MAKE_STR("\' is reserved and cannot be used");
                            {
-                              const fx_str_t strs_0[] = { slit_5, v_69, slit_6 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_70), _fx_catch_5);
+                              const fx_str_t strs_0[] = { slit_8, v_77, slit_9 };
+                              FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_78), _fx_catch_8);
                            }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_70, &v_71), _fx_catch_5);
-                           FX_THROW(&v_71, true, _fx_catch_5);
-
-                        _fx_catch_5: ;
-                           fx_free_exn(&v_71);
-                           FX_FREE_STR(&v_70);
-                           FX_FREE_STR(&v_69);
-                        }
-                        else if (n_0 == 0) {
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_6);
-                           *new_exp_0 = false;
-                           _fx_copy_N14Lexer__token_t(t_11, &t_10);
-
-                        _fx_catch_6: ;
-                        }
-                        else if (n_0 == 1) {
-                           *new_exp_0 = true; _fx_copy_N14Lexer__token_t(t_11, &t_10);
-                        }
-                        else if (n_0 == 2) {
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_7);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_11, &t_10);
-
-                        _fx_catch_7: ;
-                        }
-                        else {
-                           fx_str_t v_72 = {0};
-                           fx_str_t v_73 = {0};
-                           fx_exn_t v_74 = {0};
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_72, 0), _fx_catch_8);
-                           fx_str_t slit_7 = FX_MAKE_STR("Unexpected keyword \'");
-                           fx_str_t slit_8 = FX_MAKE_STR("\'");
-                           {
-                              const fx_str_t strs_1[] = { slit_7, v_72, slit_8 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_73), _fx_catch_8);
-                           }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_73, &v_74), _fx_catch_8);
-                           FX_THROW(&v_74, true, _fx_catch_8);
+                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_78, &v_79), _fx_catch_8);
+                           FX_THROW(&v_79, true, _fx_catch_8);
 
                         _fx_catch_8: ;
-                           fx_free_exn(&v_74);
-                           FX_FREE_STR(&v_73);
-                           FX_FREE_STR(&v_72);
+                           fx_free_exn(&v_79);
+                           FX_FREE_STR(&v_78);
+                           FX_FREE_STR(&v_77);
                         }
-                        FX_CHECK_EXN(_fx_catch_9);
-                        _fx_make_T2N14Lexer__token_tTa2i(&t_10, &loc_0, &v_60);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_60, 0, true, &result_7), _fx_catch_9);
+                        else if (n_0 == 0) {
+                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_9);
+                           *new_exp_0 = false;
+                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
+
+                        _fx_catch_9: ;
+                        }
+                        else if (n_0 == 1) {
+                           *new_exp_0 = true; _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                        }
+                        else if (n_0 == 2) {
+                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_10);
+                           *new_exp_0 = true;
+                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
+
+                        _fx_catch_10: ;
+                        }
+                        else {
+                           fx_str_t v_80 = {0};
+                           fx_str_t v_81 = {0};
+                           fx_exn_t v_82 = {0};
+                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_80, 0), _fx_catch_11);
+                           fx_str_t slit_10 = FX_MAKE_STR("Unexpected keyword \'");
+                           fx_str_t slit_11 = FX_MAKE_STR("\'");
+                           {
+                              const fx_str_t strs_1[] = { slit_10, v_80, slit_11 };
+                              FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_81), _fx_catch_11);
+                           }
+                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_81, &v_82), _fx_catch_11);
+                           FX_THROW(&v_82, true, _fx_catch_11);
+
+                        _fx_catch_11: ;
+                           fx_free_exn(&v_82);
+                           FX_FREE_STR(&v_81);
+                           FX_FREE_STR(&v_80);
+                        }
+                        FX_CHECK_EXN(_fx_catch_12);
+                        _fx_make_T2N14Lexer__token_tTa2i(&t_12, &loc_0, &v_68);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_68, 0, true, &result_7), _fx_catch_12);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_7, &result_0);
-                        FX_BREAK(_fx_catch_9);
+                        FX_BREAK(_fx_catch_12);
 
-                     _fx_catch_9: ;
+                     _fx_catch_12: ;
                         if (result_7) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_7);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_60);
-                        _fx_free_N14Lexer__token_t(&t_10);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_68);
+                        _fx_free_N14Lexer__token_t(&t_12);
                      }
                      else {
-                        fx_str_t v_75 = {0};
-                        _fx_N14Lexer__token_t t_16 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_76 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_77 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_78 = 0;
-                        _fx_N14Lexer__token_t t_17 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_79 = {0};
+                        fx_str_t v_83 = {0};
+                        _fx_N14Lexer__token_t t_18 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_84 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_85 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_86 = 0;
+                        _fx_N14Lexer__token_t t_19 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_87 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_8 = 0;
                         if (c_0 == (char_)64) {
-                           FX_CALL(fx_substr(&ident_0, 1, 0, 1, 2, &v_75), _fx_catch_10);
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_75, &t_16);
+                           FX_CALL(fx_substr(&ident_0, 1, 0, 1, 2, &v_83), _fx_catch_13);
+                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_83, &t_18);
                            *new_exp_0 = false;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_76);
-                           _fx_Ta2i v_80;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 + 1, strm_0, &v_80, 0),
-                              _fx_catch_10);
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_16, &v_80, &v_77);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_77, 0, true, &v_78), _fx_catch_10);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_76, v_78, false, &v_78), _fx_catch_10);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_84);
+                           _fx_Ta2i v_88;
+                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 + 1, strm_0, &v_88, 0),
+                              _fx_catch_13);
+                           _fx_make_T2N14Lexer__token_tTa2i(&t_18, &v_88, &v_85);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_85, 0, true, &v_86), _fx_catch_13);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_84, v_86, false, &v_86), _fx_catch_13);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(v_78, &result_0);
-                           FX_BREAK(_fx_catch_10);
+                           FX_COPY_PTR(v_86, &result_0);
+                           FX_BREAK(_fx_catch_13);
                         }
                         else {
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_17);
+                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_19);
                            *new_exp_0 = false;
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_17, &loc_0, &v_79);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_79, 0, true, &result_8), _fx_catch_10);
+                           _fx_make_T2N14Lexer__token_tTa2i(&t_19, &loc_0, &v_87);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_87, 0, true, &result_8), _fx_catch_13);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_8, &result_0);
-                           FX_BREAK(_fx_catch_10);
+                           FX_BREAK(_fx_catch_13);
                         }
 
-                     _fx_catch_10: ;
+                     _fx_catch_13: ;
                         if (result_8) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_8);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_79);
-                        _fx_free_N14Lexer__token_t(&t_17);
-                        if (v_78) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_78);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_87);
+                        _fx_free_N14Lexer__token_t(&t_19);
+                        if (v_86) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_86);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_77);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_76);
-                        _fx_free_N14Lexer__token_t(&t_16);
-                        FX_FREE_STR(&v_75);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_85);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_84);
+                        _fx_free_N14Lexer__token_t(&t_18);
+                        FX_FREE_STR(&v_83);
                      }
-                     FX_CHECK_EXN(_fx_catch_63);
+                     FX_CHECK_EXN(_fx_catch_66);
                   }
                   else {
                      bool prev_ne_0 = *new_exp_0;
                      *prev_dot_0 = false;
                      *new_exp_0 = true;
                      int_ res_4;
-                     FX_CALL(_fx_M5LexerFM3mini2ii(*pos_0 + 1, len_0, &res_4, 0), _fx_catch_63);
+                     FX_CALL(_fx_M5LexerFM3mini2ii(*pos_0 + 1, len_0, &res_4, 0), _fx_catch_66);
                      *pos_0 = res_4;
-                     int_ v_81 = *pos_0 + 1;
-                     char_ c2_0 = FX_STR_ELEM_ZERO(buf_0, v_81);
-                     int_ v_82 = *pos_0 + 2;
-                     char_ c3_0 = FX_STR_ELEM_ZERO(buf_0, v_82);
+                     int_ v_89 = *pos_0 + 1;
+                     char_ c2_0 = FX_STR_ELEM_ZERO(buf_0, v_89);
+                     int_ v_90 = *pos_0 + 2;
+                     char_ c3_0 = FX_STR_ELEM_ZERO(buf_0, v_90);
                      char_ c_2 = c_0;
                      if (c_2 == (char_)40) {
-                        _fx_N14Lexer__token_t v_83 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_84 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_85 = 0;
-                        _fx_N14Lexer__token_t v_86 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_87 = {0};
+                        _fx_N14Lexer__token_t v_91 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_92 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_93 = 0;
+                        _fx_N14Lexer__token_t v_94 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_95 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_9 = 0;
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_83);
-                        _fx_Ta2i v_88;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_88, 0), _fx_catch_11);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_83, &v_88, &v_84);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_84, *paren_stack_0, true, &v_85), _fx_catch_11);
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_91);
+                        _fx_Ta2i v_96;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_96, 0), _fx_catch_14);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_91, &v_96, &v_92);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_92, *paren_stack_0, true, &v_93), _fx_catch_14);
                         _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                        FX_COPY_PTR(v_85, paren_stack_0);
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_86);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_86, &loc_0, &v_87);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_87, 0, true, &result_9), _fx_catch_11);
+                        FX_COPY_PTR(v_93, paren_stack_0);
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_94);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_94, &loc_0, &v_95);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_95, 0, true, &result_9), _fx_catch_14);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_9, &result_0);
-                        FX_BREAK(_fx_catch_11);
+                        FX_BREAK(_fx_catch_14);
 
-                     _fx_catch_11: ;
+                     _fx_catch_14: ;
                         if (result_9) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_9);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_87);
-                        _fx_free_N14Lexer__token_t(&v_86);
-                        if (v_85) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_85);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_95);
+                        _fx_free_N14Lexer__token_t(&v_94);
+                        if (v_93) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_93);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_84);
-                        _fx_free_N14Lexer__token_t(&v_83);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_92);
+                        _fx_free_N14Lexer__token_t(&v_91);
                      }
                      else if (c_2 == (char_)41) {
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_3 = 0;
@@ -4280,100 +4355,100 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         FX_COPY_PTR(*paren_stack_0, &paren_stack_3);
                         if (paren_stack_3 != 0) {
                            if (paren_stack_3->hd.t0.tag == 44) {
-                              _fx_T2N14Lexer__token_tTa2i v_89 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_97 = {0};
                               _fx_LT2N14Lexer__token_tTa2i result_10 = 0;
                               _fx_LT2N14Lexer__token_tTa2i* rest_0 = &paren_stack_3->tl;
                               _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                               FX_COPY_PTR(*rest_0, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_89);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_89, 0, true, &result_10), _fx_catch_12);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_97);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_97, 0, true, &result_10), _fx_catch_15);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_10, &result_0);
-                              FX_BREAK(_fx_catch_12);
+                              FX_BREAK(_fx_catch_15);
 
-                           _fx_catch_12: ;
+                           _fx_catch_15: ;
                               if (result_10) {
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_10);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_89);
-                              goto _fx_endmatch_4;
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_97);
+                              goto _fx_endmatch_5;
                            }
                         }
-                        fx_exn_t v_90 = {0};
-                        fx_str_t slit_9 = FX_MAKE_STR("Unexpected \')\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_9, &v_90), _fx_catch_13);
-                        FX_THROW(&v_90, true, _fx_catch_13);
+                        fx_exn_t v_98 = {0};
+                        fx_str_t slit_12 = FX_MAKE_STR("Unexpected \')\', check parens");
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_12, &v_98), _fx_catch_16);
+                        FX_THROW(&v_98, true, _fx_catch_16);
 
-                     _fx_catch_13: ;
-                        fx_free_exn(&v_90);
+                     _fx_catch_16: ;
+                        fx_free_exn(&v_98);
 
-                     _fx_endmatch_4: ;
-                        FX_CHECK_EXN(_fx_catch_14);
+                     _fx_endmatch_5: ;
+                        FX_CHECK_EXN(_fx_catch_17);
 
-                     _fx_catch_14: ;
+                     _fx_catch_17: ;
                         if (paren_stack_3) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_3);
                         }
                      }
                      else if (c_2 == (char_)91) {
-                        _fx_N14Lexer__token_t v_91 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_92 = {0};
+                        _fx_N14Lexer__token_t v_99 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_100 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_11 = 0;
-                        _fx_N14Lexer__token_t v_93 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_94 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_95 = 0;
-                        _fx_N14Lexer__token_t v_96 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_97 = {0};
+                        _fx_N14Lexer__token_t v_101 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_102 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_103 = 0;
+                        _fx_N14Lexer__token_t v_104 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_105 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_12 = 0;
-                        bool t_18;
+                        bool t_20;
                         if (prev_ne_0) {
-                           t_18 = c1_0 == (char_)93;
+                           t_20 = c1_0 == (char_)93;
                         }
                         else {
-                           t_18 = false;
+                           t_20 = false;
                         }
-                        if (t_18) {
+                        if (t_20) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&_fx_g15Lexer__LitEmpty, &v_91);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_91, &loc_0, &v_92);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_92, 0, true, &result_11), _fx_catch_15);
+                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&_fx_g15Lexer__LitEmpty, &v_99);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_99, &loc_0, &v_100);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_100, 0, true, &result_11), _fx_catch_18);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_11, &result_0);
-                           FX_BREAK(_fx_catch_15);
+                           FX_BREAK(_fx_catch_18);
                         }
                         else {
-                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_93);
-                           _fx_Ta2i v_98;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_98, 0),
-                              _fx_catch_15);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_93, &v_98, &v_94);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_94, *paren_stack_0, true, &v_95), _fx_catch_15);
+                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_101);
+                           _fx_Ta2i v_106;
+                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_106, 0),
+                              _fx_catch_18);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_101, &v_106, &v_102);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_102, *paren_stack_0, true, &v_103), _fx_catch_18);
                            _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_95, paren_stack_0);
-                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_96);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_96, &loc_0, &v_97);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_97, 0, true, &result_12), _fx_catch_15);
+                           FX_COPY_PTR(v_103, paren_stack_0);
+                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_104);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_104, &loc_0, &v_105);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_105, 0, true, &result_12), _fx_catch_18);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_12, &result_0);
-                           FX_BREAK(_fx_catch_15);
+                           FX_BREAK(_fx_catch_18);
                         }
 
-                     _fx_catch_15: ;
+                     _fx_catch_18: ;
                         if (result_12) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_12);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_97);
-                        _fx_free_N14Lexer__token_t(&v_96);
-                        if (v_95) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_95);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_105);
+                        _fx_free_N14Lexer__token_t(&v_104);
+                        if (v_103) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_103);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_94);
-                        _fx_free_N14Lexer__token_t(&v_93);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_102);
+                        _fx_free_N14Lexer__token_t(&v_101);
                         if (result_11) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_11);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_92);
-                        _fx_free_N14Lexer__token_t(&v_91);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_100);
+                        _fx_free_N14Lexer__token_t(&v_99);
                      }
                      else if (c_2 == (char_)93) {
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_4 = 0;
@@ -4381,197 +4456,197 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         FX_COPY_PTR(*paren_stack_0, &paren_stack_4);
                         if (paren_stack_4 != 0) {
                            if (paren_stack_4->hd.t0.tag == 47) {
-                              _fx_T2N14Lexer__token_tTa2i v_99 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_107 = {0};
                               _fx_LT2N14Lexer__token_tTa2i result_13 = 0;
                               _fx_LT2N14Lexer__token_tTa2i* rest_1 = &paren_stack_4->tl;
                               _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                               FX_COPY_PTR(*rest_1, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__RSQUARE, &loc_0, &v_99);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_99, 0, true, &result_13), _fx_catch_16);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__RSQUARE, &loc_0, &v_107);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_107, 0, true, &result_13), _fx_catch_19);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_13, &result_0);
-                              FX_BREAK(_fx_catch_16);
+                              FX_BREAK(_fx_catch_19);
 
-                           _fx_catch_16: ;
+                           _fx_catch_19: ;
                               if (result_13) {
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_13);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_99);
-                              goto _fx_endmatch_5;
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_107);
+                              goto _fx_endmatch_6;
                            }
                         }
-                        fx_exn_t v_100 = {0};
-                        fx_str_t slit_10 = FX_MAKE_STR("Unexpected \']\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_10, &v_100), _fx_catch_17);
-                        FX_THROW(&v_100, true, _fx_catch_17);
+                        fx_exn_t v_108 = {0};
+                        fx_str_t slit_13 = FX_MAKE_STR("Unexpected \']\', check parens");
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_13, &v_108), _fx_catch_20);
+                        FX_THROW(&v_108, true, _fx_catch_20);
 
-                     _fx_catch_17: ;
-                        fx_free_exn(&v_100);
+                     _fx_catch_20: ;
+                        fx_free_exn(&v_108);
 
-                     _fx_endmatch_5: ;
-                        FX_CHECK_EXN(_fx_catch_18);
+                     _fx_endmatch_6: ;
+                        FX_CHECK_EXN(_fx_catch_21);
 
-                     _fx_catch_18: ;
+                     _fx_catch_21: ;
                         if (paren_stack_4) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_4);
                         }
                      }
                      else if (c_2 == (char_)123) {
-                        _fx_T2N14Lexer__token_tTa2i v_101 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_102 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_109 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_110 = 0;
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_5 = 0;
-                        _fx_Ta2i v_103;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_103, 0), _fx_catch_23);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &v_103, &v_101);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_101, *paren_stack_0, true, &v_102), _fx_catch_23);
+                        _fx_Ta2i v_111;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_111, 0), _fx_catch_26);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &v_111, &v_109);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_109, *paren_stack_0, true, &v_110), _fx_catch_26);
                         _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                        FX_COPY_PTR(v_102, paren_stack_0);
+                        FX_COPY_PTR(v_110, paren_stack_0);
                         FX_COPY_PTR(*paren_stack_0, &paren_stack_5);
                         if (paren_stack_5 != 0) {
                            if (paren_stack_5->hd.t0.tag == 49) {
-                              _fx_LT2N14Lexer__token_tTa2i v_104 = paren_stack_5->tl;
-                              if (v_104 != 0) {
-                                 if (v_104->hd.t0.tag == 9) {
-                                    _fx_T2iS v_105 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_112 = paren_stack_5->tl;
+                              if (v_112 != 0) {
+                                 if (v_112->hd.t0.tag == 9) {
+                                    _fx_T2iS v_113 = {0};
                                     fx_str_t s_0 = {0};
-                                    fx_str_t v_106 = {0};
-                                    _fx_N10Ast__lit_t v_107 = {0};
-                                    _fx_N14Lexer__token_t v_108 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_109 = {0};
+                                    fx_str_t v_114 = {0};
+                                    _fx_N10Ast__lit_t v_115 = {0};
+                                    _fx_N14Lexer__token_t v_116 = {0};
+                                    _fx_T2N14Lexer__token_tTa2i v_117 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_14 = 0;
                                     *new_exp_0 = false;
-                                    _fx_LT2N14Lexer__token_tTa2i* rest_2 = &v_104->tl;
+                                    _fx_LT2N14Lexer__token_tTa2i* rest_2 = &v_112->tl;
                                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                                     FX_COPY_PTR(*rest_2, paren_stack_0);
-                                    FX_CALL(_fx_M5LexerFM9get_ccodeT2iS2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_105, 0),
-                                       _fx_catch_19);
-                                    int_ p_6 = v_105.t0;
-                                    fx_copy_str(&v_105.t1, &s_0);
+                                    FX_CALL(_fx_M5LexerFM9get_ccodeT2iS2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_113, 0),
+                                       _fx_catch_22);
+                                    int_ p_6 = v_113.t0;
+                                    fx_copy_str(&v_113.t1, &s_0);
                                     *pos_0 = p_6;
-                                    FX_CALL(_fx_M6StringFM5stripS1S(&s_0, &v_106, 0), _fx_catch_19);
-                                    _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_106, &v_107);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_107, &v_108);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_108, &loc_0, &v_109);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_109, 0, true, &result_14), _fx_catch_19);
+                                    FX_CALL(_fx_M6StringFM5stripS1S(&s_0, &v_114, 0), _fx_catch_22);
+                                    _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_114, &v_115);
+                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_115, &v_116);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&v_116, &loc_0, &v_117);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_117, 0, true, &result_14), _fx_catch_22);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_14, &result_0);
-                                    FX_BREAK(_fx_catch_19);
+                                    FX_BREAK(_fx_catch_22);
 
-                                 _fx_catch_19: ;
+                                 _fx_catch_22: ;
                                     if (result_14) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_14);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_109);
-                                    _fx_free_N14Lexer__token_t(&v_108);
-                                    _fx_free_N10Ast__lit_t(&v_107);
-                                    FX_FREE_STR(&v_106);
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_117);
+                                    _fx_free_N14Lexer__token_t(&v_116);
+                                    _fx_free_N10Ast__lit_t(&v_115);
+                                    FX_FREE_STR(&v_114);
                                     FX_FREE_STR(&s_0);
-                                    _fx_free_T2iS(&v_105);
-                                    goto _fx_endmatch_7;
+                                    _fx_free_T2iS(&v_113);
+                                    goto _fx_endmatch_8;
                                  }
                               }
                            }
                         }
                         if (paren_stack_5 != 0) {
-                           _fx_LT2N14Lexer__token_tTa2i v_110 = paren_stack_5->tl;
-                           if (v_110 != 0) {
-                              if (v_110->hd.t0.tag == 26) {
-                                 _fx_T2N14Lexer__token_tTa2i* v_111 = &paren_stack_5->hd;
-                                 if (v_111->t0.tag == 49) {
-                                    _fx_T2N14Lexer__token_tTa2i v_112 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_113 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i v_114 = 0;
-                                    _fx_T2N14Lexer__token_tTa2i v_115 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_118 = paren_stack_5->tl;
+                           if (v_118 != 0) {
+                              if (v_118->hd.t0.tag == 26) {
+                                 _fx_T2N14Lexer__token_tTa2i* v_119 = &paren_stack_5->hd;
+                                 if (v_119->t0.tag == 49) {
+                                    _fx_T2N14Lexer__token_tTa2i v_120 = {0};
+                                    _fx_T2N14Lexer__token_tTa2i v_121 = {0};
+                                    _fx_LT2N14Lexer__token_tTa2i v_122 = 0;
+                                    _fx_T2N14Lexer__token_tTa2i v_123 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_15 = 0;
-                                    _fx_Ta2i* l1_0 = &v_111->t1;
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, l1_0, &v_112);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_113);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_113, v_110->tl, true, &v_114), _fx_catch_20);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_112, v_114, false, &v_114), _fx_catch_20);
+                                    _fx_Ta2i* l1_0 = &v_119->t1;
+                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, l1_0, &v_120);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_121);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_121, v_118->tl, true, &v_122), _fx_catch_23);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_120, v_122, false, &v_122), _fx_catch_23);
                                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                    FX_COPY_PTR(v_114, paren_stack_0);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_115);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_115, 0, true, &result_15), _fx_catch_20);
+                                    FX_COPY_PTR(v_122, paren_stack_0);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_123);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_123, 0, true, &result_15), _fx_catch_23);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_15, &result_0);
-                                    FX_BREAK(_fx_catch_20);
+                                    FX_BREAK(_fx_catch_23);
 
-                                 _fx_catch_20: ;
+                                 _fx_catch_23: ;
                                     if (result_15) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_15);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_115);
-                                    if (v_114) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&v_114);
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_123);
+                                    if (v_122) {
+                                       _fx_free_LT2N14Lexer__token_tTa2i(&v_122);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_113);
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_112);
-                                    goto _fx_endmatch_7;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_121);
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_120);
+                                    goto _fx_endmatch_8;
                                  }
                               }
                            }
                         }
-                        _fx_T2N14Lexer__token_tTa2i v_116 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_117 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i v_118 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_124 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_125 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i v_126 = 0;
                         _fx_LT2N14Lexer__token_tTa2i result_16 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &loc_0, &v_116);
-                        FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&v_117, fx_fv), _fx_catch_22);
-                        if (v_117 != 0) {
-                           _fx_T2N14Lexer__token_tTa2i* v_119 = &v_117->hd;
-                           if (v_119->t0.tag == 81) {
-                              _fx_T2N14Lexer__token_tTa2i v_120 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_121 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_122 = {0};
-                              _fx_Ta2i* p_7 = &v_119->t1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_120);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_120, *paren_stack_0, true, &v_121), _fx_catch_21);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &loc_0, &v_124);
+                        FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&v_125, fx_fv), _fx_catch_25);
+                        if (v_125 != 0) {
+                           _fx_T2N14Lexer__token_tTa2i* v_127 = &v_125->hd;
+                           if (v_127->t0.tag == 81) {
+                              _fx_T2N14Lexer__token_tTa2i v_128 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_129 = 0;
+                              _fx_T2N14Lexer__token_tTa2i v_130 = {0};
+                              _fx_Ta2i* p_7 = &v_127->t1;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_128);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_128, *paren_stack_0, true, &v_129), _fx_catch_24);
                               _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(v_121, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_122);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_122, v_117->tl, true, &v_118), _fx_catch_21);
+                              FX_COPY_PTR(v_129, paren_stack_0);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_130);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_130, v_125->tl, true, &v_126), _fx_catch_24);
 
-                           _fx_catch_21: ;
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_122);
-                              if (v_121) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_121);
+                           _fx_catch_24: ;
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_130);
+                              if (v_129) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_129);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_120);
-                              goto _fx_endmatch_6;
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_128);
+                              goto _fx_endmatch_7;
                            }
                         }
-                        FX_COPY_PTR(v_117, &v_118);
+                        FX_COPY_PTR(v_125, &v_126);
 
-                     _fx_endmatch_6: ;
-                        FX_CHECK_EXN(_fx_catch_22);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_116, v_118, true, &result_16), _fx_catch_22);
+                     _fx_endmatch_7: ;
+                        FX_CHECK_EXN(_fx_catch_25);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_124, v_126, true, &result_16), _fx_catch_25);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_16, &result_0);
-                        FX_BREAK(_fx_catch_22);
+                        FX_BREAK(_fx_catch_25);
 
-                     _fx_catch_22: ;
+                     _fx_catch_25: ;
                         if (result_16) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_16);
                         }
-                        if (v_118) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_118);
+                        if (v_126) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_126);
                         }
-                        if (v_117) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_117);
+                        if (v_125) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_125);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_116);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_124);
 
-                     _fx_endmatch_7: ;
-                        FX_CHECK_EXN(_fx_catch_23);
+                     _fx_endmatch_8: ;
+                        FX_CHECK_EXN(_fx_catch_26);
 
-                     _fx_catch_23: ;
+                     _fx_catch_26: ;
                         if (paren_stack_5) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_5);
                         }
-                        if (v_102) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_102);
+                        if (v_110) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_110);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_101);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_109);
                      }
                      else if (c_2 == (char_)125) {
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_6 = 0;
@@ -4579,1189 +4654,1191 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         FX_COPY_PTR(*paren_stack_0, &paren_stack_6);
                         if (paren_stack_6 != 0) {
                            if (paren_stack_6->hd.t0.tag == 45) {
-                              _fx_T4iSiB v_123 = {0};
+                              _fx_T4iSiB v_131 = {0};
                               fx_str_t s_1 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_124 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i v_125 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_126 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_127 = {0};
-                              _fx_N14Lexer__token_t v_128 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_129 = {0};
-                              _fx_N10Ast__lit_t v_130 = {0};
-                              _fx_N14Lexer__token_t v_131 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_132 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_132 = 0;
                               _fx_LT2N14Lexer__token_tTa2i v_133 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i v_134 = 0;
+                              _fx_T2N14Lexer__token_tTa2i v_134 = {0};
                               _fx_T2N14Lexer__token_tTa2i v_135 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_136 = 0;
-                              _fx_N14Lexer__token_t v_137 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_138 = {0};
+                              _fx_N14Lexer__token_t v_136 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_137 = {0};
+                              _fx_N10Ast__lit_t v_138 = {0};
                               _fx_N14Lexer__token_t v_139 = {0};
                               _fx_T2N14Lexer__token_tTa2i v_140 = {0};
-                              _fx_N14Lexer__token_t v_141 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_142 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_143 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_144 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_145 = 0;
+                              _fx_LT2N14Lexer__token_tTa2i v_141 = 0;
+                              _fx_LT2N14Lexer__token_tTa2i v_142 = 0;
+                              _fx_T2N14Lexer__token_tTa2i v_143 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_144 = 0;
+                              _fx_N14Lexer__token_t v_145 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_146 = {0};
+                              _fx_N14Lexer__token_t v_147 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_148 = {0};
+                              _fx_N14Lexer__token_t v_149 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_150 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_151 = 0;
+                              _fx_T2N14Lexer__token_tTa2i v_152 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_153 = 0;
                               _fx_LT2N14Lexer__token_tTa2i result_17 = 0;
                               _fx_LT2N14Lexer__token_tTa2i* rest_3 = &paren_stack_6->tl;
                               _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                               FX_COPY_PTR(*rest_3, paren_stack_0);
-                              _fx_Ta2i v_146;
-                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_146, 0),
-                                 _fx_catch_24);
+                              _fx_Ta2i v_154;
+                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_154, 0),
+                                 _fx_catch_27);
                               char_ res_5;
-                              FX_CALL(_fx_F3chrC1i(34, &res_5, 0), _fx_catch_24);
+                              FX_CALL(_fx_F3chrC1i(34, &res_5, 0), _fx_catch_27);
                               FX_CALL(
-                                 _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, *pos_0, &v_146, res_5, false, true,
-                                    &v_123, 0), _fx_catch_24);
-                              int_ p_8 = v_123.t0;
-                              fx_copy_str(&v_123.t1, &s_1);
-                              int_ dl_1 = v_123.t2;
-                              bool inline_exp_1 = v_123.t3;
+                                 _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, *pos_0, &v_154, res_5, false, true,
+                                    &v_131, 0), _fx_catch_27);
+                              int_ p_8 = v_131.t0;
+                              fx_copy_str(&v_131.t1, &s_1);
+                              int_ dl_1 = v_131.t2;
+                              bool inline_exp_1 = v_131.t3;
                               strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_1;
                               *pos_0 = p_8;
                               _fx_Nt6option1R8format_t fmt_curr_0 = *fmt_0;
                               *fmt_0 = _fx_g13Lexer__None1_;
                               FX_CALL(
                                  _fx_M5LexerFM10fmt2tokensLT2N14Lexer__token_tTa2i2Nt6option1R8format_tTa2i(&fmt_curr_0, &loc_0,
-                                    &v_124, 0), _fx_catch_24);
+                                    &v_132, 0), _fx_catch_27);
                               if (FX_STR_LENGTH(s_1) == 0) {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_126);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_126, 0, true, &v_125), _fx_catch_24);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_134);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_134, 0, true, &v_133), _fx_catch_27);
                               }
                               else {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_127);
-                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_128);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_128, &loc_0, &v_129);
-                                 _fx_M3AstFM9LitStringN10Ast__lit_t1S(&s_1, &v_130);
-                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_130, &v_131);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_131, &loc_0, &v_132);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_132, 0, true, &v_133), _fx_catch_24);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_129, v_133, false, &v_133), _fx_catch_24);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_127, v_133, true, &v_125), _fx_catch_24);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_135);
+                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_136);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_136, &loc_0, &v_137);
+                                 _fx_M3AstFM9LitStringN10Ast__lit_t1S(&s_1, &v_138);
+                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_138, &v_139);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_139, &loc_0, &v_140);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_140, 0, true, &v_141), _fx_catch_27);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_137, v_141, false, &v_141), _fx_catch_27);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_135, v_141, true, &v_133), _fx_catch_27);
                               }
                               if (inline_exp_1) {
                                  *new_exp_0 = true;
-                                 _fx_Ta2i v_147;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_147, 0),
-                                    _fx_catch_24);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_147, &v_135);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_135, *paren_stack_0, true, &v_136), _fx_catch_24);
+                                 _fx_Ta2i v_155;
+                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_155, 0),
+                                    _fx_catch_27);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_155, &v_143);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_143, *paren_stack_0, true, &v_144), _fx_catch_27);
                                  _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                 FX_COPY_PTR(v_136, paren_stack_0);
-                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_137);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_137, &loc_0, &v_138);
-                                 fx_str_t slit_11 = FX_MAKE_STR("string");
-                                 _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_11, &v_139);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_139, &loc_0, &v_140);
-                                 _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_141);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_141, &loc_0, &v_142);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_142, 0, true, &v_143), _fx_catch_24);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_140, v_143, false, &v_143), _fx_catch_24);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_138, v_143, true, &v_134), _fx_catch_24);
+                                 FX_COPY_PTR(v_144, paren_stack_0);
+                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_145);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_145, &loc_0, &v_146);
+                                 fx_str_t slit_14 = FX_MAKE_STR("string");
+                                 _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_14, &v_147);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_147, &loc_0, &v_148);
+                                 _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_149);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_149, &loc_0, &v_150);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_150, 0, true, &v_151), _fx_catch_27);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_148, v_151, false, &v_151), _fx_catch_27);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_146, v_151, true, &v_142), _fx_catch_27);
                               }
                               else {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_144);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_144, 0, true, &v_134), _fx_catch_24);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_152);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_152, 0, true, &v_142), _fx_catch_27);
                               }
                               FX_CALL(
                                  _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
-                                    v_125, v_134, &v_145, 0), _fx_catch_24);
+                                    v_133, v_142, &v_153, 0), _fx_catch_27);
                               FX_CALL(
                                  _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
-                                    v_124, v_145, &result_17, 0), _fx_catch_24);
+                                    v_132, v_153, &result_17, 0), _fx_catch_27);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_17, &result_0);
-                              FX_BREAK(_fx_catch_24);
+                              FX_BREAK(_fx_catch_27);
 
-                           _fx_catch_24: ;
+                           _fx_catch_27: ;
                               if (result_17) {
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_17);
                               }
-                              if (v_145) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_145);
+                              if (v_153) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_153);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_144);
-                              if (v_143) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_143);
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_152);
+                              if (v_151) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_151);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_142);
-                              _fx_free_N14Lexer__token_t(&v_141);
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_150);
+                              _fx_free_N14Lexer__token_t(&v_149);
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_148);
+                              _fx_free_N14Lexer__token_t(&v_147);
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_146);
+                              _fx_free_N14Lexer__token_t(&v_145);
+                              if (v_144) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_144);
+                              }
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_143);
+                              if (v_142) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_142);
+                              }
+                              if (v_141) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_141);
+                              }
                               _fx_free_T2N14Lexer__token_tTa2i(&v_140);
                               _fx_free_N14Lexer__token_t(&v_139);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_138);
-                              _fx_free_N14Lexer__token_t(&v_137);
-                              if (v_136) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_136);
-                              }
+                              _fx_free_N10Ast__lit_t(&v_138);
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_137);
+                              _fx_free_N14Lexer__token_t(&v_136);
                               _fx_free_T2N14Lexer__token_tTa2i(&v_135);
-                              if (v_134) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_134);
-                              }
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_134);
                               if (v_133) {
                                  _fx_free_LT2N14Lexer__token_tTa2i(&v_133);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_132);
-                              _fx_free_N14Lexer__token_t(&v_131);
-                              _fx_free_N10Ast__lit_t(&v_130);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_129);
-                              _fx_free_N14Lexer__token_t(&v_128);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_127);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_126);
-                              if (v_125) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_125);
-                              }
-                              if (v_124) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_124);
+                              if (v_132) {
+                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_132);
                               }
                               FX_FREE_STR(&s_1);
-                              _fx_free_T4iSiB(&v_123);
-                              goto _fx_endmatch_8;
+                              _fx_free_T4iSiB(&v_131);
+                              goto _fx_endmatch_9;
                            }
                         }
                         if (paren_stack_6 != 0) {
                            if (paren_stack_6->hd.t0.tag == 55) {
-                              _fx_LT2N14Lexer__token_tTa2i v_148 = paren_stack_6->tl;
-                              if (v_148 != 0) {
-                                 if (v_148->hd.t0.tag == 49) {
-                                    _fx_T2N14Lexer__token_tTa2i v_149 = {0};
+                              _fx_LT2N14Lexer__token_tTa2i v_156 = paren_stack_6->tl;
+                              if (v_156 != 0) {
+                                 if (v_156->hd.t0.tag == 49) {
+                                    _fx_T2N14Lexer__token_tTa2i v_157 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_18 = 0;
-                                    _fx_LT2N14Lexer__token_tTa2i* rest_4 = &v_148->tl;
+                                    _fx_LT2N14Lexer__token_tTa2i* rest_4 = &v_156->tl;
                                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                                     FX_COPY_PTR(*rest_4, paren_stack_0);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_149);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_149, 0, true, &result_18), _fx_catch_25);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_157);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_157, 0, true, &result_18), _fx_catch_28);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_18, &result_0);
-                                    FX_BREAK(_fx_catch_25);
+                                    FX_BREAK(_fx_catch_28);
 
-                                 _fx_catch_25: ;
+                                 _fx_catch_28: ;
                                     if (result_18) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_18);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_149);
-                                    goto _fx_endmatch_8;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_157);
+                                    goto _fx_endmatch_9;
                                  }
                               }
                            }
                         }
                         if (paren_stack_6 != 0) {
                            if (paren_stack_6->hd.t0.tag == 49) {
-                              _fx_T2N14Lexer__token_tTa2i v_150 = {0};
+                              _fx_T2N14Lexer__token_tTa2i v_158 = {0};
                               _fx_LT2N14Lexer__token_tTa2i result_19 = 0;
                               _fx_LT2N14Lexer__token_tTa2i* rest_5 = &paren_stack_6->tl;
                               _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                               FX_COPY_PTR(*rest_5, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_150);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_150, 0, true, &result_19), _fx_catch_26);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_158);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_158, 0, true, &result_19), _fx_catch_29);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_19, &result_0);
-                              FX_BREAK(_fx_catch_26);
+                              FX_BREAK(_fx_catch_29);
 
-                           _fx_catch_26: ;
+                           _fx_catch_29: ;
                               if (result_19) {
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_19);
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_150);
-                              goto _fx_endmatch_8;
+                              _fx_free_T2N14Lexer__token_tTa2i(&v_158);
+                              goto _fx_endmatch_9;
                            }
                         }
-                        fx_exn_t v_151 = {0};
-                        fx_str_t slit_12 = FX_MAKE_STR("Unexpected \'}\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_12, &v_151), _fx_catch_27);
-                        FX_THROW(&v_151, true, _fx_catch_27);
+                        fx_exn_t v_159 = {0};
+                        fx_str_t slit_15 = FX_MAKE_STR("Unexpected \'}\', check parens");
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_15, &v_159), _fx_catch_30);
+                        FX_THROW(&v_159, true, _fx_catch_30);
 
-                     _fx_catch_27: ;
-                        fx_free_exn(&v_151);
+                     _fx_catch_30: ;
+                        fx_free_exn(&v_159);
 
-                     _fx_endmatch_8: ;
-                        FX_CHECK_EXN(_fx_catch_28);
+                     _fx_endmatch_9: ;
+                        FX_CHECK_EXN(_fx_catch_31);
 
-                     _fx_catch_28: ;
+                     _fx_catch_31: ;
                         if (paren_stack_6) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_6);
                         }
                      }
                      else if (c_2 == (char_)124) {
-                        _fx_N14Lexer__token_t v_152 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_153 = {0};
+                        _fx_N14Lexer__token_t v_160 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_161 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_20 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_154 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_162 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_21 = 0;
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_7 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpBitwiseOr, &v_152);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_152, &loc_0, &v_153);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_153, 0, true, &result_20), _fx_catch_31);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpBitwiseOr, &v_160);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_160, &loc_0, &v_161);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_161, 0, true, &result_20), _fx_catch_34);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_20, &result_0);
-                           FX_BREAK(_fx_catch_31);
+                           FX_BREAK(_fx_catch_34);
                         }
                         else if (c1_0 == (char_)124) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__LOGICAL_OR, &loc_0, &v_154);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_154, 0, true, &result_21), _fx_catch_31);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__LOGICAL_OR, &loc_0, &v_162);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_162, 0, true, &result_21), _fx_catch_34);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_21, &result_0);
-                           FX_BREAK(_fx_catch_31);
+                           FX_BREAK(_fx_catch_34);
                         }
                         else {
                            FX_COPY_PTR(*paren_stack_0, &paren_stack_7);
                            if (paren_stack_7 != 0) {
-                              _fx_LT2N14Lexer__token_tTa2i v_155 = paren_stack_7->tl;
-                              if (v_155 != 0) {
+                              _fx_LT2N14Lexer__token_tTa2i v_163 = paren_stack_7->tl;
+                              if (v_163 != 0) {
                                  if (paren_stack_7->hd.t0.tag == 55) {
-                                    if (v_155->hd.t0.tag == 49) {
-                                       _fx_T2N14Lexer__token_tTa2i v_156 = {0};
+                                    if (v_163->hd.t0.tag == 49) {
+                                       _fx_T2N14Lexer__token_tTa2i v_164 = {0};
                                        _fx_LT2N14Lexer__token_tTa2i result_22 = 0;
-                                       _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, &loc_0, &v_156);
-                                       FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_156, 0, true, &result_22), _fx_catch_29);
+                                       _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, &loc_0, &v_164);
+                                       FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_164, 0, true, &result_22), _fx_catch_32);
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                        FX_COPY_PTR(result_22, &result_0);
-                                       FX_BREAK(_fx_catch_29);
+                                       FX_BREAK(_fx_catch_32);
 
-                                    _fx_catch_29: ;
+                                    _fx_catch_32: ;
                                        if (result_22) {
                                           _fx_free_LT2N14Lexer__token_tTa2i(&result_22);
                                        }
-                                       _fx_free_T2N14Lexer__token_tTa2i(&v_156);
-                                       goto _fx_endmatch_9;
+                                       _fx_free_T2N14Lexer__token_tTa2i(&v_164);
+                                       goto _fx_endmatch_10;
                                     }
                                  }
                               }
                            }
-                           _fx_T2N14Lexer__token_tTa2i v_157 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_165 = {0};
                            _fx_LT2N14Lexer__token_tTa2i result_23 = 0;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BITWISE_OR, &loc_0, &v_157);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_157, 0, true, &result_23), _fx_catch_30);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BITWISE_OR, &loc_0, &v_165);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_165, 0, true, &result_23), _fx_catch_33);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_23, &result_0);
-                           FX_BREAK(_fx_catch_30);
+                           FX_BREAK(_fx_catch_33);
 
-                        _fx_catch_30: ;
+                        _fx_catch_33: ;
                            if (result_23) {
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_23);
                            }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_157);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_165);
 
-                        _fx_endmatch_9: ;
-                           FX_CHECK_EXN(_fx_catch_31);
+                        _fx_endmatch_10: ;
+                           FX_CHECK_EXN(_fx_catch_34);
                         }
 
-                     _fx_catch_31: ;
+                     _fx_catch_34: ;
                         if (paren_stack_7) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_7);
                         }
                         if (result_21) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_21);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_154);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_162);
                         if (result_20) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_20);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_153);
-                        _fx_free_N14Lexer__token_t(&v_152);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_161);
+                        _fx_free_N14Lexer__token_t(&v_160);
                      }
                      else if (c_2 == (char_)43) {
-                        _fx_N14Lexer__token_t v_158 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_159 = {0};
+                        _fx_N14Lexer__token_t v_166 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_167 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_24 = 0;
-                        _fx_N14Lexer__token_t v_160 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_161 = {0};
+                        _fx_N14Lexer__token_t v_168 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_169 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_25 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpAdd, &v_158);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_158, &loc_0, &v_159);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_159, 0, true, &result_24), _fx_catch_32);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpAdd, &v_166);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_166, &loc_0, &v_167);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_167, 0, true, &result_24), _fx_catch_35);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_24, &result_0);
-                           FX_BREAK(_fx_catch_32);
+                           FX_BREAK(_fx_catch_35);
                         }
                         else {
-                           _fx_M5LexerFM4PLUSN14Lexer__token_t1B(prev_ne_0, &v_160);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_160, &loc_0, &v_161);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_161, 0, true, &result_25), _fx_catch_32);
+                           _fx_M5LexerFM4PLUSN14Lexer__token_t1B(prev_ne_0, &v_168);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_168, &loc_0, &v_169);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_169, 0, true, &result_25), _fx_catch_35);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_25, &result_0);
-                           FX_BREAK(_fx_catch_32);
+                           FX_BREAK(_fx_catch_35);
                         }
 
-                     _fx_catch_32: ;
+                     _fx_catch_35: ;
                         if (result_25) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_25);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_161);
-                        _fx_free_N14Lexer__token_t(&v_160);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_169);
+                        _fx_free_N14Lexer__token_t(&v_168);
                         if (result_24) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_24);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_159);
-                        _fx_free_N14Lexer__token_t(&v_158);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_167);
+                        _fx_free_N14Lexer__token_t(&v_166);
                      }
                      else if (c_2 == (char_)45) {
-                        _fx_N14Lexer__token_t v_162 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_163 = {0};
+                        _fx_N14Lexer__token_t v_170 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_171 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_26 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_164 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_172 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_27 = 0;
-                        _fx_N14Lexer__token_t v_165 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_166 = {0};
+                        _fx_N14Lexer__token_t v_173 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_174 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_28 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i v_167 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i ts_0 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpSub, &v_162);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_162, &loc_0, &v_163);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_163, 0, true, &result_26), _fx_catch_37);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpSub, &v_170);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_170, &loc_0, &v_171);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_171, 0, true, &result_26), _fx_catch_40);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_26, &result_0);
-                           FX_BREAK(_fx_catch_37);
+                           FX_BREAK(_fx_catch_40);
                         }
                         else if (c1_0 == (char_)62) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__ARROW, &loc_0, &v_164);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_164, 0, true, &result_27), _fx_catch_37);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__ARROW, &loc_0, &v_172);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_172, 0, true, &result_27), _fx_catch_40);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_27, &result_0);
-                           FX_BREAK(_fx_catch_37);
+                           FX_BREAK(_fx_catch_40);
                         }
                         else if (!prev_ne_0) {
-                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(false, &v_165);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_165, &loc_0, &v_166);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_166, 0, true, &result_28), _fx_catch_37);
+                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(false, &v_173);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_173, &loc_0, &v_174);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_174, 0, true, &result_28), _fx_catch_40);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_28, &result_0);
-                           FX_BREAK(_fx_catch_37);
+                           FX_BREAK(_fx_catch_40);
                         }
                         else {
-                           FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&v_167, fx_fv), _fx_catch_37);
-                           if (v_167 != 0) {
-                              _fx_N14Lexer__token_t* v_168 = &v_167->hd.t0;
-                              if (v_168->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_169 = &v_168->u.LITERAL;
-                                 if (v_169->tag == 1) {
-                                    _fx_N10Ast__lit_t v_170 = {0};
-                                    _fx_N14Lexer__token_t v_171 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_172 = {0};
+                           *expect_neg_number_0 = !*expect_neg_number_0;
+                           FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&ts_0, fx_fv), _fx_catch_40);
+                           *expect_neg_number_0 = !*expect_neg_number_0;
+                           if (ts_0 != 0) {
+                              _fx_N14Lexer__token_t* v_175 = &ts_0->hd.t0;
+                              if (v_175->tag == 1) {
+                                 _fx_N10Ast__lit_t* v_176 = &v_175->u.LITERAL;
+                                 if (v_176->tag == 1) {
+                                    _fx_N10Ast__lit_t v_177 = {0};
+                                    _fx_N14Lexer__token_t v_178 = {0};
+                                    _fx_T2N14Lexer__token_tTa2i v_179 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_29 = 0;
-                                    _fx_M3AstFM6LitIntN10Ast__lit_t1l(-v_169->u.LitInt, &v_170);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_170, &v_171);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_171, &loc_0, &v_172);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_172, v_167->tl, true, &result_29),
-                                       _fx_catch_33);
+                                    _fx_M3AstFM6LitIntN10Ast__lit_t1l(-v_176->u.LitInt, &v_177);
+                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_177, &v_178);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&v_178, &loc_0, &v_179);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_179, ts_0->tl, true, &result_29),
+                                       _fx_catch_36);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_29, &result_0);
-                                    FX_BREAK(_fx_catch_33);
+                                    FX_BREAK(_fx_catch_36);
 
-                                 _fx_catch_33: ;
+                                 _fx_catch_36: ;
                                     if (result_29) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_29);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_172);
-                                    _fx_free_N14Lexer__token_t(&v_171);
-                                    _fx_free_N10Ast__lit_t(&v_170);
-                                    goto _fx_endmatch_10;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_179);
+                                    _fx_free_N14Lexer__token_t(&v_178);
+                                    _fx_free_N10Ast__lit_t(&v_177);
+                                    goto _fx_endmatch_11;
                                  }
                               }
                            }
-                           if (v_167 != 0) {
-                              _fx_N14Lexer__token_t* v_173 = &v_167->hd.t0;
-                              if (v_173->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_174 = &v_173->u.LITERAL;
-                                 if (v_174->tag == 2) {
-                                    _fx_N10Ast__lit_t v_175 = {0};
-                                    _fx_N14Lexer__token_t v_176 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_177 = {0};
+                           if (ts_0 != 0) {
+                              _fx_N14Lexer__token_t* v_180 = &ts_0->hd.t0;
+                              if (v_180->tag == 1) {
+                                 _fx_N10Ast__lit_t* v_181 = &v_180->u.LITERAL;
+                                 if (v_181->tag == 2) {
+                                    _fx_N10Ast__lit_t v_182 = {0};
+                                    _fx_N14Lexer__token_t v_183 = {0};
+                                    _fx_T2N14Lexer__token_tTa2i v_184 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_30 = 0;
-                                    _fx_T2il* vcase_0 = &v_174->u.LitSInt;
-                                    _fx_M3AstFM7LitSIntN10Ast__lit_t2il(vcase_0->t0, -vcase_0->t1, &v_175);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_175, &v_176);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_176, &loc_0, &v_177);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_177, v_167->tl, true, &result_30),
-                                       _fx_catch_34);
+                                    _fx_T2il* vcase_0 = &v_181->u.LitSInt;
+                                    _fx_M3AstFM7LitSIntN10Ast__lit_t2il(vcase_0->t0, -vcase_0->t1, &v_182);
+                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_182, &v_183);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&v_183, &loc_0, &v_184);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_184, ts_0->tl, true, &result_30),
+                                       _fx_catch_37);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_30, &result_0);
-                                    FX_BREAK(_fx_catch_34);
+                                    FX_BREAK(_fx_catch_37);
 
-                                 _fx_catch_34: ;
+                                 _fx_catch_37: ;
                                     if (result_30) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_30);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_177);
-                                    _fx_free_N14Lexer__token_t(&v_176);
-                                    _fx_free_N10Ast__lit_t(&v_175);
-                                    goto _fx_endmatch_10;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_184);
+                                    _fx_free_N14Lexer__token_t(&v_183);
+                                    _fx_free_N10Ast__lit_t(&v_182);
+                                    goto _fx_endmatch_11;
                                  }
                               }
                            }
-                           if (v_167 != 0) {
-                              _fx_N14Lexer__token_t* v_178 = &v_167->hd.t0;
-                              if (v_178->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_179 = &v_178->u.LITERAL;
-                                 if (v_179->tag == 4) {
-                                    _fx_N10Ast__lit_t v_180 = {0};
-                                    _fx_N14Lexer__token_t v_181 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_182 = {0};
+                           if (ts_0 != 0) {
+                              _fx_N14Lexer__token_t* v_185 = &ts_0->hd.t0;
+                              if (v_185->tag == 1) {
+                                 _fx_N10Ast__lit_t* v_186 = &v_185->u.LITERAL;
+                                 if (v_186->tag == 4) {
+                                    _fx_N10Ast__lit_t v_187 = {0};
+                                    _fx_N14Lexer__token_t v_188 = {0};
+                                    _fx_T2N14Lexer__token_tTa2i v_189 = {0};
                                     _fx_LT2N14Lexer__token_tTa2i result_31 = 0;
-                                    _fx_T2id* vcase_1 = &v_179->u.LitFloat;
-                                    _fx_M3AstFM8LitFloatN10Ast__lit_t2id(vcase_1->t0, -vcase_1->t1, &v_180);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_180, &v_181);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_181, &loc_0, &v_182);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_182, v_167->tl, true, &result_31),
-                                       _fx_catch_35);
+                                    _fx_T2id* vcase_1 = &v_186->u.LitFloat;
+                                    _fx_M3AstFM8LitFloatN10Ast__lit_t2id(vcase_1->t0, -vcase_1->t1, &v_187);
+                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_187, &v_188);
+                                    _fx_make_T2N14Lexer__token_tTa2i(&v_188, &loc_0, &v_189);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_189, ts_0->tl, true, &result_31),
+                                       _fx_catch_38);
                                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                     FX_COPY_PTR(result_31, &result_0);
-                                    FX_BREAK(_fx_catch_35);
+                                    FX_BREAK(_fx_catch_38);
 
-                                 _fx_catch_35: ;
+                                 _fx_catch_38: ;
                                     if (result_31) {
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_31);
                                     }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_182);
-                                    _fx_free_N14Lexer__token_t(&v_181);
-                                    _fx_free_N10Ast__lit_t(&v_180);
-                                    goto _fx_endmatch_10;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_189);
+                                    _fx_free_N14Lexer__token_t(&v_188);
+                                    _fx_free_N10Ast__lit_t(&v_187);
+                                    goto _fx_endmatch_11;
                                  }
                               }
                            }
-                           _fx_N14Lexer__token_t v_183 = {0};
-                           _fx_T2N14Lexer__token_tTa2i v_184 = {0};
+                           _fx_N14Lexer__token_t v_190 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_191 = {0};
                            _fx_LT2N14Lexer__token_tTa2i result_32 = 0;
-                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(true, &v_183);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_183, &loc_0, &v_184);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_184, v_167, true, &result_32), _fx_catch_36);
+                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(true, &v_190);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_190, &loc_0, &v_191);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_191, ts_0, true, &result_32), _fx_catch_39);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_32, &result_0);
-                           FX_BREAK(_fx_catch_36);
+                           FX_BREAK(_fx_catch_39);
 
-                        _fx_catch_36: ;
+                        _fx_catch_39: ;
                            if (result_32) {
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_32);
                            }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_184);
-                           _fx_free_N14Lexer__token_t(&v_183);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_191);
+                           _fx_free_N14Lexer__token_t(&v_190);
 
-                        _fx_endmatch_10: ;
-                           FX_CHECK_EXN(_fx_catch_37);
+                        _fx_endmatch_11: ;
+                           FX_CHECK_EXN(_fx_catch_40);
                         }
 
-                     _fx_catch_37: ;
-                        if (v_167) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_167);
+                     _fx_catch_40: ;
+                        if (ts_0) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&ts_0);
                         }
                         if (result_28) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_28);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_166);
-                        _fx_free_N14Lexer__token_t(&v_165);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_174);
+                        _fx_free_N14Lexer__token_t(&v_173);
                         if (result_27) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_27);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_164);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_172);
                         if (result_26) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_26);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_163);
-                        _fx_free_N14Lexer__token_t(&v_162);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_171);
+                        _fx_free_N14Lexer__token_t(&v_170);
                      }
                      else if (c_2 == (char_)42) {
-                        _fx_N14Lexer__token_t v_185 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_186 = {0};
+                        _fx_N14Lexer__token_t v_192 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_193 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_33 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_187 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_194 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_34 = 0;
-                        _fx_N14Lexer__token_t v_188 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_189 = {0};
+                        _fx_N14Lexer__token_t v_195 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_196 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_35 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMul, &v_185);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_185, &loc_0, &v_186);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_186, 0, true, &result_33), _fx_catch_38);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMul, &v_192);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_192, &loc_0, &v_193);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_193, 0, true, &result_33), _fx_catch_41);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_33, &result_0);
-                           FX_BREAK(_fx_catch_38);
+                           FX_BREAK(_fx_catch_41);
                         }
                         else {
-                           bool t_19;
+                           bool t_21;
                            if (c1_0 == (char_)42) {
-                              t_19 = !prev_ne_0;
+                              t_21 = !prev_ne_0;
                            }
                            else {
-                              t_19 = false;
+                              t_21 = false;
                            }
-                           if (t_19) {
+                           if (t_21) {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__POWER, &loc_0, &v_187);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_187, 0, true, &result_34), _fx_catch_38);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__POWER, &loc_0, &v_194);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_194, 0, true, &result_34), _fx_catch_41);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_34, &result_0);
-                              FX_BREAK(_fx_catch_38);
+                              FX_BREAK(_fx_catch_41);
                            }
                            else {
-                              _fx_M5LexerFM4STARN14Lexer__token_t1B(prev_ne_0, &v_188);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_188, &loc_0, &v_189);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_189, 0, true, &result_35), _fx_catch_38);
+                              _fx_M5LexerFM4STARN14Lexer__token_t1B(prev_ne_0, &v_195);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_195, &loc_0, &v_196);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_196, 0, true, &result_35), _fx_catch_41);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_35, &result_0);
-                              FX_BREAK(_fx_catch_38);
+                              FX_BREAK(_fx_catch_41);
                            }
                         }
 
-                     _fx_catch_38: ;
+                     _fx_catch_41: ;
                         if (result_35) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_35);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_189);
-                        _fx_free_N14Lexer__token_t(&v_188);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_196);
+                        _fx_free_N14Lexer__token_t(&v_195);
                         if (result_34) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_34);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_187);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_194);
                         if (result_33) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_33);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_186);
-                        _fx_free_N14Lexer__token_t(&v_185);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_193);
+                        _fx_free_N14Lexer__token_t(&v_192);
                      }
                      else if (c_2 == (char_)47) {
-                        _fx_N14Lexer__token_t v_190 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_191 = {0};
+                        _fx_N14Lexer__token_t v_197 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_198 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_36 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_192 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_199 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_37 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpDiv, &v_190);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_190, &loc_0, &v_191);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_191, 0, true, &result_36), _fx_catch_39);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpDiv, &v_197);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_197, &loc_0, &v_198);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_198, 0, true, &result_36), _fx_catch_42);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_36, &result_0);
-                           FX_BREAK(_fx_catch_39);
+                           FX_BREAK(_fx_catch_42);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__SLASH, &loc_0, &v_192);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_192, 0, true, &result_37), _fx_catch_39);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__SLASH, &loc_0, &v_199);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_199, 0, true, &result_37), _fx_catch_42);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_37, &result_0);
-                           FX_BREAK(_fx_catch_39);
+                           FX_BREAK(_fx_catch_42);
                         }
 
-                     _fx_catch_39: ;
+                     _fx_catch_42: ;
                         if (result_37) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_37);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_192);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_199);
                         if (result_36) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_36);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_191);
-                        _fx_free_N14Lexer__token_t(&v_190);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_198);
+                        _fx_free_N14Lexer__token_t(&v_197);
                      }
                      else if (c_2 == (char_)37) {
-                        _fx_N14Lexer__token_t v_193 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_194 = {0};
+                        _fx_N14Lexer__token_t v_200 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_201 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_38 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_195 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_202 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_39 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMod, &v_193);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_193, &loc_0, &v_194);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_194, 0, true, &result_38), _fx_catch_40);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMod, &v_200);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_200, &loc_0, &v_201);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_201, 0, true, &result_38), _fx_catch_43);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_38, &result_0);
-                           FX_BREAK(_fx_catch_40);
+                           FX_BREAK(_fx_catch_43);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__PERCENT, &loc_0, &v_195);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_195, 0, true, &result_39), _fx_catch_40);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__PERCENT, &loc_0, &v_202);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_202, 0, true, &result_39), _fx_catch_43);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_39, &result_0);
-                           FX_BREAK(_fx_catch_40);
+                           FX_BREAK(_fx_catch_43);
                         }
 
-                     _fx_catch_40: ;
+                     _fx_catch_43: ;
                         if (result_39) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_39);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_195);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_202);
                         if (result_38) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_38);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_194);
-                        _fx_free_N14Lexer__token_t(&v_193);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_201);
+                        _fx_free_N14Lexer__token_t(&v_200);
                      }
                      else if (c_2 == (char_)61) {
-                        _fx_T2N14Lexer__token_tTa2i v_196 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_203 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_40 = 0;
-                        _fx_N14Lexer__token_t v_197 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_198 = {0};
+                        _fx_N14Lexer__token_t v_204 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_205 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_41 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_199 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_206 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_42 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_200 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_207 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_43 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
                            if (c2_0 == (char_)61) {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__SAME, &loc_0, &v_196);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_196, 0, true, &result_40), _fx_catch_41);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__SAME, &loc_0, &v_203);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_203, 0, true, &result_40), _fx_catch_44);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_40, &result_0);
-                              FX_BREAK(_fx_catch_41);
+                              FX_BREAK(_fx_catch_44);
                            }
                            else {
-                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_197);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_197, &loc_0, &v_198);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_198, 0, true, &result_41), _fx_catch_41);
+                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_204);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_204, &loc_0, &v_205);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_205, 0, true, &result_41), _fx_catch_44);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_41, &result_0);
-                              FX_BREAK(_fx_catch_41);
+                              FX_BREAK(_fx_catch_44);
                            }
                         }
                         else if (c1_0 == (char_)62) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g19Lexer__DOUBLE_ARROW, &loc_0, &v_199);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_199, 0, true, &result_42), _fx_catch_41);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g19Lexer__DOUBLE_ARROW, &loc_0, &v_206);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_206, 0, true, &result_42), _fx_catch_44);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_42, &result_0);
-                           FX_BREAK(_fx_catch_41);
+                           FX_BREAK(_fx_catch_44);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__EQUAL, &loc_0, &v_200);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_200, 0, true, &result_43), _fx_catch_41);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__EQUAL, &loc_0, &v_207);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_207, 0, true, &result_43), _fx_catch_44);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_43, &result_0);
-                           FX_BREAK(_fx_catch_41);
+                           FX_BREAK(_fx_catch_44);
                         }
 
-                     _fx_catch_41: ;
+                     _fx_catch_44: ;
                         if (result_43) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_43);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_200);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_207);
                         if (result_42) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_42);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_199);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_206);
                         if (result_41) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_41);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_198);
-                        _fx_free_N14Lexer__token_t(&v_197);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_205);
+                        _fx_free_N14Lexer__token_t(&v_204);
                         if (result_40) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_40);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_196);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_203);
                      }
                      else if (c_2 == (char_)94) {
-                        _fx_N14Lexer__token_t v_201 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_202 = {0};
+                        _fx_N14Lexer__token_t v_208 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_209 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_44 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_203 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_210 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_45 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseXor, &v_201);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_201, &loc_0, &v_202);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_202, 0, true, &result_44), _fx_catch_42);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseXor, &v_208);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_208, &loc_0, &v_209);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_209, 0, true, &result_44), _fx_catch_45);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_44, &result_0);
-                           FX_BREAK(_fx_catch_42);
+                           FX_BREAK(_fx_catch_45);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_XOR, &loc_0, &v_203);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_203, 0, true, &result_45), _fx_catch_42);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_XOR, &loc_0, &v_210);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_210, 0, true, &result_45), _fx_catch_45);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_45, &result_0);
-                           FX_BREAK(_fx_catch_42);
+                           FX_BREAK(_fx_catch_45);
                         }
 
-                     _fx_catch_42: ;
+                     _fx_catch_45: ;
                         if (result_45) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_45);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_203);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_210);
                         if (result_44) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_44);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_202);
-                        _fx_free_N14Lexer__token_t(&v_201);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_209);
+                        _fx_free_N14Lexer__token_t(&v_208);
                      }
                      else if (c_2 == (char_)38) {
-                        _fx_N14Lexer__token_t v_204 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_205 = {0};
+                        _fx_N14Lexer__token_t v_211 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_212 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_46 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_206 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_213 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_47 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_207 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_214 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_48 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseAnd, &v_204);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_204, &loc_0, &v_205);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_205, 0, true, &result_46), _fx_catch_43);
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseAnd, &v_211);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_211, &loc_0, &v_212);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_212, 0, true, &result_46), _fx_catch_46);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_46, &result_0);
-                           FX_BREAK(_fx_catch_43);
+                           FX_BREAK(_fx_catch_46);
                         }
                         else if (c1_0 == (char_)38) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_AND, &loc_0, &v_206);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_206, 0, true, &result_47), _fx_catch_43);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_AND, &loc_0, &v_213);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_213, 0, true, &result_47), _fx_catch_46);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_47, &result_0);
-                           FX_BREAK(_fx_catch_43);
+                           FX_BREAK(_fx_catch_46);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_AND, &loc_0, &v_207);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_207, 0, true, &result_48), _fx_catch_43);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_AND, &loc_0, &v_214);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_214, 0, true, &result_48), _fx_catch_46);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_48, &result_0);
-                           FX_BREAK(_fx_catch_43);
+                           FX_BREAK(_fx_catch_46);
                         }
 
-                     _fx_catch_43: ;
+                     _fx_catch_46: ;
                         if (result_48) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_48);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_207);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_214);
                         if (result_47) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_47);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_206);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_213);
                         if (result_46) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_46);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_205);
-                        _fx_free_N14Lexer__token_t(&v_204);
-                     }
-                     else if (c_2 == (char_)126) {
-                        _fx_T2N14Lexer__token_tTa2i v_208 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_49 = 0;
-                        _fx_Ta2i v_209;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_209, 0), _fx_catch_44);
-                        fx_str_t slit_13 = FX_MAKE_STR("~");
-                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_209, &slit_13, 0), _fx_catch_44);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__TILDE, &loc_0, &v_208);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_208, 0, true, &result_49), _fx_catch_44);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_49, &result_0);
-                        FX_BREAK(_fx_catch_44);
-
-                     _fx_catch_44: ;
-                        if (result_49) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_49);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_208);
-                     }
-                     else if (c_2 == (char_)64) {
-                        _fx_T2N14Lexer__token_tTa2i v_210 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_50 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_210);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_210, 0, true, &result_50), _fx_catch_45);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_50, &result_0);
-                        FX_BREAK(_fx_catch_45);
-
-                     _fx_catch_45: ;
-                        if (result_50) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_50);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_210);
-                     }
-                     else if (c_2 == (char_)92) {
-                        _fx_N14Lexer__token_t v_211 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_212 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_51 = 0;
-                        _fx_M5LexerFM9BACKSLASHN14Lexer__token_t1B(prev_ne_0, &v_211);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_211, &loc_0, &v_212);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_212, 0, true, &result_51), _fx_catch_46);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_51, &result_0);
-                        FX_BREAK(_fx_catch_46);
-
-                     _fx_catch_46: ;
-                        if (result_51) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_51);
                         }
                         _fx_free_T2N14Lexer__token_tTa2i(&v_212);
                         _fx_free_N14Lexer__token_t(&v_211);
                      }
-                     else if (c_2 == (char_)46) {
-                        _fx_N14Lexer__token_t v_213 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_214 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_52 = 0;
+                     else if (c_2 == (char_)126) {
                         _fx_T2N14Lexer__token_tTa2i v_215 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_53 = 0;
-                        _fx_N14Lexer__token_t v_216 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_49 = 0;
+                        _fx_Ta2i v_216;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_216, 0), _fx_catch_47);
+                        fx_str_t slit_16 = FX_MAKE_STR("~");
+                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_216, &slit_16, 0), _fx_catch_47);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__TILDE, &loc_0, &v_215);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_215, 0, true, &result_49), _fx_catch_47);
+                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
+                        FX_COPY_PTR(result_49, &result_0);
+                        FX_BREAK(_fx_catch_47);
+
+                     _fx_catch_47: ;
+                        if (result_49) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&result_49);
+                        }
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_215);
+                     }
+                     else if (c_2 == (char_)64) {
                         _fx_T2N14Lexer__token_tTa2i v_217 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_54 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_218 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_55 = 0;
-                        _fx_N14Lexer__token_t v_219 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_220 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_56 = 0;
-                        _fx_N14Lexer__token_t v_221 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_50 = 0;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_217);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_217, 0, true, &result_50), _fx_catch_48);
+                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
+                        FX_COPY_PTR(result_50, &result_0);
+                        FX_BREAK(_fx_catch_48);
+
+                     _fx_catch_48: ;
+                        if (result_50) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&result_50);
+                        }
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_217);
+                     }
+                     else if (c_2 == (char_)92) {
+                        _fx_N14Lexer__token_t v_218 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_219 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_51 = 0;
+                        _fx_M5LexerFM9BACKSLASHN14Lexer__token_t1B(prev_ne_0, &v_218);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_218, &loc_0, &v_219);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_219, 0, true, &result_51), _fx_catch_49);
+                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
+                        FX_COPY_PTR(result_51, &result_0);
+                        FX_BREAK(_fx_catch_49);
+
+                     _fx_catch_49: ;
+                        if (result_51) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&result_51);
+                        }
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_219);
+                        _fx_free_N14Lexer__token_t(&v_218);
+                     }
+                     else if (c_2 == (char_)46) {
+                        _fx_N14Lexer__token_t v_220 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_221 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_52 = 0;
                         _fx_T2N14Lexer__token_tTa2i v_222 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_57 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_53 = 0;
                         _fx_N14Lexer__token_t v_223 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_224 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_58 = 0;
-                        _fx_N14Lexer__token_t v_225 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_226 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_59 = 0;
-                        _fx_N14Lexer__token_t v_227 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_228 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_60 = 0;
-                        _fx_N14Lexer__token_t v_229 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_230 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_61 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_54 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_225 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_55 = 0;
+                        _fx_N14Lexer__token_t v_226 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_227 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_56 = 0;
+                        _fx_N14Lexer__token_t v_228 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_229 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_57 = 0;
+                        _fx_N14Lexer__token_t v_230 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_231 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_62 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_58 = 0;
                         _fx_N14Lexer__token_t v_232 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_233 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_63 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_234 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_64 = 0;
-                        _fx_N14Lexer__token_t v_235 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_236 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_65 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_59 = 0;
+                        _fx_N14Lexer__token_t v_234 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_235 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_60 = 0;
+                        _fx_N14Lexer__token_t v_236 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_237 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_66 = 0;
-                        _fx_N14Lexer__token_t v_238 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_239 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_67 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_61 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_238 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_62 = 0;
+                        _fx_N14Lexer__token_t v_239 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_240 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_68 = 0;
+                        _fx_LT2N14Lexer__token_tTa2i result_63 = 0;
                         _fx_T2N14Lexer__token_tTa2i v_241 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_64 = 0;
+                        _fx_N14Lexer__token_t v_242 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_243 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_65 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_244 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_66 = 0;
+                        _fx_N14Lexer__token_t v_245 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_246 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_67 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_247 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i result_68 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_248 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_69 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_242 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_249 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_70 = 0;
                         if (c1_0 == (char_)61) {
                            if (c2_0 == (char_)61) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_213);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_213, &loc_0, &v_214);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_214, 0, true, &result_52), _fx_catch_47);
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_220);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_220, &loc_0, &v_221);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_221, 0, true, &result_52), _fx_catch_50);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_52, &result_0);
-                              FX_BREAK(_fx_catch_47);
+                              FX_BREAK(_fx_catch_50);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_EQUAL, &loc_0, &v_215);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_215, 0, true, &result_53), _fx_catch_47);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_EQUAL, &loc_0, &v_222);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_222, 0, true, &result_53), _fx_catch_50);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_53, &result_0);
-                              FX_BREAK(_fx_catch_47);
+                              FX_BREAK(_fx_catch_50);
                            }
                         }
                         else {
-                           bool t_20;
+                           bool t_22;
                            if (c1_0 == (char_)33) {
-                              t_20 = c2_0 == (char_)61;
+                              t_22 = c2_0 == (char_)61;
                            }
                            else {
-                              t_20 = false;
+                              t_22 = false;
                            }
-                           if (t_20) {
+                           if (t_22) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_216);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_216, &loc_0, &v_217);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_217, 0, true, &result_54), _fx_catch_47);
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_223);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_223, &loc_0, &v_224);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_224, 0, true, &result_54), _fx_catch_50);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_54, &result_0);
-                              FX_BREAK(_fx_catch_47);
+                              FX_BREAK(_fx_catch_50);
                            }
                            else if (c1_0 == (char_)60) {
-                              bool t_21;
+                              bool t_23;
                               if (c2_0 == (char_)61) {
-                                 t_21 = c3_0 == (char_)62;
+                                 t_23 = c3_0 == (char_)62;
                               }
                               else {
-                                 t_21 = false;
+                                 t_23 = false;
                               }
-                              if (t_21) {
+                              if (t_23) {
                                  *pos_0 = *pos_0 + 3;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g20Lexer__DOT_SPACESHIP, &loc_0, &v_218);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_218, 0, true, &result_55), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g20Lexer__DOT_SPACESHIP, &loc_0, &v_225);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_225, 0, true, &result_55), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_55, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else if (c2_0 == (char_)61) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_219);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_219, &loc_0, &v_220);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_220, 0, true, &result_56), _fx_catch_47);
+                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_226);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_226, &loc_0, &v_227);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_227, 0, true, &result_56), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_56, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *pos_0 = *pos_0 + 1;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_221);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_221, &loc_0, &v_222);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_222, 0, true, &result_57), _fx_catch_47);
+                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_228);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_228, &loc_0, &v_229);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_229, 0, true, &result_57), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_57, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                            else if (c1_0 == (char_)62) {
                               if (c2_0 == (char_)61) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_223);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_223, &loc_0, &v_224);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_224, 0, true, &result_58), _fx_catch_47);
+                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_230);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_230, &loc_0, &v_231);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_231, 0, true, &result_58), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_58, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *pos_0 = *pos_0 + 1;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_225);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_225, &loc_0, &v_226);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_226, 0, true, &result_59), _fx_catch_47);
+                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_232);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_232, &loc_0, &v_233);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_233, 0, true, &result_59), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_59, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                            else if (c1_0 == (char_)43) {
                               *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM8DOT_PLUSN14Lexer__token_t1B(prev_ne_0, &v_227);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_227, &loc_0, &v_228);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_228, 0, true, &result_60), _fx_catch_47);
+                              _fx_M5LexerFM8DOT_PLUSN14Lexer__token_t1B(prev_ne_0, &v_234);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_234, &loc_0, &v_235);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_235, 0, true, &result_60), _fx_catch_50);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_60, &result_0);
-                              FX_BREAK(_fx_catch_47);
+                              FX_BREAK(_fx_catch_50);
                            }
                            else if (c1_0 == (char_)45) {
                               *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM9DOT_MINUSN14Lexer__token_t1B(prev_ne_0, &v_229);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_229, &loc_0, &v_230);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_230, 0, true, &result_61), _fx_catch_47);
+                              _fx_M5LexerFM9DOT_MINUSN14Lexer__token_t1B(prev_ne_0, &v_236);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_236, &loc_0, &v_237);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_237, 0, true, &result_61), _fx_catch_50);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_61, &result_0);
-                              FX_BREAK(_fx_catch_47);
+                              FX_BREAK(_fx_catch_50);
                            }
                            else if (c1_0 == (char_)42) {
                               if (c2_0 == (char_)42) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_POWER, &loc_0, &v_231);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_231, 0, true, &result_62), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_POWER, &loc_0, &v_238);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_238, 0, true, &result_62), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_62, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else if (c2_0 == (char_)61) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMul, &v_232);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_232, &loc_0, &v_233);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_233, 0, true, &result_63), _fx_catch_47);
+                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMul, &v_239);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_239, &loc_0, &v_240);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_240, 0, true, &result_63), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_63, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__DOT_STAR, &loc_0, &v_234);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_234, 0, true, &result_64), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__DOT_STAR, &loc_0, &v_241);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_241, 0, true, &result_64), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_64, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                            else if (c1_0 == (char_)47) {
                               if (c2_0 == (char_)61) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotDiv, &v_235);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_235, &loc_0, &v_236);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_236, 0, true, &result_65), _fx_catch_47);
+                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotDiv, &v_242);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_242, &loc_0, &v_243);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_243, 0, true, &result_65), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_65, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_SLASH, &loc_0, &v_237);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_237, 0, true, &result_66), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_SLASH, &loc_0, &v_244);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_244, 0, true, &result_66), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_66, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                            else if (c1_0 == (char_)37) {
                               if (c2_0 == (char_)61) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMod, &v_238);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_238, &loc_0, &v_239);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_239, 0, true, &result_67), _fx_catch_47);
+                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMod, &v_245);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_245, &loc_0, &v_246);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_246, 0, true, &result_67), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_67, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__DOT_PERCENT, &loc_0, &v_240);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_240, 0, true, &result_68), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__DOT_PERCENT, &loc_0, &v_247);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_247, 0, true, &result_68), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_68, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                            else {
-                              bool t_22;
+                              bool t_24;
                               if (c1_0 == (char_)46) {
-                                 t_22 = c2_0 == (char_)46;
+                                 t_24 = c2_0 == (char_)46;
                               }
                               else {
-                                 t_22 = false;
+                                 t_24 = false;
                               }
-                              if (t_22) {
+                              if (t_24) {
                                  *pos_0 = *pos_0 + 2;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__ELLIPSIS, &loc_0, &v_241);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_241, 0, true, &result_69), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__ELLIPSIS, &loc_0, &v_248);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_248, 0, true, &result_69), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_69, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                               else {
                                  *prev_dot_0 = true;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__DOT, &loc_0, &v_242);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_242, 0, true, &result_70), _fx_catch_47);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__DOT, &loc_0, &v_249);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_249, 0, true, &result_70), _fx_catch_50);
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                                  FX_COPY_PTR(result_70, &result_0);
-                                 FX_BREAK(_fx_catch_47);
+                                 FX_BREAK(_fx_catch_50);
                               }
                            }
                         }
 
-                     _fx_catch_47: ;
+                     _fx_catch_50: ;
                         if (result_70) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_70);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_242);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_249);
                         if (result_69) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_69);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_241);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_248);
                         if (result_68) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_68);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_240);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_247);
                         if (result_67) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_67);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_239);
-                        _fx_free_N14Lexer__token_t(&v_238);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_246);
+                        _fx_free_N14Lexer__token_t(&v_245);
                         if (result_66) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_66);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_237);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_244);
                         if (result_65) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_65);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_236);
-                        _fx_free_N14Lexer__token_t(&v_235);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_243);
+                        _fx_free_N14Lexer__token_t(&v_242);
                         if (result_64) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_64);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_234);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_241);
                         if (result_63) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_63);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_233);
-                        _fx_free_N14Lexer__token_t(&v_232);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_240);
+                        _fx_free_N14Lexer__token_t(&v_239);
                         if (result_62) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_62);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_231);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_238);
                         if (result_61) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_61);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_230);
-                        _fx_free_N14Lexer__token_t(&v_229);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_237);
+                        _fx_free_N14Lexer__token_t(&v_236);
                         if (result_60) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_60);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_228);
-                        _fx_free_N14Lexer__token_t(&v_227);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_235);
+                        _fx_free_N14Lexer__token_t(&v_234);
                         if (result_59) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_59);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_226);
-                        _fx_free_N14Lexer__token_t(&v_225);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_233);
+                        _fx_free_N14Lexer__token_t(&v_232);
                         if (result_58) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_58);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_224);
-                        _fx_free_N14Lexer__token_t(&v_223);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_231);
+                        _fx_free_N14Lexer__token_t(&v_230);
                         if (result_57) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_57);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_222);
-                        _fx_free_N14Lexer__token_t(&v_221);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_229);
+                        _fx_free_N14Lexer__token_t(&v_228);
                         if (result_56) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_56);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_220);
-                        _fx_free_N14Lexer__token_t(&v_219);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_227);
+                        _fx_free_N14Lexer__token_t(&v_226);
                         if (result_55) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_55);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_218);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_225);
                         if (result_54) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_54);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_217);
-                        _fx_free_N14Lexer__token_t(&v_216);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_224);
+                        _fx_free_N14Lexer__token_t(&v_223);
                         if (result_53) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_53);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_215);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_222);
                         if (result_52) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_52);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_214);
-                        _fx_free_N14Lexer__token_t(&v_213);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_221);
+                        _fx_free_N14Lexer__token_t(&v_220);
                      }
                      else if (c_2 == (char_)44) {
-                        _fx_T2N14Lexer__token_tTa2i v_243 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_250 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_71 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_243);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_243, 0, true, &result_71), _fx_catch_48);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_250);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_250, 0, true, &result_71), _fx_catch_51);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_71, &result_0);
-                        FX_BREAK(_fx_catch_48);
+                        FX_BREAK(_fx_catch_51);
 
-                     _fx_catch_48: ;
+                     _fx_catch_51: ;
                         if (result_71) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_71);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_243);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_250);
                      }
                      else if (c_2 == (char_)59) {
-                        _fx_T2N14Lexer__token_tTa2i v_244 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_251 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_72 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SEMICOLON, &loc_0, &v_244);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_244, 0, true, &result_72), _fx_catch_49);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SEMICOLON, &loc_0, &v_251);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_251, 0, true, &result_72), _fx_catch_52);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_72, &result_0);
-                        FX_BREAK(_fx_catch_49);
+                        FX_BREAK(_fx_catch_52);
 
-                     _fx_catch_49: ;
+                     _fx_catch_52: ;
                         if (result_72) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_72);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_244);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_251);
                      }
                      else if (c_2 == (char_)58) {
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_8 = 0;
@@ -5769,370 +5846,370 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         if (paren_stack_8 != 0) {
                            if (paren_stack_8->hd.t0.tag == 45) {
                               fx_exn_t curr_exn_0 = {0};
-                              fx_exn_t v_245 = {0};
-                              fx_exn_t v_246 = {0};
-                              _fx_T2R8format_ti v_247;
-                              FX_CALL(_fx_F12parse_formatT2R8format_ti2Si(&buf_0, *pos_0, &v_247, 0), _fx_catch_50);
+                              fx_exn_t v_252 = {0};
+                              fx_exn_t v_253 = {0};
+                              _fx_T2R8format_ti v_254;
+                              FX_CALL(_fx_F12parse_formatT2R8format_ti2Si(&buf_0, *pos_0, &v_254, 0), _fx_catch_53);
 
-                           _fx_catch_50: ;
+                           _fx_catch_53: ;
                               if (fx_status < 0) {
                                  fx_exn_get_and_reset(fx_status, &curr_exn_0);
                                  fx_status = 0;
-                                 _fx_Ta2i v_248;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_248, 0),
-                                    _fx_catch_51);
-                                 fx_str_t slit_14 = FX_MAKE_STR("invalid format specification");
-                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_248, &slit_14, &v_245), _fx_catch_51);
-                                 FX_THROW(&v_245, true, _fx_catch_51);
+                                 _fx_Ta2i v_255;
+                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_255, 0),
+                                    _fx_catch_54);
+                                 fx_str_t slit_17 = FX_MAKE_STR("invalid format specification");
+                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_255, &slit_17, &v_252), _fx_catch_54);
+                                 FX_THROW(&v_252, true, _fx_catch_54);
                               }
-                              _fx_R8format_t fmt__0 = v_247.t0;
-                              int_ end_0 = v_247.t1;
-                              _fx_Nt6option1R8format_t v_249;
-                              _fx_M5LexerFM4SomeNt6option1R8format_t1R8format_t(&fmt__0, &v_249);
-                              *fmt_0 = v_249;
+                              _fx_R8format_t fmt__0 = v_254.t0;
+                              int_ end_0 = v_254.t1;
+                              _fx_Nt6option1R8format_t v_256;
+                              _fx_M5LexerFM4SomeNt6option1R8format_t1R8format_t(&fmt__0, &v_256);
+                              *fmt_0 = v_256;
                               *pos_0 = end_0;
                               if (FX_STR_ELEM_ZERO(buf_0, *pos_0) != (char_)125) {
-                                 _fx_Ta2i v_250;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_250, 0),
-                                    _fx_catch_51);
-                                 fx_str_t slit_15 =
+                                 _fx_Ta2i v_257;
+                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_257, 0),
+                                    _fx_catch_54);
+                                 fx_str_t slit_18 =
                                     FX_MAKE_STR("\'}\' is expected after \':...\' inside interpolated expression");
-                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_250, &slit_15, &v_246), _fx_catch_51);
-                                 FX_THROW(&v_246, true, _fx_catch_51);
+                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_257, &slit_18, &v_253), _fx_catch_54);
+                                 FX_THROW(&v_253, true, _fx_catch_54);
                               }
 
-                           _fx_catch_51: ;
-                              fx_free_exn(&v_246);
-                              fx_free_exn(&v_245);
+                           _fx_catch_54: ;
+                              fx_free_exn(&v_253);
+                              fx_free_exn(&v_252);
                               fx_free_exn(&curr_exn_0);
-                              goto _fx_endmatch_11;
+                              goto _fx_endmatch_12;
                            }
                         }
-                        _fx_T2N14Lexer__token_tTa2i v_251 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_258 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_73 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_252 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_259 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_74 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_253 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_260 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_75 = 0;
                         if (c1_0 == (char_)58) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CONS, &loc_0, &v_251);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_251, 0, true, &result_73), _fx_catch_52);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CONS, &loc_0, &v_258);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_258, 0, true, &result_73), _fx_catch_55);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_73, &result_0);
-                           FX_BREAK(_fx_catch_52);
+                           FX_BREAK(_fx_catch_55);
                         }
                         else if (c1_0 == (char_)62) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CAST, &loc_0, &v_252);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_252, 0, true, &result_74), _fx_catch_52);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CAST, &loc_0, &v_259);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_259, 0, true, &result_74), _fx_catch_55);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_74, &result_0);
-                           FX_BREAK(_fx_catch_52);
+                           FX_BREAK(_fx_catch_55);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COLON, &loc_0, &v_253);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_253, 0, true, &result_75), _fx_catch_52);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COLON, &loc_0, &v_260);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_260, 0, true, &result_75), _fx_catch_55);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_75, &result_0);
-                           FX_BREAK(_fx_catch_52);
+                           FX_BREAK(_fx_catch_55);
                         }
 
-                     _fx_catch_52: ;
+                     _fx_catch_55: ;
                         if (result_75) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_75);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_253);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_260);
                         if (result_74) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_74);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_252);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_259);
                         if (result_73) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_73);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_251);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_258);
 
-                     _fx_endmatch_11: ;
-                        FX_CHECK_EXN(_fx_catch_53);
+                     _fx_endmatch_12: ;
+                        FX_CHECK_EXN(_fx_catch_56);
 
-                     _fx_catch_53: ;
+                     _fx_catch_56: ;
                         if (paren_stack_8) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_8);
                         }
                      }
                      else if (c_2 == (char_)33) {
-                        _fx_N14Lexer__token_t v_254 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_255 = {0};
+                        _fx_N14Lexer__token_t v_261 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_262 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_76 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_256 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_263 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_77 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_254);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_254, &loc_0, &v_255);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_255, 0, true, &result_76), _fx_catch_54);
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_261);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_261, &loc_0, &v_262);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_262, 0, true, &result_76), _fx_catch_57);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_76, &result_0);
-                           FX_BREAK(_fx_catch_54);
+                           FX_BREAK(_fx_catch_57);
                         }
                         else {
-                           _fx_Ta2i v_257;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_257, 0),
-                              _fx_catch_54);
-                           fx_str_t slit_16 = FX_MAKE_STR("!");
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_257, &slit_16, 0), _fx_catch_54);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_NOT, &loc_0, &v_256);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_256, 0, true, &result_77), _fx_catch_54);
+                           _fx_Ta2i v_264;
+                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_264, 0),
+                              _fx_catch_57);
+                           fx_str_t slit_19 = FX_MAKE_STR("!");
+                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_264, &slit_19, 0), _fx_catch_57);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_NOT, &loc_0, &v_263);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_263, 0, true, &result_77), _fx_catch_57);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_77, &result_0);
-                           FX_BREAK(_fx_catch_54);
+                           FX_BREAK(_fx_catch_57);
                         }
 
-                     _fx_catch_54: ;
+                     _fx_catch_57: ;
                         if (result_77) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_77);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_256);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_263);
                         if (result_76) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_76);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_255);
-                        _fx_free_N14Lexer__token_t(&v_254);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_262);
+                        _fx_free_N14Lexer__token_t(&v_261);
                      }
                      else if (c_2 == (char_)63) {
-                        _fx_T2N14Lexer__token_tTa2i v_258 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_265 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_78 = 0;
                         *new_exp_0 = false;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__QUESTION, &loc_0, &v_258);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_258, 0, true, &result_78), _fx_catch_55);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__QUESTION, &loc_0, &v_265);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_265, 0, true, &result_78), _fx_catch_58);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_78, &result_0);
-                        FX_BREAK(_fx_catch_55);
+                        FX_BREAK(_fx_catch_58);
 
-                     _fx_catch_55: ;
+                     _fx_catch_58: ;
                         if (result_78) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_78);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_258);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_265);
                      }
                      else if (c_2 == (char_)60) {
-                        _fx_T2N14Lexer__token_tTa2i v_259 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_266 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_79 = 0;
-                        _fx_N14Lexer__token_t v_260 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_261 = {0};
+                        _fx_N14Lexer__token_t v_267 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_268 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_80 = 0;
-                        _fx_N14Lexer__token_t v_262 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_263 = {0};
+                        _fx_N14Lexer__token_t v_269 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_270 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_81 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_264 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_271 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_82 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_265 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_272 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_83 = 0;
-                        _fx_N14Lexer__token_t v_266 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_267 = {0};
+                        _fx_N14Lexer__token_t v_273 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_274 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_84 = 0;
                         if (c1_0 == (char_)61) {
                            if (c2_0 == (char_)62) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SPACESHIP, &loc_0, &v_259);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_259, 0, true, &result_79), _fx_catch_56);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SPACESHIP, &loc_0, &v_266);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_266, 0, true, &result_79), _fx_catch_59);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_79, &result_0);
-                              FX_BREAK(_fx_catch_56);
+                              FX_BREAK(_fx_catch_59);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_260);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_260, &loc_0, &v_261);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_261, 0, true, &result_80), _fx_catch_56);
+                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_267);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_267, &loc_0, &v_268);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_268, 0, true, &result_80), _fx_catch_59);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_80, &result_0);
-                              FX_BREAK(_fx_catch_56);
+                              FX_BREAK(_fx_catch_59);
                            }
                         }
                         else if (c1_0 == (char_)60) {
                            if (c2_0 == (char_)61) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpShiftLeft, &v_262);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_262, &loc_0, &v_263);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_263, 0, true, &result_81), _fx_catch_56);
+                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpShiftLeft, &v_269);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_269, &loc_0, &v_270);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_270, 0, true, &result_81), _fx_catch_59);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_81, &result_0);
-                              FX_BREAK(_fx_catch_56);
+                              FX_BREAK(_fx_catch_59);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__SHIFT_LEFT, &loc_0, &v_264);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_264, 0, true, &result_82), _fx_catch_56);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__SHIFT_LEFT, &loc_0, &v_271);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_271, 0, true, &result_82), _fx_catch_59);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_82, &result_0);
-                              FX_BREAK(_fx_catch_56);
+                              FX_BREAK(_fx_catch_59);
                            }
                         }
                         else if (c1_0 == (char_)45) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BACK_ARROW, &loc_0, &v_265);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_265, 0, true, &result_83), _fx_catch_56);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BACK_ARROW, &loc_0, &v_272);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_272, 0, true, &result_83), _fx_catch_59);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_83, &result_0);
-                           FX_BREAK(_fx_catch_56);
+                           FX_BREAK(_fx_catch_59);
                         }
                         else {
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_266);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_266, &loc_0, &v_267);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_267, 0, true, &result_84), _fx_catch_56);
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_273);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_273, &loc_0, &v_274);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_274, 0, true, &result_84), _fx_catch_59);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_84, &result_0);
-                           FX_BREAK(_fx_catch_56);
+                           FX_BREAK(_fx_catch_59);
                         }
 
-                     _fx_catch_56: ;
+                     _fx_catch_59: ;
                         if (result_84) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_84);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_267);
-                        _fx_free_N14Lexer__token_t(&v_266);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_274);
+                        _fx_free_N14Lexer__token_t(&v_273);
                         if (result_83) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_83);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_265);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_272);
                         if (result_82) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_82);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_264);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_271);
                         if (result_81) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_81);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_263);
-                        _fx_free_N14Lexer__token_t(&v_262);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_270);
+                        _fx_free_N14Lexer__token_t(&v_269);
                         if (result_80) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_80);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_261);
-                        _fx_free_N14Lexer__token_t(&v_260);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_268);
+                        _fx_free_N14Lexer__token_t(&v_267);
                         if (result_79) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_79);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_259);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_266);
                      }
                      else if (c_2 == (char_)62) {
-                        _fx_N14Lexer__token_t v_268 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_269 = {0};
+                        _fx_N14Lexer__token_t v_275 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_276 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_85 = 0;
-                        _fx_N14Lexer__token_t v_270 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_271 = {0};
+                        _fx_N14Lexer__token_t v_277 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_278 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_86 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_272 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_279 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_87 = 0;
-                        _fx_N14Lexer__token_t v_273 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_274 = {0};
+                        _fx_N14Lexer__token_t v_280 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_281 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_88 = 0;
                         if (c1_0 == (char_)61) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_268);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_268, &loc_0, &v_269);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_269, 0, true, &result_85), _fx_catch_57);
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_275);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_275, &loc_0, &v_276);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_276, 0, true, &result_85), _fx_catch_60);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_85, &result_0);
-                           FX_BREAK(_fx_catch_57);
+                           FX_BREAK(_fx_catch_60);
                         }
                         else if (c1_0 == (char_)62) {
                            if (c2_0 == (char_)61) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpShiftRight, &v_270);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_270, &loc_0, &v_271);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_271, 0, true, &result_86), _fx_catch_57);
+                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpShiftRight, &v_277);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_277, &loc_0, &v_278);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_278, 0, true, &result_86), _fx_catch_60);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_86, &result_0);
-                              FX_BREAK(_fx_catch_57);
+                              FX_BREAK(_fx_catch_60);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__SHIFT_RIGHT, &loc_0, &v_272);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_272, 0, true, &result_87), _fx_catch_57);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__SHIFT_RIGHT, &loc_0, &v_279);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_279, 0, true, &result_87), _fx_catch_60);
                               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                               FX_COPY_PTR(result_87, &result_0);
-                              FX_BREAK(_fx_catch_57);
+                              FX_BREAK(_fx_catch_60);
                            }
                         }
                         else {
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_273);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_273, &loc_0, &v_274);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_274, 0, true, &result_88), _fx_catch_57);
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_280);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_280, &loc_0, &v_281);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_281, 0, true, &result_88), _fx_catch_60);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_88, &result_0);
-                           FX_BREAK(_fx_catch_57);
+                           FX_BREAK(_fx_catch_60);
                         }
 
-                     _fx_catch_57: ;
+                     _fx_catch_60: ;
                         if (result_88) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_88);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_274);
-                        _fx_free_N14Lexer__token_t(&v_273);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_281);
+                        _fx_free_N14Lexer__token_t(&v_280);
                         if (result_87) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_87);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_272);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_279);
                         if (result_86) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_86);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_271);
-                        _fx_free_N14Lexer__token_t(&v_270);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_278);
+                        _fx_free_N14Lexer__token_t(&v_277);
                         if (result_85) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_85);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_269);
-                        _fx_free_N14Lexer__token_t(&v_268);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_276);
+                        _fx_free_N14Lexer__token_t(&v_275);
                      }
                      else if (c_2 == (char_)96) {
-                        _fx_N14Lexer__token_t v_275 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_276 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_277 = 0;
-                        _fx_N14Lexer__token_t v_278 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_279 = {0};
+                        _fx_N14Lexer__token_t v_282 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_283 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_284 = 0;
+                        _fx_N14Lexer__token_t v_285 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_286 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_89 = 0;
                         fx_str_t verb_0 = {0};
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_9 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_280 = {0};
-                        _fx_N10Ast__lit_t v_281 = {0};
-                        _fx_N14Lexer__token_t v_282 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_283 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_284 = {0};
-                        fx_str_t v_285 = {0};
-                        fx_str_t v_286 = {0};
-                        _fx_N10Ast__lit_t v_287 = {0};
-                        _fx_N14Lexer__token_t v_288 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_289 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_287 = {0};
+                        _fx_N10Ast__lit_t v_288 = {0};
+                        _fx_N14Lexer__token_t v_289 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_290 = {0};
-                        _fx_N10Ast__lit_t v_291 = {0};
-                        _fx_N14Lexer__token_t v_292 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_293 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_294 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_295 = 0;
+                        _fx_T2N14Lexer__token_tTa2i v_291 = {0};
+                        fx_str_t v_292 = {0};
+                        fx_str_t v_293 = {0};
+                        _fx_N10Ast__lit_t v_294 = {0};
+                        _fx_N14Lexer__token_t v_295 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_296 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_297 = {0};
+                        _fx_N10Ast__lit_t v_298 = {0};
+                        _fx_N14Lexer__token_t v_299 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_300 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_301 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_302 = 0;
                         if (*backquote_pos_0 < 0) {
                            *backquote_pos_0 = *pos_0;
-                           _fx_Ta2i v_296;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_296, 0),
-                              _fx_catch_59);
-                           *backquote_loc_0 = v_296;
-                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_275);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_275, backquote_loc_0, &v_276);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_276, *paren_stack_0, true, &v_277), _fx_catch_59);
+                           _fx_Ta2i v_303;
+                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_303, 0),
+                              _fx_catch_62);
+                           *backquote_loc_0 = v_303;
+                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_282);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_282, backquote_loc_0, &v_283);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_283, *paren_stack_0, true, &v_284), _fx_catch_62);
                            _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_277, paren_stack_0);
-                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_278);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_278, &loc_0, &v_279);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_279, 0, true, &result_89), _fx_catch_59);
+                           FX_COPY_PTR(v_284, paren_stack_0);
+                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_285);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_285, &loc_0, &v_286);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_286, 0, true, &result_89), _fx_catch_62);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_89, &result_0);
-                           FX_BREAK(_fx_catch_59);
+                           FX_BREAK(_fx_catch_62);
                         }
                         else {
-                           FX_CALL(fx_substr(&buf_0, *backquote_pos_0, *pos_0 - 1, 1, 0, &verb_0), _fx_catch_59);
+                           FX_CALL(fx_substr(&buf_0, *backquote_pos_0, *pos_0 - 1, 1, 0, &verb_0), _fx_catch_62);
                            _fx_Ta2i endloc_0;
                            FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &endloc_0, 0),
-                              _fx_catch_59);
+                              _fx_catch_62);
                            *backquote_pos_0 = -1;
                            *new_exp_0 = false;
                            FX_COPY_PTR(*paren_stack_0, &paren_stack_9);
@@ -6141,65 +6218,65 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_LT2N14Lexer__token_tTa2i* rest_6 = &paren_stack_9->tl;
                                  _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                                  FX_COPY_PTR(*rest_6, paren_stack_0);
-                                 goto _fx_endmatch_12;
+                                 goto _fx_endmatch_13;
                               }
                            }
-                           fx_exn_t v_297 = {0};
-                           fx_str_t slit_17 = FX_MAKE_STR("Unexpected \'`\', check parens");
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_17, &v_297), _fx_catch_58);
-                           FX_THROW(&v_297, true, _fx_catch_58);
+                           fx_exn_t v_304 = {0};
+                           fx_str_t slit_20 = FX_MAKE_STR("Unexpected \'`\', check parens");
+                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_20, &v_304), _fx_catch_61);
+                           FX_THROW(&v_304, true, _fx_catch_61);
 
-                        _fx_catch_58: ;
-                           fx_free_exn(&v_297);
+                        _fx_catch_61: ;
+                           fx_free_exn(&v_304);
 
-                        _fx_endmatch_12: ;
-                           FX_CHECK_EXN(_fx_catch_59);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_280);
-                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&verb_0, &v_281);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_281, &v_282);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_282, backquote_loc_0, &v_283);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_284);
-                           fx_copy_str(&strm_0->u.stream_t.t0, &v_285);
-                           FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_285, &v_286, 0), _fx_catch_59);
-                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_286, &v_287);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_287, &v_288);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_288, backquote_loc_0, &v_289);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_290);
-                           _fx_M3AstFM6LitIntN10Ast__lit_t1l((int64_t)backquote_loc_0->t0, &v_291);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_291, &v_292);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_292, backquote_loc_0, &v_293);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &endloc_0, &v_294);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_294, 0, true, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_293, v_295, false, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_290, v_295, false, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_289, v_295, false, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_284, v_295, false, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_283, v_295, false, &v_295), _fx_catch_59);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_280, v_295, false, &v_295), _fx_catch_59);
+                        _fx_endmatch_13: ;
+                           FX_CHECK_EXN(_fx_catch_62);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_287);
+                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&verb_0, &v_288);
+                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_288, &v_289);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_289, backquote_loc_0, &v_290);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_291);
+                           fx_copy_str(&strm_0->u.stream_t.t0, &v_292);
+                           FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_292, &v_293, 0), _fx_catch_62);
+                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_293, &v_294);
+                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_294, &v_295);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_295, backquote_loc_0, &v_296);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_297);
+                           _fx_M3AstFM6LitIntN10Ast__lit_t1l((int64_t)backquote_loc_0->t0, &v_298);
+                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_298, &v_299);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_299, backquote_loc_0, &v_300);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &endloc_0, &v_301);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_301, 0, true, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_300, v_302, false, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_297, v_302, false, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_296, v_302, false, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_291, v_302, false, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_290, v_302, false, &v_302), _fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_287, v_302, false, &v_302), _fx_catch_62);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(v_295, &result_0);
-                           FX_BREAK(_fx_catch_59);
+                           FX_COPY_PTR(v_302, &result_0);
+                           FX_BREAK(_fx_catch_62);
                         }
 
-                     _fx_catch_59: ;
-                        if (v_295) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_295);
+                     _fx_catch_62: ;
+                        if (v_302) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_302);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_294);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_293);
-                        _fx_free_N14Lexer__token_t(&v_292);
-                        _fx_free_N10Ast__lit_t(&v_291);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_301);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_300);
+                        _fx_free_N14Lexer__token_t(&v_299);
+                        _fx_free_N10Ast__lit_t(&v_298);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_297);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_296);
+                        _fx_free_N14Lexer__token_t(&v_295);
+                        _fx_free_N10Ast__lit_t(&v_294);
+                        FX_FREE_STR(&v_293);
+                        FX_FREE_STR(&v_292);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_291);
                         _fx_free_T2N14Lexer__token_tTa2i(&v_290);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_289);
-                        _fx_free_N14Lexer__token_t(&v_288);
-                        _fx_free_N10Ast__lit_t(&v_287);
-                        FX_FREE_STR(&v_286);
-                        FX_FREE_STR(&v_285);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_284);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_283);
-                        _fx_free_N14Lexer__token_t(&v_282);
-                        _fx_free_N10Ast__lit_t(&v_281);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_280);
+                        _fx_free_N14Lexer__token_t(&v_289);
+                        _fx_free_N10Ast__lit_t(&v_288);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_287);
                         if (paren_stack_9) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_9);
                         }
@@ -6207,86 +6284,86 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         if (result_89) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_89);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_279);
-                        _fx_free_N14Lexer__token_t(&v_278);
-                        if (v_277) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_277);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_286);
+                        _fx_free_N14Lexer__token_t(&v_285);
+                        if (v_284) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_284);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_276);
-                        _fx_free_N14Lexer__token_t(&v_275);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_283);
+                        _fx_free_N14Lexer__token_t(&v_282);
                      }
                      else if (c_2 == (char_)0) {
                         _fx_LT2N14Lexer__token_tTa2i paren_stack_10 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_298 = {0};
+                        _fx_T2N14Lexer__token_tTa2i v_305 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_90 = 0;
                         FX_COPY_PTR(*paren_stack_0, &paren_stack_10);
                         if (paren_stack_10 != 0) {
-                           fx_str_t v_299 = {0};
-                           fx_str_t v_300 = {0};
-                           fx_str_t v_301 = {0};
-                           fx_exn_t v_302 = {0};
+                           fx_str_t v_306 = {0};
+                           fx_str_t v_307 = {0};
+                           fx_str_t v_308 = {0};
+                           fx_exn_t v_309 = {0};
                            FX_CALL(
-                              _fx_M5LexerFM8lloc2strS2Ta2iN20LexerUtils__stream_t(&paren_stack_10->hd.t1, strm_0, &v_299, 0),
-                              _fx_catch_60);
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&v_299, &v_300, 0), _fx_catch_60);
-                           fx_str_t slit_18 = FX_MAKE_STR("some braces (around ");
-                           fx_str_t slit_19 = FX_MAKE_STR(") are not closed");
+                              _fx_M5LexerFM8lloc2strS2Ta2iN20LexerUtils__stream_t(&paren_stack_10->hd.t1, strm_0, &v_306, 0),
+                              _fx_catch_63);
+                           FX_CALL(_fx_M5LexerFM6stringS1S(&v_306, &v_307, 0), _fx_catch_63);
+                           fx_str_t slit_21 = FX_MAKE_STR("some braces (around ");
+                           fx_str_t slit_22 = FX_MAKE_STR(") are not closed");
                            {
-                              const fx_str_t strs_2[] = { slit_18, v_300, slit_19 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_301), _fx_catch_60);
+                              const fx_str_t strs_2[] = { slit_21, v_307, slit_22 };
+                              FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_308), _fx_catch_63);
                            }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_301, &v_302), _fx_catch_60);
-                           FX_THROW(&v_302, true, _fx_catch_60);
+                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_308, &v_309), _fx_catch_63);
+                           FX_THROW(&v_309, true, _fx_catch_63);
 
-                        _fx_catch_60: ;
-                           fx_free_exn(&v_302);
-                           FX_FREE_STR(&v_301);
-                           FX_FREE_STR(&v_300);
-                           FX_FREE_STR(&v_299);
+                        _fx_catch_63: ;
+                           fx_free_exn(&v_309);
+                           FX_FREE_STR(&v_308);
+                           FX_FREE_STR(&v_307);
+                           FX_FREE_STR(&v_306);
                         }
-                        FX_CHECK_EXN(_fx_catch_61);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__EOF, &loc_0, &v_298);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_298, 0, true, &result_90), _fx_catch_61);
+                        FX_CHECK_EXN(_fx_catch_64);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__EOF, &loc_0, &v_305);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_305, 0, true, &result_90), _fx_catch_64);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                         FX_COPY_PTR(result_90, &result_0);
-                        FX_BREAK(_fx_catch_61);
+                        FX_BREAK(_fx_catch_64);
 
-                     _fx_catch_61: ;
+                     _fx_catch_64: ;
                         if (result_90) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_90);
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_298);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_305);
                         if (paren_stack_10) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_10);
                         }
                      }
                      else {
-                        fx_str_t v_303 = {0};
-                        fx_str_t v_304 = {0};
-                        fx_exn_t v_305 = {0};
-                        FX_CALL(_fx_F6stringS1C(c_0, &v_303, 0), _fx_catch_62);
-                        fx_str_t slit_20 = FX_MAKE_STR("unrecognized character \'");
-                        fx_str_t slit_21 = FX_MAKE_STR("\'");
+                        fx_str_t v_310 = {0};
+                        fx_str_t v_311 = {0};
+                        fx_exn_t v_312 = {0};
+                        FX_CALL(_fx_F6stringS1C(c_0, &v_310, 0), _fx_catch_65);
+                        fx_str_t slit_23 = FX_MAKE_STR("unrecognized character \'");
+                        fx_str_t slit_24 = FX_MAKE_STR("\'");
                         {
-                           const fx_str_t strs_3[] = { slit_20, v_303, slit_21 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_304), _fx_catch_62);
+                           const fx_str_t strs_3[] = { slit_23, v_310, slit_24 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_311), _fx_catch_65);
                         }
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_304, &v_305), _fx_catch_62);
-                        FX_THROW(&v_305, true, _fx_catch_62);
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_311, &v_312), _fx_catch_65);
+                        FX_THROW(&v_312, true, _fx_catch_65);
 
-                     _fx_catch_62: ;
-                        fx_free_exn(&v_305);
-                        FX_FREE_STR(&v_304);
-                        FX_FREE_STR(&v_303);
+                     _fx_catch_65: ;
+                        fx_free_exn(&v_312);
+                        FX_FREE_STR(&v_311);
+                        FX_FREE_STR(&v_310);
                      }
-                     FX_CHECK_EXN(_fx_catch_63);
+                     FX_CHECK_EXN(_fx_catch_66);
                   }
                }
             }
          }
       }
 
-   _fx_catch_63: ;
+   _fx_catch_66: ;
       _fx_free_Nt6option1T2N14Lexer__token_ti(&v_46);
       FX_FREE_STR(&ident_0);
       FX_FREE_STR(&v_45);
@@ -6387,15 +6464,16 @@ _fx_cleanup: ;
 }
 
 FX_EXTERN_C int
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i08rTa2irirNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
    struct _fx_rTa2i_data_t* arg0,
    struct _fx_ri_data_t* arg1,
-   struct _fx_rNt6option1R8format_t_data_t* arg2,
-   struct _fx_rB_data_t* arg3,
-   struct _fx_rLT2N14Lexer__token_tTa2i_data_t* arg4,
-   struct _fx_ri_data_t* arg5,
-   struct _fx_rB_data_t* arg6,
-   struct _fx_N20LexerUtils__stream_t_data_t* arg7,
+   struct _fx_rB_data_t* arg2,
+   struct _fx_rNt6option1R8format_t_data_t* arg3,
+   struct _fx_rB_data_t* arg4,
+   struct _fx_rLT2N14Lexer__token_tTa2i_data_t* arg5,
+   struct _fx_ri_data_t* arg6,
+   struct _fx_rB_data_t* arg7,
+   struct _fx_N20LexerUtils__stream_t_data_t* arg8,
    struct _fx_FPLT2N14Lexer__token_tTa2i0* fx_result)
 {
    FX_MAKE_FP_IMPL_START(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t,
@@ -6408,6 +6486,7 @@ FX_EXTERN_C int
    FX_COPY_PTR(arg5, &fcv->t5);
    FX_COPY_PTR(arg6, &fcv->t6);
    FX_COPY_PTR(arg7, &fcv->t7);
+   FX_COPY_PTR(arg8, &fcv->t8);
    return 0;
 }
 

--- a/docs/ficus_housekeeping_report.md
+++ b/docs/ficus_housekeeping_report.md
@@ -128,13 +128,19 @@ arithmetic since it has no bare literal form). `basic.int64_min` gained
 var-assignment and array-element cases. Only `Ast_typecheck.c` changed in the
 bootstrap; full ladder green.
 
-New bug filed, **not** fixed: **FB-014** — a bare *positive* `9223372036854775808`
-silently wraps to INT64_MIN in the lexer. It is pre-existing (already true for
-default-`int`); widening the bound only makes it *consistent* across default and
-sized-int coercion rather than introducing it. A real fix needs the lexer to
-distinguish a negated 2^63 from a bare one — a parse-side restructure, parked in
-`language_changes_brief.md` §1.3. Implicit literal coercion to another type is
-rare in Ficus by design (args almost never coerce), so few contexts are affected.
+**FB-014** — a bare *positive* `9223372036854775808` used to silently wrap to
+INT64_MIN in the lexer (pre-existing; already true for default-`int`, and
+widening the bound above surfaced it in sized-int coercion too). **Now fixed**
+(Vadim): `Lexer.fx` threads an `expect_neg_number` flag — the unary-minus handler
+sets it (toggle + restore) around the number-lexing call, and the number branch
+rejects a wrapped-negative magnitude unless a minus was expected. So bare
+positive 2^63 errors ("out of range"), `-9223372036854775808` still denotes
+INT64_MIN, and nested/parenthesized forms (`- -2^63`, `-(2^63)`) correctly error;
+a `-` before an unsigned literal is now a clear error too. Regression goldens:
+`test/negative/007_pos_int64_overflow`, `008_neg_unsigned_literal`. Only
+`Lexer.c` changed in the bootstrap; fixpoint holds; full ladder green.
+(Implicit literal coercion to another type stays a separate, open topic — args
+almost never coerce in Ficus by design.)
 
 ---
 

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -428,7 +428,7 @@ is the whole point of the ladder.
   `// FIXME` note points back here). This is the unit failure the PR #27 CI
   handoff saw (its log had truncated the test name); see FB-011 for the mixup.
 
-## FB-014  [open] bare positive literal 2^63 silently wraps to INT64_MIN
+## FB-014  bare positive literal 2^63 silently wrapped to INT64_MIN
 - discovered: 2026-07-07 while widening the int64 literal range (housekeeping
   follow-up to FB-010).
 - detail: the lexer (`LexerUtils.getnumber_`) accumulates a decimal magnitude in
@@ -441,15 +441,18 @@ is the whole point of the ladder.
   overflow error. Only the exact value 2^63 slips through (2^63+1.. give a lex
   OutOfRangeError).
 - config: any backend; the exact bare positive literal 2^63.
-- status: OPEN, not fixed. A correct fix must reject the bare positive 2^63 while
-  still allowing the negated form, which the lexer cannot currently distinguish
-  (the unary minus is a separate token folded after `getnumber` has already
-  wrapped the magnitude) -- a lexer/parse restructure, tracked as a language item
-  in `docs/language_changes_brief.md` §1.3. Widening the typechecker's int64
-  bound to the true INT64_MIN (housekeeping, so `var y: int64; y = -2^63` and
-  int64 array-element assignment work -- previously rejected by a symmetric
-  `[-(2^63-1), 2^63-1]` range) makes this wrap *consistent* across default-`int`
-  and sized-`int64` coercion contexts rather than introducing it: the default-int
-  case (`val x = 9223372036854775808`) already wrapped silently. NB: implicit
-  literal coercion to a different type is rare in Ficus by design (args almost
-  never coerce), so this reaches few contexts.
+- fixed: branch `housekeeping-1` (Vadim). `Lexer.fx` threads an
+  `expect_neg_number` flag: the unary-minus handler sets it (toggle + restore)
+  around the `nexttokens()` call that lexes the following number, and the number
+  branch rejects a wrapped-negative magnitude (`LitInt`/`LitSInt` with value < 0)
+  unless a minus was expected -- so bare positive `9223372036854775808` now errors
+  ("the numeric literal is out of range for the specified type") while
+  `-9223372036854775808` still denotes INT64_MIN. The toggle handles nested minus
+  by parity: `- -9223372036854775808` (= 2^63) and `-(9223372036854775808)`
+  (parenthesized, not immediately negated) both correctly error. Bonus: a `-` in
+  front of an unsigned literal (`-5u8`) is now a clear lexer error rather than a
+  silent `MINUS :: LitUInt`. Regression goldens: `test/negative/007_pos_int64_
+  overflow` and `008_neg_unsigned_literal`. Only `Lexer.c` changed in the
+  bootstrap; fixpoint holds; full ladder green. (This complements the FB-010 /
+  int64-range work: the typechecker now accepts the true INT64_MIN and the lexer
+  now rejects the bare positive 2^63 that used to alias it.)

--- a/docs/language_changes_brief.md
+++ b/docs/language_changes_brief.md
@@ -27,19 +27,23 @@ already landed in `doc/ficustut.md` during harden-1; expand at rewrite time).
 `ConstInt: (int64, bool)` with the flag set only for full-width uint64. Shift
 count must be `int`. → tutorial.
 
-### 1.3 int64 literal range — PARTLY DONE (housekeeping)
-Typechecker now accepts the full two's-complement range `[-2^63, 2^63-1]`
-(`typ_bounds_int`), so INT64_MIN can be assigned to an int64 lvalue / array
-element (was a symmetric `[-(2^63-1), 2^63-1]` placeholder — set that way in 2021
-only because INT64_MIN couldn't be spelled in the bounds table itself; the narrow
-types already used their true min). Emission fixed separately (FB-010 / WP-H3).
-REMAINING OPEN: the lexer accepts a bare **positive** `9223372036854775808` and
-silently wraps it to INT64_MIN (FB-014). A clean fix must reject the bare
-positive 2^63 while still allowing the negated form — the lexer can't currently
-tell them apart (the unary minus is folded onto the literal only after
-`getnumber` has already wrapped the magnitude). Related: implicit literal
-coercion to another type is rare in Ficus by design (args almost never coerce) —
-a separate, larger topic.
+### 1.3 int64 literal range — DONE (housekeeping)
+Three coupled pieces, now all resolved:
+- Typechecker accepts the full two's-complement range `[-2^63, 2^63-1]`
+  (`typ_bounds_int`), so INT64_MIN can be assigned to an int64 lvalue / array
+  element (was a symmetric `[-(2^63-1), 2^63-1]` placeholder — set that way in
+  2021 only because INT64_MIN couldn't be spelled in the bounds table itself; the
+  narrow types already used their true min).
+- C emission of a folded INT64_MIN uses the signed split form (FB-010 / WP-H3).
+- The lexer now rejects a bare **positive** `9223372036854775808` (which used to
+  silently wrap to INT64_MIN) while still accepting `-9223372036854775808`
+  (FB-014): an `expect_neg_number` flag, set by the unary-minus handler around
+  the number-lexing call, blesses only an immediately-negated 2^63; nested/
+  parenthesized forms (`- -2^63`, `-(2^63)`) correctly error. A `-` before an
+  unsigned literal is now a clear error too.
+
+Separate, still open: implicit literal coercion to another type is rare in Ficus
+by design (args almost never coerce) — its own topic, not addressed here.
 
 ### 1.4 Saturating arithmetic — DEFERRED (design direction only)
 With wrap as the defined default, add explicit saturating ops (integer, and

--- a/test/negative/007_pos_int64_overflow.err
+++ b/test/negative/007_pos_int64_overflow.err
@@ -1,0 +1,1 @@
+007_pos_int64_overflow.fx:3:9: error: the numeric literal is out of range for the specified type

--- a/test/negative/007_pos_int64_overflow.fx
+++ b/test/negative/007_pos_int64_overflow.fx
@@ -1,0 +1,4 @@
+// expect: out of range
+// FB-014: bare positive 2^63 has no int64 representation (only -2^63 does).
+val a = 9223372036854775808
+println(a)

--- a/test/negative/008_neg_unsigned_literal.err
+++ b/test/negative/008_neg_unsigned_literal.err
@@ -1,0 +1,1 @@
+008_neg_unsigned_literal.fx:2:10: error: '-' in front of unsigned integer literal

--- a/test/negative/008_neg_unsigned_literal.fx
+++ b/test/negative/008_neg_unsigned_literal.fx
@@ -1,0 +1,3 @@
+// expect: unsigned
+val a = -5u8
+println(a)


### PR DESCRIPTION
A bare positive `9223372036854775808` (exactly 2^63) was accepted by the lexer and silently wrapped to INT64_MIN: getnumber accumulates the magnitude in uint64 and allows up to 2^63 (so that the unary-minus fold can spell `-9223372036854775808` = INT64_MIN), but `(int64_t)(1<<63)` wraps, so a positive occurrence aliased the minimum instead of erroring.

Fix (compiler/Lexer.fx): thread an `expect_neg_number` flag. The unary-minus handler sets it (toggle + restore) around the nexttokens() call that lexes the following number; the number branch rejects a wrapped-negative magnitude (LitInt/LitSInt with value < 0) unless a minus was expected. So `-9223372036854775808` still denotes INT64_MIN, while bare positive 2^63 now errors ("the numeric literal is out of range for the specified type"). The toggle handles nesting by parity: `- -9223372036854775808` (= 2^63) and `-(9223372036854775808)` (not immediately negated) both correctly error. A `-` before an unsigned literal is now a clear error too, instead of a silent MINUS :: LitUInt.

Tests: test/negative/007_pos_int64_overflow and 008_neg_unsigned_literal golden diagnostics. Only Lexer.c changed in the bootstrap; fixpoint holds; full ladder green (unit 135, fxtest all, determinism, negative 66). FB-014 -> fixed; docs (found_bugs.md, language_changes_brief.md 1.3, housekeeping report) updated.