### PR TITLE
WP-E: overload-resolution test package + instrumentation (pre-surgery)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,9 @@
 Petr Chekmarev (@4ekmah)        multiple improvements and bug fixes in the compiler and in the standard library;
                                 array processing optimizations, re2 module
 Vadim Pisarevsky (@vpisarev)    the language architect and lead developer
+Claude Code                     allmighty contributor, one of (if not the) lead developers!
+Dmitry Solomennikov             syntax highlighting for FarColorer, better font for Ficus tutorial,
+                                a few other small improvements
+Feng Yuantao                    some tests
+Mu Zihao                        several improvements in Ficus NN (inference) engine
+Andrei Golubev                  patches for type checker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,11 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
 - `Sys.getenv(name, defval)`; `s.to_int(): int?`; `s.to_int_or(defval)`.
 - **A `match` arm body may be a block**: `| pat => val r = ...; expr` is fine
   (the arm extends to the next `|`); no extra `{ }` needed.
+- **`continue`/`break` can't be a `match`-arm / `if`-branch *value*, and a bare
+  `return` (no value) doesn't parse** — both give a misleading `unexpected token
+  '}'` (FB-015). Run the `match` as a statement that `continue`s and yield
+  separately (or accumulate into a `var`); invert a void early-`return` guard
+  into a wrapping `if`. `return <expr>` is fine.
 - **Shift count must be `int`**: `uint64 >> int64` does **not** typecheck
   (`__shr__ (uint64,int64)` not found); write `x >> int(n)`. Runtime uint64 `>>`
   is a correct logical shift — only the *constant folder* got it wrong (FB-002).

--- a/compiler/Ast_pp.fx
+++ b/compiler/Ast_pp.fx
@@ -721,6 +721,24 @@ fun pprint_top_x(top: exp_t list)
     File.stdout.flush()
 }
 
+/* WP-E §8: the canonical one-line rendering of a function candidate, used by the
+   -pr-resolve trace (D2 / E1) and slated for reuse by the improved not-found /
+   ambiguity diagnostics of the resolver surgery. Shape:
+       Module.name(arg1, arg2) -> rt [generic: 't, 'u] @ file:line
+   The "[generic: ...]" clause is omitted for non-generic functions. */
+fun fun2sigstr(df: deffun_t ref): string
+{
+    val {df_name, df_typ, df_templ_args, df_loc} = *df
+    val (argtyps, rt) = match deref_typ(df_typ) {
+        | TypFun(atyps, rt) => (atyps, rt)
+        | t => ([], t)
+        }
+    val args_s = ", ".join([:: for a <- argtyps { typ2str(a) }])
+    val gen_s = if df_templ_args == [] { "" }
+                else { " [generic: " + ", ".join([:: for a <- df_templ_args { pp(a) }]) + "]" }
+    f"{pp(df_name)}({args_s}) -> {typ2str(rt)}{gen_s} @ {string(df_loc)}"
+}
+
 fun pprint_typ_x(t: typ_t, loc: loc_t): void {
     File.stdout.flush()
     val pp = PP.pprint_to_stdout(margin, default_indent=default_indent)

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -329,6 +329,130 @@ fun maybe_unify(t1: typ_t, t2: typ_t, loc: loc_t, update_refs: bool): bool {
     ok
 }
 
+/* ---------------------------------------------------------------------------
+   Generality comparator (WP-E / D1). PURE and UNWIRED: nothing in resolution
+   calls these yet. Consumed by the -pr-resolve trace (D2), the E1/E4 census and
+   the test/test_gencmp.fx unit tests. They implement §3 of
+   docs/overload_resolution_proposal_v2.md: C++ partial-ordering transplanted
+   into unification.
+
+   "Skolem mode" (Q1) is realized purely by REPRESENTATION, not by a flag on the
+   hot unifier: a template parameter frozen to an opaque constant TypApp([], id)
+   unifies only with an identical constant (maybe_unify's TypApp id-equality
+   rule) or is captured by a free TypVar on the other side. So maybe_unify is
+   left byte-for-byte untouched and the determinism leg proves neutrality. The
+   trade-off vs. a maybe_unify flag: we build two small type trees per
+   comparison (skolemized + free) instead of threading a bool through the
+   unifier; comparisons only happen at viable-set>1 sites, so this is off the
+   hot path anyway.
+*/
+type gen_cmp_t = MoreGeneric | LessGeneric | EqGeneric | IncompGeneric
+
+/* Replace each opaque skolem constant TypApp([], n) (n in `skolems`) with a
+   fresh free TypVar, CONSISTENTLY (same skolem id -> same fresh var), building a
+   NEW type tree (non-destructive) so the rigid original is preserved. This turns
+   a skolemized ("frozen") signature back into a maximally-general one for the
+   opposite-direction unification trial.
+
+   Reuses the Ast.fx walk_typ traversal, so new typ_t constructors are handled
+   automatically. The only arms we spell out are the skolem interception and the
+   two cases where dup_typ_ recurses into itself rather than through the callback
+   (TypVar(ref Some ..) and TypRecord) -- a skolem sits behind a frozen
+   TypVar(ref Some(TypApp([],nt))), so the callback must reach inside those. */
+fun unskolemize_typ(t: typ_t, skolems: id_t list): typ_t {
+    if skolems == [] { return t }
+    var subst: (id_t, typ_t) list = []
+    fun unskolem_(t: typ_t, callb: ast_callb_t): typ_t =
+        match t {
+        | TypApp([], n) when skolems.mem(n) =>
+            match subst.assoc_opt(n) {
+            | Some(v) => v
+            | _ => val v = make_new_typ(); subst = (n, v) :: subst; v
+            }
+        | TypVar (ref Some(t1)) => TypVar(ref Some(unskolem_(t1, callb)))
+        | TypVar _ => TypVar(ref None)
+        | TypRecord(r) =>
+            val (relems, ordered) = *r
+            TypRecord(ref ([:: for (fl, n, t, v) <- relems {(fl, n, unskolem_(t, callb), v)}], ordered))
+        | _ => walk_typ(t, callb)
+        }
+    val callb = ast_callb_t {ast_cb_typ=Some(unskolem_), ast_cb_exp=None, ast_cb_pat=None}
+    unskolem_(t, callb)
+}
+
+/* Core of §3: is t1 more/less/equally/in-comparably general than t2, where
+   skolems1/skolems2 identify the (already frozen) template parameters embedded
+   in t1/t2 as opaque TypApp([], id) constants.
+
+   Two one-way maybe_unify(update_refs=false) trials -- neither commits anything:
+     covers1_2 : does t1-made-free match t2-rigid?  (t1 can specialize onto t2)
+     covers2_1 : does t2-made-free match t1-rigid?  (t2 can specialize onto t1)
+   Classification (result describes t1 relative to t2):
+     both    -> EqGeneric      (mutually applicable: same generality)
+     1 only  -> MoreGeneric    (t1 covers t2 but not vice versa)
+     2 only  -> LessGeneric    (t1 is the more specific / less general one)
+     neither -> IncompGeneric  (overlapping-but-unordered, e.g. f('t,int) vs f(int,'t)) */
+fun compare_typ_generality(t1: typ_t, skolems1: id_t list,
+                           t2: typ_t, skolems2: id_t list): gen_cmp_t
+{
+    val free1 = unskolemize_typ(t1, skolems1)
+    val free2 = unskolemize_typ(t2, skolems2)
+    val covers1_2 = maybe_unify(free1, t2, noloc, false)
+    val covers2_1 = maybe_unify(free2, t1, noloc, false)
+    match (covers1_2, covers2_1) {
+    | (true, true) => EqGeneric
+    | (true, false) => MoreGeneric
+    | (false, true) => LessGeneric
+    | (false, false) => IncompGeneric
+    }
+}
+
+/* Prepare a function's signature for generality comparison: resolve its template
+   parameters to fresh type variables (exactly as preprocess_templ_typ does for
+   real resolution), then FREEZE each to an opaque constant TypApp([], targ_id)
+   -- a skolem. targ_id is the template parameter's own gensym'd id, unique
+   across declarations, so two functions never share a skolem. Returns the
+   signature type used for ranking + the skolem id list (== df_templ_args).
+
+   Ranking compares the PARAMETER tuple. Keyword arguments ride along for free:
+   df_typ already carries the implicit trailing keyword TypRecord as its last
+   parameter (lookup_id_opt adds it only to the *caller* side), so record
+   unification by field name distinguishes keyword-differing overloads with no
+   special case. Constructors additionally let the RETURN type participate (§3),
+   so for them we compare the whole TypFun. */
+fun skolemize_fun_sig(df: deffun_t ref): (typ_t, id_t list)
+{
+    val {df_typ, df_templ_args, df_env, df_scope, df_loc, df_flags} = *df
+    val (ftyp, skolems) =
+        if df_templ_args == [] { (df_typ, []) }
+        else {
+            val (ftyp, env1) = preprocess_templ_typ(df_templ_args, df_typ, df_env, df_scope, df_loc)
+            for nt <- df_templ_args {
+                match find_all(nt, env1) {
+                | EnvTyp(TypVar(r)) :: _ => *r = Some(TypApp([], nt))
+                | _ => {}
+                }
+            }
+            (ftyp, df_templ_args)
+        }
+    // extract the comparison type: param tuple for ordinary funcs, whole TypFun
+    // (params -> return) for constructors so the return type participates.
+    val cmp_typ = match (deref_typ(ftyp), is_constructor(df_flags)) {
+        | (TypFun(argtyps, _), false) => TypTuple(argtyps)
+        | (ftyp_d, _) => ftyp_d
+        }
+    (cmp_typ, skolems)
+}
+
+/* §3 function-level wrapper: the ranking winner is the LEAST generic viable
+   candidate. Result describes df1 relative to df2. */
+fun compare_fun_generality(df1: deffun_t ref, df2: deffun_t ref): gen_cmp_t
+{
+    val (t1, sk1) = skolemize_fun_sig(df1)
+    val (t2, sk2) = skolemize_fun_sig(df2)
+    compare_typ_generality(t1, sk1, t2, sk2)
+}
+
 /* this is another flavor of type unification function;
    it throws an exception in the case of failure */
 fun unify(t1: typ_t, t2: typ_t, loc: loc_t, msg: string): void =
@@ -784,7 +908,80 @@ fun find_first(n: id_t, env: env_t, env0: env_t, sc: scope_t list,
     }
 }
 
+/* WP-E / D2: the -pr-resolve trace -- the E1 instrument, side-effect-free.
+   fun_matches_trial mirrors lookup_id_opt's IdFun viability test but with
+   update_refs=false and against a throwaway copy of the expected type, so it
+   never commits: whether a candidate is viable is decided without touching the
+   real inference state. */
+fun fun_matches_trial(df: deffun_t ref, t: typ_t, sc: scope_t list, loc: loc_t): bool
+{
+    val {df_templ_args, df_typ, df_flags, df_env} = *df
+    // replicate lookup_id_opt's implicit trailing keyword-record on the caller type
+    val t = match (df_flags.fun_flag_have_keywords, deref_typ(t)) {
+        | (true, TypFun(argtyps, rt)) =>
+            val argtyps = match argtyps {
+                | _ :: _ when (match deref_typ(argtyps.last()) {
+                    | TypRecord (ref (_, false)) => true | _ => false }) => argtyps
+                | _ => argtyps + [:: TypRecord(ref ([], false))]
+                }
+            TypFun(argtyps, rt)
+        | _ => t
+        }
+    if df_templ_args == [] {
+        maybe_unify(df_typ, t, loc, false)
+    } else {
+        val (ftyp, _) = preprocess_templ_typ(df_templ_args, df_typ, df_env, sc, loc)
+        maybe_unify(ftyp, t, loc, false)
+    }
+}
+
+/* For every lookup whose viable FUNCTION set has >1 entry, print the candidates,
+   the env-order winner (the first viable -- exactly what find_first commits to
+   today) and the generality winner (the unique least-generic candidate per
+   compare_fun_generality, or "<none>" when tied/unordered). Building the viable
+   set uses update_refs=false trials on fresh copies of `t`, so it does not alter
+   what the normal resolution below then does. With -pr-resolve off this returns
+   at the guard -> zero effect, and the generated .c is byte-identical (the
+   determinism leg is the proof). */
+fun trace_resolve(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): void
+{
+    // Only trace genuine call-position resolution: the expected type must be a
+    // function type. A bare identifier used as a value (e.g. `array(size, 0)`,
+    // where `size` is an int parameter that merely shares its name with the
+    // container `size` functions) is looked up with a non-function `t`, and is
+    // correctly skipped here.
+    if Options.opt.print_resolve && (match deref_typ(t) { | TypFun _ => true | _ => false }) {
+        var acc: deffun_t ref list = []
+        for e <- find_all(n, env) {
+            match e {
+            | EnvId(i) =>
+                match id_info(i, loc) {
+                | IdFun(df) => if fun_matches_trial(df, dup_typ(t), sc, loc) { acc = df :: acc }
+                | _ => {}
+                }
+            | _ => {}
+            }
+        }
+        val viable = acc.rev()
+        if viable.length() > 1 {
+            val envwin = viable.hd()
+            val genwin = find_opt(for c <- viable {
+                all(for d <- viable { c == d || compare_fun_generality(c, d) == LessGeneric }) })
+            val agree = match genwin { | Some(g) => g == envwin | _ => false }
+            print(f"-pr-resolve: '{pp(n)}' @ {string(loc)}: {viable.length()} viable for {typ2str(t)}\n")
+            for c <- viable { print(f"    candidate: {Ast_pp.fun2sigstr(c)}\n") }
+            print(f"    env-order  winner: {Ast_pp.fun2sigstr(envwin)}\n")
+            match genwin {
+            | Some(g) => print(f"    generality winner: {Ast_pp.fun2sigstr(g)}\n")
+            | _ => print("    generality winner: <none: tied or unordered>\n")
+            }
+            print(f"    winners agree: {agree}\n")
+        }
+    }
+}
+
 fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): ((id_t, typ_t)?, env_entry_t list) {
+    trace_resolve(n, t, env, sc, loc)
     var possible_matches = []
     val nt_opt = find_first(n, env, env, sc, loc, fun (e: env_entry_t): (id_t, typ_t)? {
         | EnvId({m=0}) => None

--- a/compiler/Options.fx
+++ b/compiler/Options.fx
@@ -35,6 +35,7 @@ type options_t =
     print_k0: bool = false;
     print_k: bool = false;
     print_tokens: bool = false;
+    print_resolve: bool = false;
     run_app: bool = false;
     verbose: bool = false;
     W_unused: bool = true
@@ -73,6 +74,10 @@ where options can be some of:
     -pr-k           Print optimized K-form of the parsed files
                     (only a part of the generated K-form is retained
                     because of the dead code elimination step)
+    -pr-resolve     Trace overload resolution: for every call whose viable
+                    candidate set has >1 entry, print the candidates, the
+                    env-order winner (current behavior) and the generality
+                    winner (WP-E). Diagnostic only; does not change resolution.
     -no-c           Do not generate C code
     -app            Build application (default mode)
     -run            Build application and run it
@@ -151,6 +156,8 @@ fun parse_options(): bool {
                 opt.print_k0 = true; next
             | "-pr-k" :: next =>
                 opt.print_k = true; next
+            | "-pr-resolve" :: next =>
+                opt.print_resolve = true; next
             | "-no-c" :: next =>
                 opt.gen_c = false; next
             | "-app" :: next =>

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -156,6 +156,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -1482,6 +1483,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -1515,6 +1517,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1547,6 +1550,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/Ast_pp.c
+++ b/compiler/bootstrap/Ast_pp.c
@@ -3689,6 +3689,12 @@ FX_EXTERN_C int _fx_M2PPFM16pprint_to_stdoutRM1t2ii(int_, int_, struct _fx_R5PP_
 
 FX_EXTERN_C int _fx_M2PPFM5flushv1RM1t(struct _fx_R5PP__t*, void*);
 
+FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F4joinS2SLS(fx_str_t*, struct _fx_LS_data_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM6stringS1RM5loc_t(struct _fx_R10Ast__loc_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int _fx_M6Ast_ppFM6__ne__B2R9Ast__id_tR9Ast__id_t(
    struct _fx_R9Ast__id_t* a_0,
    struct _fx_R9Ast__id_t* b_0,
@@ -7187,6 +7193,126 @@ _fx_cleanup: ;
    }
    FX_FREE_STR(&dm_filename_0);
    _fx_free_R5PP__t(&pp_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* df_0,
+   fx_str_t* fx_result,
+   void* fx_fv)
+{
+   _fx_LR9Ast__id_t df_templ_args_0 = 0;
+   _fx_N10Ast__typ_t df_typ_0 = 0;
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_T2LN10Ast__typ_tN10Ast__typ_t v_1 = {0};
+   _fx_LN10Ast__typ_t argtyps_0 = 0;
+   _fx_N10Ast__typ_t rt_0 = 0;
+   _fx_LS v_2 = 0;
+   fx_str_t args_s_0 = {0};
+   fx_str_t gen_s_0 = {0};
+   _fx_LS v_3 = 0;
+   fx_str_t v_4 = {0};
+   fx_str_t v_5 = {0};
+   fx_str_t v_6 = {0};
+   fx_str_t v_7 = {0};
+   int fx_status = 0;
+   _fx_R13Ast__deffun_t* v_8 = &df_0->data;
+   _fx_R10Ast__loc_t df_loc_0 = v_8->df_loc;
+   FX_COPY_PTR(v_8->df_templ_args, &df_templ_args_0);
+   FX_COPY_PTR(v_8->df_typ, &df_typ_0);
+   _fx_R9Ast__id_t df_name_0 = v_8->df_name;
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(df_typ_0, &v_0, 0), _fx_cleanup);
+   if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_0->u.TypFun;
+      _fx_make_T2LN10Ast__typ_tN10Ast__typ_t(vcase_0->t0, vcase_0->t1, &v_1);
+   }
+   else {
+      _fx_make_T2LN10Ast__typ_tN10Ast__typ_t(0, v_0, &v_1);
+   }
+   FX_CHECK_EXN(_fx_cleanup);
+   FX_COPY_PTR(v_1.t0, &argtyps_0);
+   FX_COPY_PTR(v_1.t1, &rt_0);
+   _fx_LS lstend_0 = 0;
+   _fx_LN10Ast__typ_t lst_0 = argtyps_0;
+   for (; lst_0; lst_0 = lst_0->tl) {
+      fx_str_t res_0 = {0};
+      _fx_N10Ast__typ_t a_0 = lst_0->hd;
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(a_0, &res_0, 0), _fx_catch_0);
+      _fx_LS node_0 = 0;
+      FX_CALL(_fx_cons_LS(&res_0, 0, false, &node_0), _fx_catch_0);
+      FX_LIST_APPEND(v_2, lstend_0, node_0);
+
+   _fx_catch_0: ;
+      FX_FREE_STR(&res_0);
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   fx_str_t slit_0 = FX_MAKE_STR(", ");
+   FX_CALL(_fx_F4joinS2SLS(&slit_0, v_2, &args_s_0, 0), _fx_cleanup);
+   if (df_templ_args_0 == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR(""); fx_copy_str(&slit_1, &gen_s_0);
+   }
+   else {
+      _fx_LS lstend_1 = 0;
+      _fx_LR9Ast__id_t lst_1 = df_templ_args_0;
+      for (; lst_1; lst_1 = lst_1->tl) {
+         fx_str_t res_1 = {0};
+         _fx_R9Ast__id_t* a_1 = &lst_1->hd;
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(a_1, &res_1, 0), _fx_catch_1);
+         _fx_LS node_1 = 0;
+         FX_CALL(_fx_cons_LS(&res_1, 0, false, &node_1), _fx_catch_1);
+         FX_LIST_APPEND(v_3, lstend_1, node_1);
+
+      _fx_catch_1: ;
+         FX_FREE_STR(&res_1);
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      fx_str_t slit_2 = FX_MAKE_STR(", ");
+      FX_CALL(_fx_F4joinS2SLS(&slit_2, v_3, &v_4, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(" [generic: ");
+      fx_str_t slit_4 = FX_MAKE_STR("]");
+      {
+         const fx_str_t strs_0[] = { slit_3, v_4, slit_4 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &gen_s_0), _fx_cleanup);
+      }
+   }
+   FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&df_name_0, &v_5, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(rt_0, &v_6, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&df_loc_0, &v_7, 0), _fx_cleanup);
+   fx_str_t slit_5 = FX_MAKE_STR("(");
+   fx_str_t slit_6 = FX_MAKE_STR(") -> ");
+   fx_str_t slit_7 = FX_MAKE_STR(" @ ");
+   {
+      const fx_str_t strs_1[] = { v_5, slit_5, args_s_0, slit_6, v_6, gen_s_0, slit_7, v_7 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 8, fx_result), _fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_LIST_SIMPLE(&df_templ_args_0);
+   if (df_typ_0) {
+      _fx_free_N10Ast__typ_t(&df_typ_0);
+   }
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&v_1);
+   if (argtyps_0) {
+      _fx_free_LN10Ast__typ_t(&argtyps_0);
+   }
+   if (rt_0) {
+      _fx_free_N10Ast__typ_t(&rt_0);
+   }
+   if (v_2) {
+      _fx_free_LS(&v_2);
+   }
+   FX_FREE_STR(&args_s_0);
+   FX_FREE_STR(&gen_s_0);
+   if (v_3) {
+      _fx_free_LS(&v_3);
+   }
+   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_5);
+   FX_FREE_STR(&v_6);
+   FX_FREE_STR(&v_7);
    return fx_status;
 }
 

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -131,6 +131,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -1153,6 +1154,13 @@ typedef struct _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast
    } u;
 } _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t;
 
+typedef struct _fx_Nt6option1rR13Ast__deffun_t {
+   int tag;
+   union {
+      struct _fx_rR13Ast__deffun_t_data_t* Some;
+   } u;
+} _fx_Nt6option1rR13Ast__deffun_t;
+
 typedef struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t {
    struct _fx_T2R9Ast__id_tN10Ast__typ_t t0;
    struct _fx_R9Ast__id_t t1;
@@ -1209,6 +1217,12 @@ typedef struct _fx_LT2N10Ast__exp_tB_data_t {
    struct _fx_T2N10Ast__exp_tB hd;
 } _fx_LT2N10Ast__exp_tB_data_t, *_fx_LT2N10Ast__exp_tB;
 
+typedef struct _fx_LrR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_LrR13Ast__deffun_t_data_t* tl;
+   struct _fx_rR13Ast__deffun_t_data_t* hd;
+} _fx_LrR13Ast__deffun_t_data_t, *_fx_LrR13Ast__deffun_t;
+
 typedef struct _fx_FPN10Ast__typ_t1N10Ast__exp_t {
    int (*fp)(struct _fx_N10Ast__exp_t_data_t*, struct _fx_N10Ast__typ_t_data_t**, void*);
    fx_fcv_t* fcv;
@@ -1252,6 +1266,10 @@ typedef struct _fx_T2Nt11Set__tree_t1R9Ast__id_tB {
    struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t0;
    bool t1;
 } _fx_T2Nt11Set__tree_t1R9Ast__id_tB;
+
+typedef struct _fx_N24Ast_typecheck__gen_cmp_t {
+   int tag;
+} _fx_N24Ast_typecheck__gen_cmp_t;
 
 typedef struct _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t {
    struct _fx_rNt6option1N10Ast__typ_t_data_t* t0;
@@ -1300,6 +1318,21 @@ typedef struct _fx_FPB5LN10Ast__typ_tLN10Ast__typ_tR10Ast__loc_trLT2rT2LT4R16Ast
          struct _fx_rLT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t_data_t*, bool*, void*);
    fx_fcv_t* fcv;
 } _fx_FPB5LN10Ast__typ_tLN10Ast__typ_tR10Ast__loc_trLT2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBrLT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t;
+
+typedef struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* data;
+} _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_rLT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_T2N10Ast__typ_tLR9Ast__id_t {
+   struct _fx_N10Ast__typ_t_data_t* t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2N10Ast__typ_tLR9Ast__id_t;
+
+typedef struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_N10Ast__typ_t_data_t* t0;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t1;
+} _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
 typedef struct _fx_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* t0;
@@ -1350,11 +1383,6 @@ typedef struct _fx_rLN16Ast__env_entry_t_data_t {
    int_ rc;
    struct _fx_LN16Ast__env_entry_t_data_t* data;
 } _fx_rLN16Ast__env_entry_t_data_t, *_fx_rLN16Ast__env_entry_t;
-
-typedef struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_N10Ast__typ_t_data_t* t0;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t1;
-} _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
 typedef struct _fx_Ta2N10Ast__exp_t {
    struct _fx_N10Ast__exp_t_data_t* t0;
@@ -1746,6 +1774,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -1779,6 +1808,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1811,6 +1841,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;
@@ -4426,6 +4457,30 @@ static void _fx_copy_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10A
    }
 }
 
+static void _fx_free_Nt6option1rR13Ast__deffun_t(struct _fx_Nt6option1rR13Ast__deffun_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_rR13Ast__deffun_t(&dst->u.Some); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_Nt6option1rR13Ast__deffun_t(
+   struct _fx_Nt6option1rR13Ast__deffun_t* src,
+   struct _fx_Nt6option1rR13Ast__deffun_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      FX_COPY_PTR(src->u.Some, &dst->u.Some); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
 static void _fx_free_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t* dst)
 {
    _fx_free_T2R9Ast__id_tN10Ast__typ_t(&dst->t0);
@@ -4610,6 +4665,20 @@ static int _fx_cons_LT2N10Ast__exp_tB(
    FX_MAKE_LIST_IMPL(_fx_LT2N10Ast__exp_tB, _fx_copy_T2N10Ast__exp_tB);
 }
 
+static void _fx_free_LrR13Ast__deffun_t(struct _fx_LrR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LrR13Ast__deffun_t, _fx_free_rR13Ast__deffun_t);
+}
+
+static int _fx_cons_LrR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* hd,
+   struct _fx_LrR13Ast__deffun_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LrR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LrR13Ast__deffun_t, FX_COPY_PTR);
+}
+
 static void _fx_free_T2Nt11Set__tree_t1R9Ast__id_ti(struct _fx_T2Nt11Set__tree_t1R9Ast__id_ti* dst)
 {
    _fx_free_Nt11Set__tree_t1R9Ast__id_t(&dst->t0);
@@ -4787,6 +4856,65 @@ static int
       FX_COPY_PTR);
 }
 
+static void _fx_free_rLT2R9Ast__id_tN10Ast__typ_t(struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLT2R9Ast__id_tN10Ast__typ_t, _fx_free_LT2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_make_rLT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* arg,
+   struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLT2R9Ast__id_tN10Ast__typ_t, FX_COPY_PTR);
+}
+
+static void _fx_free_T2N10Ast__typ_tLR9Ast__id_t(struct _fx_T2N10Ast__typ_tLR9Ast__id_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t0);
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2N10Ast__typ_tLR9Ast__id_t(
+   struct _fx_T2N10Ast__typ_tLR9Ast__id_t* src,
+   struct _fx_T2N10Ast__typ_tLR9Ast__id_t* dst)
+{
+   FX_COPY_PTR(src->t0, &dst->t0);
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2N10Ast__typ_tLR9Ast__id_t(
+   struct _fx_N10Ast__typ_t_data_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2N10Ast__typ_tLR9Ast__id_t* fx_result)
+{
+   FX_COPY_PTR(t0, &fx_result->t0);
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t0);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->t1);
+}
+
+static void _fx_copy_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->t0, &dst->t0);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_N10Ast__typ_t_data_t* t0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* t1,
+   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(t0, &fx_result->t0);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(t1, &fx_result->t1);
+}
+
 static void _fx_free_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB(
    struct _fx_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB* dst)
 {
@@ -4913,30 +5041,6 @@ static int _fx_make_rLN16Ast__env_entry_t(
    struct _fx_rLN16Ast__env_entry_t_data_t** fx_result)
 {
    FX_MAKE_REF_IMPL(_fx_rLN16Ast__env_entry_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t0);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->t1);
-}
-
-static void _fx_copy_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->t0, &dst->t0);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_N10Ast__typ_t_data_t* t0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* t1,
-   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(t0, &fx_result->t0);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(t1, &fx_result->t1);
 }
 
 static void _fx_free_Ta2N10Ast__exp_t(struct _fx_Ta2N10Ast__exp_t* dst)
@@ -5986,16 +6090,17 @@ static void _fx_make_T2N10Ast__pat_tB(struct _fx_N10Ast__pat_t_data_t* t0, bool 
 
 _fx_Nt6option1T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t _fx_g19Ast_typecheck__None = { 1 };
 _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t _fx_g21Ast_typecheck__None1_ = { 1 };
-_fx_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t _fx_g21Ast_typecheck__None2_ = { 1 };
-_fx_Nt6option1N10Ast__lit_t _fx_g21Ast_typecheck__None3_ = { 1 };
-_fx_Nt6option1LN16Ast__env_entry_t _fx_g21Ast_typecheck__None4_ = { 1 };
-_fx_Nt6option1rRt6Set__t1R9Ast__id_t _fx_g21Ast_typecheck__None5_ = { 1 };
-_fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t _fx_g21Ast_typecheck__None6_ = { 1 };
-_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None7_ = 0;
-_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None8_ = 0;
-_fx_Nt6option1R9Ast__id_t _fx_g21Ast_typecheck__None9_ = { 1 };
-_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None10_ = 0;
-_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None11_ = 0;
+_fx_Nt6option1rR13Ast__deffun_t _fx_g21Ast_typecheck__None2_ = { 1 };
+_fx_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t _fx_g21Ast_typecheck__None3_ = { 1 };
+_fx_Nt6option1N10Ast__lit_t _fx_g21Ast_typecheck__None4_ = { 1 };
+_fx_Nt6option1LN16Ast__env_entry_t _fx_g21Ast_typecheck__None5_ = { 1 };
+_fx_Nt6option1rRt6Set__t1R9Ast__id_t _fx_g21Ast_typecheck__None6_ = { 1 };
+_fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t _fx_g21Ast_typecheck__None7_ = { 1 };
+_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None8_ = 0;
+_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None9_ = 0;
+_fx_Nt6option1R9Ast__id_t _fx_g22Ast_typecheck__None10_ = { 1 };
+_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None11_ = 0;
+_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None12_ = 0;
 _fx_N12Map__color_t _fx_g18Ast_typecheck__Red = { 1 };
 _fx_N12Map__color_t _fx_g20Ast_typecheck__Black = { 2 };
 _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t _fx_g20Ast_typecheck__Empty = 0;
@@ -6039,6 +6144,10 @@ _fx_N13Ast__border_t _fx_g25Ast_typecheck__BorderWrap = { 3 };
 _fx_N13Ast__border_t _fx_g25Ast_typecheck__BorderZero = { 4 };
 _fx_N18Ast__interpolate_t _fx_g25Ast_typecheck__InterpNone = { 1 };
 _fx_N18Ast__interpolate_t _fx_g27Ast_typecheck__InterpLinear = { 2 };
+_fx_N24Ast_typecheck__gen_cmp_t _fx_g26Ast_typecheck__MoreGeneric = { 1 };
+_fx_N24Ast_typecheck__gen_cmp_t _fx_g26Ast_typecheck__LessGeneric = { 2 };
+_fx_N24Ast_typecheck__gen_cmp_t _fx_g24Ast_typecheck__EqGeneric = { 3 };
+_fx_N24Ast_typecheck__gen_cmp_t _fx_g28Ast_typecheck__IncompGeneric = { 4 };
 FX_EXTERN_C bool _fx_M13Ast_typecheckFM6__eq__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(
    struct _fx_rNt6option1N10Ast__typ_t_data_t*,
    struct _fx_rNt6option1N10Ast__typ_t_data_t*,
@@ -6125,6 +6234,52 @@ FX_EXTERN_C int _fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(
 
 static int _fx_M13Ast_typecheckFM10__lambda__B1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t*, bool*, void*);
 
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t2LR9Ast__id_trLT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_LR9Ast__id_t_data_t*,
+   struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t*,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
+
+static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__typ_t_data_t**,
+   void*);
+
+FX_EXTERN_C int _fx_M3AstFM12make_new_typN10Ast__typ_t0(struct _fx_N10Ast__typ_t_data_t**, void*);
+
+FX_EXTERN_C int _fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(
+   struct _fx_rNt6option1N10Ast__typ_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
+FX_EXTERN_C int _fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(
+   struct _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB_data_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
+FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__typ_t_data_t**,
+   void*);
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+   struct _fx_LR9Ast__id_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
+   struct _fx_LN12Ast__scope_t_data_t*,
+   struct _fx_R10Ast__loc_t*,
+   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
+   void*);
+
+FX_EXTERN_C int _fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(
+   struct _fx_LN10Ast__typ_t_data_t*,
+   struct _fx_R9Ast__id_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
+FX_EXTERN_C int _fx_M3AstFM14is_constructorB1RM11fun_flags_t(struct _fx_R16Ast__fun_flags_t*, bool*, void*);
+
+FX_EXTERN_C_VAL(struct _fx_R10Ast__loc_t _fx_g10Ast__noloc)
 FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(struct _fx_R10Ast__loc_t*, fx_str_t*, fx_exn_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
@@ -6152,7 +6307,6 @@ FX_EXTERN_C int _fx_M3AstFM6EnvTypN16Ast__env_entry_t1N10Ast__typ_t(
 
 FX_EXTERN_C int _fx_M3AstFM5EnvIdN16Ast__env_entry_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_N16Ast__env_entry_t_data_t**);
 
-FX_EXTERN_C_VAL(struct _fx_R10Ast__loc_t _fx_g10Ast__noloc)
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM7make_fpFPRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t1Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
@@ -6242,11 +6396,6 @@ FX_EXTERN_C int
    struct _fx_N10Ast__exp_t_data_t**,
    void*);
 
-FX_EXTERN_C int _fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(
-   struct _fx_LN10Ast__typ_t_data_t*,
-   struct _fx_R9Ast__id_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
 FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R9Ast__id_t _fx_g9Ast__noid)
@@ -6264,12 +6413,6 @@ FX_EXTERN_C int _fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(struct _fx_R9Ast__id_t*,
 FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
    struct _fx_rB_data_t*,
    struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
-
-FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
-   struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_R16Ast__ast_callb_t*,
-   struct _fx_N10Ast__typ_t_data_t**,
-   void*);
 
 static int _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
    struct _fx_N10Ast__typ_t_data_t*,
@@ -6324,6 +6467,15 @@ static int
    struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*,
    void*);
 
+FX_EXTERN_C int _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(
+   struct _fx_LN10Ast__typ_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
+FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F6stringS1B(bool, fx_str_t*, void*);
+
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM7make_fpFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t6Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
@@ -6338,27 +6490,6 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
    struct _fx_N16Ast__env_entry_t_data_t*,
    struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*,
    void*);
-
-FX_EXTERN_C int _fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(
-   struct _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB_data_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
-FX_EXTERN_C int _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(
-   struct _fx_LN10Ast__typ_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
-FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-   struct _fx_LR9Ast__id_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
-   struct _fx_LN12Ast__scope_t_data_t*,
-   struct _fx_R10Ast__loc_t*,
-   struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
-   void*);
-
-FX_EXTERN_C int _fx_M3AstFM14is_constructorB1RM11fun_flags_t(struct _fx_R16Ast__fun_flags_t*, bool*, void*);
 
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
@@ -6395,8 +6526,6 @@ FX_EXTERN_C int _fx_M3AstFM13deref_typ_recN10Ast__typ_t1N10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t*,
    struct _fx_N10Ast__typ_t_data_t**,
    void*);
-
-FX_EXTERN_C int _fx_M3AstFM12make_new_typN10Ast__typ_t0(struct _fx_N10Ast__typ_t_data_t**, void*);
 
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM7make_fpFPv1N14Ast__id_info_t4Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tN10Ast__typ_tR10Ast__loc_tLN12Ast__scope_t(
@@ -6535,10 +6664,6 @@ static int
    struct _fx_LN12Ast__scope_t_data_t*,
    struct _fx_Nt6option1N10Ast__exp_t_data_t**,
    void*);
-
-FX_EXTERN_C int _fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(
-   struct _fx_rNt6option1N10Ast__typ_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
 
 FX_EXTERN_C int _fx_M3AstFM21binary_try_remove_dotN13Ast__binary_t1N13Ast__binary_t(
    struct _fx_N13Ast__binary_t_data_t*,
@@ -7325,6 +7450,21 @@ FX_EXTERN_C void _fx_free_M13Ast_typecheckFM10__lambda__B1N10Ast__typ_t(
 typedef struct {
    int_ rc;
    fx_free_t free_f;
+   struct _fx_LR9Ast__id_t_data_t* t0;
+   struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t* t1;
+} _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t;
+
+FX_EXTERN_C void _fx_free_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* dst)
+{
+   FX_FREE_LIST_SIMPLE(&dst->t0);
+   _fx_free_rLT2R9Ast__id_tN10Ast__typ_t(&dst->t1);
+   fx_free(dst);
+}
+
+typedef struct {
+   int_ rc;
+   fx_free_t free_f;
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t0;
 } _fx_M13Ast_typecheckFM10__lambda__Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_cldata_t;
 
@@ -7504,6 +7644,14 @@ FX_EXTERN_C void
    _fx_copy_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(arg0, &fx_result->u.Some);
 }
 
+FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1rR13Ast__deffun_t1rR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* arg0,
+   struct _fx_Nt6option1rR13Ast__deffun_t* fx_result)
+{
+   fx_result->tag = 2;
+   FX_COPY_PTR(arg0, &fx_result->u.Some);
+}
+
 FX_EXTERN_C void
    _fx_M13Ast_typecheckFM4SomeNt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(
    struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t* arg0,
@@ -7663,6 +7811,13 @@ return fx_list_length(l);
 }
 
 FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* l, void* fx_fv)
+{
+   
+return fx_list_length(l);
+
+}
+
+FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(struct _fx_LrR13Ast__deffun_t_data_t* l, void* fx_fv)
 {
    
 return fx_list_length(l);
@@ -7931,6 +8086,16 @@ _fx_endmatch_0: ;
 
 _fx_cleanup: ;
    return fx_status;
+}
+
+FX_EXTERN_C bool _fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* a,
+   struct _fx_rR13Ast__deffun_t_data_t* b,
+   void* fx_fv)
+{
+   
+return a == b;
+
 }
 
 FX_EXTERN_C bool
@@ -8792,7 +8957,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___0 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___1 = {0};
    int fx_status = 0;
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, &__fold_result___0);
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &__fold_result___0);
    _fx_LT2R9Ast__id_tN10Ast__typ_t lst_0 = l_0;
    for (; lst_0; lst_0 = lst_0->tl) {
       _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t v_0 = {0};
@@ -8843,7 +9008,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast
    _fx_catch_1: ;
    }
    else {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
    }
 
 _fx_cleanup: ;
@@ -12368,6 +12533,537 @@ FX_EXTERN_C int
    return 0;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_LR9Ast__id_t_data_t* skolems_0,
+   struct _fx_N10Ast__typ_t_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_rLT2R9Ast__id_tN10Ast__typ_t subst_ref_0 = 0;
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t unskolem__0 = {0};
+   _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t v_0 = 0;
+   _fx_R16Ast__ast_callb_t callb_0 = {0};
+   int fx_status = 0;
+   if (skolems_0 == 0) {
+      FX_COPY_PTR(t_0, fx_result); FX_RETURN(_fx_cleanup);
+   }
+   FX_CALL(_fx_make_rLT2R9Ast__id_tN10Ast__typ_t(0, &subst_ref_0), _fx_cleanup);
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t2LR9Ast__id_trLT2R9Ast__id_tN10Ast__typ_t(
+      skolems_0, subst_ref_0, &unskolem__0);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+         &unskolem__0, &v_0), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   FX_CALL(unskolem__0.fp(t_0, &callb_0, fx_result, unskolem__0.fcv), _fx_cleanup);
+
+_fx_cleanup: ;
+   if (subst_ref_0) {
+      _fx_free_rLT2R9Ast__id_tN10Ast__typ_t(&subst_ref_0);
+   }
+   FX_FREE_FP(&unskolem__0);
+   if (v_0) {
+      _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&v_0);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_0);
+   return FX_CHECK_RETURN();
+}
+
+static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_R16Ast__ast_callb_t* callb_0,
+   struct _fx_N10Ast__typ_t_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_LR9Ast__id_t skolems_0 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_0 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* cv_0 =
+      (_fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
+   _fx_LT2R9Ast__id_tN10Ast__typ_t* subst_0 = &cv_0->t1->data;
+   int tag_0 = FX_REC_VARIANT_TAG(t_0);
+   if (tag_0 == 24) {
+      _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
+      if (vcase_0->t0 == 0) {
+         _fx_R9Ast__id_t* n_0 = &vcase_0->t1;
+         bool __fold_result___0 = false;
+         FX_COPY_PTR(cv_0->t0, &skolems_0);
+         _fx_LR9Ast__id_t lst_0 = skolems_0;
+         for (; lst_0; lst_0 = lst_0->tl) {
+            _fx_R9Ast__id_t* b_0 = &lst_0->hd;
+            bool __fold_result___1 = true;
+            bool t_1;
+            if (n_0->m == b_0->m) {
+               t_1 = __fold_result___1;
+            }
+            else {
+               t_1 = false;
+            }
+            __fold_result___1 = t_1;
+            bool t_2;
+            if (n_0->i == b_0->i) {
+               t_2 = __fold_result___1;
+            }
+            else {
+               t_2 = false;
+            }
+            __fold_result___1 = t_2;
+            bool t_3;
+            if (n_0->j == b_0->j) {
+               t_3 = __fold_result___1;
+            }
+            else {
+               t_3 = false;
+            }
+            __fold_result___1 = t_3;
+            if (__fold_result___1) {
+               __fold_result___0 = true; FX_BREAK(_fx_catch_0);
+            }
+
+         _fx_catch_0: ;
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         if (__fold_result___0) {
+            _fx_Nt6option1N10Ast__typ_t v_1 = 0;
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(*subst_0, n_0,
+                  &v_1, 0), _fx_catch_2);
+            if ((v_1 != 0) + 1 == 2) {
+               FX_COPY_PTR(v_1->u.Some, fx_result);
+            }
+            else {
+               _fx_N10Ast__typ_t v_2 = 0;
+               _fx_T2R9Ast__id_tN10Ast__typ_t v_3 = {0};
+               _fx_LT2R9Ast__id_tN10Ast__typ_t v_4 = 0;
+               FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_2, 0), _fx_catch_1);
+               _fx_make_T2R9Ast__id_tN10Ast__typ_t(n_0, v_2, &v_3);
+               FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__typ_t(&v_3, *subst_0, true, &v_4), _fx_catch_1);
+               _fx_free_LT2R9Ast__id_tN10Ast__typ_t(subst_0);
+               FX_COPY_PTR(v_4, subst_0);
+               FX_COPY_PTR(v_2, fx_result);
+
+            _fx_catch_1: ;
+               if (v_4) {
+                  _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&v_4);
+               }
+               _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_3);
+               if (v_2) {
+                  _fx_free_N10Ast__typ_t(&v_2);
+               }
+            }
+            FX_CHECK_EXN(_fx_catch_2);
+
+         _fx_catch_2: ;
+            if (v_1) {
+               _fx_free_Nt6option1N10Ast__typ_t(&v_1);
+            }
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_0);
+      if ((v_0 != 0) + 1 == 2) {
+         _fx_N10Ast__typ_t v_5 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_6 = 0;
+         _fx_rNt6option1N10Ast__typ_t v_7 = 0;
+         FX_CALL(
+            _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_0->u.Some, callb_0, &v_5, fx_fv),
+            _fx_catch_3);
+         FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_5, &v_6), _fx_catch_3);
+         FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_6, &v_7), _fx_catch_3);
+         FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_7, fx_result), _fx_catch_3);
+
+      _fx_catch_3: ;
+         if (v_7) {
+            _fx_free_rNt6option1N10Ast__typ_t(&v_7);
+         }
+         if (v_6) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_6);
+         }
+         if (v_5) {
+            _fx_free_N10Ast__typ_t(&v_5);
+         }
+         goto _fx_endmatch_0;
+      }
+   }
+   if (tag_0 == 1) {
+      _fx_rNt6option1N10Ast__typ_t v_8 = 0;
+      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None12_, &v_8), _fx_catch_4);
+      FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_8, fx_result), _fx_catch_4);
+
+   _fx_catch_4: ;
+      if (v_8) {
+         _fx_free_rNt6option1N10Ast__typ_t(&v_8);
+      }
+      goto _fx_endmatch_0;
+   }
+   if (tag_0 == 20) {
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_9 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = {0};
+      _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_11 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_12 = &t_0->u.TypRecord->data;
+      FX_COPY_PTR(v_12->t0, &relems_0);
+      bool ordered_0 = v_12->t1;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lstend_0 = 0;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_1 = relems_0;
+      for (; lst_1; lst_1 = lst_1->tl) {
+         _fx_R16Ast__val_flags_t fl_0 = {0};
+         _fx_N10Ast__typ_t t_4 = 0;
+         _fx_N10Ast__exp_t v_13 = 0;
+         _fx_N10Ast__typ_t v_14 = 0;
+         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t tup_0 = {0};
+         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_1->hd;
+         _fx_copy_R16Ast__val_flags_t(&__pat___0->t0, &fl_0);
+         _fx_R9Ast__id_t n_1 = __pat___0->t1;
+         FX_COPY_PTR(__pat___0->t2, &t_4);
+         FX_COPY_PTR(__pat___0->t3, &v_13);
+         FX_CALL(_fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_4, callb_0, &v_14, fx_fv),
+            _fx_catch_5);
+         _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&fl_0, &n_1, v_14, v_13, &tup_0);
+         _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t node_0 = 0;
+         FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0, 0, false, &node_0), _fx_catch_5);
+         FX_LIST_APPEND(v_9, lstend_0, node_0);
+
+      _fx_catch_5: ;
+         _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0);
+         if (v_14) {
+            _fx_free_N10Ast__typ_t(&v_14);
+         }
+         if (v_13) {
+            _fx_free_N10Ast__exp_t(&v_13);
+         }
+         if (t_4) {
+            _fx_free_N10Ast__typ_t(&t_4);
+         }
+         _fx_free_R16Ast__val_flags_t(&fl_0);
+         FX_CHECK_EXN(_fx_catch_6);
+      }
+      _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_9, ordered_0, &v_10);
+      FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10, &v_11), _fx_catch_6);
+      FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_11, fx_result),
+         _fx_catch_6);
+
+   _fx_catch_6: ;
+      if (v_11) {
+         _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11);
+      }
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+      if (v_9) {
+         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_9);
+      }
+      if (relems_0) {
+         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
+      }
+      goto _fx_endmatch_0;
+   }
+   FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0, callb_0, fx_result, 0), _fx_catch_7);
+
+_fx_catch_7: ;
+
+_fx_endmatch_0: ;
+
+_fx_cleanup: ;
+   FX_FREE_LIST_SIMPLE(&skolems_0);
+   if (v_0) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_0);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t2LR9Ast__id_trLT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_LR9Ast__id_t_data_t* arg0,
+   struct _fx_rLT2R9Ast__id_tN10Ast__typ_t_data_t* arg1,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t* fx_result)
+{
+   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t,
+      _fx_free_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t,
+      _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t);
+   FX_COPY_PTR(arg0, &fcv->t0);
+   FX_COPY_PTR(arg1, &fcv->t1);
+   return 0;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* df_0,
+   struct _fx_T2N10Ast__typ_tLR9Ast__id_t* fx_result,
+   void* fx_fv)
+{
+   _fx_LN12Ast__scope_t df_scope_0 = 0;
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env_0 = {0};
+   _fx_LR9Ast__id_t df_templ_args_0 = 0;
+   _fx_N10Ast__typ_t df_typ_0 = 0;
+   _fx_T2N10Ast__typ_tLR9Ast__id_t v_0 = {0};
+   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_1 = {0};
+   _fx_N10Ast__typ_t ftyp_0 = 0;
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
+   _fx_N10Ast__typ_t ftyp_1 = 0;
+   _fx_LR9Ast__id_t skolems_0 = 0;
+   _fx_N10Ast__typ_t v_2 = 0;
+   _fx_N10Ast__typ_t cmp_typ_0 = 0;
+   int fx_status = 0;
+   _fx_R13Ast__deffun_t* v_3 = &df_0->data;
+   _fx_R16Ast__fun_flags_t df_flags_0 = v_3->df_flags;
+   _fx_R10Ast__loc_t df_loc_0 = v_3->df_loc;
+   FX_COPY_PTR(v_3->df_scope, &df_scope_0);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3->df_env, &df_env_0);
+   FX_COPY_PTR(v_3->df_templ_args, &df_templ_args_0);
+   FX_COPY_PTR(v_3->df_typ, &df_typ_0);
+   if (df_templ_args_0 == 0) {
+      _fx_make_T2N10Ast__typ_tLR9Ast__id_t(df_typ_0, 0, &v_0);
+   }
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+            df_templ_args_0, df_typ_0, &df_env_0, df_scope_0, &df_loc_0, &v_1, 0), _fx_cleanup);
+      FX_COPY_PTR(v_1.t0, &ftyp_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1.t1, &env1_0);
+      _fx_LR9Ast__id_t lst_0 = df_templ_args_0;
+      for (; lst_0; lst_0 = lst_0->tl) {
+         _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t v_4 = 0;
+         _fx_FPi2R9Ast__id_tR9Ast__id_t v_5 = {0};
+         _fx_Nt6option1LN16Ast__env_entry_t result_0 = {0};
+         _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t t_0 = 0;
+         _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_0 = {0};
+         _fx_Nt6option1LN16Ast__env_entry_t v_6 = {0};
+         _fx_LN16Ast__env_entry_t v_7 = 0;
+         _fx_R9Ast__id_t* nt_0 = &lst_0->hd;
+         FX_COPY_PTR(env1_0.root, &v_4);
+         FX_COPY_FP(&env1_0.cmp, &v_5);
+         FX_COPY_PTR(v_4, &t_0);
+         _fx_R9Ast__id_t xk_0 = *nt_0;
+         FX_COPY_FP(&v_5, &cmp_0);
+         for (;;) {
+            _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t t_1 = 0;
+            _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_1 = {0};
+            FX_COPY_PTR(t_0, &t_1);
+            _fx_R9Ast__id_t xk_1 = xk_0;
+            FX_COPY_FP(&cmp_0, &cmp_1);
+            if ((t_1 != 0) + 1 == 2) {
+               _fx_Nt6option1LN16Ast__env_entry_t result_1 = {0};
+               _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tR9Ast__id_tLN16Ast__env_entry_tNt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t*
+                  vcase_0 = &t_1->u.Node;
+               int_ c_0;
+               FX_CALL(cmp_1.fp(&xk_1, &vcase_0->t2, &c_0, cmp_1.fcv), _fx_catch_0);
+               if (c_0 < 0) {
+                  _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t* l_0 = &vcase_0->t1;
+                  _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_0);
+                  FX_COPY_PTR(*l_0, &t_0);
+                  xk_0 = xk_1;
+                  FX_FREE_FP(&cmp_0);
+                  FX_COPY_FP(&cmp_1, &cmp_0);
+               }
+               else if (c_0 > 0) {
+                  _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t* r_0 = &vcase_0->t4;
+                  _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_0);
+                  FX_COPY_PTR(*r_0, &t_0);
+                  xk_0 = xk_1;
+                  FX_FREE_FP(&cmp_0);
+                  FX_COPY_FP(&cmp_1, &cmp_0);
+               }
+               else {
+                  _fx_M13Ast_typecheckFM4SomeNt6option1LN16Ast__env_entry_t1LN16Ast__env_entry_t(vcase_0->t3, &result_1);
+                  _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
+                  _fx_copy_Nt6option1LN16Ast__env_entry_t(&result_1, &result_0);
+                  FX_BREAK(_fx_catch_0);
+               }
+
+            _fx_catch_0: ;
+               _fx_free_Nt6option1LN16Ast__env_entry_t(&result_1);
+            }
+            else {
+               _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
+               _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
+               FX_BREAK(_fx_catch_1);
+
+            _fx_catch_1: ;
+            }
+            FX_CHECK_EXN(_fx_catch_2);
+
+         _fx_catch_2: ;
+            FX_FREE_FP(&cmp_1);
+            if (t_1) {
+               _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_1);
+            }
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_4);
+         }
+         _fx_copy_Nt6option1LN16Ast__env_entry_t(&result_0, &v_6);
+         if (v_6.tag == 2) {
+            FX_COPY_PTR(v_6.u.Some, &v_7);
+         }
+         FX_CHECK_EXN(_fx_catch_4);
+         if (v_7 != 0) {
+            _fx_N16Ast__env_entry_t v_8 = v_7->hd;
+            if (FX_REC_VARIANT_TAG(v_8) == 2) {
+               _fx_N10Ast__typ_t v_9 = v_8->u.EnvTyp;
+               if (FX_REC_VARIANT_TAG(v_9) == 1) {
+                  _fx_N10Ast__typ_t v_10 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_11 = 0;
+                  FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, nt_0, &v_10), _fx_catch_3);
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_10, &v_11), _fx_catch_3);
+                  _fx_Nt6option1N10Ast__typ_t* v_12 = &v_9->u.TypVar->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_12);
+                  FX_COPY_PTR(v_11, v_12);
+
+               _fx_catch_3: ;
+                  if (v_11) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_11);
+                  }
+                  if (v_10) {
+                     _fx_free_N10Ast__typ_t(&v_10);
+                  }
+                  goto _fx_endmatch_0;
+               }
+            }
+         }
+
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_catch_4);
+
+      _fx_catch_4: ;
+         if (v_7) {
+            _fx_free_LN16Ast__env_entry_t(&v_7);
+         }
+         _fx_free_Nt6option1LN16Ast__env_entry_t(&v_6);
+         FX_FREE_FP(&cmp_0);
+         if (t_0) {
+            _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_0);
+         }
+         _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
+         FX_FREE_FP(&v_5);
+         if (v_4) {
+            _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&v_4);
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      _fx_make_T2N10Ast__typ_tLR9Ast__id_t(ftyp_0, df_templ_args_0, &v_0);
+   }
+   FX_COPY_PTR(v_0.t0, &ftyp_1);
+   FX_COPY_PTR(v_0.t1, &skolems_0);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(ftyp_1, &v_2, 0), _fx_cleanup);
+   bool res_0;
+   FX_CALL(_fx_M3AstFM14is_constructorB1RM11fun_flags_t(&df_flags_0, &res_0, 0), _fx_cleanup);
+   if (res_0 == false) {
+      if (FX_REC_VARIANT_TAG(v_2) == 14) {
+         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_2->u.TypFun.t0, &cmp_typ_0), _fx_catch_5);
+
+      _fx_catch_5: ;
+         goto _fx_endmatch_1;
+      }
+   }
+   FX_COPY_PTR(v_2, &cmp_typ_0);
+
+_fx_endmatch_1: ;
+   FX_CHECK_EXN(_fx_cleanup);
+   _fx_make_T2N10Ast__typ_tLR9Ast__id_t(cmp_typ_0, skolems_0, fx_result);
+
+_fx_cleanup: ;
+   FX_FREE_LIST_SIMPLE(&df_scope_0);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&df_env_0);
+   FX_FREE_LIST_SIMPLE(&df_templ_args_0);
+   if (df_typ_0) {
+      _fx_free_N10Ast__typ_t(&df_typ_0);
+   }
+   _fx_free_T2N10Ast__typ_tLR9Ast__id_t(&v_0);
+   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1);
+   if (ftyp_0) {
+      _fx_free_N10Ast__typ_t(&ftyp_0);
+   }
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
+   if (ftyp_1) {
+      _fx_free_N10Ast__typ_t(&ftyp_1);
+   }
+   FX_FREE_LIST_SIMPLE(&skolems_0);
+   if (v_2) {
+      _fx_free_N10Ast__typ_t(&v_2);
+   }
+   if (cmp_typ_0) {
+      _fx_free_N10Ast__typ_t(&cmp_typ_0);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__gen_cmp_t2rR13Ast__deffun_trR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* df1_0,
+   struct _fx_rR13Ast__deffun_t_data_t* df2_0,
+   struct _fx_N24Ast_typecheck__gen_cmp_t* fx_result,
+   void* fx_fv)
+{
+   _fx_T2N10Ast__typ_tLR9Ast__id_t v_0 = {0};
+   _fx_N10Ast__typ_t t1_0 = 0;
+   _fx_LR9Ast__id_t sk1_0 = 0;
+   _fx_T2N10Ast__typ_tLR9Ast__id_t v_1 = {0};
+   _fx_N10Ast__typ_t t2_0 = 0;
+   _fx_LR9Ast__id_t sk2_0 = 0;
+   _fx_N10Ast__typ_t free1_0 = 0;
+   _fx_N10Ast__typ_t free2_0 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df1_0, &v_0, 0), _fx_cleanup);
+   FX_COPY_PTR(v_0.t0, &t1_0);
+   FX_COPY_PTR(v_0.t1, &sk1_0);
+   FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df2_0, &v_1, 0), _fx_cleanup);
+   FX_COPY_PTR(v_1.t0, &t2_0);
+   FX_COPY_PTR(v_1.t1, &sk2_0);
+   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t1_0, sk1_0, &free1_0, 0),
+      _fx_cleanup);
+   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t2_0, sk2_0, &free2_0, 0),
+      _fx_cleanup);
+   bool covers1_2_0;
+   FX_CALL(
+      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free1_0, t2_0, &_fx_g10Ast__noloc, false,
+         &covers1_2_0, 0), _fx_cleanup);
+   bool covers2_1_0;
+   FX_CALL(
+      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free2_0, t1_0, &_fx_g10Ast__noloc, false,
+         &covers2_1_0, 0), _fx_cleanup);
+   if (covers2_1_0 == true) {
+      if (covers1_2_0 == true) {
+         *fx_result = _fx_g24Ast_typecheck__EqGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == false) {
+      if (covers1_2_0 == true) {
+         *fx_result = _fx_g26Ast_typecheck__MoreGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == true) {
+      if (covers1_2_0 == false) {
+         *fx_result = _fx_g26Ast_typecheck__LessGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == false) {
+      if (covers1_2_0 == false) {
+         *fx_result = _fx_g28Ast_typecheck__IncompGeneric; goto _fx_endmatch_0;
+      }
+   }
+   FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+
+_fx_endmatch_0: ;
+
+_fx_cleanup: ;
+   _fx_free_T2N10Ast__typ_tLR9Ast__id_t(&v_0);
+   if (t1_0) {
+      _fx_free_N10Ast__typ_t(&t1_0);
+   }
+   FX_FREE_LIST_SIMPLE(&sk1_0);
+   _fx_free_T2N10Ast__typ_tLR9Ast__id_t(&v_1);
+   if (t2_0) {
+      _fx_free_N10Ast__typ_t(&t2_0);
+   }
+   FX_FREE_LIST_SIMPLE(&sk2_0);
+   if (free1_0) {
+      _fx_free_N10Ast__typ_t(&free1_0);
+   }
+   if (free2_0) {
+      _fx_free_N10Ast__typ_t(&free2_0);
+   }
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(
    struct _fx_N10Ast__typ_t_data_t* t1_0,
    struct _fx_N10Ast__typ_t_data_t* t2_0,
@@ -12435,7 +13131,7 @@ _fx_catch_0: ;
          _fx_free_Nt6option1N10Ast__typ_t(fx_result);
       }
       if (exn_0.tag == _FX_EXN_E17Ast__CompileError) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
       }
       else {
          FX_RETHROW(&exn_0, _fx_cleanup);
@@ -13023,7 +13719,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tR
       }
       else {
          _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
-         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None4_, &result_0);
+         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
          FX_BREAK(_fx_catch_1);
 
       _fx_catch_1: ;
@@ -13474,7 +14170,7 @@ static int
       }
       else {
          _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
-         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None4_, &result_0);
+         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
          FX_BREAK(_fx_catch_1);
 
       _fx_catch_1: ;
@@ -14310,12 +15006,12 @@ FX_EXTERN_C int
                         _fx_free_N10Ast__lit_t(&v_12);
                      }
                      else {
-                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None3_, &v_opt_0);
+                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
                      }
                      FX_CHECK_EXN(_fx_catch_0);
                   }
                   else {
-                     _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None3_, &v_opt_0);
+                     _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
                   }
 
                _fx_catch_0: ;
@@ -14355,14 +15051,14 @@ FX_EXTERN_C int
                            _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__lit_t1N10Ast__lit_t(&v_13, &v_opt_0);
                         }
                         else {
-                           _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None3_, &v_opt_0);
+                           _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
                         }
 
                      _fx_catch_1: ;
                         _fx_free_N10Ast__lit_t(&v_13);
                      }
                      else {
-                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None3_, &v_opt_0);
+                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
                      }
                      FX_CHECK_EXN(_fx_catch_2);
 
@@ -14370,7 +15066,7 @@ FX_EXTERN_C int
                      goto _fx_endmatch_1;
                   }
                }
-               _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None3_, &v_opt_0);
+               _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
 
             _fx_endmatch_1: ;
                FX_CHECK_EXN(_fx_catch_5);
@@ -14523,7 +15219,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             _fx_free_R17Ast__defvariant_t(&v_1);
          }
          FX_CHECK_EXN(_fx_catch_3);
-         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g21Ast_typecheck__None9_;
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
          _fx_LR9Ast__id_t lst_0 = inst_list_0;
          for (; lst_0; lst_0 = lst_0->tl) {
             _fx_N14Ast__id_info_t v_2 = {0};
@@ -14568,7 +15264,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
          }
          FX_CHECK_EXN(_fx_catch_3);
       }
@@ -14754,7 +15450,7 @@ FX_EXTERN_C int
 
       _fx_endmatch_1: ;
          FX_CHECK_EXN(_fx_catch_6);
-         _fx_copy_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___0);
+         _fx_copy_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(&_fx_g21Ast_typecheck__None3_, &__fold_result___0);
          FX_COPY_PTR(dvar_cases_1, &dvar_cases_0);
          _fx_LT2R9Ast__id_tN10Ast__typ_t lst_0 = dvar_cases_0;
          FX_COPY_PTR(v_17.dvar_ctors, &dvar_ctors_0);
@@ -14933,7 +15629,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &is_real_typ__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None8_, _fx_g21Ast_typecheck__None7_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
    if (tag_0 == 24) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
@@ -15209,7 +15905,7 @@ FX_EXTERN_C int
          }
          else {
             _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_0);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
             FX_BREAK(_fx_catch_2);
 
          _fx_catch_2: ;
@@ -15286,7 +15982,7 @@ static int
       int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
       if (dot_pos_2 < 0) {
          _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_0);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
          FX_BREAK(_fx_catch_3);
       }
       else {
@@ -15332,7 +16028,7 @@ static int
                }
                else {
                   _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
@@ -15441,7 +16137,7 @@ FX_EXTERN_C int
          }
          else {
             _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-            _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, &result_0);
+            _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
             FX_BREAK(_fx_catch_2);
 
          _fx_catch_2: ;
@@ -15516,7 +16212,7 @@ static int
       int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
       if (dot_pos_2 < 0) {
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, &result_0);
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
          FX_BREAK(_fx_catch_3);
       }
       else {
@@ -15560,7 +16256,7 @@ static int
                }
                else {
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, &result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
@@ -15602,6 +16298,479 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(
+   struct _fx_rR13Ast__deffun_t_data_t* df_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   bool* fx_result,
+   void* fx_fv)
+{
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env_0 = {0};
+   _fx_N10Ast__typ_t df_typ_0 = 0;
+   _fx_LR9Ast__id_t df_templ_args_0 = 0;
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_N10Ast__typ_t t_1 = 0;
+   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_1 = {0};
+   _fx_N10Ast__typ_t ftyp_0 = 0;
+   int fx_status = 0;
+   _fx_R13Ast__deffun_t* v_2 = &df_0->data;
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_2->df_env, &df_env_0);
+   _fx_R16Ast__fun_flags_t df_flags_0 = v_2->df_flags;
+   FX_COPY_PTR(v_2->df_typ, &df_typ_0);
+   FX_COPY_PTR(v_2->df_templ_args, &df_templ_args_0);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+   if (df_flags_0.fun_flag_have_keywords == true) {
+      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+         _fx_LN10Ast__typ_t argtyps_0 = 0;
+         _fx_N10Ast__typ_t result_0 = 0;
+         _fx_LN10Ast__typ_t __pat___0 = 0;
+         _fx_N10Ast__typ_t v_3 = 0;
+         _fx_N10Ast__typ_t v_4 = 0;
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_5 = {0};
+         _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_0->u.TypFun;
+         _fx_LN10Ast__typ_t argtyps_1 = vcase_0->t0;
+         if (argtyps_1 != 0) {
+            FX_COPY_PTR(argtyps_1, &__pat___0);
+            for (;;) {
+               _fx_LN10Ast__typ_t __pat___1 = 0;
+               FX_COPY_PTR(__pat___0, &__pat___1);
+               if (__pat___1 != 0) {
+                  if (__pat___1->tl == 0) {
+                     _fx_N10Ast__typ_t result_1 = 0;
+                     FX_COPY_PTR(__pat___1->hd, &result_1);
+                     _fx_free_N10Ast__typ_t(&result_0);
+                     FX_COPY_PTR(result_1, &result_0);
+                     FX_BREAK(_fx_catch_0);
+
+                  _fx_catch_0: ;
+                     if (result_1) {
+                        _fx_free_N10Ast__typ_t(&result_1);
+                     }
+                     goto _fx_endmatch_0;
+                  }
+               }
+               if (__pat___1 != 0) {
+                  _fx_LN10Ast__typ_t* rest_0 = &__pat___1->tl;
+                  _fx_free_LN10Ast__typ_t(&__pat___0);
+                  FX_COPY_PTR(*rest_0, &__pat___0);
+                  goto _fx_endmatch_0;
+               }
+               FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_1);
+
+            _fx_endmatch_0: ;
+               FX_CHECK_EXN(_fx_catch_1);
+
+            _fx_catch_1: ;
+               if (__pat___1) {
+                  _fx_free_LN10Ast__typ_t(&__pat___1);
+               }
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_5);
+            }
+            FX_COPY_PTR(result_0, &v_3);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_3, &v_4, 0), _fx_catch_5);
+            bool res_0;
+            if (FX_REC_VARIANT_TAG(v_4) == 20) {
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_4->u.TypRecord->data, &v_5);
+               if (v_5.t1 == false) {
+                  res_0 = true; goto _fx_endmatch_1;
+               }
+            }
+            res_0 = false;
+
+         _fx_endmatch_1: ;
+            FX_CHECK_EXN(_fx_catch_5);
+            if (res_0) {
+               FX_COPY_PTR(argtyps_1, &argtyps_0); goto _fx_endmatch_2;
+            }
+         }
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_6 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_7 = 0;
+         _fx_N10Ast__typ_t v_8 = 0;
+         _fx_LN10Ast__typ_t v_9 = 0;
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_6);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_6, &v_7), _fx_catch_4);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_7, &v_8),
+            _fx_catch_4);
+         FX_CALL(_fx_cons_LN10Ast__typ_t(v_8, 0, true, &v_9), _fx_catch_4);
+         if (argtyps_1 == 0) {
+            FX_COPY_PTR(v_9, &argtyps_0);
+         }
+         else if (v_9 == 0) {
+            FX_COPY_PTR(argtyps_1, &argtyps_0);
+         }
+         else {
+            _fx_LN10Ast__typ_t v_10 = 0;
+            _fx_LN10Ast__typ_t argtyps_2 = 0;
+            _fx_LN10Ast__typ_t lstend_0 = 0;
+            FX_COPY_PTR(argtyps_1, &argtyps_2);
+            _fx_LN10Ast__typ_t lst_0 = argtyps_2;
+            for (; lst_0; lst_0 = lst_0->tl) {
+               _fx_N10Ast__typ_t x_0 = lst_0->hd;
+               _fx_LN10Ast__typ_t node_0 = 0;
+               FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_2);
+               FX_LIST_APPEND(v_10, lstend_0, node_0);
+
+            _fx_catch_2: ;
+               FX_CHECK_EXN(_fx_catch_3);
+            }
+            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_10, v_9, &argtyps_0, 0);
+
+         _fx_catch_3: ;
+            if (argtyps_2) {
+               _fx_free_LN10Ast__typ_t(&argtyps_2);
+            }
+            if (v_10) {
+               _fx_free_LN10Ast__typ_t(&v_10);
+            }
+         }
+         FX_CHECK_EXN(_fx_catch_4);
+
+      _fx_catch_4: ;
+         if (v_9) {
+            _fx_free_LN10Ast__typ_t(&v_9);
+         }
+         if (v_8) {
+            _fx_free_N10Ast__typ_t(&v_8);
+         }
+         if (v_7) {
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_7);
+         }
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_6);
+
+      _fx_endmatch_2: ;
+         FX_CHECK_EXN(_fx_catch_5);
+         FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(argtyps_0, vcase_0->t1, &t_1), _fx_catch_5);
+
+      _fx_catch_5: ;
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_5);
+         if (v_4) {
+            _fx_free_N10Ast__typ_t(&v_4);
+         }
+         if (v_3) {
+            _fx_free_N10Ast__typ_t(&v_3);
+         }
+         if (__pat___0) {
+            _fx_free_LN10Ast__typ_t(&__pat___0);
+         }
+         if (result_0) {
+            _fx_free_N10Ast__typ_t(&result_0);
+         }
+         if (argtyps_0) {
+            _fx_free_LN10Ast__typ_t(&argtyps_0);
+         }
+         goto _fx_endmatch_3;
+      }
+   }
+   FX_COPY_PTR(t_0, &t_1);
+
+_fx_endmatch_3: ;
+   FX_CHECK_EXN(_fx_cleanup);
+   if (df_templ_args_0 == 0) {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(df_typ_0, t_1, loc_0, false, fx_result,
+            0), _fx_cleanup);
+   }
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+            df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_1, 0), _fx_cleanup);
+      FX_COPY_PTR(v_1.t0, &ftyp_0);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, false, fx_result, 0),
+         _fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&df_env_0);
+   if (df_typ_0) {
+      _fx_free_N10Ast__typ_t(&df_typ_0);
+   }
+   FX_FREE_LIST_SIMPLE(&df_templ_args_0);
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (t_1) {
+      _fx_free_N10Ast__typ_t(&t_1);
+   }
+   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1);
+   if (ftyp_0) {
+      _fx_free_N10Ast__typ_t(&ftyp_0);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM13trace_resolvev5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   void* fx_fv)
+{
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_LrR13Ast__deffun_t acc_0 = 0;
+   _fx_LN16Ast__env_entry_t v_1 = 0;
+   _fx_LrR13Ast__deffun_t __fold_result___0 = 0;
+   _fx_LrR13Ast__deffun_t viable_0 = 0;
+   _fx_rR13Ast__deffun_t envwin_0 = 0;
+   _fx_Nt6option1rR13Ast__deffun_t __fold_result___1 = {0};
+   _fx_LrR13Ast__deffun_t viable_1 = 0;
+   _fx_Nt6option1rR13Ast__deffun_t genwin_0 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
+   fx_str_t v_4 = {0};
+   fx_str_t v_5 = {0};
+   fx_str_t v_6 = {0};
+   fx_str_t v_7 = {0};
+   fx_str_t v_8 = {0};
+   fx_str_t v_9 = {0};
+   fx_str_t v_10 = {0};
+   int fx_status = 0;
+   bool v_11;
+   if (_fx_g12Options__opt.print_resolve) {
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+         v_11 = true;
+      }
+      else {
+         v_11 = false;
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   else {
+      v_11 = false;
+   }
+   if (v_11) {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(n_0, env_0,
+            &v_1, 0), _fx_cleanup);
+      _fx_LN16Ast__env_entry_t lst_0 = v_1;
+      for (; lst_0; lst_0 = lst_0->tl) {
+         _fx_N16Ast__env_entry_t e_0 = lst_0->hd;
+         if (FX_REC_VARIANT_TAG(e_0) == 1) {
+            _fx_N14Ast__id_info_t v_12 = {0};
+            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&e_0->u.EnvId, loc_0, &v_12, 0), _fx_catch_1);
+            if (v_12.tag == 3) {
+               _fx_N10Ast__typ_t v_13 = 0;
+               _fx_LrR13Ast__deffun_t v_14 = 0;
+               _fx_rR13Ast__deffun_t df_0 = v_12.u.IdFun;
+               FX_CALL(_fx_M3AstFM7dup_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_13, 0), _fx_catch_0);
+               bool v_15;
+               FX_CALL(
+                  _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(df_0,
+                     v_13, sc_0, loc_0, &v_15, 0), _fx_catch_0);
+               if (v_15) {
+                  FX_CALL(_fx_cons_LrR13Ast__deffun_t(df_0, acc_0, true, &v_14), _fx_catch_0);
+                  _fx_free_LrR13Ast__deffun_t(&acc_0);
+                  FX_COPY_PTR(v_14, &acc_0);
+               }
+
+            _fx_catch_0: ;
+               if (v_14) {
+                  _fx_free_LrR13Ast__deffun_t(&v_14);
+               }
+               if (v_13) {
+                  _fx_free_N10Ast__typ_t(&v_13);
+               }
+            }
+            FX_CHECK_EXN(_fx_catch_1);
+
+         _fx_catch_1: ;
+            _fx_free_N14Ast__id_info_t(&v_12);
+         }
+         FX_CHECK_EXN(_fx_catch_2);
+
+      _fx_catch_2: ;
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      _fx_LrR13Ast__deffun_t lst_1 = acc_0;
+      for (; lst_1; lst_1 = lst_1->tl) {
+         _fx_LrR13Ast__deffun_t r_0 = 0;
+         _fx_rR13Ast__deffun_t a_0 = lst_1->hd;
+         FX_COPY_PTR(__fold_result___0, &r_0);
+         FX_CALL(_fx_cons_LrR13Ast__deffun_t(a_0, r_0, false, &r_0), _fx_catch_3);
+         _fx_free_LrR13Ast__deffun_t(&__fold_result___0);
+         FX_COPY_PTR(r_0, &__fold_result___0);
+
+      _fx_catch_3: ;
+         if (r_0) {
+            _fx_free_LrR13Ast__deffun_t(&r_0);
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      FX_COPY_PTR(__fold_result___0, &viable_0);
+      int_ v_16 = _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(viable_0, 0);
+      if (v_16 > 1) {
+         if (viable_0 != 0) {
+            FX_COPY_PTR(viable_0->hd, &envwin_0);
+         }
+         else {
+            FX_FAST_THROW(FX_EXN_NullListError, _fx_cleanup);
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+         _fx_copy_Nt6option1rR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___1);
+         FX_COPY_PTR(viable_0, &viable_1);
+         _fx_LrR13Ast__deffun_t lst_2 = viable_1;
+         for (; lst_2; lst_2 = lst_2->tl) {
+            _fx_Nt6option1rR13Ast__deffun_t v_17 = {0};
+            _fx_rR13Ast__deffun_t c_0 = lst_2->hd;
+            bool __fold_result___2 = true;
+            _fx_LrR13Ast__deffun_t lst_3 = viable_0;
+            for (; lst_3; lst_3 = lst_3->tl) {
+               _fx_rR13Ast__deffun_t d_0 = lst_3->hd;
+               bool v_18;
+               if (_fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(c_0, d_0, 0)) {
+                  v_18 = true;
+               }
+               else {
+                  _fx_N24Ast_typecheck__gen_cmp_t v_19;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__gen_cmp_t2rR13Ast__deffun_trR13Ast__deffun_t(
+                        c_0, d_0, &v_19, 0), _fx_catch_4);
+                  v_18 = v_19.tag == 2;
+               }
+               if (!v_18) {
+                  __fold_result___2 = false; FX_BREAK(_fx_catch_4);
+               }
+
+            _fx_catch_4: ;
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_5);
+            }
+            if (__fold_result___2) {
+               _fx_M13Ast_typecheckFM4SomeNt6option1rR13Ast__deffun_t1rR13Ast__deffun_t(c_0, &v_17);
+               _fx_free_Nt6option1rR13Ast__deffun_t(&__fold_result___1);
+               _fx_copy_Nt6option1rR13Ast__deffun_t(&v_17, &__fold_result___1);
+               FX_BREAK(_fx_catch_5);
+            }
+
+         _fx_catch_5: ;
+            _fx_free_Nt6option1rR13Ast__deffun_t(&v_17);
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         _fx_copy_Nt6option1rR13Ast__deffun_t(&__fold_result___1, &genwin_0);
+         bool agree_0;
+         if (genwin_0.tag == 2) {
+            agree_0 = _fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(genwin_0.u.Some, envwin_0, 0);
+         }
+         else {
+            agree_0 = false;
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_2, 0), _fx_cleanup);
+         FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_3, 0), _fx_cleanup);
+         int_ v_20 = _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(viable_0, 0);
+         FX_CALL(_fx_F6stringS1i(v_20, &v_4, 0), _fx_cleanup);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_5, 0), _fx_cleanup);
+         fx_str_t slit_0 = FX_MAKE_STR("-pr-resolve: \'");
+         fx_str_t slit_1 = FX_MAKE_STR("\' @ ");
+         fx_str_t slit_2 = FX_MAKE_STR(": ");
+         fx_str_t slit_3 = FX_MAKE_STR(" viable for ");
+         fx_str_t slit_4 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_0[] = { slit_0, v_2, slit_1, v_3, slit_2, v_4, slit_3, v_5, slit_4 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_6), _fx_cleanup);
+         }
+         _fx_F12print_stringv1S(&v_6, 0);
+         _fx_LrR13Ast__deffun_t lst_4 = viable_0;
+         for (; lst_4; lst_4 = lst_4->tl) {
+            fx_str_t v_21 = {0};
+            fx_str_t v_22 = {0};
+            _fx_rR13Ast__deffun_t c_1 = lst_4->hd;
+            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(c_1, &v_21, 0), _fx_catch_6);
+            fx_str_t slit_5 = FX_MAKE_STR("    candidate: ");
+            fx_str_t slit_6 = FX_MAKE_STR("\n");
+            {
+               const fx_str_t strs_1[] = { slit_5, v_21, slit_6 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_22), _fx_catch_6);
+            }
+            _fx_F12print_stringv1S(&v_22, 0);
+
+         _fx_catch_6: ;
+            FX_FREE_STR(&v_22);
+            FX_FREE_STR(&v_21);
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_7, 0), _fx_cleanup);
+         fx_str_t slit_7 = FX_MAKE_STR("    env-order  winner: ");
+         fx_str_t slit_8 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_2[] = { slit_7, v_7, slit_8 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_8), _fx_cleanup);
+         }
+         _fx_F12print_stringv1S(&v_8, 0);
+         if (genwin_0.tag == 2) {
+            fx_str_t v_23 = {0};
+            fx_str_t v_24 = {0};
+            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(genwin_0.u.Some, &v_23, 0), _fx_catch_7);
+            fx_str_t slit_9 = FX_MAKE_STR("    generality winner: ");
+            fx_str_t slit_10 = FX_MAKE_STR("\n");
+            {
+               const fx_str_t strs_3[] = { slit_9, v_23, slit_10 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_24), _fx_catch_7);
+            }
+            _fx_F12print_stringv1S(&v_24, 0);
+
+         _fx_catch_7: ;
+            FX_FREE_STR(&v_24);
+            FX_FREE_STR(&v_23);
+         }
+         else {
+            fx_str_t slit_11 = FX_MAKE_STR("    generality winner: <none: tied or unordered>\n");
+            _fx_F12print_stringv1S(&slit_11, 0);
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+         FX_CALL(_fx_F6stringS1B(agree_0, &v_9, 0), _fx_cleanup);
+         fx_str_t slit_12 = FX_MAKE_STR("    winners agree: ");
+         fx_str_t slit_13 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_4[] = { slit_12, v_9, slit_13 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_10), _fx_cleanup);
+         }
+         _fx_F12print_stringv1S(&v_10, 0);
+      }
+   }
+
+_fx_cleanup: ;
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (acc_0) {
+      _fx_free_LrR13Ast__deffun_t(&acc_0);
+   }
+   if (v_1) {
+      _fx_free_LN16Ast__env_entry_t(&v_1);
+   }
+   if (__fold_result___0) {
+      _fx_free_LrR13Ast__deffun_t(&__fold_result___0);
+   }
+   if (viable_0) {
+      _fx_free_LrR13Ast__deffun_t(&viable_0);
+   }
+   if (envwin_0) {
+      _fx_free_rR13Ast__deffun_t(&envwin_0);
+   }
+   _fx_free_Nt6option1rR13Ast__deffun_t(&__fold_result___1);
+   if (viable_1) {
+      _fx_free_LrR13Ast__deffun_t(&viable_1);
+   }
+   _fx_free_Nt6option1rR13Ast__deffun_t(&genwin_0);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
+   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_5);
+   FX_FREE_STR(&v_6);
+   FX_FREE_STR(&v_7);
+   FX_FREE_STR(&v_8);
+   FX_FREE_STR(&v_9);
+   FX_FREE_STR(&v_10);
+   return fx_status;
+}
+
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM13lookup_id_optT2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* n_0,
@@ -15616,6 +16785,9 @@ FX_EXTERN_C int
    _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t __lambda___0 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t nt_opt_0 = {0};
    int fx_status = 0;
+   FX_CALL(
+      _fx_M13Ast_typecheckFM13trace_resolvev5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+         n_0, t_0, env_0, sc_0, loc_0, 0), _fx_cleanup);
    FX_CALL(_fx_make_rLN16Ast__env_entry_t(0, &possible_matches_ref_0), _fx_cleanup);
    _fx_M13Ast_typecheckFM7make_fpFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t6Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
       env_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0, &__lambda___0);
@@ -15648,7 +16820,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 1) {
       if (e_0->u.EnvId.m == 0) {
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result); goto _fx_endmatch_5;
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_5;
       }
    }
    if (tag_0 == 1) {
@@ -15877,7 +17049,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
                _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_10, fx_result);
             }
             else {
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result);
+               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
             }
          }
          else {
@@ -15891,7 +17063,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
                _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, true, &v_24,
                   0), _fx_catch_13);
             if (!v_24) {
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result);
+               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
             }
             else {
                bool res_1;
@@ -15927,7 +17099,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
                   _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_12, fx_result);
                }
                else {
-                  _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g21Ast_typecheck__None9_;
+                  _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
                   FX_COPY_PTR(df_templ_inst_0->data, &v_13);
                   _fx_LR9Ast__id_t lst_1 = v_13;
                   for (; lst_1; lst_1 = lst_1->tl) {
@@ -16144,7 +17316,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
       }
       FX_CHECK_EXN(_fx_catch_18);
       if (res_3) {
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result); goto _fx_endmatch_4;
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_4;
       }
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_18);
 
@@ -16159,7 +17331,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_
       goto _fx_endmatch_5;
    }
    if (tag_0 == 2) {
-      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result); goto _fx_endmatch_5;
+      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_5;
    }
    FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
 
@@ -16343,7 +17515,7 @@ FX_EXTERN_C int
          }
       }
    }
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, fx_result);
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
 
 _fx_endmatch_0: ;
 
@@ -17502,7 +18674,7 @@ FX_EXTERN_C int
             _fx_R9Ast__id_t* n2_2 = &e2_0->u.ExpIdent.t0;
             FX_CALL(
                _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                  &_fx_g21Ast_typecheck__None9_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
+                  &_fx_g22Ast_typecheck__None10_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
             FX_COPY_PTR(v_31.t1, &relems_0);
             _fx_M13Ast_typecheckFM7make_fpFPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(n2_2,
                &__lambda___0);
@@ -17772,7 +18944,7 @@ FX_EXTERN_C int
                FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(new_e2_1, &v_62), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                     v_61, _fx_g22Ast_typecheck__None10_, v_62, &ctx_0, &result_11), _fx_catch_24);
+                     v_61, _fx_g22Ast_typecheck__None11_, v_62, &ctx_0, &result_11), _fx_catch_24);
                _fx_free_N10Ast__exp_t(&result_0);
                FX_COPY_PTR(result_11, &result_0);
                FX_BREAK(_fx_catch_24);
@@ -17980,7 +19152,7 @@ FX_EXTERN_C int
                         }
                         goto _fx_endmatch_2;
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
 
                   _fx_endmatch_2: ;
                      FX_CHECK_EXN(_fx_catch_29);
@@ -18082,7 +19254,7 @@ FX_EXTERN_C int
                            }
                         }
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
 
                   _fx_endmatch_3: ;
                      FX_CHECK_EXN(_fx_catch_32);
@@ -18124,7 +19296,7 @@ FX_EXTERN_C int
                            _fx_catch_33);
                      }
                      else {
-                        FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &result_exp_opt_0);
+                        FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
                      }
 
                   _fx_catch_33: ;
@@ -18147,7 +19319,7 @@ FX_EXTERN_C int
                      }
                   }
                   else {
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
                   }
                   FX_CHECK_EXN(_fx_catch_34);
 
@@ -18157,7 +19329,7 @@ FX_EXTERN_C int
                   }
                   goto _fx_endmatch_4;
                }
-               FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &result_exp_opt_0);
+               FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
 
             _fx_endmatch_4: ;
                FX_CHECK_EXN(_fx_catch_37);
@@ -18361,7 +19533,7 @@ FX_EXTERN_C int
                         &f_id_1, v_96, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &probably_result_0, 0), _fx_catch_41);
                }
                else {
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &probably_result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &probably_result_0);
                }
                bool v_101;
                FX_CALL(
@@ -18393,7 +19565,7 @@ FX_EXTERN_C int
                   _fx_N10Ast__exp_t v_105 = 0;
                   _fx_N10Ast__exp_t binres_0 = 0;
                   _fx_N10Ast__exp_t v_106 = 0;
-                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None11_, &v_102), _fx_catch_40);
+                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None12_, &v_102), _fx_catch_40);
                   FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_102, &v_103), _fx_catch_40);
                   _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_103, &eloc_0, &v_104);
                   FX_CALL(
@@ -18676,7 +19848,7 @@ FX_EXTERN_C int
                   goto _fx_endmatch_8;
                }
             }
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &typ_opt_3);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &typ_opt_3);
 
          _fx_endmatch_8: ;
             FX_CHECK_EXN(_fx_catch_50);
@@ -18742,10 +19914,10 @@ FX_EXTERN_C int
                _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, v_120, &v_112);
             }
             else if (FX_REC_VARIANT_TAG(etyp1_6) == 10) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None11_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
             }
             else {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None11_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
             }
 
          _fx_catch_52: ;
@@ -18778,18 +19950,18 @@ FX_EXTERN_C int
                v_124 = false;
             }
             if (v_124) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None11_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
             }
             else {
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_6, &v_122, 0), _fx_catch_53);
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp2_2, &v_123, 0), _fx_catch_53);
                if (FX_REC_VARIANT_TAG(v_122) == 10) {
                   if (FX_REC_VARIANT_TAG(v_123) == 10) {
-                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None11_, &v_112);
+                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
                      goto _fx_endmatch_9;
                   }
                }
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None11_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
 
             _fx_endmatch_9: ;
                FX_CHECK_EXN(_fx_catch_53);
@@ -18813,7 +19985,7 @@ FX_EXTERN_C int
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypBool,
                   &eloc_0, &slit_38, 0), _fx_catch_54);
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None11_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
 
          _fx_catch_54: ;
             goto _fx_endmatch_10;
@@ -18852,7 +20024,7 @@ FX_EXTERN_C int
             goto _fx_endmatch_10;
          }
          if (tag_6 == 5) {
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None11_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
             goto _fx_endmatch_10;
          }
          FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_61);
@@ -22900,7 +24072,7 @@ FX_EXTERN_C int
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, &v_407);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &v_407);
          }
          FX_CHECK_EXN(_fx_catch_160);
          FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_407, &eloc_0, &result_45), _fx_catch_160);
@@ -23751,7 +24923,7 @@ FX_EXTERN_C int
                r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_184);
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g21Ast_typecheck__None9_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_184);
+               &_fx_g22Ast_typecheck__None10_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_184);
          FX_COPY_PTR(v_481.t1, &relems_2);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_14 = 0;
          FX_COPY_PTR(r_initializers_5, &r_initializers_4);
@@ -24804,7 +25976,7 @@ static int
       fx_exn_t exn_0 = {0};
       FX_CALL(
          _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-            &_fx_g21Ast_typecheck__None9_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
+            &_fx_g22Ast_typecheck__None10_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
 
    _fx_catch_0: ;
       if (fx_status < 0) {
@@ -25639,7 +26811,7 @@ static int
          _fx_LN10Ast__exp_t v_33 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g21Ast_typecheck__None9_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
+               &_fx_g22Ast_typecheck__None10_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
          FX_COPY_PTR(v_18.t1, &relems_0);
          FX_COPY_PTR(relems_0, &l_2);
          int_ n_2 = idx_0;
@@ -26403,7 +27575,7 @@ static int
       _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_1);
    }
    else if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
    }
    else {
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
@@ -26516,7 +27688,7 @@ static int _fx_M13Ast_typecheckFM9is_lvalueB4BN10Ast__exp_tT2N10Ast__typ_tR10Ast
                FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(rec_0, &rtyp_0, 0), _fx_catch_6);
                FX_CALL(
                   _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                     &_fx_g21Ast_typecheck__None9_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
+                     &_fx_g22Ast_typecheck__None10_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
                FX_COPY_PTR(v_2.t1, &relems_0);
                _fx_copy_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g21Ast_typecheck__None1_,
                   &__fold_result___0);
@@ -26669,7 +27841,7 @@ static int
    FX_CALL(fx_check_stack(), _fx_cleanup);
    int tag_0 = (e_opt_0 != 0) + 1;
    if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None10_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
    }
    else if (tag_0 == 2) {
       _fx_T2N10Ast__typ_tR10Ast__loc_t v_0 = {0};
@@ -30339,7 +31511,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 1) {
       if (e_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 1) {
@@ -30425,7 +31597,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
          FX_FREE_STR(&v_4);
          goto _fx_endmatch_0;
       }
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
 
    _fx_endmatch_0: ;
       FX_CHECK_EXN(_fx_catch_3);
@@ -30736,7 +31908,7 @@ FX_EXTERN_C int
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &check_typ__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None8_, _fx_g21Ast_typecheck__None7_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
    FX_CALL(check_typ__0.fp(t_0, &callb_0, &v_1, check_typ__0.fcv), _fx_cleanup);
    _fx_make_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_1, &r_env_ref_0->data, fx_result);
 
@@ -31141,7 +32313,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
    }
    if (tag_0 == 1) {
       if (entry_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result); goto _fx_endmatch_2;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_2;
       }
    }
    if (tag_0 == 1) {
@@ -31170,7 +32342,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
       }
       FX_CHECK_EXN(_fx_catch_10);
       if (res_0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_1;
       }
       if (tag_1 == 7) {
          _fx_R19Ast__definterface_t v_4 = {0};
@@ -31382,7 +32554,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
          else if (cv_0->t6) {
             FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(ty_args_0, &dvar_name_0, &t1_0), _fx_catch_9);
             FX_COPY_PTR(dvar_templ_inst_0->data, &v_25);
-            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g21Ast_typecheck__None9_;
+            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g22Ast_typecheck__None10_;
             _fx_LR9Ast__id_t lst_2 = v_25;
             for (; lst_2; lst_2 = lst_2->tl) {
                _fx_N14Ast__id_info_t v_27 = {0};
@@ -31525,7 +32697,7 @@ FX_EXTERN_C int
    int fx_status = 0;
    FX_CALL(
       _fx_M13Ast_typecheckFM30check_typ_and_collect_typ_varsT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tNt6option1rRt6Set__t1R9Ast__id_tLN12Ast__scope_tR10Ast__loc_tB(
-         t_0, env_0, &_fx_g21Ast_typecheck__None5_, sc_0, loc_0, false, &v_0, 0), _fx_cleanup);
+         t_0, env_0, &_fx_g21Ast_typecheck__None6_, sc_0, loc_0, false, &v_0, 0), _fx_cleanup);
    FX_COPY_PTR(v_0.t0, fx_result);
 
 _fx_cleanup: ;
@@ -34430,7 +35602,7 @@ static int
                   _fx_T2LT2R9Ast__id_tN10Ast__typ_tLR9Ast__id_t v_17 = {0};
                   _fx_LT2R9Ast__id_tN10Ast__typ_t v_18 = 0;
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___1 = {0};
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None6_, &__fold_result___0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &__fold_result___0);
                   FX_CALL(
                      _fx_M13Ast_typecheckFM17get_variant_casesT2LT2R9Ast__id_tN10Ast__typ_tLR9Ast__id_t2N10Ast__typ_tR10Ast__loc_t(
                         t_0, loc_3, &v_17, 0), _fx_catch_9);
@@ -34850,7 +36022,7 @@ static int
          _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(&ctor_0, &v_53);
       }
       else {
-         v_53 = _fx_g21Ast_typecheck__None9_;
+         v_53 = _fx_g22Ast_typecheck__None10_;
       }
       FX_CALL(
          _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&v_53, new_relems_0, loc_4, &v_42),
@@ -34888,7 +36060,7 @@ static int
                      0), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(
-                     &_fx_g21Ast_typecheck__None9_, relems_0, loc_4, &v_54), _fx_catch_24);
+                     &_fx_g22Ast_typecheck__None10_, relems_0, loc_4, &v_54), _fx_catch_24);
                FX_CALL(_fx_cons_LN10Ast__pat_t(v_54, 0, true, &v_55), _fx_catch_24);
                FX_CALL(_fx_M3AstFM10PatVariantN10Ast__pat_t3RM4id_tLN10Ast__pat_tRM5loc_t(&v_57, v_55, loc_4, &v_56),
                   _fx_catch_24);
@@ -35016,7 +36188,7 @@ static int
          _fx_M13Ast_typecheckFM4SomeNt6option1rRt6Set__t1R9Ast__id_t1rRt6Set__t1R9Ast__id_t(r_typ_vars_0, &v_64);
       }
       else {
-         _fx_copy_Nt6option1rRt6Set__t1R9Ast__id_t(&_fx_g21Ast_typecheck__None5_, &v_64);
+         _fx_copy_Nt6option1rRt6Set__t1R9Ast__id_t(&_fx_g21Ast_typecheck__None6_, &v_64);
       }
       FX_CALL(
          _fx_M13Ast_typecheckFM30check_typ_and_collect_typ_varsT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tNt6option1rRt6Set__t1R9Ast__id_tLN12Ast__scope_tR10Ast__loc_tB(

--- a/compiler/bootstrap/C_pp.c
+++ b/compiler/bootstrap/C_pp.c
@@ -72,6 +72,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -964,6 +965,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -997,6 +999,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1029,6 +1032,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -151,6 +151,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -2332,6 +2333,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -2365,6 +2367,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -2397,6 +2400,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/K_inline.c
+++ b/compiler/bootstrap/K_inline.c
@@ -117,6 +117,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -1259,6 +1260,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -1292,6 +1294,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1324,6 +1327,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -111,6 +111,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -1218,6 +1219,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -1251,6 +1253,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1283,6 +1286,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/Options.c
+++ b/compiler/bootstrap/Options.c
@@ -68,6 +68,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -198,6 +199,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -231,6 +233,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -263,6 +266,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;
@@ -511,7 +515,7 @@ FX_EXTERN_C int _fx_M7OptionsFM15default_optionsRM9options_t0(struct _fx_R18Opti
    fx_str_t slit_5 = FX_MAKE_STR("");
    fx_str_t slit_6 = FX_MAKE_STR("");
    _fx_make_R18Options__options_t(0, &slit_0, true, false, &slit_1, &slit_2, &slit_3, &slit_4, false, &slit_5, true, 0, false,
-      0, 0, 100, true, false, true, true, 1, &slit_6, false, false, false, false, false, false, false, true, fx_result);
+      0, 0, 100, true, false, true, true, 1, &slit_6, false, false, false, false, false, false, false, false, true, fx_result);
    return fx_status;
 }
 
@@ -585,6 +589,10 @@ FX_EXTERN_C int _fx_M7OptionsFM10print_helpv1B(bool detailed_0, void* fx_fv)
             U"    -pr-k           Print optimized K-form of the parsed files\n"
             U"                    (only a part of the generated K-form is retained\n"
             U"                    because of the dead code elimination step)\n"
+            U"    -pr-resolve     Trace overload resolution: for every call whose viable\n"
+            U"                    candidate set has >1 entry, print the candidates, the\n"
+            U"                    env-order winner (current behavior) and the generality\n"
+            U"                    winner (WP-E). Diagnostic only; does not change resolution.\n"
             U"    -no-c           Do not generate C code\n"
             U"    -app            Build application (default mode)\n"
             U"    -run            Build application and run it\n"
@@ -747,62 +755,68 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_8 = FX_MAKE_STR("-no-c");
+         fx_str_t slit_8 = FX_MAKE_STR("-pr-resolve");
          if (fx_streq(&args_1->hd, &slit_8)) {
+            _fx_g12Options__opt.print_resolve = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_9 = FX_MAKE_STR("-no-c");
+         if (fx_streq(&args_1->hd, &slit_9)) {
             _fx_g12Options__opt.gen_c = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_9 = FX_MAKE_STR("-app");
-         if (fx_streq(&args_1->hd, &slit_9)) {
+         fx_str_t slit_10 = FX_MAKE_STR("-app");
+         if (fx_streq(&args_1->hd, &slit_10)) {
             _fx_g12Options__opt.make_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_10 = FX_MAKE_STR("-run");
-         if (fx_streq(&args_1->hd, &slit_10)) {
+         fx_str_t slit_11 = FX_MAKE_STR("-run");
+         if (fx_streq(&args_1->hd, &slit_11)) {
             _fx_g12Options__opt.run_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_11 = FX_MAKE_STR("-O0");
-         if (fx_streq(&args_1->hd, &slit_11)) {
+         fx_str_t slit_12 = FX_MAKE_STR("-O0");
+         if (fx_streq(&args_1->hd, &slit_12)) {
             _fx_g12Options__opt.optimize_level = 0; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_12 = FX_MAKE_STR("-O1");
-         if (fx_streq(&args_1->hd, &slit_12)) {
+         fx_str_t slit_13 = FX_MAKE_STR("-O1");
+         if (fx_streq(&args_1->hd, &slit_13)) {
             _fx_g12Options__opt.optimize_level = 1; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_13 = FX_MAKE_STR("-O3");
-         if (fx_streq(&args_1->hd, &slit_13)) {
+         fx_str_t slit_14 = FX_MAKE_STR("-O3");
+         if (fx_streq(&args_1->hd, &slit_14)) {
             _fx_g12Options__opt.optimize_level = 3; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_14 = FX_MAKE_STR("-Ofast");
-         if (fx_streq(&args_1->hd, &slit_14)) {
+         fx_str_t slit_15 = FX_MAKE_STR("-Ofast");
+         if (fx_streq(&args_1->hd, &slit_15)) {
             _fx_g12Options__opt.optimize_level = 100; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_15 = FX_MAKE_STR("-no-openmp");
-         if (fx_streq(&args_1->hd, &slit_15)) {
+         fx_str_t slit_16 = FX_MAKE_STR("-no-openmp");
+         if (fx_streq(&args_1->hd, &slit_16)) {
             _fx_g12Options__opt.enable_openmp = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_16 = FX_MAKE_STR("-debug");
-         if (fx_streq(&args_1->hd, &slit_16)) {
+         fx_str_t slit_17 = FX_MAKE_STR("-debug");
+         if (fx_streq(&args_1->hd, &slit_17)) {
             _fx_g12Options__opt.debug = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_17 = FX_MAKE_STR("-optim-iters");
-         if (fx_streq(&args_1->hd, &slit_17)) {
+         fx_str_t slit_18 = FX_MAKE_STR("-optim-iters");
+         if (fx_streq(&args_1->hd, &slit_18)) {
             _fx_LS v_32 = args_1->tl;
             if (v_32 != 0) {
                fx_str_t v_33 = {0};
@@ -813,11 +827,11 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                   _fx_g12Options__opt.optim_iters = i_0; FX_COPY_PTR(v_32->tl, &v_31);
                }
                else {
-                  fx_str_t slit_18 = FX_MAKE_STR("[31;1merror:[0m");
-                  FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_18, &v_33, 0), _fx_catch_0);
-                  fx_str_t slit_19 = FX_MAKE_STR(" invalid -optim-iters argument; must be a non-negative integer");
+                  fx_str_t slit_19 = FX_MAKE_STR("[31;1merror:[0m");
+                  FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_19, &v_33, 0), _fx_catch_0);
+                  fx_str_t slit_20 = FX_MAKE_STR(" invalid -optim-iters argument; must be a non-negative integer");
                   {
-                     const fx_str_t strs_0[] = { v_33, slit_19 };
+                     const fx_str_t strs_0[] = { v_33, slit_20 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_0, 2, &v_34), _fx_catch_0);
                   }
                   FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_34, 0), _fx_catch_0);
@@ -832,8 +846,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_20 = FX_MAKE_STR("-inline-threshold");
-         if (fx_streq(&args_1->hd, &slit_20)) {
+         fx_str_t slit_21 = FX_MAKE_STR("-inline-threshold");
+         if (fx_streq(&args_1->hd, &slit_21)) {
             _fx_LS v_35 = args_1->tl;
             if (v_35 != 0) {
                fx_str_t v_36 = {0};
@@ -844,11 +858,11 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                   _fx_g12Options__opt.optim_iters = i_1; FX_COPY_PTR(v_35->tl, &v_31);
                }
                else {
-                  fx_str_t slit_21 = FX_MAKE_STR("[31;1merror:[0m");
-                  FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_21, &v_36, 0), _fx_catch_1);
-                  fx_str_t slit_22 = FX_MAKE_STR(" invalid -inline-threshold argument; must be a non-negative integer");
+                  fx_str_t slit_22 = FX_MAKE_STR("[31;1merror:[0m");
+                  FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_22, &v_36, 0), _fx_catch_1);
+                  fx_str_t slit_23 = FX_MAKE_STR(" invalid -inline-threshold argument; must be a non-negative integer");
                   {
-                     const fx_str_t strs_1[] = { v_36, slit_22 };
+                     const fx_str_t strs_1[] = { v_36, slit_23 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 2, &v_37), _fx_catch_1);
                   }
                   FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_37, 0), _fx_catch_1);
@@ -863,26 +877,26 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_23 = FX_MAKE_STR("-relax");
-         if (fx_streq(&args_1->hd, &slit_23)) {
+         fx_str_t slit_24 = FX_MAKE_STR("-relax");
+         if (fx_streq(&args_1->hd, &slit_24)) {
             _fx_g12Options__opt.relax = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_24 = FX_MAKE_STR("-Wno-unused");
-         if (fx_streq(&args_1->hd, &slit_24)) {
+         fx_str_t slit_25 = FX_MAKE_STR("-Wno-unused");
+         if (fx_streq(&args_1->hd, &slit_25)) {
             _fx_g12Options__opt.W_unused = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_25 = FX_MAKE_STR("-verbose");
-         if (fx_streq(&args_1->hd, &slit_25)) {
+         fx_str_t slit_26 = FX_MAKE_STR("-verbose");
+         if (fx_streq(&args_1->hd, &slit_26)) {
             _fx_g12Options__opt.verbose = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_26 = FX_MAKE_STR("-o");
-         if (fx_streq(&args_1->hd, &slit_26)) {
+         fx_str_t slit_27 = FX_MAKE_STR("-o");
+         if (fx_streq(&args_1->hd, &slit_27)) {
             _fx_LS v_38 = args_1->tl;
             if (v_38 != 0) {
                fx_str_t* v_39 = &_fx_g12Options__opt.output_name;
@@ -895,8 +909,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_27 = FX_MAKE_STR("-D");
-         if (fx_streq(&args_1->hd, &slit_27)) {
+         fx_str_t slit_28 = FX_MAKE_STR("-D");
+         if (fx_streq(&args_1->hd, &slit_28)) {
             _fx_LS v_40 = args_1->tl;
             if (v_40 != 0) {
                _fx_Ta2S v_41 = {0};
@@ -918,7 +932,7 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                fx_str_t* nameval_0 = &v_40->hd;
                int_ p1_0 = _fx_M6StringFM4findi2SC(nameval_0, (char_)61, 0);
                if (p1_0 < 0) {
-                  fx_str_t slit_28 = FX_MAKE_STR("true"); _fx_make_Ta2S(nameval_0, &slit_28, &v_41);
+                  fx_str_t slit_29 = FX_MAKE_STR("true"); _fx_make_Ta2S(nameval_0, &slit_29, &v_41);
                }
                else {
                   FX_CALL(fx_substr(nameval_0, 0, p1_0, 1, 1, &v_42), _fx_catch_4);
@@ -969,62 +983,62 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                }
                if (v_53) {
                   bool v_55;
-                  fx_str_t slit_29 = FX_MAKE_STR("TRUE");
+                  fx_str_t slit_30 = FX_MAKE_STR("TRUE");
                   bool t_1;
-                  if (_fx_F6__eq__B2SS(&value_0, &slit_29, 0)) {
+                  if (_fx_F6__eq__B2SS(&value_0, &slit_30, 0)) {
                      t_1 = true;
                   }
                   else {
-                     fx_str_t slit_30 = FX_MAKE_STR("true"); t_1 = _fx_F6__eq__B2SS(&value_0, &slit_30, 0);
+                     fx_str_t slit_31 = FX_MAKE_STR("true"); t_1 = _fx_F6__eq__B2SS(&value_0, &slit_31, 0);
                   }
                   bool t_2;
                   if (t_1) {
                      t_2 = true;
                   }
                   else {
-                     fx_str_t slit_31 = FX_MAKE_STR("ON"); t_2 = _fx_F6__eq__B2SS(&value_0, &slit_31, 0);
+                     fx_str_t slit_32 = FX_MAKE_STR("ON"); t_2 = _fx_F6__eq__B2SS(&value_0, &slit_32, 0);
                   }
                   if (t_2) {
                      v_55 = true;
                   }
                   else {
-                     fx_str_t slit_32 = FX_MAKE_STR("on"); v_55 = _fx_F6__eq__B2SS(&value_0, &slit_32, 0);
+                     fx_str_t slit_33 = FX_MAKE_STR("on"); v_55 = _fx_F6__eq__B2SS(&value_0, &slit_33, 0);
                   }
                   if (v_55) {
                      _fx_M7OptionsFM7OptBoolN17Options__optval_t1B(true, &value_1);
                   }
                   else {
                      bool v_56;
-                     fx_str_t slit_33 = FX_MAKE_STR("FALSE");
+                     fx_str_t slit_34 = FX_MAKE_STR("FALSE");
                      bool t_3;
-                     if (_fx_F6__eq__B2SS(&value_0, &slit_33, 0)) {
+                     if (_fx_F6__eq__B2SS(&value_0, &slit_34, 0)) {
                         t_3 = true;
                      }
                      else {
-                        fx_str_t slit_34 = FX_MAKE_STR("false"); t_3 = _fx_F6__eq__B2SS(&value_0, &slit_34, 0);
+                        fx_str_t slit_35 = FX_MAKE_STR("false"); t_3 = _fx_F6__eq__B2SS(&value_0, &slit_35, 0);
                      }
                      bool t_4;
                      if (t_3) {
                         t_4 = true;
                      }
                      else {
-                        fx_str_t slit_35 = FX_MAKE_STR("OFF"); t_4 = _fx_F6__eq__B2SS(&value_0, &slit_35, 0);
+                        fx_str_t slit_36 = FX_MAKE_STR("OFF"); t_4 = _fx_F6__eq__B2SS(&value_0, &slit_36, 0);
                      }
                      if (t_4) {
                         v_56 = true;
                      }
                      else {
-                        fx_str_t slit_36 = FX_MAKE_STR("off"); v_56 = _fx_F6__eq__B2SS(&value_0, &slit_36, 0);
+                        fx_str_t slit_37 = FX_MAKE_STR("off"); v_56 = _fx_F6__eq__B2SS(&value_0, &slit_37, 0);
                      }
                      if (v_56) {
                         _fx_M7OptionsFM7OptBoolN17Options__optval_t1B(false, &value_1);
                      }
                      else if (FX_STR_LENGTH(value_0) == 0) {
                         FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_44, 0), _fx_catch_4);
-                        fx_str_t slit_37 = FX_MAKE_STR("a value should follow after \'");
-                        fx_str_t slit_38 = FX_MAKE_STR("=\'");
+                        fx_str_t slit_38 = FX_MAKE_STR("a value should follow after \'");
+                        fx_str_t slit_39 = FX_MAKE_STR("=\'");
                         {
-                           const fx_str_t strs_2[] = { slit_37, v_44, slit_38 };
+                           const fx_str_t strs_2[] = { slit_38, v_44, slit_39 };
                            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_45), _fx_catch_4);
                         }
                         FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_45, 0), _fx_catch_4);
@@ -1059,11 +1073,11 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                               fx_str_t v_61 = {0};
                               FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_59, 0), _fx_catch_3);
                               FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_60, 0), _fx_catch_3);
-                              fx_str_t slit_39 = FX_MAKE_STR("invalid numerical value \'");
-                              fx_str_t slit_40 = FX_MAKE_STR("\' of a symbol \'");
-                              fx_str_t slit_41 = FX_MAKE_STR("\'; if you meant a string, enclose it in double quotes");
+                              fx_str_t slit_40 = FX_MAKE_STR("invalid numerical value \'");
+                              fx_str_t slit_41 = FX_MAKE_STR("\' of a symbol \'");
+                              fx_str_t slit_42 = FX_MAKE_STR("\'; if you meant a string, enclose it in double quotes");
                               {
-                                 const fx_str_t strs_3[] = { slit_39, v_59, slit_40, v_60, slit_41 };
+                                 const fx_str_t strs_3[] = { slit_40, v_59, slit_41, v_60, slit_42 };
                                  FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_61), _fx_catch_3);
                               }
                               FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_61, 0), _fx_catch_3);
@@ -1083,10 +1097,10 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                               bool v_63 = _fx_M6StringFM8endswithB2SC(&value_0, (char_)34, 0);
                               if (!v_63) {
                                  FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_46, 0), _fx_catch_4);
-                                 fx_str_t slit_42 = FX_MAKE_STR("the value ");
-                                 fx_str_t slit_43 = FX_MAKE_STR(" starts with \'\"\', but does not terminate with \'\"\'");
+                                 fx_str_t slit_43 = FX_MAKE_STR("the value ");
+                                 fx_str_t slit_44 = FX_MAKE_STR(" starts with \'\"\', but does not terminate with \'\"\'");
                                  {
-                                    const fx_str_t strs_4[] = { slit_42, v_46, slit_43 };
+                                    const fx_str_t strs_4[] = { slit_43, v_46, slit_44 };
                                     FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_47), _fx_catch_4);
                                  }
                                  FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_47, 0), _fx_catch_4);
@@ -1107,10 +1121,10 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                }
                else {
                   FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_49, 0), _fx_catch_4);
-                  fx_str_t slit_44 = FX_MAKE_STR("identifier \'");
-                  fx_str_t slit_45 = FX_MAKE_STR("\' contains incorrect characters");
+                  fx_str_t slit_45 = FX_MAKE_STR("identifier \'");
+                  fx_str_t slit_46 = FX_MAKE_STR("\' contains incorrect characters");
                   {
-                     const fx_str_t strs_5[] = { slit_44, v_49, slit_45 };
+                     const fx_str_t strs_5[] = { slit_45, v_49, slit_46 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_50), _fx_catch_4);
                   }
                   FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_50, 0), _fx_catch_4);
@@ -1151,8 +1165,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_46 = FX_MAKE_STR("-I");
-         if (fx_streq(&args_1->hd, &slit_46)) {
+         fx_str_t slit_47 = FX_MAKE_STR("-I");
+         if (fx_streq(&args_1->hd, &slit_47)) {
             _fx_LS v_65 = args_1->tl;
             if (v_65 != 0) {
                _fx_LS v_66 = 0;
@@ -1181,8 +1195,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_47 = FX_MAKE_STR("-B");
-         if (fx_streq(&args_1->hd, &slit_47)) {
+         fx_str_t slit_48 = FX_MAKE_STR("-B");
+         if (fx_streq(&args_1->hd, &slit_48)) {
             _fx_LS v_70 = args_1->tl;
             if (v_70 != 0) {
                fx_str_t* v_71 = &_fx_g12Options__opt.build_rootdir;
@@ -1195,14 +1209,14 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_48 = FX_MAKE_STR("-c++");
-         if (fx_streq(&args_1->hd, &slit_48)) {
+         fx_str_t slit_49 = FX_MAKE_STR("-c++");
+         if (fx_streq(&args_1->hd, &slit_49)) {
             _fx_g12Options__opt.compile_by_cpp = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_49 = FX_MAKE_STR("-cflags");
-         if (fx_streq(&args_1->hd, &slit_49)) {
+         fx_str_t slit_50 = FX_MAKE_STR("-cflags");
+         if (fx_streq(&args_1->hd, &slit_50)) {
             _fx_LS v_72 = args_1->tl;
             if (v_72 != 0) {
                fx_str_t v_73 = {0};
@@ -1215,9 +1229,9 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                }
                else {
                   fx_copy_str(&_fx_g12Options__opt.cflags, &v_75);
-                  fx_str_t slit_50 = FX_MAKE_STR(" ");
+                  fx_str_t slit_51 = FX_MAKE_STR(" ");
                   {
-                     const fx_str_t strs_6[] = { v_75, slit_50, *cflags_0 };
+                     const fx_str_t strs_6[] = { v_75, slit_51, *cflags_0 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &v_74), _fx_catch_6);
                   }
                }
@@ -1235,8 +1249,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_51 = FX_MAKE_STR("-clibs");
-         if (fx_streq(&args_1->hd, &slit_51)) {
+         fx_str_t slit_52 = FX_MAKE_STR("-clibs");
+         if (fx_streq(&args_1->hd, &slit_52)) {
             _fx_LS v_77 = args_1->tl;
             if (v_77 != 0) {
                fx_str_t v_78 = {0};
@@ -1249,9 +1263,9 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                }
                else {
                   fx_copy_str(&_fx_g12Options__opt.clibs, &v_80);
-                  fx_str_t slit_52 = FX_MAKE_STR(" ");
+                  fx_str_t slit_53 = FX_MAKE_STR(" ");
                   {
-                     const fx_str_t strs_7[] = { v_80, slit_52, *clibs_0 };
+                     const fx_str_t strs_7[] = { v_80, slit_53, *clibs_0 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &v_79), _fx_catch_7);
                   }
                }
@@ -1270,20 +1284,20 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       }
       bool res_0;
       if (args_1 != 0) {
-         fx_str_t slit_53 = FX_MAKE_STR("-h");
-         if (fx_streq(&args_1->hd, &slit_53)) {
-            res_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_54 = FX_MAKE_STR("-help");
+         fx_str_t slit_54 = FX_MAKE_STR("-h");
          if (fx_streq(&args_1->hd, &slit_54)) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_55 = FX_MAKE_STR("--help");
+         fx_str_t slit_55 = FX_MAKE_STR("-help");
          if (fx_streq(&args_1->hd, &slit_55)) {
+            res_0 = true; goto _fx_endmatch_0;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_56 = FX_MAKE_STR("--help");
+         if (fx_streq(&args_1->hd, &slit_56)) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
@@ -1296,20 +1310,20 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       }
       bool res_1;
       if (args_1 != 0) {
-         fx_str_t slit_56 = FX_MAKE_STR("-v");
-         if (fx_streq(&args_1->hd, &slit_56)) {
-            res_1 = true; goto _fx_endmatch_1;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_57 = FX_MAKE_STR("-version");
+         fx_str_t slit_57 = FX_MAKE_STR("-v");
          if (fx_streq(&args_1->hd, &slit_57)) {
             res_1 = true; goto _fx_endmatch_1;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_58 = FX_MAKE_STR("--version");
+         fx_str_t slit_58 = FX_MAKE_STR("-version");
          if (fx_streq(&args_1->hd, &slit_58)) {
+            res_1 = true; goto _fx_endmatch_1;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_59 = FX_MAKE_STR("--version");
+         if (fx_streq(&args_1->hd, &slit_59)) {
             res_1 = true; goto _fx_endmatch_1;
          }
       }
@@ -1321,8 +1335,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          prver_0 = true; goto _fx_endmatch_2;
       }
       if (args_1 != 0) {
-         fx_str_t slit_59 = FX_MAKE_STR("--");
-         if (fx_streq(&args_1->hd, &slit_59)) {
+         fx_str_t slit_60 = FX_MAKE_STR("--");
+         if (fx_streq(&args_1->hd, &slit_60)) {
             _fx_LS* v_82 = &_fx_g12Options__opt.app_args;
             _fx_LS* next_0 = &args_1->tl;
             _fx_free_LS(v_82);
@@ -1344,40 +1358,40 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          fx_str_t v_93 = {0};
          fx_str_t* a_0 = &args_1->hd;
          bool v_94;
-         fx_str_t slit_60 = FX_MAKE_STR("-");
-         v_94 = _fx_M6StringFM10startswithB2SS(a_0, &slit_60, 0);
+         fx_str_t slit_61 = FX_MAKE_STR("-");
+         v_94 = _fx_M6StringFM10startswithB2SS(a_0, &slit_61, 0);
          if (v_94) {
-            fx_str_t slit_61 = FX_MAKE_STR("-clibs");
-            FX_CALL(_fx_cons_LS(&slit_61, 0, true, &v_83), _fx_catch_8);
-            fx_str_t slit_62 = FX_MAKE_STR("-cflags");
-            FX_CALL(_fx_cons_LS(&slit_62, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_63 = FX_MAKE_STR("-B");
+            fx_str_t slit_62 = FX_MAKE_STR("-clibs");
+            FX_CALL(_fx_cons_LS(&slit_62, 0, true, &v_83), _fx_catch_8);
+            fx_str_t slit_63 = FX_MAKE_STR("-cflags");
             FX_CALL(_fx_cons_LS(&slit_63, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_64 = FX_MAKE_STR("-o");
+            fx_str_t slit_64 = FX_MAKE_STR("-B");
             FX_CALL(_fx_cons_LS(&slit_64, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_65 = FX_MAKE_STR("-inline-threshold");
+            fx_str_t slit_65 = FX_MAKE_STR("-o");
             FX_CALL(_fx_cons_LS(&slit_65, v_83, false, &v_83), _fx_catch_8);
+            fx_str_t slit_66 = FX_MAKE_STR("-inline-threshold");
+            FX_CALL(_fx_cons_LS(&slit_66, v_83, false, &v_83), _fx_catch_8);
             bool v_95;
             FX_CALL(_fx_M7OptionsFM3memB2LSS(v_83, a_0, &v_95, 0), _fx_catch_8);
             if (v_95) {
-               fx_str_t slit_66 = FX_MAKE_STR("[31;1merror:[0m");
-               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_66, &v_84, 0), _fx_catch_8);
+               fx_str_t slit_67 = FX_MAKE_STR("[31;1merror:[0m");
+               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_67, &v_84, 0), _fx_catch_8);
                FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_85, 0), _fx_catch_8);
-               fx_str_t slit_67 = FX_MAKE_STR(" option ");
-               fx_str_t slit_68 = FX_MAKE_STR(" needs an argument");
+               fx_str_t slit_68 = FX_MAKE_STR(" option ");
+               fx_str_t slit_69 = FX_MAKE_STR(" needs an argument");
                {
-                  const fx_str_t strs_8[] = { v_84, slit_67, v_85, slit_68 };
+                  const fx_str_t strs_8[] = { v_84, slit_68, v_85, slit_69 };
                   FX_CALL(fx_strjoin(0, 0, 0, strs_8, 4, &v_86), _fx_catch_8);
                }
                FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_86, 0), _fx_catch_8);
             }
             else {
-               fx_str_t slit_69 = FX_MAKE_STR("[31;1merror:[0m");
-               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_69, &v_87, 0), _fx_catch_8);
+               fx_str_t slit_70 = FX_MAKE_STR("[31;1merror:[0m");
+               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_70, &v_87, 0), _fx_catch_8);
                FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_88, 0), _fx_catch_8);
-               fx_str_t slit_70 = FX_MAKE_STR(" unrecognized option ");
+               fx_str_t slit_71 = FX_MAKE_STR(" unrecognized option ");
                {
-                  const fx_str_t strs_9[] = { v_87, slit_70, v_88 };
+                  const fx_str_t strs_9[] = { v_87, slit_71, v_88 };
                   FX_CALL(fx_strjoin(0, 0, 0, strs_9, 3, &v_89), _fx_catch_8);
                }
                FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_89, 0), _fx_catch_8);
@@ -1388,14 +1402,14 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
             FX_FREE_STR(&inputfile_0); fx_copy_str(a_0, &inputfile_0); FX_COPY_PTR(args_1->tl, &v_31);
          }
          else {
-            fx_str_t slit_71 = FX_MAKE_STR("[31;1merror:[0m");
-            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_71, &v_90, 0), _fx_catch_8);
+            fx_str_t slit_72 = FX_MAKE_STR("[31;1merror:[0m");
+            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_72, &v_90, 0), _fx_catch_8);
             FX_CALL(_fx_cons_LS(a_0, 0, true, &v_91), _fx_catch_8);
             FX_CALL(_fx_cons_LS(&inputfile_0, v_91, false, &v_91), _fx_catch_8);
             FX_CALL(_fx_M7OptionsFM6stringS1LS(v_91, &v_92, 0), _fx_catch_8);
-            fx_str_t slit_72 = FX_MAKE_STR(" more than one input file is specified: ");
+            fx_str_t slit_73 = FX_MAKE_STR(" more than one input file is specified: ");
             {
-               const fx_str_t strs_10[] = { v_90, slit_72, v_92 };
+               const fx_str_t strs_10[] = { v_90, slit_73, v_92 };
                FX_CALL(fx_strjoin(0, 0, 0, strs_10, 3, &v_93), _fx_catch_8);
             }
             FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_93, 0), _fx_catch_8);
@@ -1467,11 +1481,11 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       if (FX_STR_LENGTH(inputfile_0) == 0) {
          FX_CALL(_fx_M7OptionsFM2tlLS1LS(_fx_g9Sys__argv, &v_1, 0), _fx_cleanup);
          if (v_1 != 0) {
-            fx_str_t slit_73 = FX_MAKE_STR("[31;1merror:[0m");
-            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_73, &v_2, 0), _fx_cleanup);
-            fx_str_t slit_74 = FX_MAKE_STR(" input file name is missing");
+            fx_str_t slit_74 = FX_MAKE_STR("[31;1merror:[0m");
+            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_74, &v_2, 0), _fx_cleanup);
+            fx_str_t slit_75 = FX_MAKE_STR(" input file name is missing");
             {
-               const fx_str_t strs_11[] = { v_2, slit_74 };
+               const fx_str_t strs_11[] = { v_2, slit_75 };
                FX_CALL(fx_strjoin(0, 0, 0, strs_11, 2, &v_3), _fx_cleanup);
             }
             FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_3, 0), _fx_cleanup);
@@ -1496,11 +1510,11 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          t_10 = false;
       }
       if (t_10) {
-         fx_str_t slit_75 = FX_MAKE_STR("[31;1merror:[0m");
-         FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_75, &v_4, 0), _fx_cleanup);
-         fx_str_t slit_76 = FX_MAKE_STR(" -no-c option cannot be used together with -run or -c++");
+         fx_str_t slit_76 = FX_MAKE_STR("[31;1merror:[0m");
+         FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_76, &v_4, 0), _fx_cleanup);
+         fx_str_t slit_77 = FX_MAKE_STR(" -no-c option cannot be used together with -run or -c++");
          {
-            const fx_str_t strs_12[] = { v_4, slit_76 };
+            const fx_str_t strs_12[] = { v_4, slit_77 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &v_5), _fx_cleanup);
          }
          FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_5, 0), _fx_cleanup);
@@ -1510,27 +1524,27 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
    if (prver_0) {
       FX_CALL(_fx_M7OptionsFM6stringS1S(&_fx_g21__ficus_version_str__, &v_6, 0), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&_fx_g20__ficus_git_commit__, &v_7, 0), _fx_cleanup);
-      fx_str_t slit_77 = FX_MAKE_STR("Ficus version: ");
-      fx_str_t slit_78 = FX_MAKE_STR(" (git commit: ");
-      fx_str_t slit_79 = FX_MAKE_STR(")");
+      fx_str_t slit_78 = FX_MAKE_STR("Ficus version: ");
+      fx_str_t slit_79 = FX_MAKE_STR(" (git commit: ");
+      fx_str_t slit_80 = FX_MAKE_STR(")");
       {
-         const fx_str_t strs_13[] = { slit_77, v_6, slit_78, v_7, slit_79 };
+         const fx_str_t strs_13[] = { slit_78, v_6, slit_79, v_7, slit_80 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_13, 5, &v_8), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_8, 0), _fx_cleanup);
       FX_CALL(_fx_g11Sys__osname.fp(true, &v_9, _fx_g11Sys__osname.fcv), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&v_9, &v_10, 0), _fx_cleanup);
-      fx_str_t slit_80 = FX_MAKE_STR("Platform: ");
+      fx_str_t slit_81 = FX_MAKE_STR("Platform: ");
       {
-         const fx_str_t strs_14[] = { slit_80, v_10 };
+         const fx_str_t strs_14[] = { slit_81, v_10 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_14, 2, &v_11), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_11, 0), _fx_cleanup);
       FX_CALL(_fx_M3SysFM10cc_versionS0(&v_12, 0), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&v_12, &v_13, 0), _fx_cleanup);
-      fx_str_t slit_81 = FX_MAKE_STR("C/C++ Compiler: ");
+      fx_str_t slit_82 = FX_MAKE_STR("C/C++ Compiler: ");
       {
-         const fx_str_t strs_15[] = { slit_81, v_13 };
+         const fx_str_t strs_15[] = { slit_82, v_13 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_15, 2, &v_14), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_14, 0), _fx_cleanup);
@@ -1556,8 +1570,8 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       FX_FREE_STR(v_97);
       fx_copy_str(&v_18, v_97);
       fx_copy_str(&_fx_g12Options__opt.build_rootdir, &v_19);
-      fx_str_t slit_82 = FX_MAKE_STR("__fxbuild__");
-      FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_19, &slit_82, &v_20, 0), _fx_cleanup);
+      fx_str_t slit_83 = FX_MAKE_STR("__fxbuild__");
+      FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_19, &slit_83, &v_20, 0), _fx_cleanup);
       fx_str_t* v_98 = &_fx_g12Options__opt.build_rootdir;
       FX_FREE_STR(v_98);
       fx_copy_str(&v_20, v_98);

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -116,6 +116,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -1641,6 +1642,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -1674,6 +1676,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -1706,6 +1709,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/compiler/bootstrap/fx.c
+++ b/compiler/bootstrap/fx.c
@@ -56,6 +56,7 @@ typedef struct _fx_R18Options__options_t {
    bool print_k0;
    bool print_k;
    bool print_tokens;
+   bool print_resolve;
    bool run_app;
    bool verbose;
    bool W_unused;
@@ -219,6 +220,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->print_k0 = src->print_k0;
    dst->print_k = src->print_k;
    dst->print_tokens = src->print_tokens;
+   dst->print_resolve = src->print_resolve;
    dst->run_app = src->run_app;
    dst->verbose = src->verbose;
    dst->W_unused = src->W_unused;
@@ -252,6 +254,7 @@ static void _fx_make_R18Options__options_t(
    bool r_print_k0,
    bool r_print_k,
    bool r_print_tokens,
+   bool r_print_resolve,
    bool r_run_app,
    bool r_verbose,
    bool r_W_unused,
@@ -284,6 +287,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->print_k0 = r_print_k0;
    fx_result->print_k = r_print_k;
    fx_result->print_tokens = r_print_tokens;
+   fx_result->print_resolve = r_print_resolve;
    fx_result->run_app = r_run_app;
    fx_result->verbose = r_verbose;
    fx_result->W_unused = r_W_unused;

--- a/docs/ficus_todo_2026.md
+++ b/docs/ficus_todo_2026.md
@@ -1,10 +1,16 @@
 # Syntax and semantics
 
-- [ ] properly resolve instances of generic functions. Adjust the type checker not to stop at the first appropriate candidate.
+- [ ] properly resolve instances of generic functions.
+      Adjust the type checker not to stop at the first appropriate candidate.
 - [ ] new syntax for generic types and its instances: `t list => list<t>
   - [ ] Q: what would be a syntax for generic functions? `fun [u, v] add(a: u, b: v) {...}`?
 - [ ] new syntax for fold: `fold acc = 0 for x <- arr {acc + x}` => `fold acc = 0 for x <- arr {acc += x}`
-- [ ] add syntax to append elements to lists, vectors during fold? We already have runtime support for vector writers for vector comprehensions, maybe need to add list writer as well. E.g. fold val l = [] for x <- 1:n {if isprime(n) {l+=x}}. It partially duplicates list comprehensions, but fold is more universal. In fact, list comprehensions can then be converted to just fold's that are, in their turn, are converted to simple loops.   
+- [ ] add syntax to append elements to lists, vectors during fold?
+      We already have runtime support for vector writers for vector comprehensions,
+      maybe need to add list writer as well. E.g. fold val l = [] for x <- 1:n {if isprime(n) {l+=x}}.
+      It partially duplicates list comprehensions, but fold is more universal.
+      In fact, list comprehensions can then be converted to just fold's that are,
+      in their turn, are converted to simple loops.
 - [ ] because of new syntax for generic types, we can get rid of (x :> new_type) type cast syntax and switch to normal new_type(x).
 - [ ] currently we use Matlab-style .op for elemwise-operations, but it looks weird
       sometimes for those who are not familiar with Matlab. Shall we drop all .op
@@ -15,42 +21,78 @@
 - [ ] revise records:
   - [ ] keep/drop/revise record update syntax?
         `var pt = Point {x=5, y=10}; pt .= {y = pt.y+5}`.
-        actually, we can simply write `pt.y += 5`. The syntax above might be useful for non-destructive record update (`pt.{y = pt.y + 5}`). But is it really useful in
+        actually, we can simply write `pt.y += 5`. The syntax above might be useful for
+        non-destructive record update (`pt.{y = pt.y + 5}`). But is it really useful in
         practice?
   - [ ] when we have variant type with record options, there is no way to pack data
-        for the particular option: `type employee_t = Engineer: {age: int; computer: string; claude_subscr: string} | Manager: {age: int; tablet: string; team: list[employee_t]}`, how to we take and operate on all Engineer fields as a whole? It's suggested to automatically introduce `Engineer.t` type. It should be possible to construct employee_t directly from Engineer.t: `val e = Engineer(data: Engineer.t)`
+        for the particular option: `type employee_t = Engineer: {age: int; computer: string; claude_subscr: string} | Manager: {age: int; tablet: string; team: list[employee_t]}`, how to we take and operate on all Engineer fields as a whole?
+        It's suggested to automatically introduce `Engineer.t` type. It should be possible to
+        construct employee_t directly from Engineer.t: `val e = Engineer(data: Engineer.t)`
 - [ ] rename half to `hfloat` (as in OpenCV) or `float16`, because half is quite generic name.
 - [ ] add `bfloat` or `bfloat16`.
-- [ ] add more array reductions, e.g. sum(0., for x <- arr {x**2}). Shall we somehow infer automatically the initial value, not to pass explicit '0.'?
-- [ ] do we want a generic macro-like syntax to define, e.g., new specialized forms of array comprehensions/reductions, e.g. all(for x <- arr {predicate(x)})?
+- [ ] add more array reductions, e.g. sum(0., for x <- arr {x**2}).
+      Shall we somehow infer automatically the initial value, not to pass explicit '0.'?
+- [ ] do we want a generic macro-like syntax to define, e.g., new specialized forms of array
+      comprehensions/reductions, e.g. all(for x <- arr {predicate(x)})?
 - [ ] do we want a ternary selection operator? (a ? b : c) (we now use if(a) {b} else {c})
 - [ ] support variadic functions, e.g. println(a, b, c); max(a, b, c, d)
-- [ ] remove restriction for modules to start with a capital letter; in fact, it's not a mandatory thing already, see examples/fst.fx that imports 'testmod.fx'. But this rule should probably be propagated to std lib
-- [ ] require that complex modules included __init__.fx in the root and any subdirectories, just like Python. otherwise it's impossible to differentiate between just a tree of files and complex hierarchical modules.
+- [ ] remove restriction for modules to start with a capital letter; in fact, it's not a mandatory thing already,
+      see examples/fst.fx that imports 'testmod.fx'. But this rule should probably be propagated to std lib
+- [ ] require that complex modules included __init__.fx in the root and any subdirectories,
+      just like Python. otherwise it's impossible to differentiate between just a tree of
+      files and complex hierarchical modules.
 - [ ] support more than 5-dimensional arrays. Maybe 7-dimensional arrays?
 - [ ] shall we add a syntax for saturating +,-,*,/ (including floating-point types)?
-- [ ] syntax like `@parallel_if(condition) for {...}` to run loop as sequential if the problem is small enough. Compilers cannot always figure the bounary properly.
+- [ ] syntax like `@parallel_if(condition) for {...}` to run loop as sequential if the problem is small enough.
+      Compilers cannot always figure the bounary properly.
 - [ ] implement einsum and support it at compiler level.
-- [ ] support numpy-style broadcasting, e.g. [@broadcast for a <- A, b <- B {a*b}]. It makes sense to explicitly specify that we need broadcasting, because in certain scenarios size mismatch is undesirable and is an error that must be reported (via exception).
-- [ ] it would be nice to have automatically generated functions to serialize/deserialize arbitrary data structures with user-provided hooks for sub-structures. E.g. be able to represent any structure in json or yaml or python's pickle structure or a flatbuffer. We already have automatically generated functions to print structures, so that would be a further extension of it.
-- [ ] add dynamically-typed `tensor` type? Currently we have array, which is statically typed and CPU-only (for now). In many cases static typing really helps, we get performance close to C/C++. In some cases static typing is inconvenient, e.g. for OpenCV bindings. Maybe we need to add `tensor` type that is a black box, sitting in CPU, GPU or NPU memory and there is a set of operations on it (with fusion etc.)
+- [ ] support numpy-style broadcasting, e.g. [@broadcast for a <- A, b <- B {a*b}].
+      It makes sense to explicitly specify that we need broadcasting, because in certain scenarios
+      size mismatch is undesirable and is an error that must be reported (via exception).
+- [ ] it would be nice to have automatically generated functions to serialize/deserialize
+      arbitrary data structures with user-provided hooks for sub-structures.
+      E.g. be able to represent any structure in json or yaml or python's pickle
+      structure or a flatbuffer. We already have automatically generated functions to
+      print structures, so that would be a further extension of it.
+- [ ] add dynamically-typed `tensor` type? Currently we have array, which is statically typed and CPU-only (for now).
+      In many cases static typing really helps, we get performance close to C/C++. In some cases static typing is inconvenient,
+      e.g. for OpenCV bindings. Maybe we need to add `tensor` type that is a black box, sitting in CPU, GPU or NPU memory and
+      there is a set of operations on it (with fusion etc.)
+- [ ] try to accept `(op)` everywhere where `__opname__` is accepted, e.g. `Complex.(*)(a, b)`
 
 # Code generation, runtime
-- [+] (we now put compiler modification date, its binary size and the compiler flags as the 'signature') put compiler version (git commit?) into __fxbuild__/<something> directories, so that after compiler is updated, all the previously generated .c files are discarded.
+- [+] (we now put compiler modification date, its binary size and the compiler flags as the 'signature')
+      put compiler version (git commit?) into __fxbuild__/<something> directories,
+      so that after compiler is updated, all the previously generated .c files are discarded.
 - [ ] we now use compact rpmalloc. Shall we replace it with bigger, but hopefully better supported mimalloc?
-- [ ] we use atomic reference counting, and many of ficus data key structures are immutable or have immutable headers, but still multi-threaded program may crash, e.g. when two different threads are writing into the same mutable location, e.g. array consisting of arrays, e.g. float [,] [,] (2D array of 2D arrays of floats): `for k <- 0:100 { val i=rng.uniform(0, n), j = rng.uniform(0, n); arr[i, j] = array((rng.iniform(1, 10), rng.uniform(1, 10)), rng.uniform(-1.f, 1.f))}`. That is, 'complex' mutable fields should probably be written in transaction-style way, even if it's slower. For general number cranching it should not affect speed (maybe do something like '"Cache-Sensitive Software Transactional Memory" by Robert Ennals'?)
+- [ ] we use atomic reference counting, and many of ficus data key structures are immutable or have immutable headers,
+      but still multi-threaded program may crash, e.g. when two different threads are writing into the same mutable location,
+      e.g. array consisting of arrays, e.g. float [,] [,] (2D array of 2D arrays of floats):
+      `for k <- 0:100 { val i=rng.uniform(0, n), j = rng.uniform(0, n); arr[i, j] = array((rng.iniform(1, 10), rng.uniform(1, 10)), rng.uniform(-1.f, 1.f))}`.
+      That is, 'complex' mutable fields should probably be written in transaction-style way, even if it's slower.
+      For general number cranching it should not affect speed (maybe do something like
+      '"Cache-Sensitive Software Transactional Memory" by Robert Ennals'?)
 
 # Convenience stuff:
 
 - [ ] better diagnostic of errors. This is too generic request, some details are needed.
   - [ ] for example, when a reserved name/keyword is used as identifier
-- [ ] more convenient error messages, similar to gcc/clang or other compilers when we display code line and put '^' mark below it where the error occured
-- [+] (added tools/update_compiler.py) regenerate bootstrap sources with a special compiler key or at least some python script (tools/update_compiler.py?)
+- [ ] more convenient error messages, similar to gcc/clang or other compilers when we display code
+      line and put '^' mark below it where the error occured
+- [+] (added tools/update_compiler.py) regenerate bootstrap sources with a special compiler key or
+      at least some python script (tools/update_compiler.py?)
+- [ ] compiler as a library? Currently compiler uses many global variables.
+      It would be nice to be able to create a compiler instance and make some experiments with it
+      (build AST, K-form, generate final .c code etc.)
 
 # Optimizations:
 
-- [ ] instantiate (not necessarily generic) functions that take callbacks known at compile time. The most classic example is qsort — if we pass known comparison function to it, we can create a copy of qsort with that function embedded.
-- [ ] compile ficus compiler itself and all programs by default with '-Ofast'. Currently, it's broken for some reason
+- [ ] instantiate (not necessarily generic) functions that take callbacks known at compile time.
+      The most classic example is qsort — if we pass known comparison function to it,
+      we can create a copy of qsort with that function embedded.
+- [ ] compile ficus compiler itself and all programs by default with '-Ofast'.
+      Currently, it's broken for some reason
 - [ ] extend constant folding to support math functions
-- [ ] generalization of the previous part: can we include some simple k-form interpreter for a subset of language to const-fold expressions that use user functions, including recursive functions operating on immutable data structures, scalars, calling intrinsics etc?
-
+- [ ] generalization of the previous part: can we include some simple k-form interpreter for a subset of
+      language to const-fold expressions that use user functions, including recursive functions operating on
+      immutable data structures, scalars, calling intrinsics etc?

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -264,6 +264,24 @@ is the whole point of the ladder.
 - config: -no-c typecheck already fails, all platforms.
 - status: fenced by keeping both blocks commented (`lib/Complex.fx:15-44`,
   `examples/fst.fx:125-127`); recorded here per commit 786b446's note.
+- WP-E update (2026-07-08): all three symptoms **re-confirmed** live by
+  uncommenting `lib/Complex.fx:15-44`:
+  - S2 — `val c = ref (1 + 1.fi); *c *= 2` resolves `__mul__` to the ARRAY
+    multiply (`lib/Array.fx:341: unsupported iteration domain`).
+  - S3 — typechecking `examples/vision_classify.fx` infers
+    `nnop_t list Complex.complex` for a plain `nnop_t list` (`lib/Complex.fx:17`),
+    cascading to `NN/FromOnnx.fx:1018`.
+  Finding: the symptoms are **not reproducible in a self-contained mini-`cplx`
+  class** — S2 needs the `N.fi` imaginary literal (complex-specific) and S3 needs
+  the NN library's generic `+` on `nnop_t list` colliding with the over-general
+  `operator +(a:'t, b:'t complex)`. So the fenced reproductions live against the
+  real `Complex.fx` (uncomment) + `fst.fx`/`vision_classify.fx`, documented as
+  commented `FIXME(FB-007)` blocks in `test/test_resolve.fx` and analyzed in
+  `docs/wpe_tests_report.md`. The minimal, self-contained form of the underlying
+  greedy-first-match gap is split out as **FB-016**. The D1 generality comparator
+  (`compare_fun_generality`) already ranks the concrete `complex` operators over
+  the generic ones correctly where it can (`-pr-resolve` confirms); the S3
+  over-general match is the `int + 't` deferral gap (proposal §5, tranche B).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the
@@ -428,7 +446,7 @@ is the whole point of the ladder.
   `// FIXME` note points back here). This is the unit failure the PR #27 CI
   handoff saw (its log had truncated the test name); see FB-011 for the mixup.
 
-## FB-014  bare positive literal 2^63 silently wrapped to INT64_MIN
+## (FIXED in PR #29) FB-014  bare positive literal 2^63 silently wrapped to INT64_MIN
 - discovered: 2026-07-07 while widening the int64 literal range (housekeeping
   follow-up to FB-010).
 - detail: the lexer (`LexerUtils.getnumber_`) accumulates a decimal magnitude in
@@ -456,3 +474,92 @@ is the whole point of the ladder.
   bootstrap; fixpoint holds; full ladder green. (This complements the FB-010 /
   int64-range work: the typechecker now accepts the true INT64_MIN and the lexer
   now rejects the bare positive 2^63 that used to alias it.)
+
+## FB-015  parser: `continue`/`break` and bare `return` rejected in expression position
+- discovered: 2026-07-08 while writing the WP-E `-pr-resolve` trace (`trace_resolve`
+  in `Ast_typecheck.fx`).
+- detail: two related parser limitations, both surfacing as a misleading
+  `error: unexpected token '}'. An identifier, literal or expression ... is
+  expected here` rather than a targeted diagnostic:
+  1. **`continue` (and presumably `break`) cannot be the *value* of a `match`
+     arm / `if` branch.** `[:: for e <- xs { match e { | A(x) => x | _ => continue } }]`
+     fails to parse; the working idiom is to run the `match` as a statement that
+     may `continue` and yield the element separately (see the existing
+     `add_id_to_env_check`, `Ast_typecheck.fx`), or accumulate into a `var` list.
+  2. **A bare `return` (no value) in a `: void` function does not parse.**
+     `if !cond { return }` errors at the `}`; `return <expr>` is fine (used widely),
+     so only the value-less form is affected. Worked around by inverting the guard
+     into a wrapping `if cond { ... }` instead of an early `return`.
+- config: parser only; both are compile-time parse errors, no codegen involved.
+- status: routed around in `trace_resolve` (accumulator loop + wrapping `if`, no
+  bare `return`, no `continue`-as-expression). NOT a blocker for anything; logged
+  for a later parser look (control-flow keywords as unit-typed expressions, and a
+  clearer diagnostic than "unexpected token '}'"). Also noted in CLAUDE.md gotchas.
+
+## FB-016  overload resolution: greedy first-match ignores specificity (last-declared overload wins)
+- discovered: 2026-07-08 during WP-E, via the new `-pr-resolve` trace / the D1
+  generality comparator. This is the **minimal, self-contained** form of FB-007's
+  symptom S2 (no `complex`/NN machinery needed).
+- repro (`bin/ficus -run`):
+  ```
+  fun f(x: int) = x + 1     // concrete
+  fun f(x: 't) = x          // generic (identity)
+  val a = f(5); println(a)  // prints 5  -- the GENERIC f('t) is chosen
+  ```
+  Reversing the two declarations makes `f(5)` print `6` (the concrete wins). So
+  the chosen overload is purely the **last-declared** one that unifies
+  (`find_first` commits to the first entry in env-list order, which is
+  most-recently-added-first), NOT the most specific. The meaning of `f(5)` thus
+  depends on the declaration order of otherwise-unrelated overloads.
+- expected (per `docs/overload_resolution_proposal_v2.md` §2-§3): collect all
+  viable candidates, then pick the least-generic (most specific); `f(int)` should
+  win regardless of order. The D1 `compare_fun_generality` already returns the
+  right answer here (`f(int)` is `LessGeneric`); `-pr-resolve` shows
+  `env-order winner: f('t)` vs `generality winner: f(int)`, `winners agree: false`.
+- config: any backend; `-no-c` typecheck already selects the wrong instance.
+- status: NOT fenced (it is latent current behavior, not a crash); it is the very
+  thing the resolver surgery (tranche A) fixes. Tracked by: the `-pr-resolve`
+  instrument (D2), the E1 census (`docs/wpe_experiments/e1_census.md`), and a
+  fenced `// FIXME(FB-016/FB-007)` case in `test/test_resolve.fx` that flips to
+  pass when tranche A lands. Corpus note: the compiler's OWN code contains no site
+  where specificity would flip a *concrete* winner (E1: 0 different-concrete-winner
+  disagreements over 344 viable>1 sites; all 227 disagreements are `<none>` ties
+  from under-constrained arguments) -- so this bites user code like the above, not
+  the bootstrap.
+
+## FB-017  generality comparator can't order `{...}` (TypVarRecord) auto-generics vs a concrete record
+- discovered: 2026-07-08, WP-E D1/E1. Limitation of the NEW (unwired)
+  `compare_typ_generality` in `Ast_typecheck.fx`; not a shipping-compiler defect,
+  but it is the dominant reason the E1 census shows so many `<none>` verdicts and
+  it must be closed before the resolver surgery relies on the comparator.
+- detail: the auto-generated record/variant operators are typed with `{...}` =
+  `TypVarRecord` (e.g. `template<__var_record__> operator ==(a: {...}, b: {...})`
+  in `Builtins.fx:580`, and `string`/`<=>`/`hash`/`print` likewise). The
+  comparator ranks generality with two one-way `maybe_unify(update_refs=false)`
+  trials, but `maybe_unify` treats a record-var **symmetrically** -- a
+  `TypVar(ref Some(TypVarRecord))` binds to a concrete record in *either*
+  direction -- so both "covers" trials succeed and the pair is reported
+  `EqGeneric`/`IncompGeneric` (`<none>`) instead of "concrete `≻` `{...}`".
+  Repro: `bin/ficus -no-c -pr-resolve` on
+  ```
+  type pt = {x:int; y:int}
+  fun myeq(a: {...}, b: {...}) = true
+  fun myeq(a: pt, b: pt) = a.x==b.x && a.y==b.y
+  val r = myeq(pt{x=1,y=2}, pt{x=1,y=2})
+  ```
+  -> `env-order winner: myeq(pt,pt)` (correct), `generality winner: <none>`.
+- impact on E1: 224 of 227 census `<none>` sites are exactly this shape
+  (`__eq__` 141, `string` 83) plus a few genuine identical-signature duplicates
+  (e.g. `length(string)` defined in both `String.fx:10` and `Builtins.fx:133`).
+  Crucially NONE is a real divergence: env-order already picks the concrete, and
+  a *complete* comparator would too -- so tranche A stays corpus-invariant once
+  this is fixed. It is comparator incompleteness, not a resolution flip.
+- fix sketch (for the surgery session): skolemize `TypVarRecord` (and by symmetry
+  `TypVarTuple`/`TypVarArray`) on the RIGID side into an opaque "some specific
+  record" sentinel that a *different* concrete record does not unify with, while
+  `unskolemize_typ` restores it to a free `TypVar(ref Some(TypVarRecord))` on the
+  FREE side -- the same rigid-vs-free asymmetry already used for `'t` skolems,
+  extended to the `TypVar*` family. Deliberately NOT done in this WP-E test/instr
+  package (D1 scope is `df_templ_args` + keyword `TypRecord` + constructor return
+  type); documented in `docs/wpe_tests_report.md` and noted in `test/test_gencmp.fx`.
+- status: not fenced (unwired code); tracked here + in the E1 census + the report.

--- a/docs/wpe_experiments/e1_census.md
+++ b/docs/wpe_experiments/e1_census.md
@@ -1,0 +1,89 @@
+# E1 census — env-order vs generality winner (WP-E)
+
+Instrument: `-pr-resolve` (D2). For every lookup whose expected type is a function
+type and whose viable **function** set has >1 entry, the trace prints the
+candidates, the **env-order winner** (the first viable in env-list order — exactly
+what today's `find_first` commits to) and the **generality winner** (the unique
+least-generic candidate per `compare_fun_generality`, or `<none>` when tied /
+unordered). Raw dump: `e1_compiler_raw.txt` (regenerate with
+`bin/ficus -no-c -pr-resolve compiler/fx.fx`).
+
+The compiler itself (`compiler/fx.fx`, ~54 modules incl. the whole stdlib
+preamble) is the corpus here — the largest real Ficus program available.
+
+## Headline numbers (compiler/fx.fx)
+
+| metric | count |
+|---|---|
+| call sites with viable set > 1 | 344 |
+| winners **agree** (generality confirms env-order) | 117 |
+| winners **disagree** | 227 |
+| — of which generality = `<none>` (tie/unordered) | 227 |
+| — of which generality picks a **different concrete** winner | **0** |
+
+**The go/no-go result for tranche A: zero sites where specificity ranking would
+select a different concrete function than today.** Every disagreement is a
+`<none>` — the comparator failing to *confirm* env-order's pick, never
+*contradicting* it. So a resolver that ranks by specificity and falls back to
+first-match on a tie stays byte-for-byte corpus-invariant on the compiler.
+
+## Anatomy of the 227 `<none>` sites
+
+By viable-set size: 226 have exactly 2 viable candidates, 1 has 21.
+By name: `__eq__` ×141, `string` ×83, `length`/`join`/`__cmp__` ×1 each.
+
+Two root causes, neither a real divergence:
+
+1. **Auto-generated record/variant generics vs a concrete type (~224 sites)** —
+   `__eq__`/`string`/`<=>`/`hash`/`print` for records are typed with `{...}`
+   (`TypVarRecord`), e.g. `template<__var_record__> operator ==(a:{...}, b:{...})`.
+   `maybe_unify` treats a record-var **symmetrically** (it binds to a concrete
+   record in either direction), so the two one-way generality trials both
+   succeed and the pair reads as `EqGeneric`. The concrete overload *should* be
+   ranked strictly more specific; the comparator can't see it yet. This is
+   **FB-017** (a documented limitation of the new comparator, to be closed in the
+   surgery session by skolemizing the `TypVar*` family). Env-order already picks
+   the concrete at every one of these sites, and a completed comparator would
+   too — so this is comparator *incompleteness*, not a resolution flip.
+
+2. **Genuine identical-signature duplicates (2 sites)** — `length(string)->int`
+   and `join(string, string list)->string` are declared in **both** `Builtins.fx`
+   and `String.fx` (String.fx re-declares them as `@inline` wrappers). Distinct
+   `deffun_t`s, byte-identical signatures → truly `EqGeneric`. See E4.
+
+## The 117 agreements
+
+These are the clean concrete-beats-generic sites the comparator *can* order:
+`repr(char)` vs `repr('t)`, `string(string,fmt)` vs `string('t,fmt)`,
+`print(string)` vs `print('t)`, etc. — env-order and generality both pick the
+concrete. These are the cases that already work and that the comparator's D1
+unit tests (`test/test_gencmp.fx`) lock as the contract.
+
+## Self-contained divergence NOT in the compiler corpus
+
+The compiler's own code contains **no** site where a concrete overload declared
+*before* a generic one would flip. User code can hit it trivially (**FB-016**):
+
+```
+fun f(x: int) = x + 1
+fun f(x: 't)  = x
+val a = f(5)      // == 5 today (generic wins by env order); a complete
+                  // specificity resolver returns 6 (concrete wins)
+```
+
+`-pr-resolve` on this shows `env-order winner: f('t)`, `generality winner:
+f(int)`, `winners agree: false` with a real (non-`<none>`) generality winner —
+the shape the census found **zero** of inside the compiler. This is the
+tranche-B "a real program's resolution flips" bucket.
+
+## Caveats of the instrument
+
+- The viable set is captured at `lookup_id_opt` entry with the expected type as
+  the resolver sees it; when the argument type is still under-constrained (a
+  free var), many generic overloads are trivially viable (the one 21-viable
+  site, and the container-`size`/`string` families). Env-order picks the first
+  and the subsequent unification narrows it — faithful to today's behavior.
+- Only function candidates are collected; a same-named value/constructor is
+  ignored. The trace is gated to fire only when the expected type is a `TypFun`,
+  so value uses that merely share a function's name (e.g. a parameter named
+  `size`) do not produce spurious entries.

--- a/docs/wpe_experiments/e1_compiler_raw.txt
+++ b/docs/wpe_experiments/e1_compiler_raw.txt
@@ -1,0 +1,2083 @@
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:388:47: 2 viable for (char -> <unknown>)
+    candidate: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    generality winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:488:48: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:488:41: 2 viable for ((string, format_t@14) -> <unknown>)
+    candidate: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    candidate: string('t, format_t@14) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:407:1
+    env-order  winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    generality winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:490:52: 2 viable for (char vector -> <unknown>)
+    candidate: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    candidate: string('t vector) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:349:1
+    env-order  winner: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    generality winner: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:490:45: 2 viable for ((string, format_t@14) -> <unknown>)
+    candidate: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    candidate: string('t, format_t@14) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:407:1
+    env-order  winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    generality winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:29: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:42: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:52: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1042:27: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1042:49: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1117:25: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'float' @ /home/vpisarev/work/ficus/lib/Math.fx:243:5: 2 viable for (Math.RNG@2 -> <unknown>)
+    candidate: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    candidate: float('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:783:1
+    env-order  winner: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    generality winner: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    winners agree: true
+-pr-resolve: 'double' @ /home/vpisarev/work/ficus/lib/Math.fx:246:5: 2 viable for (Math.RNG@2 -> <unknown>)
+    candidate: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    candidate: double('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:784:1
+    env-order  winner: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    generality winner: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    winners agree: true
+-pr-resolve: 'length' @ /home/vpisarev/work/ficus/lib/String.fx:84:66: 2 viable for (string -> <unknown>)
+    candidate: length(string) -> int @ /home/vpisarev/work/ficus/lib/String.fx:10:9
+    candidate: length(string) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:133:1
+    env-order  winner: length(string) -> int @ /home/vpisarev/work/ficus/lib/String.fx:10:9
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'join' @ /home/vpisarev/work/ficus/lib/String.fx:347:5: 2 viable for ((string, string list) -> <unknown>)
+    candidate: join(string, string list) -> string @ /home/vpisarev/work/ficus/lib/String.fx:12:9
+    candidate: join(string, string list) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:154:1
+    env-order  winner: join(string, string list) -> string @ /home/vpisarev/work/ficus/lib/String.fx:12:9
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Filename.fx:51:66: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Filename.fx:100:66: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__cmp__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:128:38: 21 viable for ((<unknown>, <unknown>) -> <unknown>)
+    candidate: __cmp__(string, string) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:732:16
+    candidate: __cmp__('t option@12, 't option@12) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:719:1
+    candidate: __cmp__(long, long) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:598:16
+    candidate: __cmp__(bool, bool) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:597:1
+    candidate: __cmp__(char, char) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:596:1
+    candidate: __cmp__(double, double) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:595:1
+    candidate: __cmp__(float, float) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:594:1
+    candidate: __cmp__(uint64, uint64) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:593:1
+    candidate: __cmp__(int64, int64) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:592:1
+    candidate: __cmp__(uint32, uint32) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:591:1
+    candidate: __cmp__(int32, int32) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:590:1
+    candidate: __cmp__(uint16, uint16) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:589:1
+    candidate: __cmp__(int16, int16) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:588:1
+    candidate: __cmp__(uint8, uint8) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:587:1
+    candidate: __cmp__(int8, int8) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:586:1
+    candidate: __cmp__(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:585:1
+    candidate: __cmp__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:582:1
+    candidate: __cmp__((...), (...)) -> <unknown> [generic: __var_tuple__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:578:1
+    candidate: __cmp__('t [], 't []) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:558:1
+    candidate: __cmp__('t vector, 't vector) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:542:1
+    candidate: __cmp__('t list, 't list) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:526:1
+    env-order  winner: __cmp__(string, string) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:732:16
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/File.fx:163:5: 2 viable for ((File.t@9, string) -> void)
+    candidate: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    candidate: print(File.t@9, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/File.fx:122:1
+    env-order  winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    generality winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Sys.fx:99:28: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Sys.fx:105:51: 2 viable for ((double, double) -> <unknown>)
+    candidate: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    generality winner: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/Sys.fx:106:47: 2 viable for ((double, double) -> double)
+    candidate: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    generality winner: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1118:22: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1118:32: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:343:68: 2 viable for (string -> <unknown>)
+    candidate: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    generality winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Options.fx:281:23: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Ast.fx:85:23: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Ast.fx:86:22: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast.fx:87:23: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast.fx:88:22: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:513:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:521:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:537:21: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:546:21: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast.fx:567:9: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:747:27: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:748:29: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:749:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1212:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1225:20: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1226:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1295:26: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:127:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1619:14: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1621:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:64:11: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/PP.fx:109:30: 2 viable for ((File.t@9, string) -> <unknown>)
+    candidate: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    candidate: print(File.t@9, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/File.fx:122:1
+    env-order  winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    generality winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/PP.fx:326:30: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:326:26: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/PP.fx:346:27: 2 viable for ((int, int) -> int)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:348:27: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:359:23: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:18:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:221:21: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:314:34: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:314:34: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:394:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:739:58: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Lexer.fx:275:42: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Lexer.fx:517:19: 2 viable for ((int, int) -> int)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:41:54: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:244:49: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Parser.fx:1235:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:1909:36: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2079:50: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2446:25: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2465:47: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2506:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2509:17: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:55:19: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:58:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:80:28: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:58:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:80:28: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:230:32: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:237:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:242:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:469:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:472:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:507:73: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:507:69: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:508:59: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:509:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:510:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:511:59: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:512:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:513:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:555:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:558:56: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:568:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:608:40: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:617:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:618:40: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:795:37: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:795:77: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:800:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:807:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:838:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:843:36: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:971:47: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:971:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:972:31: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:973:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:975:26: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:976:20: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:978:13: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1040:63: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1091:17: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1115:70: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1123:72: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1136:76: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1152:190: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1322:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1433:73: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1500:47: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1515:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1528:51: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1537:61: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1542:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1542:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1977:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1977:63: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2081:28: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2549:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2549:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2604:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2904:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2904:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3123:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3183:21: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3197:51: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3349:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3369:68: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3385:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3385:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3385:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3443:65: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3463:26: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3484:51: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3572:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3580:55: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3580:63: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3611:23: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3702:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3802:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3803:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3803:38: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3812:47: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3812:79: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3843:36: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3888:44: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3932:89: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:398:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:422:19: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:427:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:511:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:522:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:765:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:781:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:809:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:823:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:841:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:858:25: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1244:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1249:43: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1252:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1269:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1451:22: 2 viable for (char -> string)
+    candidate: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    generality winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1483:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1485:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1489:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1491:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:67:48: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:237:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:243:19: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:355:59: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:368:17: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:376:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:534:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:537:40: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:557:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:565:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:582:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:669:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:786:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:786:81: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:795:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:809:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:827:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:833:124: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:935:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:988:25: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1087:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1147:43: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1194:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1249:83: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1266:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1363:61: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1363:61: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1377:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1406:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1427:56: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1427:79: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1475:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1475:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1489:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1506:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1522:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1564:41: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1564:65: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1571:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1571:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_annotate.fx:52:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:577:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_mangle.fx:412:29: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:59:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:201:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:267:78: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:292:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:293:55: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/Hashset.fx:300:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_lift_simple.fx:86:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_lift_simple.fx:86:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:30:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:131:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:157:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:182:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:177:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:269:62: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:281:56: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:478:32: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:261:23: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:58: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:348:43: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:352:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:352:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:353:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:369:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:473:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:482:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:487:60: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:585:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fuse_loops.fx:151:58: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_nothrow_wrappers.fx:43:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:263:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:411:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:469:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:516:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:566:53: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:629:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:634:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/C_form.fx:415:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/C_form.fx:424:9: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:155:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:158:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:180:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:180:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:198:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:198:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:217:16: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:573:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:630:27: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_fdecls.fx:79:37: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:177:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:714:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:577:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:592:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:1378:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:311:66: 2 viable for (string -> <unknown>)
+    candidate: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    generality winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:27: 2 viable for (Ast.id_t@29 -> string)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:1946:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2028:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2043:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2973:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3042:42: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3247:69: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3322:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3331:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3343:32: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3358:80: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3441:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Compiler.fx:220:25: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Compiler.fx:600:44: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true

--- a/docs/wpe_tests_report.md
+++ b/docs/wpe_tests_report.md
@@ -1,0 +1,164 @@
+# WP-E test package + experiments — report
+
+Branch `wpe-tests-1`. This is the safety-net + data-gathering pass that precedes
+the overload-resolver surgery (a later session). Nothing here changes resolution
+behavior: every addition is a test, behavior-neutral instrumentation behind a
+flag, or a pure function nothing in the decision path calls yet. Handoff:
+`docs/wpe_tests_handoff.md`; design: `docs/overload_resolution_proposal_v2.md`.
+
+## Deliverables
+
+### D1 — generality comparator (pure, unwired) — `compiler/Ast_typecheck.fx`
+
+`type gen_cmp_t = MoreGeneric | LessGeneric | EqGeneric | IncompGeneric` plus
+`compare_typ_generality(t1, skolems1, t2, skolems2)` and
+`compare_fun_generality(df1, df2)`, sitting next to `maybe_unify`. Implements §3:
+C++ partial ordering transplanted into unification (A ≻ B iff B-matches-A and not
+A-matches-B), via two one-way `maybe_unify(update_refs=false)` trials.
+
+**Q1 answer (skolem mode): realized by REPRESENTATION, not a flag on the hot
+unifier.** A template parameter frozen to an opaque constant `TypApp([], id)`
+unifies only with an identical constant (`maybe_unify`'s existing TypApp
+id-equality) or is captured by a free `TypVar` on the other side — exactly skolem
+semantics with `maybe_unify` left byte-for-byte untouched. The rigid↔free
+conversion for the opposite-direction trial is `unskolemize_typ`, written on top
+of Ast.fx's `walk_typ`/`ast_callb_t` traversal (per review feedback — less code,
+auto-generalizes to new `typ_t` constructors; the only hand-spelled arms are the
+skolem interception and the two non-destructive cases `dup_typ_` uses,
+`TypVar(ref Some …)` and `TypRecord`, since `walk_typ` mutates those in place).
+
+`compare_fun_generality` compares the parameter tuple; keyword args ride along
+for free (`df_typ` already carries the implicit trailing keyword `TypRecord`);
+constructors additionally let the return type participate.
+
+**Unit tests — `test/test_gencmp.fx`** (imports the compiler as a library via
+`-I compiler`, calls the comparator on hand-built `typ_t`; wired into the fxtest
+corpus). Verdicts locked as the surgery's contract: non-generic ≻ generic,
+`'t complex` ≻ `'t`, `int complex` ≻ `'t complex`, EqGeneric pairs, the
+incomparable `f('t,int)`/`f(int,'t)`, keyword-record subsumption (currently
+IncompGeneric — the §10.Q2 default, no keyword tie-break), and a **fenced**
+interface-direction case (see limitations).
+
+### D2 — resolution trace `-pr-resolve` + `fun2sigstr`
+
+`fun2sigstr(df)` in `Ast_pp.fx` renders one candidate as
+`Module.name(argtyps) -> rt [generic: 't,…] @ file:line`. `-pr-resolve`
+(`Options.fx`) makes `trace_resolve` (in `Ast_typecheck.fx`) print, for every
+call whose expected type is a function type and whose viable **function** set has
+>1 entry: the candidates, the env-order winner (what `find_first` commits to
+today) and the generality winner. The viable set is built with
+`update_refs=false` trials on throwaway copies of the expected type, so it never
+touches inference state. **With the flag off it returns at the guard → the
+generated `.c` is byte-identical** (verified directly and by the determinism
+leg). This trace is the E1 instrument and a permanent debugging aid.
+
+### D3 — test suites
+
+- **T-res positive — `test/test_resolve.fx`** (+ helper `test/ResHelper.fx`).
+  Self-asserting; locks current behavior: keyword-arg overload distinction,
+  constructor-under-expected-type, concrete-beats-generic when order permits, the
+  cross-module qualified-operator call (Q4), and the E0 instance-sees-caller's-`==`
+  case. Fenced `FIXME(FB-016)` case locks the greedy-first-match bug (flips on
+  fix); a commented `FIXME(FB-007)` block documents the real reproductions.
+- **T3+ negative goldens** — `test/negative/009_overload_arity`,
+  `010_overload_keyword`, `011_overload_not_found_candidates`: lock today's
+  not-found/arity/keyword diagnostic format (incl. the `Candidates:` listing) so
+  the surgery's richer messages are reviewed golden changes.
+- **T4+ IR snapshot** — `test/ir/overload_resolve.fx`: mixed generic/non-generic
+  overloads; the selected `@instance` names are visible in the dumps. It plainly
+  shows FB-016 today (all calls, even `pick(5)`, bind the generic instance; the
+  concrete overloads are dead) and will diff when the surgery lands.
+
+All wired into `fxtest all` (corpus manifest gained an `extra_flags` key for the
+`-I compiler` entry; negative/ir dirs auto-discover).
+
+### D4 — experiments (findings only; nothing changed on their basis)
+
+- **E0 (notes-#8): OBSOLETE concern.** A generic `rmem(x,l)` using `==` in module
+  `ResHelper`, called from a module that defines a local `color_t` + `==`, sees
+  that `==` when instantiated (`ResHelper.rmem(Green, […])` → `true`). So
+  `inst_merge_env(env, env1)` already exposes call-site candidates to instances;
+  no visibility mechanism is needed for this case. Kept as a positive test.
+- **E1 (env-order vs generality census): the go/no-go proof.** Full writeup in
+  `docs/wpe_experiments/e1_census.md`; raw trace `e1_compiler_raw.txt`. Over the
+  compiler (`compiler/fx.fx`): 344 viable>1 sites, 117 agree, 227 disagree — and
+  **0 of the disagreements pick a different concrete winner**; all 227 are
+  `<none>` (generality can't rank). Of those, ~224 are the FB-017 record-generic
+  limitation and 2 are genuine identical-signature duplicates (E4). Conclusion:
+  a specificity resolver with first-match tie-fallback is corpus-invariant on the
+  compiler. The self-contained divergence (FB-016) does not occur in the
+  bootstrap; it is a user-code / tranche-B concern.
+- **E2 (intra-generic-body op bound):** static grep over `lib` + `compiler`:
+  **492** generic functions (≥1 type-param arg) and **165** generic operator
+  definitions — the upper bound on §5's deferral sites.
+- **E3 (instance re-typecheck): CONFIRMED from AST.** `instantiate_fun_`
+  (`Ast_typecheck.fx`) does `inst_body = if instantiate { dup_exp(df_body) }` and
+  re-checks it via `instantiate_fun_body`; args re-checked via `dup_pat`. The only
+  cache is `df_templ_inst` (per-instance-**type** reuse scanned in
+  `lookup_id_opt`), not a typecheck bypass. So tranche B's defer-then-resolve is
+  nearly free.
+- **E4 (ninja-name equal-specificity collisions): ~0, 2 benign.** Mined from the
+  E1 census: exactly two genuine identical-signature pairs, both String.fx
+  re-declaring a Builtins helper — `length(string) -> int` (String.fx:10 vs
+  Builtins.fx:133) and `join(string, string list) -> string`. A permanent
+  fxtest lint (Q5) is worth having but should wait until FB-017 is fixed,
+  otherwise the record-generics swamp it with false positives.
+
+## Q4 — qualified-call escape hatch (what parses today)
+
+- `Module.__mul__(a, b)` — the module-qualified **mangled operator name** —
+  **parses and typechecks** for user operators (encoded as `op.qualified_mangled`
+  in `test/test_resolve.fx`). This is the working disambiguation hatch the
+  proposal (§4) assumes.
+- `__mul__(a, b)` (bare mangled name) also resolves for user types.
+- `Module.(*)` / `Module.(+)` (operator-in-parens) — **does not parse**
+  (`unexpected token '.'`). If the prettier form is wanted, it needs grammar work.
+- (`Builtins.__add__(1,2)` fails only because integer `+` is an intrinsic, not an
+  `__add__` function — not a syntax limit.)
+
+So the surgery's ambiguity hint should suggest `Module.__op__(a, b)` today, and a
+nicer `Module.(op)` spelling is a separate Brief-#3 grammar item.
+
+## Bugs found (all in `docs/found_bugs.md`)
+
+- **FB-015** — parser: `continue`/`break` can't be a `match`-arm/`if`-branch
+  value; a bare `return` (no value) doesn't parse. Both misreport as
+  `unexpected token '}'`. Routed around in `trace_resolve`; also in CLAUDE.md.
+- **FB-016** — overload resolution: greedy first-match ignores specificity; the
+  **last-declared** viable overload wins, so `f(5)` with `f(int)` then `f('t)`
+  returns 5 (generic), reversing the declarations returns 6. The minimal,
+  self-contained form of FB-007's S2. Tracked by `-pr-resolve`, the E1 census,
+  and the fenced `test/test_resolve.fx` case + the `test/ir/overload_resolve`
+  golden.
+- **FB-017** — the D1 comparator can't order `{...}` (`TypVarRecord`)
+  auto-generics (`__eq__`/`string`/… on records) vs a concrete record, because
+  `maybe_unify` treats record-vars symmetrically → `EqGeneric`. Dominates the E1
+  `<none>` count (~224 sites) but is comparator *incompleteness*, never a
+  resolution flip. Fix sketch in the entry (skolemize the `TypVar*` family on the
+  rigid side); left for the surgery session (out of D1's stated scope).
+- **FB-007** — re-confirmed live and ground-truthed (S2 via `fst.fx`, S3 via
+  `vision_classify.fx`); the symptoms need the real `Complex.fx` + those
+  programs, not a mini-class. Entry updated.
+
+## Lessons for CLAUDE.md / methodology
+
+- The compiler is importable as a library (`-I compiler`) — enables direct
+  unit-testing of internals (the comparator) from an ordinary `.fx` under fxtest.
+- Adding a field to `Options.options_t` propagates the struct (decl/copy/make)
+  into every module that embeds it: a one-line source change touched **10**
+  bootstrap `.c` files (3 edited + 7 struct-layout). So the handoff's "only the
+  modules you touched may differ" is an idealization — cross-module record-layout
+  propagation is expected and benign (fixpoint still holds, determinism green).
+  Added to CLAUDE.md via FB-015's note; worth a line in the housekeeping notes.
+- FB-015 (`continue`/`return` in expression position) is now in CLAUDE.md gotchas.
+
+## Closing checklist
+
+- `make` + `bin/ficus -run test/test_all.fx` — 135/135.
+- `python3 tools/fxtest/fxtest.py all` — unit + negative(72) + ir(63) + cfold +
+  corpus (incl. `test_gencmp`, `test_resolve`) all green.
+- `determinism` — PASS=3 (byte-identical rebuild + neutral instrumentation).
+- `sanitize` — ASan+UBSan clean.
+- `python3 tools/update_compiler.py` — fixpoint holds.
+- `-pr-resolve` OFF → `.c` byte-identical; ON → trace sanity on real programs.
+- Not pushed; diffs left for review.

--- a/test/ResHelper.fx
+++ b/test/ResHelper.fx
@@ -1,0 +1,10 @@
+/*
+    Helper module for test/test_resolve.fx (WP-E D3). Kept separate so the test
+    can exercise CROSS-MODULE resolution and the module-qualified operator-call
+    escape hatch (Q4). Name is case-insensitively unique vs the stdlib.
+*/
+type rvec_t = {x: int; y: int}
+operator * (a: rvec_t, b: rvec_t): int = a.x*b.x + a.y*b.y
+// a generic membership using ==, to probe that an instance sees a caller's
+// == overload (E0 / notes-#8) across a module boundary.
+fun rmem(x: 't, l: 't list): bool = exists(for y <- l {y == x})

--- a/test/ir/overload_resolve.ast.golden
+++ b/test/ir/overload_resolve.ast.golden
@@ -1,0 +1,32 @@
+from Builtins import *
+from Math import *
+from Complex import *
+from Array import *
+import List
+import Vector
+import Char
+import String
+fun overload_resolve.pick@g0(overload_resolve.x@g1: int): (int -> int) = { (<int>overload_resolve.x@g1 + 1) }
+
+fun overload_resolve.pick@g2(overload_resolve.x@g3: float): (float -> int) = { 2 }
+
+template<'t> fun overload_resolve.pick@g4(x: 't): ('t -> int) = { 0 }
+[[instances:
+   @instance fun overload_resolve.pick@g5(overload_resolve.x@g6: int list): (int list -> int) = { 0 }
+
+   @instance fun overload_resolve.pick@g7(overload_resolve.x@g8: string): (string -> int) = { 0 }
+
+   @instance fun overload_resolve.pick@g9(overload_resolve.x@g10: float): (float -> int) = { 0 }
+
+   @instance fun overload_resolve.pick@g11(overload_resolve.x@g12: int): (int -> int) = { 0 }
+
+   ]]
+val overload_resolve.a@g13: int = <(int -> int)>overload_resolve.pick@g11(5)
+val overload_resolve.b@g14: int = <(float -> int)>overload_resolve.pick@g9(3.0f)
+val overload_resolve.c@g15: int = <(string -> int)>overload_resolve.pick@g7("hi")
+val overload_resolve.d@g16: int = <(int list -> int)>overload_resolve.pick@g5((1 :: 2 :: []))
+<(string ->
+    void)>Builtins.println@g17(((((((<(int -> string)>Builtins.string@g18(<int>overload_resolve.a@g13) + " ") +
+                                      <(int -> string)>Builtins.string@g18(<int>overload_resolve.b@g14)) + " ") +
+                                    <(int -> string)>Builtins.string@g18(<int>overload_resolve.c@g15)) + " ") +
+                                  <(int -> string)>Builtins.string@g18(<int>overload_resolve.d@g16)))

--- a/test/ir/overload_resolve.fx
+++ b/test/ir/overload_resolve.fx
@@ -1,0 +1,15 @@
+// WP-E / D3 -- resolution-sensitive IR snapshot. Mixed generic/non-generic
+// overloads called at several types; the selected instance names are visible in
+// the AST/K-form dumps, so any change in overload resolution shows up as a diff.
+// NOTE: today (FB-016) the generic pick('t), declared LAST, wins ALL calls --
+// even pick(5)/pick(3.0f) route to @instance of the generic (returning 0), and
+// the concrete pick(int)/pick(float) are dead. When the resolver surgery lands,
+// pick(5)->concrete (6) and pick(3.0f)->concrete (2); this golden then changes.
+fun pick(x: int): int = x + 1
+fun pick(x: float): int = 2
+fun pick(x: 't): int = 0
+val a = pick(5)        // concrete int
+val b = pick(3.0f)     // concrete float
+val c = pick("hi")     // generic 't
+val d = pick([:: 1,2]) // generic 't (list)
+println(f"{a} {b} {c} {d}")

--- a/test/ir/overload_resolve.k.golden
+++ b/test/ir/overload_resolve.k.golden
@@ -1,0 +1,7 @@
+@temp val v@g0: string = _fx_F6stringS1i(0)
+@temp val v@g1: string = _fx_F6stringS1i(0)
+@temp val v@g2: string = _fx_F6stringS1i(0)
+@temp val v@g3: string = _fx_F6stringS1i(0)
+@temp val v@g4: string = __intrin_str_concat__(v@g0, " ", v@g1, " ", v@g2, " ", v@g3)
+_fx_F12print_stringv1S(v@g4)
+_fx_F12print_stringv1S("\n")

--- a/test/ir/overload_resolve.k0.golden
+++ b/test/ir/overload_resolve.k0.golden
@@ -1,0 +1,30 @@
+fun overload_resolve.pick@g0(x@g1: int): int { x@g1 + 1 }
+
+fun overload_resolve.pick@g2(x@g3: float): int { 2 }
+
+@instance fun overload_resolve.pick@g4(x@g5: int list): int { 0 }
+
+@instance fun overload_resolve.pick@g6(x@g7: string): int { 0 }
+
+@instance fun overload_resolve.pick@g8(x@g9: float): int { 0 }
+
+@instance fun overload_resolve.pick@g10(x@g11: int): int { 0 }
+
+@global val overload_resolve.a@g12: int = overload_resolve.pick@g10(5)
+@global val overload_resolve.b@g13: int = overload_resolve.pick@g8(3.0f)
+@global val overload_resolve.c@g14: int = overload_resolve.pick@g6("hi")
+@temp val z@g15: int list = null
+@temp val v@g16: int list = 2 :: z@g15
+@temp val v@g17: int list = 1 :: v@g16
+@global val overload_resolve.d@g18: int = overload_resolve.pick@g4(v@g17)
+@temp val v@g19: string = string@g20(overload_resolve.a@g12)
+@temp val v@g21: string = __intrin_str_concat__(v@g19, " ")
+@temp val v@g22: string = string@g20(overload_resolve.b@g13)
+@temp val v@g23: string = __intrin_str_concat__(v@g21, v@g22)
+@temp val v@g24: string = __intrin_str_concat__(v@g23, " ")
+@temp val v@g25: string = string@g20(overload_resolve.c@g14)
+@temp val v@g26: string = __intrin_str_concat__(v@g24, v@g25)
+@temp val v@g27: string = __intrin_str_concat__(v@g26, " ")
+@temp val v@g28: string = string@g20(overload_resolve.d@g18)
+@temp val v@g29: string = __intrin_str_concat__(v@g27, v@g28)
+println@g30(v@g29)

--- a/test/negative/009_overload_arity.err
+++ b/test/negative/009_overload_arity.err
@@ -1,0 +1,6 @@
+009_overload_arity.fx:5:9: error: the appropriate match for 'ff' of type '(int -> <unknown>)' is not found.
+Candidates:
+ 'ff: ((int, int) -> int)' defined at 009_overload_arity.fx:4:1
+
+
+1 errors occured during type checking.

--- a/test/negative/009_overload_arity.fx
+++ b/test/negative/009_overload_arity.fx
@@ -1,0 +1,6 @@
+// expect: is not found
+// WP-E: arity mismatch -- locks today's not-found diagnostic format so the
+// resolver surgery's improved message is a reviewed golden change.
+fun ff(a: int, b: int) = a + b
+val r = ff(1)
+println(r)

--- a/test/negative/010_overload_keyword.err
+++ b/test/negative/010_overload_keyword.err
@@ -1,0 +1,6 @@
+010_overload_keyword.fx:4:9: error: the appropriate match for 'kk' of type '({z: int} -> <unknown>)' is not found.
+Candidates:
+ 'kk: ({a: int} -> int)' defined at 010_overload_keyword.fx:3:1
+
+
+1 errors occured during type checking.

--- a/test/negative/010_overload_keyword.fx
+++ b/test/negative/010_overload_keyword.fx
@@ -1,0 +1,5 @@
+// expect: is not found
+// WP-E: keyword mismatch (unknown keyword 'z').
+fun kk(~a: int) = a
+val r = kk(z=5)
+println(r)

--- a/test/negative/011_overload_not_found_candidates.err
+++ b/test/negative/011_overload_not_found_candidates.err
@@ -1,0 +1,7 @@
+011_overload_not_found_candidates.fx:6:9: error: the appropriate match for 'oo' of type '(string -> <unknown>)' is not found.
+Candidates:
+ 'oo: (int -> int)' defined at 011_overload_not_found_candidates.fx:4:1,
+ 'oo: (float -> int)' defined at 011_overload_not_found_candidates.fx:5:1
+
+
+1 errors occured during type checking.

--- a/test/negative/011_overload_not_found_candidates.fx
+++ b/test/negative/011_overload_not_found_candidates.fx
@@ -1,0 +1,7 @@
+// expect: is not found
+// WP-E: no overload accepts a string; locks the candidate-listing format that
+// report_not_found_typed prints today (the surgery will enrich it).
+fun oo(a: int) = a
+fun oo(a: float) = 1
+val r = oo("x")
+println(r)

--- a/test/test_gencmp.fx
+++ b/test/test_gencmp.fx
@@ -1,0 +1,97 @@
+/*
+    WP-E / D1 unit tests for the generality comparator
+    (compare_typ_generality / compare_fun_generality) added to Ast_typecheck.fx.
+
+    These tests are the "contract" the later overload-resolver surgery session
+    must keep (or deliberately, loudly break). They call the comparator DIRECTLY
+    on hand-built typ_t values, so the file imports the compiler as a library:
+
+        bin/ficus -run -I compiler test/test_gencmp.fx
+
+    (fxtest passes `-I compiler` for this entry; see tools/fxtest/manifest.toml.)
+
+    compare_typ_generality is pure structural: it only uses unskolemize_typ (a
+    local tree walk) and maybe_unify, never id_info on these inputs, so no global
+    compiler state beyond get_id() is needed. Skolems ('t, 'u) are modelled as
+    opaque constants TypApp([], id) exactly as skolemize_fun_sig freezes them.
+
+    Result of compare_typ_generality(t1, .., t2, ..) describes t1 RELATIVE TO t2:
+      MoreGeneric  - t1 accepts strictly more than t2 (t1 is the fallback)
+      LessGeneric  - t1 is strictly more specific (the ranking WINNER)
+      EqGeneric    - mutually applicable (ambiguous: "qualify the call")
+      IncompGeneric- overlapping but unordered (ambiguous: needs a disambiguator)
+*/
+import Ast, Ast_typecheck
+from Ast import *
+from Ast_typecheck import *
+
+fun gc2str(c: gen_cmp_t) = match c {
+    | MoreGeneric => "MoreGeneric" | LessGeneric => "LessGeneric"
+    | EqGeneric => "EqGeneric"     | IncompGeneric => "IncompGeneric" }
+
+var fails = 0
+fun check(name: string, got: gen_cmp_t, want: gen_cmp_t) {
+    val g = gc2str(got), w = gc2str(want)
+    if g == w { println(f"ok    {name}: {g}") }
+    else { fails += 1; println(f"FAIL  {name}: got {g}, want {w}") }
+}
+
+val t_id = get_id("t"), u_id = get_id("u")
+val skT: typ_t = TypApp([], t_id)          // opaque skolem 't
+val skU: typ_t = TypApp([], u_id)          // opaque skolem 'u
+val cplx_id = get_id("complex")
+fun cplx(t: typ_t) = TypApp([:: t], cplx_id)   // 't complex stand-in
+
+// ---- non-generic beats generic (the fully-skolem limit case of §3) ----------
+check("int_vs_t", compare_typ_generality(TypInt, [], skT, [:: t_id]), LessGeneric)
+check("t_vs_int", compare_typ_generality(skT, [:: t_id], TypInt, []), MoreGeneric)
+
+// ---- EqGeneric: mutually applicable ----------------------------------------
+check("int_vs_int", compare_typ_generality(TypInt, [], TypInt, []), EqGeneric)
+check("t_vs_u",     compare_typ_generality(skT, [:: t_id], skU, [:: u_id]), EqGeneric)
+
+// ---- 't vs 't complex: the S2 shape ('t complex * int lost to array __mul__) -
+check("t_vs_tcomplex", compare_typ_generality(skT, [:: t_id], cplx(skT), [:: t_id]), MoreGeneric)
+check("tcomplex_vs_t", compare_typ_generality(cplx(skT), [:: t_id], skT, [:: t_id]), LessGeneric)
+// 't complex (generic arg) vs int complex (concrete arg)
+check("tcplx_vs_intcplx", compare_typ_generality(cplx(skT), [:: t_id], cplx(TypInt), []), MoreGeneric)
+check("intcplx_vs_tcplx", compare_typ_generality(cplx(TypInt), [], cplx(skT), [:: t_id]), LessGeneric)
+
+// ---- genuinely incomparable: f('t, int) vs f(int, 'u) on (int,int) ----------
+val a1 = TypTuple([:: skT, TypInt]), b1 = TypTuple([:: TypInt, skU])
+check("Ttup_int_vs_int_Utup", compare_typ_generality(a1, [:: t_id], b1, [:: u_id]), IncompGeneric)
+
+// ---- keyword-record subsumption ---------------------------------------------
+// Keyword args travel as an implicit trailing TypRecord; overloads differing
+// only in keyword sets meet here. Per proposal §10.Q2 the DEFAULT policy adds NO
+// "fewer-defaults-preferred" tie-break, so distinct keyword sets do NOT order ->
+// IncompGeneric (ambiguity). Locked as the contract; the surgery session flips
+// this ONLY if the corpus (E4/E1) shows a real need for a keyword tie-break.
+val nop = ExpNop(noloc), df = default_val_flags()
+fun recf(fields: (id_t, typ_t) list, closed: bool) =
+    TypRecord(ref ([:: for (n,t) <- fields {(df, n, t, nop)}], closed))
+val recA_open  = recf([:: (get_id("a"), TypInt)], false)
+val recA_clsd  = recf([:: (get_id("a"), TypInt)], true)
+val recAB_clsd = recf([:: (get_id("a"), TypInt), (get_id("b"), TypInt)], true)
+check("kw_open_a_vs_closed_ab",   compare_typ_generality(recA_open, [], recAB_clsd, []), IncompGeneric) // FIXME(WP-E Q2)
+check("kw_closed_a_vs_closed_ab", compare_typ_generality(recA_clsd, [], recAB_clsd, []), IncompGeneric) // FIXME(WP-E Q2)
+
+// ---- interface direction: FENCED --------------------------------------------
+// §3 wants "concrete class less generic than its interface" and "child iface
+// less generic than parent". That needs UPCAST-AWARE unification (same_or_parent
+// / dvar_ifaces), which lives in the cast logic, NOT in maybe_unify. The pure
+// structural comparator therefore reports two distinct nominal types as
+// IncompGeneric today. Locked here so it flips LOUDLY when the surgery session
+// teaches the comparator about class->interface / child->parent upcasts.
+val cls_id = get_id("MyClass"), iface_id = get_id("MyIface")
+check("class_vs_iface_FENCED",
+      compare_typ_generality(TypApp([],cls_id), [], TypApp([],iface_id), []),
+      IncompGeneric) // FIXME(WP-E surgery): should become LessGeneric once upcast-aware
+
+// Note: compare_fun_generality (the deffun_t ref wrapper: skolemization + keyword
+// record + constructor return-type rule) is exercised end-to-end by the
+// -pr-resolve census on real programs (D2/E1), since building valid deffun_t
+// refs by hand needs the full typechecker environment.
+
+println(f"\ntest_gencmp: {fails} failure(s)")
+if fails > 0 { throw Fail("test_gencmp failed") }

--- a/test/test_resolve.fx
+++ b/test/test_resolve.fx
@@ -1,0 +1,93 @@
+/*
+    WP-E / D3 — T-res positive suite. Locks CURRENT overload-resolution behavior
+    so the later resolver surgery flips each change deliberately (a failing
+    assertion here == a reviewed decision, not an accident).
+
+    Self-asserting program (no UTest, no compiler-internal imports): it prints
+    each check and throws on the first wrong value, so the fxtest O0/O3
+    differential doubles as an assertion at both opt levels.
+
+    Cases marked FIXME(FB-016)/FIXME(FB-007) lock behavior that is WRONG today and
+    is expected to change when tranche A of the resolver surgery lands; when it
+    does, the corresponding assertion fails loudly and is updated in review.
+
+    See docs/overload_resolution_proposal_v2.md and docs/wpe_tests_report.md.
+*/
+import ResHelper
+from ResHelper import *
+
+var fails = 0
+fun check(name: string, got: int, want: int) {
+    if got == want { println(f"ok    {name} = {got}") }
+    else { fails += 1; println(f"FAIL  {name}: got {got}, want {want}") }
+}
+
+// ---------------------------------------------------------------------------
+// PASSING behavior (correct today; must stay correct through the surgery)
+// ---------------------------------------------------------------------------
+
+// (1) Overloads differing only in keyword arguments are distinguished.
+fun kw(~a: int) = a * 10
+fun kw(~a: int, ~b: int) = a + b
+check("kw.one_key", kw(a=5), 50)
+check("kw.two_keys", kw(a=5, b=3), 8)
+
+// (2) Constructor resolution under an expected type.
+type box_t = Empty | Full: int
+val boxed: box_t = Full(7)
+check("ctor.under_expected", (match boxed { | Full(v) => v | Empty => -1 }), 7)
+
+// (3) A concrete overload declared AFTER a generic one wins (env order happens
+//     to agree with specificity here). Locks the common good case.
+fun good(x: 't) = 0
+fun good(x: int) = 1
+check("concrete_last_wins", good(5), 1)
+
+// (4) Cross-module: module-qualified operator call via the mangled name is the
+//     working disambiguation escape hatch (Q4). Both the operator form and the
+//     ResHelper.__mul__ qualified form select the rvec_t operator.
+val v = rvec_t {x=2, y=3}
+check("op.infix", v * v, 13)
+check("op.qualified_mangled", ResHelper.__mul__(v, v), 13)
+
+// (5) E0 / notes-#8: a generic function in another module, using ==, sees THIS
+//     module's == overload for a locally-defined type when instantiated here.
+type color_t = Red | Green | Blue
+operator == (a: color_t, b: color_t): bool =
+    (a.__tag__ == b.__tag__)
+check("xmodule.instance_sees_local_eq",
+      (if ResHelper.rmem(Green, [:: Red, Green, Blue]) {1} else {0}), 1)
+
+// ---------------------------------------------------------------------------
+// FENCED — behavior that is WRONG today; flips when the surgery lands
+// ---------------------------------------------------------------------------
+
+// FIXME(FB-016): greedy first-match. A concrete overload declared BEFORE a
+// generic one LOSES to the generic (env-list is most-recent-first). So bad(5)
+// calls the generic identity and yields 5; a specificity resolver yields 6.
+// When tranche A lands, this assertion fails -> change 5 to 6 and drop the fence.
+fun bad(x: int) = x + 1
+fun bad(x: 't) = x
+check("FIXME_FB016.generic_beats_concrete", bad(5), 5)   // want-after-fix: 6
+
+/*
+   FIXME(FB-007): the three generic-`complex` resolution symptoms are NOT
+   reproducible in a self-contained mini-class — they require the real
+   lib/Complex.fx operators (uncommented) plus the `N.fi` imaginary literal and
+   the NN library's generic `+` on `nnop_t list`. Ground-truthed in this WP-E
+   (see docs/found_bugs.md FB-007 and docs/wpe_tests_report.md):
+
+   - S2 (operator mis-resolution): with Complex.fx ops uncommented,
+       val c = ref (1 + 1.fi); *c *= 2
+     resolves `__mul__` to the ARRAY multiply
+     (lib/Array.fx:341: "unsupported iteration domain").
+   - S3 (inference pollution): compiling examples/vision_classify.fx with those
+     ops on infers `nnop_t list Complex.complex` for a plain `nnop_t list`
+     (lib/Complex.fx:17), cascading to NN/FromOnnx.fx:1018.
+
+   These flip to pass when tranche A lands; they are fenced by keeping
+   lib/Complex.fx:15-44 and examples/fst.fx:125-127 commented in-tree.
+*/
+
+println(f"\ntest_resolve: {fails} failure(s)")
+if fails > 0 { throw Fail("test_resolve failed") }

--- a/tools/fxtest/fxtest.py
+++ b/tools/fxtest/fxtest.py
@@ -261,11 +261,15 @@ def _build_root(name, opt, suffix=""):
 
 
 def compile_and_run(name, src, opt, args, timeout, *,
-                    openmp=False, cpp=False, artifact=None, suffix=""):
+                    openmp=False, cpp=False, artifact=None, suffix="",
+                    extra_flags=None):
     """Compile `src` at `opt` and run it, returning a RunOutcome.
 
     Runs with cwd=build_root so any relative output files (artifacts) are
     isolated per (entry, opt).  -no-openmp unless openmp=True.
+
+    `extra_flags` (list) are inserted before the source path -- used e.g. by the
+    test_gencmp entry, which imports the compiler as a library ("-I compiler").
     """
     broot = _build_root(name, opt, suffix)
     os.makedirs(broot, exist_ok=True)
@@ -274,6 +278,14 @@ def compile_and_run(name, src, opt, args, timeout, *,
         cmd.append("-no-openmp")
     if cpp:
         cmd.append("-c++")
+    if extra_flags:
+        # runs with cwd=broot, so make any "-I <dir>" argument absolute (relative
+        # to the repo root) rather than to the transient build directory.
+        ef = list(extra_flags)
+        for k in range(len(ef) - 1):
+            if ef[k] == "-I" and not os.path.isabs(ef[k + 1]):
+                ef[k + 1] = os.path.join(REPO, ef[k + 1])
+        cmd += ef
     cmd += ["-B", broot, os.path.abspath(src)]
     if args:
         cmd += ["--"] + list(args)
@@ -313,6 +325,7 @@ def _entry_cfg(raw):
         "timeout_sec": int(raw.get("timeout_sec", 60)),
         "compile_timeout_sec": int(raw.get("compile_timeout_sec", 180)),
         "quarantine": raw.get("quarantine"),
+        "extra_flags": raw.get("extra_flags", []),
     }
 
 
@@ -356,7 +369,7 @@ def run_corpus_entry(name, raw, opts):
     for opt in opts:
         runs[opt] = compile_and_run(
             name, src, opt, cfg["args"], timeout,
-            artifact=cfg["artifact"],
+            artifact=cfg["artifact"], extra_flags=cfg["extra_flags"],
         )
     ref_opt = opts[0]
     if len(opts) == 1:

--- a/tools/fxtest/manifest.toml
+++ b/tools/fxtest/manifest.toml
@@ -31,6 +31,25 @@ compile_timeout_sec = 300
 # FB-001 (interface C++ codegen) fixed on harden-1: the -c++ smoke now passes,
 # so the cpp_xfail fence is removed and the -c++ build is checked for real.
 
+# ---- WP-E/D1: generality-comparator unit tests ------------------------------
+# Imports the compiler itself as a library (needs -I compiler) and asserts the
+# gen_cmp_t verdicts of compare_typ_generality on hand-built types. The program
+# throws (nonzero exit) on any wrong verdict, so the O0/O3 differential doubles
+# as an assertion at both opt levels.
+[corpus.test_gencmp]
+path = "test/test_gencmp.fx"
+compare = "exact"
+extra_flags = ["-I", "compiler"]
+compile_timeout_sec = 300
+
+# ---- WP-E/D3: overload-resolution behavior lock (T-res positive suite) -------
+# Self-asserting (throws on a wrong resolution); imports test/ResHelper.fx (a
+# sibling module, found via the source dir -- no -I needed). FIXME(FB-016) cases
+# lock today's wrong behavior and flip when the resolver surgery lands.
+[corpus.test_resolve]
+path = "test/test_resolve.fx"
+compare = "exact"
+
 # ---- self-contained deterministic examples ----------------------------------
 [corpus.btree]
 path = "examples/btree.fx"


### PR DESCRIPTION
Safety net and data-gathering pass before the overload-resolver surgery. Nothing changes resolution behavior: additions are tests, flag-gated instrumentation, or pure functions nothing in the decision path calls yet. Determinism + sanitize green; bootstrap fixpoint holds.

D1 - generality comparator (pure, unwired) in Ast_typecheck.fx: gen_cmp_t, compare_typ_generality, compare_fun_generality, unskolemize_typ. Skolem mode via representation (opaque TypApp constants), so maybe_unify is untouched; unskolemize_typ reuses walk_typ/ast_callb_t. Unit tests test/test_gencmp.fx (imports the compiler as a library via -I compiler).

D2 - resolution trace: fun2sigstr (Ast_pp.fx) + -pr-resolve (Options.fx, trace_resolve in Ast_typecheck.fx). Off -> generated .c byte-identical.

D3 - suites: test/test_resolve.fx (+test/ResHelper.fx), negative goldens 009-011, IR snapshot test/ir/overload_resolve. manifest gains extra_flags.

D4 - experiments (docs/wpe_experiments/, docs/wpe_tests_report.md): E1 census over the compiler shows 0 different-concrete-winner disagreements (corpus invariant for tranche A); E0 notes-#8 obsolete; E3 instances re-typecheck from AST; E2 492 generic funcs/165 generic ops; E4 2 benign equal-sig duplicates. Q4: Module.__mul__(a,b) is the working qualified-call hatch; Module.(*) does not parse.

Bugs logged (docs/found_bugs.md): FB-015 (continue/bare-return in expression position), FB-016 (greedy first-match: last-declared overload wins), FB-017 (comparator can't order {...} record generics vs concrete). FB-007 re-confirmed live and ground-truthed.