### PR TITLE
Fixed name overloading mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,15 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
 - **Shift count must be `int`**: `uint64 >> int64` does **not** typecheck
   (`__shr__ (uint64,int64)` not found); write `x >> int(n)`. Runtime uint64 `>>`
   is a correct logical shift — only the *constant folder* got it wrong (FB-002).
+- **Overload resolution (resolve-1): the least-generic viable candidate wins**,
+  independent of declaration/import order (concrete beats generic, `int complex`
+  beats `'t complex`). If no candidate is strictly most specific at a call whose
+  argument types are fully known, it's an **ambiguity error** — disambiguate
+  with a module-qualified call; for operators use the mangled name:
+  `Module.__mul__(a, b)` (`Module.(*)` does not parse). Two identical-signature
+  overloads only error at a call that sees both. When argument types still
+  contain free type vars, ties silently fall back to first-match (deferral is
+  pending) — don't rely on it in new code.
 
 ### Build/run & measurement traps (Brief #2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,9 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
   `Module.__mul__(a, b)` (`Module.(*)` does not parse). Two identical-signature
   overloads only error at a call that sees both. When argument types still
   contain free type vars, ties silently fall back to first-match (deferral is
-  pending) — don't rely on it in new code.
+  pending) — don't rely on it in new code. A candidate viable only via
+  all-defaulted keyword args loses to an exact keywordless match
+  (`sqrt(81.0)` → `Math.sqrt(double)`, not a local `sqrt('t, ~n=2)`).
 
 ### Build/run & measurement traps (Brief #2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
   pending) — don't rely on it in new code. A candidate viable only via
   all-defaulted keyword args loses to an exact keywordless match
   (`sqrt(81.0)` → `Math.sqrt(double)`, not a local `sqrt('t, ~n=2)`).
+- **`[]` is typed "some collection" (resolve-2, `TypVarCollection`)**: it
+  unifies only with a list/vector/array (or a free type var), so
+  `val n: int = []` is a typecheck error and a `[]`-initialized fold
+  accumulator can't be captured by a non-collection overload. If the
+  collection kind is never pinned, K-normalization asks for an annotation.
 
 ### Build/run & measurement traps (Brief #2)
 

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -121,6 +121,13 @@ type typ_t =
     | TypVarTuple: typ_t?
     | TypVarArray: typ_t
     | TypVarRecord
+    /* "some collection" (list, vector or array), element type yet unknown.
+       This is the type of the empty-collection literal []: unlike a plain
+       free TypVar it refuses to unify with scalars, records, functions etc.,
+       so `val n: int = []` or `[] + 3.14` fail in the type checker, and an
+       overload trial cannot bind a free-typed [] accumulator to an unrelated
+       generic parameter (the FB-007/S3 collision shape). */
+    | TypVarCollection
     | TypInt
     | TypSInt: int
     | TypUInt: int
@@ -853,7 +860,7 @@ fun get_lit_typ(l: lit_t) {
     | LitString _ => TypString
     | LitChar _ => TypChar
     | LitBool _ => TypBool
-    | LitEmpty => make_new_typ()
+    | LitEmpty => TypVar(ref Some(TypVarCollection))
     | LitNull => TypCPointer
 }
 
@@ -870,6 +877,7 @@ fun deref_typ(t: typ_t): typ_t {
             | TypVar (ref Some(TypVarArray _)) => t
             | TypVar (ref Some(TypVarTuple _)) => t
             | TypVar (ref Some(TypVarRecord)) => t
+            | TypVar (ref Some(TypVarCollection)) => t
             | TypVar (ref Some(t2)) => find_root(t2)
             | _ => t
         }
@@ -1261,6 +1269,7 @@ fun typ2str(t: typ_t): string {
     | TypVarTuple _ => "(...)"
     | TypVarArray(t) => f"{typ2str(t)} [+]"
     | TypVarRecord => "{...}"
+    | TypVarCollection => "[...]"
     | TypVar ((ref Some(t)) as r) => f"{typ2str(t)}"
     | TypVar (r) => "<unknown>"
     | TypApp([], i) => id2str_m(i)
@@ -1384,6 +1393,7 @@ fun walk_typ(t: typ_t, callb: ast_callb_t) =
     | TypArray(d, et) => TypArray(d, check_n_walk_typ(et, callb))
     | TypVarArray(et) => TypVarArray(check_n_walk_typ(et, callb))
     | TypVarRecord => t
+    | TypVarCollection => t
     | TypRecord((ref (relems, ordered)) as r) =>
         val new_relems = [:: for (flags, n, t, v) <- relems {
             (flags, n, check_n_walk_typ(t, callb), check_n_walk_exp(v, callb))} ]

--- a/compiler/Ast_pp.fx
+++ b/compiler/Ast_pp.fx
@@ -66,7 +66,7 @@ fun get_typ_pr(t: typ_t): typ_pr_t
         TypPrBase
     | TypApp([], _) => TypPrBase
     | TypTuple _ | TypVarTuple _ => TypPrBase
-    | TypRecord _ | TypVarRecord => TypPrBase
+    | TypRecord _ | TypVarRecord | TypVarCollection => TypPrBase
     | TypList _ | TypVector _ | TypRef _ | TypArray(_, _) | TypVarArray _ | TypApp(_, _) => TypPrComplex
     | TypFun(_, _) => TypPrFun
 }
@@ -118,6 +118,7 @@ fun pprint_typ(pp: PP.t, t: typ_t, loc: loc_t, ~brief:bool=false)
             pptypsuf(t1, f"[{shape}]")
         | TypVarArray(t1) => pptypsuf(t1, "[+]")
         | TypVarRecord => pp.str("{...}")
+        | TypVarCollection => pp.str("[...]")
         | TypApp([], n) => ppid(pp, n)
         | TypApp([:: t1], n) => pptypsuf(t1, ppid2str(n))
         | TypApp(tl, n) => pptypsuf(TypTuple(tl), ppid2str(n))

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -330,11 +330,12 @@ fun maybe_unify(t1: typ_t, t2: typ_t, loc: loc_t, update_refs: bool): bool {
 }
 
 /* ---------------------------------------------------------------------------
-   Generality comparator (WP-E / D1). PURE and UNWIRED: nothing in resolution
-   calls these yet. Consumed by the -pr-resolve trace (D2), the E1/E4 census and
-   the test/test_gencmp.fx unit tests. They implement §3 of
-   docs/overload_resolution_proposal_v2.md: C++ partial-ordering transplanted
-   into unification.
+   Generality comparator (WP-E / D1, wired into resolution by resolve-1):
+   lookup_id_opt ranks the viable overload set with compare_fun_generality --
+   the unique LEAST generic viable candidate wins. Also consumed by the
+   -pr-resolve trace, the E1/E4 census and the test/test_gencmp.fx unit tests.
+   Implements §3 of docs/overload_resolution_proposal_v2.md: C++
+   partial-ordering transplanted into unification.
 
    "Skolem mode" (Q1) is realized purely by REPRESENTATION, not by a flag on the
    hot unifier: a template parameter frozen to an opaque constant TypApp([], id)
@@ -502,6 +503,31 @@ fun compare_fun_generality(df1: deffun_t ref, df2: deffun_t ref): gen_cmp_t
     val (t1, sk1) = skolemize_fun_sig(df1)
     val (t2, sk2) = skolemize_fun_sig(df2)
     compare_typ_generality(t1, sk1, t2, sk2)
+}
+
+/* Does the type still contain free type variables (including the still-unbound
+   var-form generics {...} / (...) / 't [+])? Used by the overload-resolution
+   tie policy: a call is "fully determined" iff none of its argument types has
+   free vars -- only then is an unresolvable tie a hard ambiguity error;
+   otherwise resolution falls back to env-order first-match (today's semantics)
+   until under-constrained calls get proper deferral (session 2).
+   A more conservative flavor of Ast.is_fixed_typ: var-forms count as free. */
+fun typ_has_free_vars(t: typ_t): bool {
+    var has_free = false
+    fun check_(t: typ_t, callb: ast_callb_t): typ_t =
+        if has_free { t }
+        else {
+            match deref_typ(t) {
+            | TypVar (ref None) => has_free = true; t
+            | TypVar (ref Some(TypVarRecord)) => has_free = true; t
+            | TypVar (ref Some(TypVarTuple _)) => has_free = true; t
+            | TypVar (ref Some(TypVarArray _)) => has_free = true; t
+            | t1 => walk_typ(t1, callb)
+            }
+        }
+    val callb = ast_callb_t {ast_cb_typ=Some(check_), ast_cb_exp=None, ast_cb_pat=None}
+    val _ = check_(t, callb)
+    has_free
 }
 
 /* this is another flavor of type unification function;
@@ -959,11 +985,12 @@ fun find_first(n: id_t, env: env_t, env0: env_t, sc: scope_t list,
     }
 }
 
-/* WP-E / D2: the -pr-resolve trace -- the E1 instrument, side-effect-free.
-   fun_matches_trial mirrors lookup_id_opt's IdFun viability test but with
-   update_refs=false and against a throwaway copy of the expected type, so it
-   never commits: whether a candidate is viable is decided without touching the
-   real inference state. */
+/* The side-effect-free viability trial of the collect phase (resolve-1):
+   mirrors commit_fun's unification (including the implicit trailing keyword
+   record) but with update_refs=false, so whether a candidate is viable is
+   decided without touching the real inference state. The constructor
+   return-type check and the instance-cache scan are commit-only concerns:
+   viability does not depend on them. */
 fun fun_matches_trial(df: deffun_t ref, t: typ_t, sc: scope_t list, loc: loc_t): bool
 {
     val {df_templ_args, df_typ, df_flags, df_env} = *df
@@ -986,137 +1013,224 @@ fun fun_matches_trial(df: deffun_t ref, t: typ_t, sc: scope_t list, loc: loc_t):
     }
 }
 
-/* For every lookup whose viable FUNCTION set has >1 entry, print the candidates,
-   the env-order winner (the first viable -- exactly what find_first commits to
-   today) and the generality winner (the unique least-generic candidate per
-   compare_fun_generality, or "<none>" when tied/unordered). Building the viable
-   set uses update_refs=false trials on fresh copies of `t`, so it does not alter
-   what the normal resolution below then does. With -pr-resolve off this returns
-   at the guard -> zero effect, and the generated .c is byte-identical (the
-   determinism leg is the proof). */
-fun trace_resolve(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): void
-{
-    // Only trace genuine call-position resolution: the expected type must be a
-    // function type. A bare identifier used as a value (e.g. `array(size, 0)`,
-    // where `size` is an int parameter that merely shares its name with the
-    // container `size` functions) is looked up with a non-function `t`, and is
-    // correctly skipped here.
-    if Options.opt.print_resolve && (match deref_typ(t) { | TypFun _ => true | _ => false }) {
-        var acc: deffun_t ref list = []
-        for e <- find_all(n, env) {
-            match e {
-            | EnvId(i) =>
-                match id_info(i, loc) {
-                | IdFun(df) => if fun_matches_trial(df, dup_typ(t), sc, loc) { acc = df :: acc }
-                | _ => {}
+/* resolve-1 (WP-E §2): overload resolution is collect -> rank -> commit.
+
+   For each environment level (the direct hit for `n`, or the module found by
+   the dotted-path search), ALL candidate entries are scanned:
+     - every IdFun is TRIED side-effect-free (fun_matches_trial,
+       update_refs=false) and collected into the viable set; nothing binds;
+     - a non-function entry (value/module/exception) keeps its first-match
+       semantics: it wins immediately if no viable function precedes it
+       (exactly today's behavior), and is skipped otherwise.
+   The viable set is then RANKED by compare_fun_generality: the unique
+   least-generic candidate wins. On a tie (EqGeneric/IncompGeneric at the top):
+     - fully-determined call (no free type vars among the expected argument
+       types) -> ambiguity error listing the tied candidates;
+     - under-constrained call -> fall back to env-order first-match, i.e.
+       today's semantics, until deferral of such calls lands (session 2).
+   The winner is COMMITTED by re-running the pre-resolve-1 success path
+   (unify with update_refs=true + constructor return check + instance cache
+   scan + instantiation) exactly once, for the right candidate.
+
+   With -pr-resolve on, every viable>1 ranking prints the candidates, the
+   env-order winner, the generality winner and the outcome -- this IS the
+   decision path, not a parallel reconstruction. */
+fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): ((id_t, typ_t)?, env_entry_t list) {
+    val curr_m_idx = curr_module(sc)
+    var possible_matches: env_entry_t list = []
+
+    // today's success path, executed once for the winner
+    fun commit_fun(i: id_t, df: deffun_t ref): (id_t, typ_t)? {
+        val {df_name, df_templ_args, df_typ, df_flags, df_templ_inst, df_env} = *df
+        // if the function has keyword parameters, we implicitly add a dummy record argument
+        // to the end of arguments' type list of t
+        val t = match (df_flags.fun_flag_have_keywords, deref_typ(t)) {
+            | (true, TypFun(argtyps, rt)) =>
+                val argtyps = match argtyps {
+                    | _ :: _ when (match deref_typ(argtyps.last()) {
+                        | TypRecord (ref (_, false)) => true
+                        | _ => false }) =>
+                        argtyps
+                    | _ => argtyps + [:: TypRecord(ref ([], false))]
+                    }
+                TypFun(argtyps, rt)
+            | _ => t
+            }
+        if df_templ_args == [] {
+            if maybe_unify(df_typ, t, loc, true) { Some((i, t)) }
+            else { throw compile_err(loc, f"internal error: the winning overload of \
+                   '{pp(n)}' failed to re-unify at commit") }
+        } else {
+            val (ftyp, env1) = preprocess_templ_typ(df_templ_args, df_typ, df_env, sc, loc)
+            if !maybe_unify(ftyp, t, loc, true) {
+                throw compile_err(loc, f"internal error: the winning overload of \
+                    '{pp(n)}' failed to re-unify at commit")
+            }
+            /* a necessary extra step to do before function instantiation;
+                if it's a constructor, we first need to check the return type.
+                this check may implicitly instantiate generic variant type, and so
+                the df_templ_inst list of this constructor will be expanded with new instance.
+                In theory, with such an extra step we should never enter
+                'instantiate_fun' for constructors, because they all will be
+                instantiated from check_typ => instantiate_variant => register_typ_constructor. */
+            val return_orig =
+                if !is_constructor(df_flags) {false}
+                else {
+                    match ftyp {
+                    | TypFun(_, rt) =>
+                        val _ = check_typ(rt, env1, sc, loc); false
+                    | _ => !is_fixed_typ(t)
+                    }
                 }
-            | _ => {}
+            if return_orig { Some((df_name, t)) }
+            else {
+                val inst_name_opt = find_opt(for inst <- *df_templ_inst {
+                    match id_info(inst, loc) {
+                    | IdFun (ref {df_typ=inst_typ}) =>
+                        maybe_unify(inst_typ, t, loc, true)
+                    | _ => throw compile_err(loc, f"invalid (non-function) instance \
+                                             {inst} of template function {pp(df_name)}")
+                    }})
+                match inst_name_opt {
+                | Some(inst_name) => Some((inst_name, t))
+                | _ =>
+                    /* the generic function matches the requested type,
+                        but there is no appropriate instance;
+                        let's create a new one */
+                    val inst_env = inst_merge_env(env, env1)
+                    val { df_name=inst_name, df_typ=inst_typ } =
+                        *instantiate_fun(df, ftyp, inst_env, loc, true)
+                    unify(inst_typ, t, loc, "inconsistent type of the instantiated function")
+                    Some((inst_name, t))
+                }
             }
-        }
-        val viable = acc.rev()
-        if viable.length() > 1 {
-            val envwin = viable.hd()
-            val genwin = find_opt(for c <- viable {
-                all(for d <- viable { c == d || compare_fun_generality(c, d) == LessGeneric }) })
-            val agree = match genwin { | Some(g) => g == envwin | _ => false }
-            print(f"-pr-resolve: '{pp(n)}' @ {string(loc)}: {viable.length()} viable for {typ2str(t)}\n")
-            for c <- viable { print(f"    candidate: {Ast_pp.fun2sigstr(c)}\n") }
-            print(f"    env-order  winner: {Ast_pp.fun2sigstr(envwin)}\n")
-            match genwin {
-            | Some(g) => print(f"    generality winner: {Ast_pp.fun2sigstr(g)}\n")
-            | _ => print("    generality winner: <none: tied or unordered>\n")
-            }
-            print(f"    winners agree: {agree}\n")
         }
     }
-}
 
-fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): ((id_t, typ_t)?, env_entry_t list) {
-    trace_resolve(n, t, env, sc, loc)
-    var possible_matches = []
-    val nt_opt = find_first(n, env, env, sc, loc, fun (e: env_entry_t): (id_t, typ_t)? {
-        | EnvId({m=0}) => None
-        | EnvId(i) =>
-            possible_matches = e :: possible_matches
-            match id_info(i, loc) {
-            | IdDVal ({dv_typ}) =>
-                unify(dv_typ, t, loc, f"incorrect type of value '{pp(n)}': \
-                      expected='{typ2str(t)}', actual='{typ2str(dv_typ)}'")
-                Some((i, t))
-            | IdFun(df) =>
-                val {df_name, df_templ_args, df_typ, df_flags, df_templ_inst, df_env} = *df
-                // if the function has keyword parameters, we implicitly add a dummy record argument
-                // to the end of arguments' type list of t
-                val t = match (df_flags.fun_flag_have_keywords, deref_typ(t)) {
-                    | (true, TypFun(argtyps, rt)) =>
-                        val argtyps = match argtyps {
-                            | _ :: _ when (match deref_typ(argtyps.last()) {
-                                | TypRecord (ref (_, false)) => true
-                                | _ => false }) =>
-                                argtyps
-                            | _ => argtyps + [:: TypRecord(ref ([], false))]
-                            }
-                        TypFun(argtyps, rt)
-                    | _ => t
-                    }
-                if df_templ_args == [] {
-                    if maybe_unify(df_typ, t, loc, true) { Some((i, t)) } else { None }
-                } else {
-                    val (ftyp, env1) = preprocess_templ_typ(df_templ_args, df_typ, df_env, sc, loc)
-                    // first try to unify the type with the generic template type
-                    if !maybe_unify(ftyp, t, loc, true) { None }
-                    else {
-                        /* a necessary extra step to do before function instantiation;
-                            if it's a constructor, we first need to check the return type.
-                            this check may implicitly instantiate generic variant type, and so
-                            the df_templ_inst list of this constructor will be expanded with new instance.
-                            In theory, with such an extra step we should never enter
-                            'instantiate_fun' for constructors, because they all will be
-                            instantiated from check_typ => instantiate_variant => register_typ_constructor. */
-                        val return_orig =
-                            if !is_constructor(df_flags) {false}
-                            else {
-                                match ftyp {
-                                | TypFun(_, rt) =>
-                                    val _ = check_typ(rt, env1, sc, loc); false
-                                | _ => !is_fixed_typ(t)
-                                }
-                            }
-                        if return_orig { Some((df_name, t)) }
-                        else {
-                            val inst_name_opt = find_opt(for inst <- *df_templ_inst {
-                                match id_info(inst, loc) {
-                                | IdFun (ref {df_typ=inst_typ}) =>
-                                    maybe_unify(inst_typ, t, loc, true)
-                                | _ => throw compile_err(loc, f"invalid (non-function) instance \
-                                                         {inst} of template function {pp(df_name)}")
-                                }})
-                            match inst_name_opt {
-                            | Some(inst_name) => Some((inst_name, t))
-                            | _ =>
-                                /* the generic function matches the requested type,
-                                    but there is no appropriate instance;
-                                    let's create a new one */
-                                val inst_env = inst_merge_env(env, env1)
-                                val { df_name=inst_name, df_typ=inst_typ } =
-                                    *instantiate_fun(df, ftyp, inst_env, loc, true)
-                                unify(inst_typ, t, loc, "inconsistent type of the instantiated function")
-                                Some((inst_name, t))
-                            }
-                        }
-                    }
+    fun rank_and_commit(viable: (id_t, deffun_t ref) list): (id_t, typ_t)? =
+        match viable {
+        | [] => None
+        | [:: (i, df)] => commit_fun(i, df)
+        | _ =>
+            val cands = [:: for (_, df) <- viable {df}]
+            val genwin_opt = find_opt(for (i, c) <- viable {
+                all(for d <- cands { c == d || compare_fun_generality(c, d) == LessGeneric }) })
+            val fully_determined = match deref_typ(t) {
+                | TypFun(argtyps, _) => argtyps.all(fun (at: typ_t) { !typ_has_free_vars(at) })
+                | _ => false
                 }
-            | IdModule _ =>
-                unify(TypModule, t, loc, "unexpected module name")
-                Some((i, t))
-            | IdExn (ref {dexn_typ, dexn_loc }) =>
-                val ctyp = typ2constr(dexn_typ, TypExn, dexn_loc)
-                unify(ctyp, t, loc, "uncorrect type of exception constructor and/or its arguments")
-                Some((i, t))
-            | IdNone | IdTyp _ | IdVariant _ | IdInterface _ => None
+            if Options.opt.print_resolve {
+                val (envwin_i, envwin) = viable.hd()
+                val agree = match genwin_opt { | Some((gi, _)) => gi == envwin_i | _ => false }
+                print(f"-pr-resolve: '{pp(n)}' @ {string(loc)}: {viable.length()} viable for {typ2str(t)}\n")
+                for (_, c) <- viable { print(f"    candidate: {Ast_pp.fun2sigstr(c)}\n") }
+                print(f"    env-order  winner: {Ast_pp.fun2sigstr(envwin)}\n")
+                match genwin_opt {
+                | Some((_, g)) => print(f"    generality winner: {Ast_pp.fun2sigstr(g)}\n")
+                | _ => print("    generality winner: <none: tied or unordered>\n")
+                }
+                print(f"    winners agree: {agree}\n")
+                val outcome = match genwin_opt {
+                    | Some _ => "ranked"
+                    | _ => if fully_determined {"ambiguity error"}
+                           else {"env-order fallback (under-constrained tie)"}
+                    }
+                print(f"    outcome: {outcome}\n")
             }
-        | EnvTyp _ => None
-        })
+            match genwin_opt {
+            | Some((i, df)) => commit_fun(i, df)
+            | _ =>
+                if fully_determined {
+                    val cand_lines = "\n    ".join([:: for (_, c) <- viable {Ast_pp.fun2sigstr(c)}])
+                    throw compile_err(loc, f"ambiguous call of overloaded '{pp(n)}': \
+                        no candidate is more specific than the others. Candidates:\n    {cand_lines}\n\
+                        consider a module-qualified call (e.g. Module.{pp(n)}(...)) to disambiguate")
+                } else {
+                    // under-constrained tie: keep today's env-order first-match
+                    // semantics until deferral lands (session 2)
+                    val (i, df) = viable.hd()
+                    commit_fun(i, df)
+                }
+            }
+        }
+
+    /* scan one env level's entries in order: trial functions (collecting the
+       viable ones), let a non-function entry win immediately when no viable
+       function precedes it -- both exactly mirroring the pre-resolve-1
+       find_first semantics. */
+    fun scan_(elist: env_entry_t list, viable: (id_t, deffun_t ref) list): (id_t, typ_t)? =
+        match elist {
+        | e :: rest =>
+            match e {
+            | EnvId({m=0}) => scan_(rest, viable)
+            | EnvId(i) =>
+                possible_matches = e :: possible_matches
+                match id_info(i, loc) {
+                | IdFun(df) =>
+                    val viable = if fun_matches_trial(df, t, sc, loc) {(i, df) :: viable}
+                                 else {viable}
+                    scan_(rest, viable)
+                | IdDVal ({dv_typ}) =>
+                    match viable {
+                    | [] =>
+                        unify(dv_typ, t, loc, f"incorrect type of value '{pp(n)}': \
+                              expected='{typ2str(t)}', actual='{typ2str(dv_typ)}'")
+                        Some((i, t))
+                    | _ => scan_(rest, viable)  // a viable function shadows it, as today
+                    }
+                | IdModule _ =>
+                    match viable {
+                    | [] =>
+                        unify(TypModule, t, loc, "unexpected module name")
+                        Some((i, t))
+                    | _ => scan_(rest, viable)
+                    }
+                | IdExn (ref {dexn_typ, dexn_loc }) =>
+                    match viable {
+                    | [] =>
+                        val ctyp = typ2constr(dexn_typ, TypExn, dexn_loc)
+                        unify(ctyp, t, loc, "uncorrect type of exception constructor and/or its arguments")
+                        Some((i, t))
+                    | _ => scan_(rest, viable)
+                    }
+                | IdNone | IdTyp _ | IdVariant _ | IdInterface _ => scan_(rest, viable)
+                }
+            | EnvTyp _ => scan_(rest, viable)
+            }
+        | _ => rank_and_commit(viable.rev())
+        }
+
+    /* one lookup level: direct entries if any, otherwise the dotted-path
+       module search (same logic and comments as find_first's search_path) */
+    fun lookup_(n2: id_t, env2: env_t): (id_t, typ_t)? {
+        fun search_path_(n_path: string, dot_pos: int): (id_t, typ_t)? {
+            val dot_pos = n_path.rfind('.', dot_pos)
+            if dot_pos < 0 {None}
+            else {
+                match find_all(get_id(n_path[:dot_pos]), env2) {
+                | EnvId m :: _ =>
+                    match id_info(m, loc) {
+                    | IdModule m_idx =>
+                        val env3 = if m_idx == curr_m_idx {env} else {get_module_env(m_idx)}
+                        lookup_(get_id(n_path[dot_pos+1:]), env3)
+                    | _ => None
+                    }
+                | _ =>
+                    search_path_(n_path, dot_pos-1)
+                }
+            }
+        }
+        val e_all = find_all(n2, env2)
+        val e_all = if e_all == [] && is_unique_id(n2) { [:: EnvId(n2)] } else { e_all }
+        match e_all {
+        | [] =>
+            val n_path = pp(n2)
+            search_path_(n_path, n_path.length()-1)
+        | _ => scan_(e_all, [])
+        }
+    }
+
+    val nt_opt = lookup_(n, env)
     (nt_opt, possible_matches)
 }
 

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -380,6 +380,52 @@ fun unskolemize_typ(t: typ_t, skolems: id_t list): typ_t {
     unskolem_(t, callb)
 }
 
+/* FB-017 fix: freeze the anonymous "var-form" template types -- {...}
+   (TypVarRecord), (...) / ('t ...) (TypVarTuple), 't [+] (TypVarArray) -- into
+   opaque "some specific, but unknown" sentinels on the RIGID side of a
+   generality trial, mirroring what skolemize_fun_sig does for named template
+   parameters. Without this maybe_unify binds a free record/tuple/array-var to
+   a concrete type in EITHER direction, so "concrete record vs {...}-generic"
+   read as EqGeneric and ~224 real sites of the E1 census could not be ranked.
+
+   Sentinel choices (each still unifies with a FREE var-form of the same kind
+   or a plain free TypVar on the other side, but never with a *different*
+   concrete type):
+     {...}    -> TypRecord with a single __skolem_rec__ field: a record no
+                 user record matches (the field name+type cannot unify)
+     (...)    -> TypTuple of two DISTINCT opaque constants: a free (...)
+                 still covers it, but ('t ...) does not (elements differ),
+                 and no concrete tuple matches the opaque constants
+     ('t ...) -> TypTuple([frozen 't]): covered by (...) and ('u ...), not by
+                 (int ...) or any concrete tuple
+     't [+]   -> TypArray(-1, frozen 't): dimension -1 matches no concrete
+                 array, so only 'u [+] and plain 'u cover it
+   Non-destructive (same walk_typ pattern as unskolemize_typ): the input tree,
+   which callers and test_gencmp reuse, is never mutated. */
+fun freeze_varform_typs(t: typ_t): typ_t {
+    fun freeze_(t: typ_t, callb: ast_callb_t): typ_t =
+        match t {
+        | TypVar (ref Some(TypVarRecord)) =>
+            val k = get_id("__skolem_rec__")
+            TypRecord(ref ([:: (default_val_flags(), k, TypApp([], k), ExpNop(noloc))], true))
+        | TypVar (ref Some(TypVarTuple(t_opt))) =>
+            match t_opt {
+            | Some(t1) => TypTuple([:: freeze_(t1, callb)])
+            | _ => TypTuple([:: TypApp([], get_id("__skolem1__")),
+                               TypApp([], get_id("__skolem2__"))])
+            }
+        | TypVar (ref Some(TypVarArray(et))) => TypArray(-1, freeze_(et, callb))
+        | TypVar (ref Some(t1)) => TypVar(ref Some(freeze_(t1, callb)))
+        | TypVar _ => t
+        | TypRecord(r) =>
+            val (relems, ordered) = *r
+            TypRecord(ref ([:: for (fl, n, t, v) <- relems {(fl, n, freeze_(t, callb), v)}], ordered))
+        | _ => walk_typ(t, callb)
+        }
+    val callb = ast_callb_t {ast_cb_typ=Some(freeze_), ast_cb_exp=None, ast_cb_pat=None}
+    freeze_(t, callb)
+}
+
 /* Core of §3: is t1 more/less/equally/in-comparably general than t2, where
    skolems1/skolems2 identify the (already frozen) template parameters embedded
    in t1/t2 as opaque TypApp([], id) constants.
@@ -387,6 +433,9 @@ fun unskolemize_typ(t: typ_t, skolems: id_t list): typ_t {
    Two one-way maybe_unify(update_refs=false) trials -- neither commits anything:
      covers1_2 : does t1-made-free match t2-rigid?  (t1 can specialize onto t2)
      covers2_1 : does t2-made-free match t1-rigid?  (t2 can specialize onto t1)
+   The rigid side additionally has its var-form types ({...} & friends) frozen
+   by freeze_varform_typs (FB-017); on the free side they remain free var-forms,
+   which is exactly their "maximally general" reading.
    Classification (result describes t1 relative to t2):
      both    -> EqGeneric      (mutually applicable: same generality)
      1 only  -> MoreGeneric    (t1 covers t2 but not vice versa)
@@ -397,8 +446,10 @@ fun compare_typ_generality(t1: typ_t, skolems1: id_t list,
 {
     val free1 = unskolemize_typ(t1, skolems1)
     val free2 = unskolemize_typ(t2, skolems2)
-    val covers1_2 = maybe_unify(free1, t2, noloc, false)
-    val covers2_1 = maybe_unify(free2, t1, noloc, false)
+    val rigid1 = freeze_varform_typs(t1)
+    val rigid2 = freeze_varform_typs(t2)
+    val covers1_2 = maybe_unify(free1, rigid2, noloc, false)
+    val covers2_1 = maybe_unify(free2, rigid1, noloc, false)
     match (covers1_2, covers2_1) {
     | (true, true) => EqGeneric
     | (true, false) => MoreGeneric

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -502,6 +502,29 @@ fun compare_fun_generality(df1: deffun_t ref, df2: deffun_t ref): gen_cmp_t
 {
     val (t1, sk1) = skolemize_fun_sig(df1)
     val (t2, sk2) = skolemize_fun_sig(df2)
+    /* Keyword normalization (Q2 revision, resolve-1): when exactly one of the
+       two candidates has keyword parameters, append an empty OPEN keyword
+       record to the keywordless one's parameter tuple -- mirroring what
+       lookup_id_opt does to the CALLER type per-candidate. Without this the
+       pair reads as arity-incomparable, which is an artifact of the implicit
+       trailing record, not real overlap. With it the coverage test gives the
+       natural order on keywordless calls: a candidate that is viable only via
+       all-defaulted keywords accepts strictly more, so an exact keywordless
+       match ranks more specific (e.g. string(nntensor_t, ~border=..) beats
+       the record-generic string({...}) on string(t); Math.sqrt(double) beats
+       a local sqrt('t, ~n=2) on sqrt(81.0)). This is coverage semantics, not
+       a Swift-style tie-break ladder. */
+    val kw1 = df1->df_flags.fun_flag_have_keywords
+    val kw2 = df2->df_flags.fun_flag_have_keywords
+    val (t1, t2) =
+        if kw1 == kw2 { (t1, t2) }
+        else {
+            fun add_kwrec(t: typ_t) = match t {
+                | TypTuple(tl) => TypTuple(tl + [:: TypRecord(ref ([], false))])
+                | _ => t   // constructors compare the whole TypFun: skip
+                }
+            if kw1 { (t1, add_kwrec(t2)) } else { (add_kwrec(t1), t2) }
+        }
     compare_typ_generality(t1, sk1, t2, sk2)
 }
 

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -136,7 +136,7 @@ fun maybe_unify(t1: typ_t, t2: typ_t, loc: loc_t, update_refs: bool): bool {
         | TypApp(tl2, _) => occurs(r1, tl2)
         | TypInt | TypLong | TypSInt _ | TypUInt _ | TypFloat _ | TypString
         | TypChar | TypBool | TypVoid | TypExn | TypErr
-        | TypCPointer | TypDecl | TypModule | TypVarRecord =>
+        | TypCPointer | TypDecl | TypModule | TypVarRecord | TypVarCollection =>
             false
         }
     fun occurs(r1: typ_t? ref, tl: typ_t list): bool =
@@ -219,6 +219,33 @@ fun maybe_unify(t1: typ_t, t2: typ_t, loc: loc_t, update_refs: bool): bool {
             | _ => false
             }
         | (_, TypVar (ref Some(TypVarRecord))) => maybe_unify_(t2, t1, loc)
+        /* TypVarCollection ("some collection", the type of a []-literal):
+           binds only to a list, vector or array (or to an array-var 't [+],
+           or is captured by a plain free var / merged with another
+           collection-var). Everything else is a unification failure -- this
+           is the whole point: [] no longer poses as "anything". */
+        | (TypVar((ref Some(TypVarCollection)) as r1), t2) =>
+            val t2 = deref_typ(t2)
+            match t2 {
+            | TypVar((ref Some(TypVarCollection)) as r2) =>
+                if r1 != r2 {
+                    undo_stack = (r2, *r2) :: undo_stack
+                    *r2 = Some(t1)
+                }
+                true
+            | TypVar((ref None) as r2) =>
+                undo_stack = (r2, *r2) :: undo_stack
+                *r2 = Some(t1)
+                true
+            | TypList _ | TypVector _ | TypArray(_, _)
+            | TypVar(ref Some(TypVarArray _)) =>
+                undo_stack = (r1, *r1) :: undo_stack
+                *r1 = Some(t2)
+                true
+            | TypErr => true
+            | _ => false
+            }
+        | (_, TypVar (ref Some(TypVarCollection))) => maybe_unify_(t2, t1, loc)
         | (TypRef(drt1), TypRef(drt2)) => maybe_unify_(drt1, drt2, loc)
         | (TypRecord(r1), TypRecord(r2)) when r1 == r2 => true
         | (TypRecord (ref (_, false)), TypRecord (ref (_, true))) => maybe_unify_(t2, t1, loc)
@@ -416,6 +443,12 @@ fun freeze_varform_typs(t: typ_t): typ_t {
                                TypApp([], get_id("__skolem2__"))])
             }
         | TypVar (ref Some(TypVarArray(et))) => TypArray(-1, freeze_(et, callb))
+        /* [] / TypVarCollection: freeze to an opaque constant -- "some
+           specific collection, could be list OR vector OR array", so neither
+           't list, 't [], 't vector nor 't [+] covers it; only a plain free
+           't does. (Signatures written in source can't contain it; this arm
+           matters only if a collection-var flows in via inference.) */
+        | TypVar (ref Some(TypVarCollection)) => TypApp([], get_id("__skolem_coll__"))
         | TypVar (ref Some(t1)) => TypVar(ref Some(freeze_(t1, callb)))
         | TypVar _ => t
         | TypRecord(r) =>
@@ -545,6 +578,7 @@ fun typ_has_free_vars(t: typ_t): bool {
             | TypVar (ref Some(TypVarRecord)) => has_free = true; t
             | TypVar (ref Some(TypVarTuple _)) => has_free = true; t
             | TypVar (ref Some(TypVarArray _)) => has_free = true; t
+            | TypVar (ref Some(TypVarCollection)) => has_free = true; t
             | t1 => walk_typ(t1, callb)
             }
         }

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -905,8 +905,69 @@ fun is_real_typ(t: typ_t) {
 fun report_not_found(n: id_t, loc: loc_t) =
     compile_err(loc, f"the appropriate match for '{pp(n)}' is not found")
 
-fun report_not_found_typed(n: id_t, t: typ_t, possible_matches: env_entry_t list, loc: loc_t) {
+/* one-line explanation of why a function candidate does not accept the call:
+   arity, keyword acceptance, or the first mismatching argument (tested with
+   side-effect-free trials on a fresh copy of the signature; the *displayed*
+   parameter type comes from the raw signature so template parameters keep
+   their 't names). */
+fun fun_mismatch_reason(df: deffun_t ref, call_argtyps: typ_t list,
+                        sc: scope_t list, loc: loc_t): string
+{
+    val {df_templ_args, df_typ, df_flags, df_env} = *df
+    val have_kw = df_flags.fun_flag_have_keywords
+    val caller_has_kwrec = match call_argtyps {
+        | _ :: _ => (match deref_typ(call_argtyps.last()) {
+                     | TypRecord (ref (_, false)) => true | _ => false })
+        | _ => false
+        }
+    if !have_kw && caller_has_kwrec { return "does not accept keyword arguments" }
+    val call_argtyps = if have_kw && !caller_has_kwrec {
+            call_argtyps + [:: TypRecord(ref ([], false))]
+        } else { call_argtyps }
+    val ftyp = if df_templ_args == [] { dup_typ(df_typ) }
+               else { preprocess_templ_typ(df_templ_args, df_typ, df_env, sc, loc).0 }
+    val ptyps_disp = match deref_typ(df_typ) { | TypFun(ptyps, _) => ptyps | _ => [] }
+    match deref_typ(ftyp) {
+    | TypFun(ptyps, _) =>
+        val np = ptyps.length(), nc = call_argtyps.length()
+        if np != nc {
+            val kw_extra = if have_kw {1} else {0}
+            val pos_s = if have_kw {"positional "} else {""}
+            f"takes {np - kw_extra} {pos_s}argument(s), but {nc - kw_extra} given"
+        } else {
+            fun first_mismatch_(ptl: typ_t list, ctl: typ_t list, k: int): (int, typ_t, typ_t)? =
+                match (ptl, ctl) {
+                | (pt :: ptl_rest, ct :: ctl_rest) =>
+                    if !maybe_unify(pt, dup_typ(ct), loc, false) { Some((k, pt, ct)) }
+                    else { first_mismatch_(ptl_rest, ctl_rest, k+1) }
+                | _ => None
+                }
+            val mism = first_mismatch_(ptyps, call_argtyps, 0)
+            match mism {
+            | Some((k, pt, ct)) =>
+                val pt_disp = match ptyps_disp {
+                    | _ :: _ when ptyps_disp.length() == np => ptyps_disp.nth(k)
+                    | _ => pt
+                    }
+                if have_kw && k == np - 1 {
+                    f"keyword arguments '{typ2str(ct)}' do not match the accepted '{typ2str(pt_disp)}'"
+                } else {
+                    f"argument {k + 1} of type '{typ2str(ct)}' does not match '{typ2str(pt_disp)}'"
+                }
+            | _ => "the return type or the signature as a whole does not match"
+            }
+        }
+    | _ => "is not a function"
+    }
+}
+
+fun report_not_found_typed(n: id_t, t: typ_t, possible_matches: env_entry_t list,
+                           sc: scope_t list, loc: loc_t) {
     val nstr = pp(n)
+    val call_argtyps_opt = match deref_typ(t) {
+        | TypFun(argtyps, _) => Some(argtyps)
+        | _ => None
+        }
     val strs = [:: for e <- possible_matches {
             val n = match e {
                 | EnvId(n) => n
@@ -915,9 +976,14 @@ fun report_not_found_typed(n: id_t, t: typ_t, possible_matches: env_entry_t list
             if n == noid { continue }
             val info = id_info(n, loc)
             if (match info {|IdNone _ => true | _ => false}) { continue }
-            val tj = get_idinfo_typ(info, loc)
-            val locj = get_idinfo_loc(info)
-            f"'{nstr}: {typ2str(tj)}' defined at {locj}"
+            match (info, call_argtyps_opt) {
+            | (IdFun(df), Some(call_argtyps)) =>
+                f"{Ast_pp.fun2sigstr(df)} -- {fun_mismatch_reason(df, call_argtyps, sc, loc)}"
+            | _ =>
+                val tj = get_idinfo_typ(info, loc)
+                val locj = get_idinfo_loc(info)
+                f"'{nstr}: {typ2str(tj)}' defined at {locj}"
+            }
         } ]
     val candidates_msg =
         if strs == [] { "" }
@@ -1142,9 +1208,18 @@ fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): 
             | _ =>
                 if fully_determined {
                     val cand_lines = "\n    ".join([:: for (_, c) <- viable {Ast_pp.fun2sigstr(c)}])
+                    // EqGeneric everywhere = identical applicability (qualify the call);
+                    // any IncompGeneric = overlapping but unordered (a more specific
+                    // overload can also break the tie)
+                    val all_eq = all(for (_, c) <- viable {
+                        all(for d <- cands { c == d || compare_fun_generality(c, d) == EqGeneric }) })
+                    val why = if all_eq { "the candidates are equally applicable" }
+                              else { "the candidates overlap, but none is the most specific" }
+                    val hint = if all_eq { f"use a module-qualified call (e.g. Module.{pp(n)}(...)) to select one" }
+                               else { f"define/import a more specific overload, or use a \
+                                        module-qualified call (e.g. Module.{pp(n)}(...)) to disambiguate" }
                     throw compile_err(loc, f"ambiguous call of overloaded '{pp(n)}': \
-                        no candidate is more specific than the others. Candidates:\n    {cand_lines}\n\
-                        consider a module-qualified call (e.g. Module.{pp(n)}(...)) to disambiguate")
+                        {why}. Candidates:\n    {cand_lines}\n{hint}")
                 } else {
                     // under-constrained tie: keep today's env-order first-match
                     // semantics until deferral lands (session 2)
@@ -1242,7 +1317,7 @@ fun lookup_id(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): (id_
     | None =>
         match try_autogen_symbols(n, t, env, sc, loc) {
         | Some(nt1) => nt1
-        | _ => throw report_not_found_typed(n, t, possible_matches, loc)
+        | _ => throw report_not_found_typed(n, t, possible_matches, sc, loc)
         }
     }
 }
@@ -1697,7 +1772,7 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
             | Some((f, t, _)) =>
                 ExpMem(new_e1, ExpIdent(f, (t, eloc)), ctx)
             | _ =>
-                throw report_not_found_typed(n2, etyp, candidates, eloc)
+                throw report_not_found_typed(n2, etyp, candidates, sc, eloc)
             }
         | (TypExn, _, ExpIdent(n2, (etyp2, eloc2))) when n2 == std__tag__ =>
             unify(etyp, TypInt, eloc, "variant tag is integer, but the other type is expected")

--- a/compiler/K_normalize.fx
+++ b/compiler/K_normalize.fx
@@ -51,6 +51,9 @@ fun typ2ktyp(t: typ_t, loc: loc_t): ktyp_t
             "variable array type cannot be inferenced; please, use explicit type annotation")
         | TypVarRecord => throw compile_err(loc,
             "variable record type cannot be inferenced; please, use explicit type annotation")
+        | TypVarCollection => throw compile_err(loc,
+            "[] denotes an empty collection (list, vector or array), but which one cannot be " +
+            "inferenced here; please, use explicit type annotation")
         | TypFun(args, rt) => KTypFun([::for t <- args {typ2ktyp_(t)} ], typ2ktyp_(rt))
         | TypRecord (ref (relems, true)) =>
             KTypRecord(noid, [:: for (_, ni, ti, _) <- relems { (ni, typ2ktyp_(ti)) } ])

--- a/compiler/Lexer.fx
+++ b/compiler/Lexer.fx
@@ -388,8 +388,18 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
             if c == 'l' {
                 [:: (IDENT(true, "long"), loc), (LPAREN(false), loc), (t, loc), (RPAREN, loc)]
             } else if c == 'c' {
+                /* an imaginary literal N.fi/N.i/N.hi is desugared into
+                   complex(0, N); the zero real part must be a float literal
+                   of the SAME width as the imaginary part, or the
+                   complex(float,float)/complex(double,double) constructors
+                   won't match (the imaginary suffix is float-only, see
+                   LexerUtils.getnumber_) */
+                val zero = match t {
+                    | LITERAL(Ast.LitFloat(bits, _)) => Ast.LitFloat(bits, 0.)
+                    | _ => Ast.LitInt(0i64)
+                    }
                 [:: (IDENT(true, "complex"), loc), (LPAREN(false), loc),
-                    (LITERAL(Ast.LitInt(0i64)), loc), (COMMA, loc), (t, loc), (RPAREN, loc)]
+                    (LITERAL(zero), loc), (COMMA, loc), (t, loc), (RPAREN, loc)]
             } else {
                 [:: (t, loc)]
             }

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -3065,21 +3065,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;
@@ -4619,23 +4619,25 @@ _fx_Nt11Set__tree_t1S _fx_g12Ast__Empty2_ = 0;
 _fx_Nt11Set__tree_t1R9Ast__id_t _fx_g12Ast__Empty3_ = 0;
 int _FX_EXN_E17Ast__CompileError = 0;
 int _FX_EXN_E26Ast__PropagateCompileError = 0;
-static _fx_N10Ast__typ_t_data_t TypInt_data_0 = { 1, 5 };
+static _fx_N10Ast__typ_t_data_t TypVarCollection_data_0 = { 1, 5 };
+_fx_N10Ast__typ_t _fx_g21Ast__TypVarCollection = &TypVarCollection_data_0;
+static _fx_N10Ast__typ_t_data_t TypInt_data_0 = { 1, 6 };
 _fx_N10Ast__typ_t _fx_g11Ast__TypInt = &TypInt_data_0;
-static _fx_N10Ast__typ_t_data_t TypString_data_0 = { 1, 10 };
+static _fx_N10Ast__typ_t_data_t TypString_data_0 = { 1, 11 };
 _fx_N10Ast__typ_t _fx_g14Ast__TypString = &TypString_data_0;
-static _fx_N10Ast__typ_t_data_t TypChar_data_0 = { 1, 11 };
+static _fx_N10Ast__typ_t_data_t TypChar_data_0 = { 1, 12 };
 _fx_N10Ast__typ_t _fx_g12Ast__TypChar = &TypChar_data_0;
-static _fx_N10Ast__typ_t_data_t TypBool_data_0 = { 1, 12 };
+static _fx_N10Ast__typ_t_data_t TypBool_data_0 = { 1, 13 };
 _fx_N10Ast__typ_t _fx_g12Ast__TypBool = &TypBool_data_0;
-static _fx_N10Ast__typ_t_data_t TypVoid_data_0 = { 1, 13 };
+static _fx_N10Ast__typ_t_data_t TypVoid_data_0 = { 1, 14 };
 _fx_N10Ast__typ_t _fx_g12Ast__TypVoid = &TypVoid_data_0;
-static _fx_N10Ast__typ_t_data_t TypErr_data_0 = { 1, 22 };
+static _fx_N10Ast__typ_t_data_t TypErr_data_0 = { 1, 23 };
 _fx_N10Ast__typ_t _fx_g11Ast__TypErr = &TypErr_data_0;
-static _fx_N10Ast__typ_t_data_t TypCPointer_data_0 = { 1, 23 };
+static _fx_N10Ast__typ_t_data_t TypCPointer_data_0 = { 1, 24 };
 _fx_N10Ast__typ_t _fx_g16Ast__TypCPointer = &TypCPointer_data_0;
-static _fx_N10Ast__typ_t_data_t TypDecl_data_0 = { 1, 25 };
+static _fx_N10Ast__typ_t_data_t TypDecl_data_0 = { 1, 26 };
 _fx_N10Ast__typ_t _fx_g12Ast__TypDecl = &TypDecl_data_0;
-static _fx_N10Ast__typ_t_data_t TypModule_data_0 = { 1, 26 };
+static _fx_N10Ast__typ_t_data_t TypModule_data_0 = { 1, 27 };
 _fx_N10Ast__typ_t _fx_g14Ast__TypModule = &TypModule_data_0;
 static _fx_N13Ast__binary_t_data_t OpMul_data_0 = { 1, 3 };
 _fx_N13Ast__binary_t _fx_g10Ast__OpMul = &OpMul_data_0;
@@ -6598,7 +6600,7 @@ FX_EXTERN_C int _fx_M3AstFM11TypVarArrayN10Ast__typ_t1N10Ast__typ_t(
 FX_EXTERN_C int _fx_M3AstFM7TypSIntN10Ast__typ_t1i(int_ arg0, struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 6;
+   v->tag = 7;
    v->u.TypSInt = arg0;
    return 0;
 }
@@ -6606,7 +6608,7 @@ FX_EXTERN_C int _fx_M3AstFM7TypSIntN10Ast__typ_t1i(int_ arg0, struct _fx_N10Ast_
 FX_EXTERN_C int _fx_M3AstFM7TypUIntN10Ast__typ_t1i(int_ arg0, struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 7;
+   v->tag = 8;
    v->u.TypUInt = arg0;
    return 0;
 }
@@ -6614,7 +6616,7 @@ FX_EXTERN_C int _fx_M3AstFM7TypUIntN10Ast__typ_t1i(int_ arg0, struct _fx_N10Ast_
 FX_EXTERN_C int _fx_M3AstFM8TypFloatN10Ast__typ_t1i(int_ arg0, struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 9;
+   v->tag = 10;
    v->u.TypFloat = arg0;
    return 0;
 }
@@ -6625,7 +6627,7 @@ FX_EXTERN_C int _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 14;
+   v->tag = 15;
    FX_COPY_PTR(arg0, &v->u.TypFun.t0);
    FX_COPY_PTR(arg1, &v->u.TypFun.t1);
    return 0;
@@ -6636,7 +6638,7 @@ FX_EXTERN_C int _fx_M3AstFM7TypListN10Ast__typ_t1N10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 15;
+   v->tag = 16;
    FX_COPY_PTR(arg0, &v->u.TypList);
    return 0;
 }
@@ -6646,7 +6648,7 @@ FX_EXTERN_C int _fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 16;
+   v->tag = 17;
    FX_COPY_PTR(arg0, &v->u.TypVector);
    return 0;
 }
@@ -6656,7 +6658,7 @@ FX_EXTERN_C int _fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 17;
+   v->tag = 18;
    FX_COPY_PTR(arg0, &v->u.TypTuple);
    return 0;
 }
@@ -6666,7 +6668,7 @@ FX_EXTERN_C int _fx_M3AstFM6TypRefN10Ast__typ_t1N10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 18;
+   v->tag = 19;
    FX_COPY_PTR(arg0, &v->u.TypRef);
    return 0;
 }
@@ -6677,7 +6679,7 @@ FX_EXTERN_C int _fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 19;
+   v->tag = 20;
    v->u.TypArray.t0 = arg0;
    FX_COPY_PTR(arg1, &v->u.TypArray.t1);
    return 0;
@@ -6688,7 +6690,7 @@ FX_EXTERN_C int _fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 20;
+   v->tag = 21;
    FX_COPY_PTR(arg0, &v->u.TypRecord);
    return 0;
 }
@@ -6699,7 +6701,7 @@ FX_EXTERN_C int _fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(
    struct _fx_N10Ast__typ_t_data_t** fx_result)
 {
    FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_N10Ast__typ_t);
-   v->tag = 24;
+   v->tag = 25;
    FX_COPY_PTR(arg0, &v->u.TypApp.t0);
    v->u.TypApp.t1 = *arg1;
    return 0;
@@ -10711,13 +10713,18 @@ FX_EXTERN_C int _fx_M3AstFM11get_lit_typN10Ast__typ_t1N10Ast__lit_t(
       FX_COPY_PTR(_fx_g12Ast__TypBool, fx_result);
    }
    else if (tag_0 == 8) {
-      _fx_rNt6option1N10Ast__typ_t v_0 = 0;
-      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None4_, &v_0), _fx_catch_3);
-      FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_0, fx_result), _fx_catch_3);
+      _fx_Nt6option1N10Ast__typ_t v_0 = 0;
+      _fx_rNt6option1N10Ast__typ_t v_1 = 0;
+      FX_CALL(_fx_M3AstFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast__TypVarCollection, &v_0), _fx_catch_3);
+      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_0, &v_1), _fx_catch_3);
+      FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_1, fx_result), _fx_catch_3);
 
    _fx_catch_3: ;
+      if (v_1) {
+         _fx_free_rNt6option1N10Ast__typ_t(&v_1);
+      }
       if (v_0) {
-         _fx_free_rNt6option1N10Ast__typ_t(&v_0);
+         _fx_free_Nt6option1N10Ast__typ_t(&v_0);
       }
    }
    else if (tag_0 == 9) {
@@ -10746,6 +10753,7 @@ FX_EXTERN_C int _fx_M3AstFM9find_rootN10Ast__typ_t1N10Ast__typ_t(
       _fx_Nt6option1N10Ast__typ_t v_1 = 0;
       _fx_Nt6option1N10Ast__typ_t v_2 = 0;
       _fx_Nt6option1N10Ast__typ_t v_3 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_4 = 0;
       FX_COPY_PTR(t_1, &t_2);
       int tag_0 = FX_REC_VARIANT_TAG(t_2);
       if (tag_0 == 1) {
@@ -10790,19 +10798,35 @@ FX_EXTERN_C int _fx_M3AstFM9find_rootN10Ast__typ_t1N10Ast__typ_t(
       if (tag_0 == 1) {
          FX_COPY_PTR(t_2->u.TypVar->data, &v_3);
          if ((v_3 != 0) + 1 == 2) {
-            _fx_N10Ast__typ_t* t2_0 = &v_3->u.Some; _fx_free_N10Ast__typ_t(&t_1); FX_COPY_PTR(*t2_0, &t_1); goto _fx_endmatch_0;
+            if (FX_REC_VARIANT_TAG(v_3->u.Some) == 5) {
+               _fx_free_N10Ast__typ_t(&result_0);
+               FX_COPY_PTR(t_2, &result_0);
+               FX_BREAK(_fx_catch_3);
+
+            _fx_catch_3: ;
+               goto _fx_endmatch_0;
+            }
+         }
+      }
+      if (tag_0 == 1) {
+         FX_COPY_PTR(t_2->u.TypVar->data, &v_4);
+         if ((v_4 != 0) + 1 == 2) {
+            _fx_N10Ast__typ_t* t2_0 = &v_4->u.Some; _fx_free_N10Ast__typ_t(&t_1); FX_COPY_PTR(*t2_0, &t_1); goto _fx_endmatch_0;
          }
       }
       _fx_free_N10Ast__typ_t(&result_0);
       FX_COPY_PTR(t_2, &result_0);
-      FX_BREAK(_fx_catch_3);
-
-   _fx_catch_3: ;
-
-   _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_catch_4);
+      FX_BREAK(_fx_catch_4);
 
    _fx_catch_4: ;
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_catch_5);
+
+   _fx_catch_5: ;
+      if (v_4) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_4);
+      }
       if (v_3) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_3);
       }
@@ -10940,22 +10964,22 @@ FX_EXTERN_C int _fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(struct _fx_N10Ast__typ
       FX_COPY_PTR(t_1, &t_2);
       int tag_0 = FX_REC_VARIANT_TAG(t_2);
       bool res_0;
-      if (tag_0 == 5) {
-         res_0 = true;
-      }
-      else if (tag_0 == 6) {
+      if (tag_0 == 6) {
          res_0 = true;
       }
       else if (tag_0 == 7) {
          res_0 = true;
       }
-      else if (tag_0 == 9) {
+      else if (tag_0 == 8) {
+         res_0 = true;
+      }
+      else if (tag_0 == 10) {
+         res_0 = true;
+      }
+      else if (tag_0 == 13) {
          res_0 = true;
       }
       else if (tag_0 == 12) {
-         res_0 = true;
-      }
-      else if (tag_0 == 11) {
          res_0 = true;
       }
       else {
@@ -11104,25 +11128,25 @@ FX_EXTERN_C int _fx_M3AstFM20get_numeric_typ_sizei2N10Ast__typ_tB(
       }
       FX_CHECK_EXN(_fx_catch_14);
       int tag_0 = FX_REC_VARIANT_TAG(v_0);
-      if (tag_0 == 5) {
+      if (tag_0 == 6) {
          result_0 = 8; FX_BREAK(_fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 8) {
+      if (tag_0 == 9) {
          result_0 = -1; FX_BREAK(_fx_catch_5);  _fx_catch_5: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 6) {
+      if (tag_0 == 7) {
          result_0 = v_0->u.TypSInt / 8; FX_BREAK(_fx_catch_6);  _fx_catch_6: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 7) {
+      if (tag_0 == 8) {
          result_0 = v_0->u.TypUInt / 8; FX_BREAK(_fx_catch_7);  _fx_catch_7: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          result_0 = v_0->u.TypFloat / 8; FX_BREAK(_fx_catch_8);  _fx_catch_8: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 12) {
+      if (tag_0 == 13) {
          result_0 = 1; FX_BREAK(_fx_catch_9);  _fx_catch_9: ; goto _fx_endmatch_1;
       }
-      if (tag_0 == 11) {
+      if (tag_0 == 12) {
          result_0 = 4; FX_BREAK(_fx_catch_10);  _fx_catch_10: ; goto _fx_endmatch_1;
       }
       if (tag_0 == 1) {
@@ -11135,7 +11159,7 @@ FX_EXTERN_C int _fx_M3AstFM20get_numeric_typ_sizei2N10Ast__typ_tB(
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          _fx_LN10Ast__typ_t tl_0 = 0;
          if (!allow_tuples_2) {
             result_0 = -1; FX_BREAK(_fx_catch_12);
@@ -21534,7 +21558,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
    }
    FX_CHECK_EXN(_fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(v_0);
-   if (tag_0 == 5) {
+   if (tag_0 == 6) {
       fx_arr_t v_6 = {0};
       fx_arr_t old_data_0 = {0};
       fx_str_t val0_0 = {0};
@@ -21658,7 +21682,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
       FX_FREE_ARR(&v_6);
       goto _fx_endmatch_1;
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (v_0->u.TypSInt == 8) {
          fx_exn_t v_15 = {0};
          int_ h_idx_1;
@@ -21692,7 +21716,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (v_0->u.TypSInt == 16) {
          fx_exn_t v_17 = {0};
          int_ h_idx_2;
@@ -21726,7 +21750,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (v_0->u.TypSInt == 32) {
          fx_exn_t v_19 = {0};
          int_ h_idx_3;
@@ -21760,7 +21784,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (v_0->u.TypSInt == 64) {
          fx_exn_t v_21 = {0};
          int_ h_idx_4;
@@ -21794,7 +21818,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (v_0->u.TypUInt == 8) {
          fx_exn_t v_23 = {0};
          int_ h_idx_5;
@@ -21828,7 +21852,7 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (v_0->u.TypUInt == 16) {
          fx_exn_t v_25 = {0};
          int_ h_idx_6;
@@ -21862,30 +21886,30 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
          goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (v_0->u.TypUInt == 32) {
          FX_CALL(_fx_M3AstFM15fname_to_uint32RM4id_t0(fx_result, 0), _fx_catch_13);  _fx_catch_13: ; goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (v_0->u.TypUInt == 64) {
          FX_CALL(_fx_M3AstFM15fname_to_uint64RM4id_t0(fx_result, 0), _fx_catch_14);  _fx_catch_14: ; goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 9) {
+   if (tag_0 == 10) {
       if (v_0->u.TypFloat == 32) {
          FX_CALL(_fx_M3AstFM14fname_to_floatRM4id_t0(fx_result, 0), _fx_catch_15);  _fx_catch_15: ; goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 9) {
+   if (tag_0 == 10) {
       if (v_0->u.TypFloat == 64) {
          FX_CALL(_fx_M3AstFM15fname_to_doubleRM4id_t0(fx_result, 0), _fx_catch_16);  _fx_catch_16: ; goto _fx_endmatch_1;
       }
    }
-   if (tag_0 == 12) {
+   if (tag_0 == 13) {
       FX_CALL(_fx_M3AstFM13fname_to_boolRM4id_t0(fx_result, 0), _fx_catch_17);  _fx_catch_17: ; goto _fx_endmatch_1;
    }
-   if (tag_0 == 10) {
+   if (tag_0 == 11) {
       FX_CALL(_fx_M3AstFM12fname_stringRM4id_t0(fx_result, 0), _fx_catch_18);  _fx_catch_18: ; goto _fx_endmatch_1;
    }
    fx_str_t v_27 = {0};
@@ -22330,14 +22354,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_3: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 1) {
-         FX_COPY_PTR(t_2->u.TypVar->data, &v_0);
-         if ((v_0 != 0) + 1 == 2) {
-            _fx_N10Ast__typ_t* t_3 = &v_0->u.Some; _fx_free_N10Ast__typ_t(&t_1); FX_COPY_PTR(*t_3, &t_1); goto _fx_endmatch_1;
-         }
-      }
-      if (tag_0 == 1) {
-         fx_str_t slit_5 = FX_MAKE_STR("<unknown>");
+      if (tag_0 == 5) {
+         fx_str_t slit_5 = FX_MAKE_STR("[...]");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_5, &result_0);
          FX_BREAK(_fx_catch_4);
@@ -22345,53 +22363,59 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_4: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 1) {
+         FX_COPY_PTR(t_2->u.TypVar->data, &v_0);
+         if ((v_0 != 0) + 1 == 2) {
+            _fx_N10Ast__typ_t* t_3 = &v_0->u.Some; _fx_free_N10Ast__typ_t(&t_1); FX_COPY_PTR(*t_3, &t_1); goto _fx_endmatch_1;
+         }
+      }
+      if (tag_0 == 1) {
+         fx_str_t slit_6 = FX_MAKE_STR("<unknown>");
+         FX_FREE_STR(&result_0);
+         fx_copy_str(&slit_6, &result_0);
+         FX_BREAK(_fx_catch_5);
+
+      _fx_catch_5: ;
+         goto _fx_endmatch_1;
+      }
+      if (tag_0 == 25) {
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_2->u.TypApp;
          if (vcase_0->t0 == 0) {
             fx_str_t result_3 = {0};
-            FX_CALL(_fx_M3AstFM8id2str_mS1RM4id_t(&vcase_0->t1, &result_3, 0), _fx_catch_5);
+            FX_CALL(_fx_M3AstFM8id2str_mS1RM4id_t(&vcase_0->t1, &result_3, 0), _fx_catch_6);
             FX_FREE_STR(&result_0);
             fx_copy_str(&result_3, &result_0);
-            FX_BREAK(_fx_catch_5);
+            FX_BREAK(_fx_catch_6);
 
-         _fx_catch_5: ;
+         _fx_catch_6: ;
             FX_FREE_STR(&result_3);
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          fx_str_t v_4 = {0};
          fx_str_t v_5 = {0};
          fx_str_t result_4 = {0};
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_1 = &t_2->u.TypApp;
-         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_1->t0, &v_4, 0), _fx_catch_6);
-         FX_CALL(_fx_M3AstFM8id2str_mS1RM4id_t(&vcase_1->t1, &v_5, 0), _fx_catch_6);
-         fx_str_t slit_6 = FX_MAKE_STR(" ");
+         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_1->t0, &v_4, 0), _fx_catch_7);
+         FX_CALL(_fx_M3AstFM8id2str_mS1RM4id_t(&vcase_1->t1, &v_5, 0), _fx_catch_7);
+         fx_str_t slit_7 = FX_MAKE_STR(" ");
          {
-            const fx_str_t strs_2[] = { v_4, slit_6, v_5 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &result_4), _fx_catch_6);
+            const fx_str_t strs_2[] = { v_4, slit_7, v_5 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &result_4), _fx_catch_7);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_4, &result_0);
-         FX_BREAK(_fx_catch_6);
+         FX_BREAK(_fx_catch_7);
 
-      _fx_catch_6: ;
+      _fx_catch_7: ;
          FX_FREE_STR(&result_4);
          FX_FREE_STR(&v_5);
          FX_FREE_STR(&v_4);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 5) {
-         fx_str_t slit_7 = FX_MAKE_STR("int");
-         FX_FREE_STR(&result_0);
-         fx_copy_str(&slit_7, &result_0);
-         FX_BREAK(_fx_catch_7);
-
-      _fx_catch_7: ;
-         goto _fx_endmatch_1;
-      }
-      if (tag_0 == 8) {
-         fx_str_t slit_8 = FX_MAKE_STR("long");
+      if (tag_0 == 6) {
+         fx_str_t slit_8 = FX_MAKE_STR("int");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_8, &result_0);
          FX_BREAK(_fx_catch_8);
@@ -22399,67 +22423,76 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_8: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 6) {
-         fx_str_t v_6 = {0};
-         fx_str_t result_5 = {0};
-         FX_CALL(_fx_F6stringS1i(t_2->u.TypSInt, &v_6, 0), _fx_catch_9);
-         fx_str_t slit_9 = FX_MAKE_STR("int");
-         {
-            const fx_str_t strs_3[] = { slit_9, v_6 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 2, &result_5), _fx_catch_9);
-         }
+      if (tag_0 == 9) {
+         fx_str_t slit_9 = FX_MAKE_STR("long");
          FX_FREE_STR(&result_0);
-         fx_copy_str(&result_5, &result_0);
+         fx_copy_str(&slit_9, &result_0);
          FX_BREAK(_fx_catch_9);
 
       _fx_catch_9: ;
+         goto _fx_endmatch_1;
+      }
+      if (tag_0 == 7) {
+         fx_str_t v_6 = {0};
+         fx_str_t result_5 = {0};
+         FX_CALL(_fx_F6stringS1i(t_2->u.TypSInt, &v_6, 0), _fx_catch_10);
+         fx_str_t slit_10 = FX_MAKE_STR("int");
+         {
+            const fx_str_t strs_3[] = { slit_10, v_6 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 2, &result_5), _fx_catch_10);
+         }
+         FX_FREE_STR(&result_0);
+         fx_copy_str(&result_5, &result_0);
+         FX_BREAK(_fx_catch_10);
+
+      _fx_catch_10: ;
          FX_FREE_STR(&result_5);
          FX_FREE_STR(&v_6);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 7) {
+      if (tag_0 == 8) {
          fx_str_t v_7 = {0};
          fx_str_t result_6 = {0};
-         FX_CALL(_fx_F6stringS1i(t_2->u.TypUInt, &v_7, 0), _fx_catch_10);
-         fx_str_t slit_10 = FX_MAKE_STR("uint");
+         FX_CALL(_fx_F6stringS1i(t_2->u.TypUInt, &v_7, 0), _fx_catch_11);
+         fx_str_t slit_11 = FX_MAKE_STR("uint");
          {
-            const fx_str_t strs_4[] = { slit_10, v_7 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 2, &result_6), _fx_catch_10);
+            const fx_str_t strs_4[] = { slit_11, v_7 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 2, &result_6), _fx_catch_11);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_6, &result_0);
-         FX_BREAK(_fx_catch_10);
+         FX_BREAK(_fx_catch_11);
 
-      _fx_catch_10: ;
+      _fx_catch_11: ;
          FX_FREE_STR(&result_6);
          FX_FREE_STR(&v_7);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          int_ n_0 = t_2->u.TypFloat;
          if (n_0 == 16) {
-            fx_str_t slit_11 = FX_MAKE_STR("half");
-            FX_FREE_STR(&result_0);
-            fx_copy_str(&slit_11, &result_0);
-            FX_BREAK(_fx_catch_11);
-
-         _fx_catch_11: ;
-         }
-         else if (n_0 == 32) {
-            fx_str_t slit_12 = FX_MAKE_STR("float");
+            fx_str_t slit_12 = FX_MAKE_STR("half");
             FX_FREE_STR(&result_0);
             fx_copy_str(&slit_12, &result_0);
             FX_BREAK(_fx_catch_12);
 
          _fx_catch_12: ;
          }
-         else if (n_0 == 64) {
-            fx_str_t slit_13 = FX_MAKE_STR("double");
+         else if (n_0 == 32) {
+            fx_str_t slit_13 = FX_MAKE_STR("float");
             FX_FREE_STR(&result_0);
             fx_copy_str(&slit_13, &result_0);
             FX_BREAK(_fx_catch_13);
 
          _fx_catch_13: ;
+         }
+         else if (n_0 == 64) {
+            fx_str_t slit_14 = FX_MAKE_STR("double");
+            FX_FREE_STR(&result_0);
+            fx_copy_str(&slit_14, &result_0);
+            FX_BREAK(_fx_catch_14);
+
+         _fx_catch_14: ;
          }
          else {
             fx_str_t v_8 = {0};
@@ -22470,24 +22503,24 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
             _fx_LS all_compile_err_ctx_0 = 0;
             fx_str_t whole_msg_1 = {0};
             fx_exn_t v_11 = {0};
-            FX_CALL(_fx_F6stringS1i(n_0, &v_8, 0), _fx_catch_15);
+            FX_CALL(_fx_F6stringS1i(n_0, &v_8, 0), _fx_catch_16);
             if (_fx_g10Ast__noloc.m_idx >= 0) {
                int_ v_12 = _fx_g10Ast__noloc.m_idx;
-               FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_12), _fx_catch_15);
+               FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_12), _fx_catch_16);
                fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_12))->u.defmodule_t.t1, &fname_0);
             }
             else {
-               fx_str_t slit_14 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_14, &fname_0);
+               fx_str_t slit_15 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_15, &fname_0);
             }
-            FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_9, 0), _fx_catch_15);
-            FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_10, 0), _fx_catch_15);
-            fx_str_t slit_15 = FX_MAKE_STR(":");
+            FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_9, 0), _fx_catch_16);
+            FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_10, 0), _fx_catch_16);
             fx_str_t slit_16 = FX_MAKE_STR(":");
-            fx_str_t slit_17 = FX_MAKE_STR(": error: bad floating-point type TypFloat(");
-            fx_str_t slit_18 = FX_MAKE_STR(")");
+            fx_str_t slit_17 = FX_MAKE_STR(":");
+            fx_str_t slit_18 = FX_MAKE_STR(": error: bad floating-point type TypFloat(");
+            fx_str_t slit_19 = FX_MAKE_STR(")");
             {
-               const fx_str_t strs_5[] = { fname_0, slit_15, v_9, slit_16, v_10, slit_17, v_8, slit_18 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_5, 8, &whole_msg_0), _fx_catch_15);
+               const fx_str_t strs_5[] = { fname_0, slit_16, v_9, slit_17, v_10, slit_18, v_8, slit_19 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_5, 8, &whole_msg_0), _fx_catch_16);
             }
             FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
             if (all_compile_err_ctx_0 == 0) {
@@ -22495,22 +22528,22 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
             }
             else {
                _fx_LS v_13 = 0;
-               FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_13), _fx_catch_14);
-               fx_str_t slit_19 =
+               FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_13), _fx_catch_15);
+               fx_str_t slit_20 =
                   FX_MAKE_STR("\n"
                      U"\t");
-               FX_CALL(_fx_F4joinS2SLS(&slit_19, v_13, &whole_msg_1, 0), _fx_catch_14);
+               FX_CALL(_fx_F4joinS2SLS(&slit_20, v_13, &whole_msg_1, 0), _fx_catch_15);
 
-            _fx_catch_14: ;
+            _fx_catch_15: ;
                if (v_13) {
                   _fx_free_LS(&v_13);
                }
             }
-            FX_CHECK_EXN(_fx_catch_15);
-            FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_11), _fx_catch_15);
-            FX_THROW(&v_11, true, _fx_catch_15);
+            FX_CHECK_EXN(_fx_catch_16);
+            FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_11), _fx_catch_16);
+            FX_THROW(&v_11, true, _fx_catch_16);
 
-         _fx_catch_15: ;
+         _fx_catch_16: ;
             fx_free_exn(&v_11);
             FX_FREE_STR(&whole_msg_1);
             if (all_compile_err_ctx_0) {
@@ -22522,22 +22555,13 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
             FX_FREE_STR(&fname_0);
             FX_FREE_STR(&v_8);
          }
-         FX_CHECK_EXN(_fx_catch_16);
-
-      _fx_catch_16: ;
-         goto _fx_endmatch_1;
-      }
-      if (tag_0 == 13) {
-         fx_str_t slit_20 = FX_MAKE_STR("void");
-         FX_FREE_STR(&result_0);
-         fx_copy_str(&slit_20, &result_0);
-         FX_BREAK(_fx_catch_17);
+         FX_CHECK_EXN(_fx_catch_17);
 
       _fx_catch_17: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 12) {
-         fx_str_t slit_21 = FX_MAKE_STR("bool");
+      if (tag_0 == 14) {
+         fx_str_t slit_21 = FX_MAKE_STR("void");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_21, &result_0);
          FX_BREAK(_fx_catch_18);
@@ -22545,8 +22569,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_18: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 11) {
-         fx_str_t slit_22 = FX_MAKE_STR("char");
+      if (tag_0 == 13) {
+         fx_str_t slit_22 = FX_MAKE_STR("bool");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_22, &result_0);
          FX_BREAK(_fx_catch_19);
@@ -22554,8 +22578,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_19: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 10) {
-         fx_str_t slit_23 = FX_MAKE_STR("string");
+      if (tag_0 == 12) {
+         fx_str_t slit_23 = FX_MAKE_STR("char");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_23, &result_0);
          FX_BREAK(_fx_catch_20);
@@ -22563,8 +22587,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_20: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 23) {
-         fx_str_t slit_24 = FX_MAKE_STR("cptr");
+      if (tag_0 == 11) {
+         fx_str_t slit_24 = FX_MAKE_STR("string");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_24, &result_0);
          FX_BREAK(_fx_catch_21);
@@ -22572,66 +22596,75 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_21: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 14) {
+      if (tag_0 == 24) {
+         fx_str_t slit_25 = FX_MAKE_STR("cptr");
+         FX_FREE_STR(&result_0);
+         fx_copy_str(&slit_25, &result_0);
+         FX_BREAK(_fx_catch_22);
+
+      _fx_catch_22: ;
+         goto _fx_endmatch_1;
+      }
+      if (tag_0 == 15) {
          fx_str_t v_14 = {0};
          fx_str_t v_15 = {0};
          fx_str_t result_7 = {0};
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_2 = &t_2->u.TypFun;
-         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_2->t0, &v_14, 0), _fx_catch_22);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_2->t1, &v_15, 0), _fx_catch_22);
-         fx_str_t slit_25 = FX_MAKE_STR("(");
-         fx_str_t slit_26 = FX_MAKE_STR(" -> ");
-         fx_str_t slit_27 = FX_MAKE_STR(")");
+         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_2->t0, &v_14, 0), _fx_catch_23);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_2->t1, &v_15, 0), _fx_catch_23);
+         fx_str_t slit_26 = FX_MAKE_STR("(");
+         fx_str_t slit_27 = FX_MAKE_STR(" -> ");
+         fx_str_t slit_28 = FX_MAKE_STR(")");
          {
-            const fx_str_t strs_6[] = { slit_25, v_14, slit_26, v_15, slit_27 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_6, 5, &result_7), _fx_catch_22);
+            const fx_str_t strs_6[] = { slit_26, v_14, slit_27, v_15, slit_28 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_6, 5, &result_7), _fx_catch_23);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_7, &result_0);
-         FX_BREAK(_fx_catch_22);
+         FX_BREAK(_fx_catch_23);
 
-      _fx_catch_22: ;
+      _fx_catch_23: ;
          FX_FREE_STR(&result_7);
          FX_FREE_STR(&v_15);
          FX_FREE_STR(&v_14);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          fx_str_t s_0 = {0};
          _fx_LN10Ast__typ_t tl_0 = t_2->u.TypTuple;
-         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(tl_0, &s_0, 0), _fx_catch_25);
+         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(tl_0, &s_0, 0), _fx_catch_26);
          if (tl_0 != 0) {
             if (tl_0->tl == 0) {
                fx_str_t result_8 = {0};
-               fx_str_t slit_28 = FX_MAKE_STR("(");
-               fx_str_t slit_29 = FX_MAKE_STR(",)");
+               fx_str_t slit_29 = FX_MAKE_STR("(");
+               fx_str_t slit_30 = FX_MAKE_STR(",)");
                {
-                  const fx_str_t strs_7[] = { slit_28, s_0, slit_29 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &result_8), _fx_catch_23);
+                  const fx_str_t strs_7[] = { slit_29, s_0, slit_30 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &result_8), _fx_catch_24);
                }
                FX_FREE_STR(&result_0);
                fx_copy_str(&result_8, &result_0);
-               FX_BREAK(_fx_catch_23);
+               FX_BREAK(_fx_catch_24);
 
-            _fx_catch_23: ;
+            _fx_catch_24: ;
                FX_FREE_STR(&result_8);
                goto _fx_endmatch_0;
             }
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&s_0, &result_0);
-         FX_BREAK(_fx_catch_24);
-
-      _fx_catch_24: ;
-
-      _fx_endmatch_0: ;
-         FX_CHECK_EXN(_fx_catch_25);
+         FX_BREAK(_fx_catch_25);
 
       _fx_catch_25: ;
+
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_catch_26);
+
+      _fx_catch_26: ;
          FX_FREE_STR(&s_0);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 20) {
+      if (tag_0 == 21) {
          _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = {0};
          fx_arr_t v_17 = {0};
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
@@ -22644,7 +22677,7 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          {
             const int_ shape_0[] = { len_0 };
             FX_CALL(fx_make_arr(1, shape_0, sizeof(fx_str_t), (fx_free_t)fx_free_str, (fx_copy_t)fx_copy_str, 0, &v_17),
-               _fx_catch_27);
+               _fx_catch_28);
          }
          dstptr_0 = (fx_str_t*)v_17.data;
          for (; lst_0; lst_0 = lst_0->tl, dstptr_0++) {
@@ -22661,10 +22694,10 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
             _fx_R9Ast__id_t i_0 = __pat___0->t1;
             FX_COPY_PTR(__pat___0->t2, &t_4);
             if (flags_0.val_flag_mutable) {
-               fx_str_t slit_30 = FX_MAKE_STR("var "); fx_copy_str(&slit_30, &prefix_0);
+               fx_str_t slit_31 = FX_MAKE_STR("var "); fx_copy_str(&slit_31, &prefix_0);
             }
             else {
-               fx_str_t slit_31 = FX_MAKE_STR(""); fx_copy_str(&slit_31, &prefix_0);
+               fx_str_t slit_32 = FX_MAKE_STR(""); fx_copy_str(&slit_32, &prefix_0);
             }
             bool t_5;
             if ((bool)((i_0.m == _fx_g9Ast__noid.m) & (i_0.i == _fx_g9Ast__noid.i))) {
@@ -22674,33 +22707,33 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
                t_5 = false;
             }
             if (t_5) {
-               fx_str_t slit_32 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_32, &v_18);
+               fx_str_t slit_33 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_33, &v_18);
             }
             else {
                int_ v_21 = i_0.i;
-               FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_21), _fx_catch_26);
+               FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_21), _fx_catch_27);
                fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_21), &prefix_1);
                if (i_0.m == 0) {
                   fx_copy_str(&prefix_1, &v_18);
                }
                else {
-                  FX_CALL(_fx_F6stringS1i(i_0.j, &v_19, 0), _fx_catch_26);
-                  fx_str_t slit_33 = FX_MAKE_STR("@");
+                  FX_CALL(_fx_F6stringS1i(i_0.j, &v_19, 0), _fx_catch_27);
+                  fx_str_t slit_34 = FX_MAKE_STR("@");
                   {
-                     const fx_str_t strs_8[] = { prefix_1, slit_33, v_19 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_8, 3, &v_18), _fx_catch_26);
+                     const fx_str_t strs_8[] = { prefix_1, slit_34, v_19 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_8, 3, &v_18), _fx_catch_27);
                   }
                }
             }
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_4, &v_20, 0), _fx_catch_26);
-            fx_str_t slit_34 = FX_MAKE_STR(": ");
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_4, &v_20, 0), _fx_catch_27);
+            fx_str_t slit_35 = FX_MAKE_STR(": ");
             {
-               const fx_str_t strs_9[] = { prefix_0, v_18, slit_34, v_20 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_9, 4, &concat_str_0), _fx_catch_26);
+               const fx_str_t strs_9[] = { prefix_0, v_18, slit_35, v_20 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_9, 4, &concat_str_0), _fx_catch_27);
             }
             fx_copy_str(&concat_str_0, dstptr_0);
 
-         _fx_catch_26: ;
+         _fx_catch_27: ;
             FX_FREE_STR(&concat_str_0);
             FX_FREE_STR(&v_20);
             FX_FREE_STR(&v_19);
@@ -22711,17 +22744,17 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
                _fx_free_N10Ast__typ_t(&t_4);
             }
             _fx_free_R16Ast__val_flags_t(&flags_0);
-            FX_CHECK_EXN(_fx_catch_27);
+            FX_CHECK_EXN(_fx_catch_28);
          }
-         fx_str_t slit_35 = FX_MAKE_STR("{");
-         fx_str_t slit_36 = FX_MAKE_STR("}");
-         fx_str_t slit_37 = FX_MAKE_STR("; ");
-         FX_CALL(_fx_F12join_embraceS4SSSA1S(&slit_35, &slit_36, &slit_37, &v_17, &result_9, 0), _fx_catch_27);
+         fx_str_t slit_36 = FX_MAKE_STR("{");
+         fx_str_t slit_37 = FX_MAKE_STR("}");
+         fx_str_t slit_38 = FX_MAKE_STR("; ");
+         FX_CALL(_fx_F12join_embraceS4SSSA1S(&slit_36, &slit_37, &slit_38, &v_17, &result_9, 0), _fx_catch_28);
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_9, &result_0);
-         FX_BREAK(_fx_catch_27);
+         FX_BREAK(_fx_catch_28);
 
-      _fx_catch_27: ;
+      _fx_catch_28: ;
          FX_FREE_STR(&result_9);
          if (relems_0) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
@@ -22730,94 +22763,85 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 19) {
+      if (tag_0 == 20) {
          fx_str_t v_22 = {0};
          fx_str_t v_23 = {0};
          fx_str_t result_10 = {0};
          _fx_T2iN10Ast__typ_t* vcase_3 = &t_2->u.TypArray;
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_3->t1, &v_22, 0), _fx_catch_28);
-         FX_CALL(_fx_F7__mul__S2Ci((char_)44, vcase_3->t0 - 1, &v_23, 0), _fx_catch_28);
-         fx_str_t slit_38 = FX_MAKE_STR(" [");
-         fx_str_t slit_39 = FX_MAKE_STR("]");
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_3->t1, &v_22, 0), _fx_catch_29);
+         FX_CALL(_fx_F7__mul__S2Ci((char_)44, vcase_3->t0 - 1, &v_23, 0), _fx_catch_29);
+         fx_str_t slit_39 = FX_MAKE_STR(" [");
+         fx_str_t slit_40 = FX_MAKE_STR("]");
          {
-            const fx_str_t strs_10[] = { v_22, slit_38, v_23, slit_39 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_10, 4, &result_10), _fx_catch_28);
+            const fx_str_t strs_10[] = { v_22, slit_39, v_23, slit_40 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_10, 4, &result_10), _fx_catch_29);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_10, &result_0);
-         FX_BREAK(_fx_catch_28);
+         FX_BREAK(_fx_catch_29);
 
-      _fx_catch_28: ;
+      _fx_catch_29: ;
          FX_FREE_STR(&result_10);
          FX_FREE_STR(&v_23);
          FX_FREE_STR(&v_22);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 15) {
+      if (tag_0 == 16) {
          fx_str_t v_24 = {0};
          fx_str_t result_11 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypList, &v_24, 0), _fx_catch_29);
-         fx_str_t slit_40 = FX_MAKE_STR(" list");
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypList, &v_24, 0), _fx_catch_30);
+         fx_str_t slit_41 = FX_MAKE_STR(" list");
          {
-            const fx_str_t strs_11[] = { v_24, slit_40 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_11, 2, &result_11), _fx_catch_29);
+            const fx_str_t strs_11[] = { v_24, slit_41 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_11, 2, &result_11), _fx_catch_30);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_11, &result_0);
-         FX_BREAK(_fx_catch_29);
+         FX_BREAK(_fx_catch_30);
 
-      _fx_catch_29: ;
+      _fx_catch_30: ;
          FX_FREE_STR(&result_11);
          FX_FREE_STR(&v_24);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 16) {
+      if (tag_0 == 17) {
          fx_str_t v_25 = {0};
          fx_str_t result_12 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypVector, &v_25, 0), _fx_catch_30);
-         fx_str_t slit_41 = FX_MAKE_STR(" vector");
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypVector, &v_25, 0), _fx_catch_31);
+         fx_str_t slit_42 = FX_MAKE_STR(" vector");
          {
-            const fx_str_t strs_12[] = { v_25, slit_41 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &result_12), _fx_catch_30);
+            const fx_str_t strs_12[] = { v_25, slit_42 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &result_12), _fx_catch_31);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_12, &result_0);
-         FX_BREAK(_fx_catch_30);
+         FX_BREAK(_fx_catch_31);
 
-      _fx_catch_30: ;
+      _fx_catch_31: ;
          FX_FREE_STR(&result_12);
          FX_FREE_STR(&v_25);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 18) {
+      if (tag_0 == 19) {
          fx_str_t v_26 = {0};
          fx_str_t result_13 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypRef, &v_26, 0), _fx_catch_31);
-         fx_str_t slit_42 = FX_MAKE_STR(" ref");
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypRef, &v_26, 0), _fx_catch_32);
+         fx_str_t slit_43 = FX_MAKE_STR(" ref");
          {
-            const fx_str_t strs_13[] = { v_26, slit_42 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_13, 2, &result_13), _fx_catch_31);
+            const fx_str_t strs_13[] = { v_26, slit_43 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_13, 2, &result_13), _fx_catch_32);
          }
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_13, &result_0);
-         FX_BREAK(_fx_catch_31);
+         FX_BREAK(_fx_catch_32);
 
-      _fx_catch_31: ;
+      _fx_catch_32: ;
          FX_FREE_STR(&result_13);
          FX_FREE_STR(&v_26);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 21) {
-         fx_str_t slit_43 = FX_MAKE_STR("exn");
-         FX_FREE_STR(&result_0);
-         fx_copy_str(&slit_43, &result_0);
-         FX_BREAK(_fx_catch_32);
-
-      _fx_catch_32: ;
-         goto _fx_endmatch_1;
-      }
       if (tag_0 == 22) {
-         fx_str_t slit_44 = FX_MAKE_STR("<err>");
+         fx_str_t slit_44 = FX_MAKE_STR("exn");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_44, &result_0);
          FX_BREAK(_fx_catch_33);
@@ -22825,8 +22849,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_33: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 25) {
-         fx_str_t slit_45 = FX_MAKE_STR("<decl>");
+      if (tag_0 == 23) {
+         fx_str_t slit_45 = FX_MAKE_STR("<err>");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_45, &result_0);
          FX_BREAK(_fx_catch_34);
@@ -22835,7 +22859,7 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          goto _fx_endmatch_1;
       }
       if (tag_0 == 26) {
-         fx_str_t slit_46 = FX_MAKE_STR("<module>");
+         fx_str_t slit_46 = FX_MAKE_STR("<decl>");
          FX_FREE_STR(&result_0);
          fx_copy_str(&slit_46, &result_0);
          FX_BREAK(_fx_catch_35);
@@ -22843,12 +22867,21 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
       _fx_catch_35: ;
          goto _fx_endmatch_1;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_36);
+      if (tag_0 == 27) {
+         fx_str_t slit_47 = FX_MAKE_STR("<module>");
+         FX_FREE_STR(&result_0);
+         fx_copy_str(&slit_47, &result_0);
+         FX_BREAK(_fx_catch_36);
+
+      _fx_catch_36: ;
+         goto _fx_endmatch_1;
+      }
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_37);
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_36);
+      FX_CHECK_EXN(_fx_catch_37);
 
-   _fx_catch_36: ;
+   _fx_catch_37: ;
       if (v_0) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_0);
       }
@@ -23370,9 +23403,6 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_Nt6option1N10Ast__typ_t(&v_0);
       }
    }
-   else if (tag_0 == 5) {
-      FX_COPY_PTR(t_0, fx_result);
-   }
    else if (tag_0 == 6) {
       FX_COPY_PTR(t_0, fx_result);
    }
@@ -23398,6 +23428,9 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
       FX_COPY_PTR(t_0, fx_result);
    }
    else if (tag_0 == 14) {
+      FX_COPY_PTR(t_0, fx_result);
+   }
+   else if (tag_0 == 15) {
       _fx_LN10Ast__typ_t v_4 = 0;
       _fx_N10Ast__typ_t v_5 = 0;
       _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &t_0->u.TypFun;
@@ -23415,7 +23448,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_LN10Ast__typ_t(&v_4);
       }
    }
-   else if (tag_0 == 15) {
+   else if (tag_0 == 16) {
       _fx_N10Ast__typ_t v_6 = 0;
       FX_CALL(_fx_M3AstFM16check_n_walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0->u.TypList, callb_0, &v_6, 0),
          _fx_catch_3);
@@ -23426,7 +23459,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_N10Ast__typ_t(&v_6);
       }
    }
-   else if (tag_0 == 16) {
+   else if (tag_0 == 17) {
       _fx_N10Ast__typ_t v_7 = 0;
       FX_CALL(_fx_M3AstFM16check_n_walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0->u.TypVector, callb_0, &v_7, 0),
          _fx_catch_4);
@@ -23437,7 +23470,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_N10Ast__typ_t(&v_7);
       }
    }
-   else if (tag_0 == 17) {
+   else if (tag_0 == 18) {
       _fx_LN10Ast__typ_t v_8 = 0;
       FX_CALL(_fx_M3AstFM18check_n_walk_tlistLN10Ast__typ_t2LN10Ast__typ_tRM11ast_callb_t(t_0->u.TypTuple, callb_0, &v_8, 0),
          _fx_catch_5);
@@ -23473,7 +23506,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_Nt6option1N10Ast__typ_t(&v_9);
       }
    }
-   else if (tag_0 == 18) {
+   else if (tag_0 == 19) {
       _fx_N10Ast__typ_t v_11 = 0;
       FX_CALL(_fx_M3AstFM16check_n_walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0->u.TypRef, callb_0, &v_11, 0),
          _fx_catch_8);
@@ -23484,7 +23517,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_N10Ast__typ_t(&v_11);
       }
    }
-   else if (tag_0 == 19) {
+   else if (tag_0 == 20) {
       _fx_N10Ast__typ_t v_12 = 0;
       _fx_T2iN10Ast__typ_t* vcase_1 = &t_0->u.TypArray;
       FX_CALL(_fx_M3AstFM16check_n_walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(vcase_1->t1, callb_0, &v_12, 0),
@@ -23510,7 +23543,10 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
    else if (tag_0 == 4) {
       FX_COPY_PTR(t_0, fx_result);
    }
-   else if (tag_0 == 20) {
+   else if (tag_0 == 5) {
+      FX_COPY_PTR(t_0, fx_result);
+   }
+   else if (tag_0 == 21) {
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_14 = {0};
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t new_relems_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
@@ -23573,9 +23609,6 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
       }
       _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_14);
    }
-   else if (tag_0 == 21) {
-      FX_COPY_PTR(t_0, fx_result);
-   }
    else if (tag_0 == 22) {
       FX_COPY_PTR(t_0, fx_result);
    }
@@ -23583,6 +23616,9 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
       FX_COPY_PTR(t_0, fx_result);
    }
    else if (tag_0 == 24) {
+      FX_COPY_PTR(t_0, fx_result);
+   }
+   else if (tag_0 == 25) {
       _fx_LN10Ast__typ_t v_20 = 0;
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_2 = &t_0->u.TypApp;
       FX_CALL(_fx_M3AstFM18check_n_walk_tlistLN10Ast__typ_t2LN10Ast__typ_tRM11ast_callb_t(vcase_2->t0, callb_0, &v_20, 0),
@@ -23594,10 +23630,10 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          _fx_free_LN10Ast__typ_t(&v_20);
       }
    }
-   else if (tag_0 == 25) {
+   else if (tag_0 == 26) {
       FX_COPY_PTR(t_0, fx_result);
    }
-   else if (tag_0 == 26) {
+   else if (tag_0 == 27) {
       FX_COPY_PTR(t_0, fx_result);
    }
    else {
@@ -24990,7 +25026,7 @@ FX_EXTERN_C int _fx_M3AstFM8dup_typ_N10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
       }
       goto _fx_endmatch_0;
    }
-   if (tag_0 == 20) {
+   if (tag_0 == 21) {
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t new_relems_0 = 0;
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_5 = {0};

--- a/compiler/bootstrap/Ast_pp.c
+++ b/compiler/bootstrap/Ast_pp.c
@@ -2009,21 +2009,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;
@@ -3981,19 +3981,16 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
          }
       }
       bool res_0;
-      if (tag_0 == 5) {
+      if (tag_0 == 6) {
          res_0 = true;
       }
-      else if (tag_0 == 8) {
-         res_0 = true;
-      }
-      else if (tag_0 == 6) {
+      else if (tag_0 == 9) {
          res_0 = true;
       }
       else if (tag_0 == 7) {
          res_0 = true;
       }
-      else if (tag_0 == 9) {
+      else if (tag_0 == 8) {
          res_0 = true;
       }
       else if (tag_0 == 10) {
@@ -4008,7 +4005,7 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
       else if (tag_0 == 13) {
          res_0 = true;
       }
-      else if (tag_0 == 21) {
+      else if (tag_0 == 14) {
          res_0 = true;
       }
       else if (tag_0 == 22) {
@@ -4017,10 +4014,13 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
       else if (tag_0 == 23) {
          res_0 = true;
       }
-      else if (tag_0 == 25) {
+      else if (tag_0 == 24) {
          res_0 = true;
       }
       else if (tag_0 == 26) {
+         res_0 = true;
+      }
+      else if (tag_0 == 27) {
          res_0 = true;
       }
       else {
@@ -4030,13 +4030,13 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
       if (res_0) {
          result_0 = _fx_g17Ast_pp__TypPrBase; FX_BREAK(_fx_catch_1);  _fx_catch_1: ; goto _fx_endmatch_0;
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          if (t_2->u.TypApp.t0 == 0) {
             result_0 = _fx_g17Ast_pp__TypPrBase; FX_BREAK(_fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_0;
          }
       }
       bool res_1;
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          res_1 = true;
       }
       else if (tag_0 == 2) {
@@ -4050,10 +4050,13 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
          result_0 = _fx_g17Ast_pp__TypPrBase; FX_BREAK(_fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_0;
       }
       bool res_2;
-      if (tag_0 == 20) {
+      if (tag_0 == 21) {
          res_2 = true;
       }
       else if (tag_0 == 4) {
+         res_2 = true;
+      }
+      else if (tag_0 == 5) {
          res_2 = true;
       }
       else {
@@ -4064,22 +4067,22 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
          result_0 = _fx_g17Ast_pp__TypPrBase; FX_BREAK(_fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_0;
       }
       bool res_3;
-      if (tag_0 == 15) {
+      if (tag_0 == 16) {
          res_3 = true;
       }
-      else if (tag_0 == 16) {
-         res_3 = true;
-      }
-      else if (tag_0 == 18) {
+      else if (tag_0 == 17) {
          res_3 = true;
       }
       else if (tag_0 == 19) {
          res_3 = true;
       }
+      else if (tag_0 == 20) {
+         res_3 = true;
+      }
       else if (tag_0 == 3) {
          res_3 = true;
       }
-      else if (tag_0 == 24) {
+      else if (tag_0 == 25) {
          res_3 = true;
       }
       else {
@@ -4089,7 +4092,7 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(
       if (res_3) {
          result_0 = _fx_g20Ast_pp__TypPrComplex; FX_BREAK(_fx_catch_5);  _fx_catch_5: ; goto _fx_endmatch_0;
       }
-      if (tag_0 == 14) {
+      if (tag_0 == 15) {
          result_0 = _fx_g16Ast_pp__TypPrFun; FX_BREAK(_fx_catch_6);  _fx_catch_6: ; goto _fx_endmatch_0;
       }
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_7);
@@ -4158,7 +4161,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       FX_COPY_PTR(t_1, &t_2);
       _fx_N16Ast_pp__typ_pr_t p1_2 = p1_1;
       _fx_N16Ast_pp__typ_pr_t prec_0;
-      FX_CALL(_fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(t_2, &prec_0, 0), _fx_catch_38);
+      FX_CALL(_fx_M6Ast_ppFM10get_typ_prN16Ast_pp__typ_pr_t1N10Ast__typ_t(t_2, &prec_0, 0), _fx_catch_39);
       int tag_0 = FX_REC_VARIANT_TAG(t_2);
       if (tag_0 == 1) {
          FX_COPY_PTR(t_2->u.TypVar->data, &v_0);
@@ -4181,7 +4184,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 5) {
+      if (tag_0 == 6) {
          fx_str_t slit_1 = FX_MAKE_STR("int");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_1, 0), _fx_catch_1);
          FX_BREAK(_fx_catch_1);
@@ -4189,7 +4192,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_1: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 8) {
+      if (tag_0 == 9) {
          fx_str_t slit_2 = FX_MAKE_STR("long");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_2, 0), _fx_catch_2);
          FX_BREAK(_fx_catch_2);
@@ -4197,7 +4200,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_2: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 6) {
+      if (tag_0 == 7) {
          fx_str_t v_2 = {0};
          fx_str_t v_3 = {0};
          FX_CALL(_fx_F6stringS1i(t_2->u.TypSInt, &v_2, 0), _fx_catch_3);
@@ -4214,7 +4217,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          FX_FREE_STR(&v_2);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 7) {
+      if (tag_0 == 8) {
          fx_str_t v_4 = {0};
          fx_str_t v_5 = {0};
          FX_CALL(_fx_F6stringS1i(t_2->u.TypUInt, &v_4, 0), _fx_catch_4);
@@ -4231,7 +4234,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          FX_FREE_STR(&v_4);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          if (t_2->u.TypFloat == 16) {
             fx_str_t slit_5 = FX_MAKE_STR("half");
             FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_5, 0), _fx_catch_5);
@@ -4241,7 +4244,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          if (t_2->u.TypFloat == 32) {
             fx_str_t slit_6 = FX_MAKE_STR("float");
             FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_6, 0), _fx_catch_6);
@@ -4251,7 +4254,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          if (t_2->u.TypFloat == 64) {
             fx_str_t slit_7 = FX_MAKE_STR("double");
             FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_7, 0), _fx_catch_7);
@@ -4261,7 +4264,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          fx_str_t v_6 = {0};
          fx_str_t v_7 = {0};
          fx_exn_t v_8 = {0};
@@ -4281,7 +4284,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          FX_FREE_STR(&v_6);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 10) {
+      if (tag_0 == 11) {
          fx_str_t slit_10 = FX_MAKE_STR("string");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_10, 0), _fx_catch_9);
          FX_BREAK(_fx_catch_9);
@@ -4289,7 +4292,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_9: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 11) {
+      if (tag_0 == 12) {
          fx_str_t slit_11 = FX_MAKE_STR("char");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_11, 0), _fx_catch_10);
          FX_BREAK(_fx_catch_10);
@@ -4297,7 +4300,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_10: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 12) {
+      if (tag_0 == 13) {
          fx_str_t slit_12 = FX_MAKE_STR("bool");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_12, 0), _fx_catch_11);
          FX_BREAK(_fx_catch_11);
@@ -4305,7 +4308,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_11: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 13) {
+      if (tag_0 == 14) {
          fx_str_t slit_13 = FX_MAKE_STR("void");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_13, 0), _fx_catch_12);
          FX_BREAK(_fx_catch_12);
@@ -4313,7 +4316,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_12: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 14) {
+      if (tag_0 == 15) {
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &t_2->u.TypFun;
          _fx_LN10Ast__typ_t tl_0 = vcase_0->t0;
          FX_CALL(_fx_M2PPFM5beginv1RM1t(pp_0, 0), _fx_catch_16);
@@ -4364,7 +4367,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_16: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 15) {
+      if (tag_0 == 16) {
          fx_str_t slit_18 = FX_MAKE_STR("list");
          FX_CALL(
             _fx_M6Ast_ppFM8pptypsufv7N10Ast__typ_tSBR10Ast__loc_tN16Ast_pp__typ_pr_tR5PP__tN16Ast_pp__typ_pr_t(t_2->u.TypList,
@@ -4374,7 +4377,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_17: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 16) {
+      if (tag_0 == 17) {
          fx_str_t slit_19 = FX_MAKE_STR("vector");
          FX_CALL(
             _fx_M6Ast_ppFM8pptypsufv7N10Ast__typ_tSBR10Ast__loc_tN16Ast_pp__typ_pr_tR5PP__tN16Ast_pp__typ_pr_t(t_2->u.TypVector,
@@ -4384,7 +4387,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_18: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 18) {
+      if (tag_0 == 19) {
          fx_str_t slit_20 = FX_MAKE_STR("ref");
          FX_CALL(
             _fx_M6Ast_ppFM8pptypsufv7N10Ast__typ_tSBR10Ast__loc_tN16Ast_pp__typ_pr_tR5PP__tN16Ast_pp__typ_pr_t(t_2->u.TypRef,
@@ -4394,7 +4397,7 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_19: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 19) {
+      if (tag_0 == 20) {
          fx_str_t shape_0 = {0};
          fx_str_t v_10 = {0};
          fx_str_t v_11 = {0};
@@ -4442,82 +4445,90 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       _fx_catch_22: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 5) {
+         fx_str_t slit_26 = FX_MAKE_STR("[...]");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_26, 0), _fx_catch_23);
+         FX_BREAK(_fx_catch_23);
+
+      _fx_catch_23: ;
+         goto _fx_endmatch_1;
+      }
+      if (tag_0 == 25) {
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_2 = &t_2->u.TypApp;
          if (vcase_2->t0 == 0) {
-            FX_CALL(_fx_M6Ast_ppFM4ppidv2R5PP__tR9Ast__id_t(pp_0, &vcase_2->t1, 0), _fx_catch_23);
-            FX_BREAK(_fx_catch_23);
+            FX_CALL(_fx_M6Ast_ppFM4ppidv2R5PP__tR9Ast__id_t(pp_0, &vcase_2->t1, 0), _fx_catch_24);
+            FX_BREAK(_fx_catch_24);
 
-         _fx_catch_23: ;
+         _fx_catch_24: ;
             goto _fx_endmatch_1;
          }
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_3 = &t_2->u.TypApp;
          _fx_LN10Ast__typ_t v_12 = vcase_3->t0;
          if (v_12 != 0) {
             if (v_12->tl == 0) {
                fx_str_t v_13 = {0};
-               FX_CALL(_fx_M6Ast_ppFM8ppid2strS1R9Ast__id_t(&vcase_3->t1, &v_13, 0), _fx_catch_24);
+               FX_CALL(_fx_M6Ast_ppFM8ppid2strS1R9Ast__id_t(&vcase_3->t1, &v_13, 0), _fx_catch_25);
                FX_CALL(
                   _fx_M6Ast_ppFM8pptypsufv7N10Ast__typ_tSBR10Ast__loc_tN16Ast_pp__typ_pr_tR5PP__tN16Ast_pp__typ_pr_t(v_12->hd,
-                     &v_13, brief_0, loc_0, &p1_2, pp_0, &prec_0, 0), _fx_catch_24);
-               FX_BREAK(_fx_catch_24);
+                     &v_13, brief_0, loc_0, &p1_2, pp_0, &prec_0, 0), _fx_catch_25);
+               FX_BREAK(_fx_catch_25);
 
-            _fx_catch_24: ;
+            _fx_catch_25: ;
                FX_FREE_STR(&v_13);
                goto _fx_endmatch_1;
             }
          }
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          _fx_N10Ast__typ_t v_14 = 0;
          fx_str_t v_15 = {0};
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_4 = &t_2->u.TypApp;
-         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(vcase_4->t0, &v_14), _fx_catch_25);
-         FX_CALL(_fx_M6Ast_ppFM8ppid2strS1R9Ast__id_t(&vcase_4->t1, &v_15, 0), _fx_catch_25);
+         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(vcase_4->t0, &v_14), _fx_catch_26);
+         FX_CALL(_fx_M6Ast_ppFM8ppid2strS1R9Ast__id_t(&vcase_4->t1, &v_15, 0), _fx_catch_26);
          FX_CALL(
             _fx_M6Ast_ppFM8pptypsufv7N10Ast__typ_tSBR10Ast__loc_tN16Ast_pp__typ_pr_tR5PP__tN16Ast_pp__typ_pr_t(v_14, &v_15,
-               brief_0, loc_0, &p1_2, pp_0, &prec_0, 0), _fx_catch_25);
-         FX_BREAK(_fx_catch_25);
+               brief_0, loc_0, &p1_2, pp_0, &prec_0, 0), _fx_catch_26);
+         FX_BREAK(_fx_catch_26);
 
-      _fx_catch_25: ;
+      _fx_catch_26: ;
          FX_FREE_STR(&v_15);
          if (v_14) {
             _fx_free_N10Ast__typ_t(&v_14);
          }
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          _fx_LN10Ast__typ_t tl_1 = 0;
-         fx_str_t slit_26 = FX_MAKE_STR("(");
-         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_26, 0), _fx_catch_27);
-         FX_CALL(_fx_M2PPFM3cutv1RM1t(pp_0, 0), _fx_catch_27);
-         FX_CALL(_fx_M2PPFM5beginv1RM1t(pp_0, 0), _fx_catch_27);
+         fx_str_t slit_27 = FX_MAKE_STR("(");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_27, 0), _fx_catch_28);
+         FX_CALL(_fx_M2PPFM3cutv1RM1t(pp_0, 0), _fx_catch_28);
+         FX_CALL(_fx_M2PPFM5beginv1RM1t(pp_0, 0), _fx_catch_28);
          int_ i_0 = 0;
          FX_COPY_PTR(t_2->u.TypTuple, &tl_1);
          _fx_LN10Ast__typ_t lst_0 = tl_1;
          for (; lst_0; lst_0 = lst_0->tl, i_0 += 1) {
             _fx_N10Ast__typ_t t_3 = lst_0->hd;
             if (i_0 > 0) {
-               fx_str_t slit_27 = FX_MAKE_STR(",");
-               FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_27, 0), _fx_catch_26);
-               FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_26);
+               fx_str_t slit_28 = FX_MAKE_STR(",");
+               FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_28, 0), _fx_catch_27);
+               FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_27);
             }
             FX_CALL(
                _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_tR5PP__t(t_3, &_fx_g14Ast_pp__TypPr0,
-                  brief_0, loc_0, pp_0, 0), _fx_catch_26);
+                  brief_0, loc_0, pp_0, 0), _fx_catch_27);
 
-         _fx_catch_26: ;
-            FX_CHECK_EXN(_fx_catch_27);
+         _fx_catch_27: ;
+            FX_CHECK_EXN(_fx_catch_28);
          }
-         FX_CALL(_fx_M2PPFM3cutv1RM1t(pp_0, 0), _fx_catch_27);
-         FX_CALL(_fx_M2PPFM3endv1RM1t(pp_0, 0), _fx_catch_27);
-         fx_str_t slit_28 = FX_MAKE_STR(")");
-         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_28, 0), _fx_catch_27);
-         FX_BREAK(_fx_catch_27);
+         FX_CALL(_fx_M2PPFM3cutv1RM1t(pp_0, 0), _fx_catch_28);
+         FX_CALL(_fx_M2PPFM3endv1RM1t(pp_0, 0), _fx_catch_28);
+         fx_str_t slit_29 = FX_MAKE_STR(")");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_29, 0), _fx_catch_28);
+         FX_BREAK(_fx_catch_28);
 
-      _fx_catch_27: ;
+      _fx_catch_28: ;
          if (tl_1) {
             _fx_free_LN10Ast__typ_t(&tl_1);
          }
@@ -4525,44 +4536,44 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
       }
       if (tag_0 == 2) {
          _fx_Nt6option1N10Ast__typ_t t_opt_0 = t_2->u.TypVarTuple;
-         fx_str_t slit_29 = FX_MAKE_STR("(");
-         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_29, 0), _fx_catch_29);
+         fx_str_t slit_30 = FX_MAKE_STR("(");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_30, 0), _fx_catch_30);
          if ((t_opt_0 != 0) + 1 == 2) {
             FX_CALL(
                _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_tR5PP__t(t_opt_0->u.Some,
-                  &_fx_g14Ast_pp__TypPr0, brief_0, loc_0, pp_0, 0), _fx_catch_28);
-            FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_28);
+                  &_fx_g14Ast_pp__TypPr0, brief_0, loc_0, pp_0, 0), _fx_catch_29);
+            FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_29);
 
-         _fx_catch_28: ;
+         _fx_catch_29: ;
          }
-         FX_CHECK_EXN(_fx_catch_29);
-         fx_str_t slit_30 = FX_MAKE_STR("...)");
-         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_30, 0), _fx_catch_29);
-         FX_BREAK(_fx_catch_29);
+         FX_CHECK_EXN(_fx_catch_30);
+         fx_str_t slit_31 = FX_MAKE_STR("...)");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_31, 0), _fx_catch_30);
+         FX_BREAK(_fx_catch_30);
 
-      _fx_catch_29: ;
+      _fx_catch_30: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 20) {
+      if (tag_0 == 21) {
          _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = {0};
          fx_str_t v_17 = {0};
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t rec_elems_0 = 0;
          _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t_2->u.TypRecord->data, &v_16);
          if (brief_0) {
-            fx_str_t slit_31 = FX_MAKE_STR("{...}");
-            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_31, 0), _fx_catch_32);
-            FX_BREAK(_fx_catch_32);
+            fx_str_t slit_32 = FX_MAKE_STR("{...}");
+            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_32, 0), _fx_catch_33);
+            FX_BREAK(_fx_catch_33);
          }
          else {
-            FX_CALL(_fx_M2PPFM5beginv1RM1t(pp_0, 0), _fx_catch_32);
+            FX_CALL(_fx_M2PPFM5beginv1RM1t(pp_0, 0), _fx_catch_33);
             if (v_16.t1) {
-               fx_str_t slit_32 = FX_MAKE_STR("{"); fx_copy_str(&slit_32, &v_17);
+               fx_str_t slit_33 = FX_MAKE_STR("{"); fx_copy_str(&slit_33, &v_17);
             }
             else {
-               fx_str_t slit_33 = FX_MAKE_STR("@ordered {"); fx_copy_str(&slit_33, &v_17);
+               fx_str_t slit_34 = FX_MAKE_STR("@ordered {"); fx_copy_str(&slit_34, &v_17);
             }
-            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &v_17, 0), _fx_catch_32);
-            FX_CALL(_fx_M2PPFM6breakiv1RM1t(pp_0, 0), _fx_catch_32);
+            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &v_17, 0), _fx_catch_33);
+            FX_CALL(_fx_M2PPFM6breakiv1RM1t(pp_0, 0), _fx_catch_33);
             int_ i_1 = 0;
             FX_COPY_PTR(v_16.t0, &rec_elems_0);
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_1 = rec_elems_0;
@@ -4576,30 +4587,30 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
                FX_COPY_PTR(__pat___0->t2, &t_4);
                FX_COPY_PTR(__pat___0->t3, &v0_0);
                if (i_1 > 0) {
-                  fx_str_t slit_34 = FX_MAKE_STR(";");
-                  FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_34, 0), _fx_catch_31);
-                  FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_31);
+                  fx_str_t slit_35 = FX_MAKE_STR(";");
+                  FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_35, 0), _fx_catch_32);
+                  FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_32);
                }
                if (flags_0.val_flag_mutable) {
-                  fx_str_t slit_35 = FX_MAKE_STR("var "); FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_35, 0), _fx_catch_31);
+                  fx_str_t slit_36 = FX_MAKE_STR("var "); FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_36, 0), _fx_catch_32);
                }
-               FX_CALL(_fx_M6Ast_ppFM4ppidv2R5PP__tR9Ast__id_t(pp_0, &n_0, 0), _fx_catch_31);
-               fx_str_t slit_36 = FX_MAKE_STR(":");
-               FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_36, 0), _fx_catch_31);
-               FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_31);
+               FX_CALL(_fx_M6Ast_ppFM4ppidv2R5PP__tR9Ast__id_t(pp_0, &n_0, 0), _fx_catch_32);
+               fx_str_t slit_37 = FX_MAKE_STR(":");
+               FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_37, 0), _fx_catch_32);
+               FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_32);
                FX_CALL(
                   _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_tR5PP__t(t_4, &_fx_g14Ast_pp__TypPr0,
-                     brief_0, loc_0, pp_0, 0), _fx_catch_31);
+                     brief_0, loc_0, pp_0, 0), _fx_catch_32);
                if (FX_REC_VARIANT_TAG(v0_0) != 1) {
-                  fx_str_t slit_37 = FX_MAKE_STR("=");
-                  FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_37, 0), _fx_catch_30);
-                  FX_CALL(_fx_M6Ast_ppFM10pprint_expv2R5PP__tN10Ast__exp_t(pp_0, v0_0, 0), _fx_catch_30);
+                  fx_str_t slit_38 = FX_MAKE_STR("=");
+                  FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_38, 0), _fx_catch_31);
+                  FX_CALL(_fx_M6Ast_ppFM10pprint_expv2R5PP__tN10Ast__exp_t(pp_0, v0_0, 0), _fx_catch_31);
 
-               _fx_catch_30: ;
+               _fx_catch_31: ;
                }
-               FX_CHECK_EXN(_fx_catch_31);
+               FX_CHECK_EXN(_fx_catch_32);
 
-            _fx_catch_31: ;
+            _fx_catch_32: ;
                if (v0_0) {
                   _fx_free_N10Ast__exp_t(&v0_0);
                }
@@ -4607,16 +4618,16 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
                   _fx_free_N10Ast__typ_t(&t_4);
                }
                _fx_free_R16Ast__val_flags_t(&flags_0);
-               FX_CHECK_EXN(_fx_catch_32);
+               FX_CHECK_EXN(_fx_catch_33);
             }
-            FX_CALL(_fx_M2PPFM6breakuv1RM1t(pp_0, 0), _fx_catch_32);
-            fx_str_t slit_38 = FX_MAKE_STR("}");
-            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_38, 0), _fx_catch_32);
-            FX_CALL(_fx_M2PPFM3endv1RM1t(pp_0, 0), _fx_catch_32);
-            FX_BREAK(_fx_catch_32);
+            FX_CALL(_fx_M2PPFM6breakuv1RM1t(pp_0, 0), _fx_catch_33);
+            fx_str_t slit_39 = FX_MAKE_STR("}");
+            FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_39, 0), _fx_catch_33);
+            FX_CALL(_fx_M2PPFM3endv1RM1t(pp_0, 0), _fx_catch_33);
+            FX_BREAK(_fx_catch_33);
          }
 
-      _fx_catch_32: ;
+      _fx_catch_33: ;
          if (rec_elems_0) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&rec_elems_0);
          }
@@ -4624,16 +4635,8 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 21) {
-         fx_str_t slit_39 = FX_MAKE_STR("exn");
-         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_39, 0), _fx_catch_33);
-         FX_BREAK(_fx_catch_33);
-
-      _fx_catch_33: ;
-         goto _fx_endmatch_1;
-      }
       if (tag_0 == 22) {
-         fx_str_t slit_40 = FX_MAKE_STR("err");
+         fx_str_t slit_40 = FX_MAKE_STR("exn");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_40, 0), _fx_catch_34);
          FX_BREAK(_fx_catch_34);
 
@@ -4641,15 +4644,15 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          goto _fx_endmatch_1;
       }
       if (tag_0 == 23) {
-         fx_str_t slit_41 = FX_MAKE_STR("cptr");
+         fx_str_t slit_41 = FX_MAKE_STR("err");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_41, 0), _fx_catch_35);
          FX_BREAK(_fx_catch_35);
 
       _fx_catch_35: ;
          goto _fx_endmatch_1;
       }
-      if (tag_0 == 25) {
-         fx_str_t slit_42 = FX_MAKE_STR("<decl>");
+      if (tag_0 == 24) {
+         fx_str_t slit_42 = FX_MAKE_STR("cptr");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_42, 0), _fx_catch_36);
          FX_BREAK(_fx_catch_36);
 
@@ -4657,19 +4660,27 @@ static int _fx_M6Ast_ppFM7pptype_v5N10Ast__typ_tN16Ast_pp__typ_pr_tBR10Ast__loc_
          goto _fx_endmatch_1;
       }
       if (tag_0 == 26) {
-         fx_str_t slit_43 = FX_MAKE_STR("<module>");
+         fx_str_t slit_43 = FX_MAKE_STR("<decl>");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_43, 0), _fx_catch_37);
          FX_BREAK(_fx_catch_37);
 
       _fx_catch_37: ;
          goto _fx_endmatch_1;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_38);
+      if (tag_0 == 27) {
+         fx_str_t slit_44 = FX_MAKE_STR("<module>");
+         FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_44, 0), _fx_catch_38);
+         FX_BREAK(_fx_catch_38);
+
+      _fx_catch_38: ;
+         goto _fx_endmatch_1;
+      }
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_39);
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_38);
+      FX_CHECK_EXN(_fx_catch_39);
 
-   _fx_catch_38: ;
+   _fx_catch_39: ;
       if (v_1) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_1);
       }
@@ -5155,7 +5166,7 @@ static int _fx_M6Ast_ppFM5ppexpv2N10Ast__exp_tR5PP__t(
       fx_str_t slit_19 = FX_MAKE_STR("exception ");
       FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_19, 0), _fx_catch_9);
       FX_CALL(_fx_M6Ast_ppFM4ppidv2R5PP__tR9Ast__id_t(pp_0, &v_11.dexn_name, 0), _fx_catch_9);
-      if (FX_REC_VARIANT_TAG(dexn_typ_0) != 13) {
+      if (FX_REC_VARIANT_TAG(dexn_typ_0) != 14) {
          fx_str_t slit_20 = FX_MAKE_STR(":");
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_20, 0), _fx_catch_8);
          FX_CALL(_fx_M2PPFM5spacev1RM1t(pp_0, 0), _fx_catch_8);
@@ -5702,7 +5713,7 @@ static int _fx_M6Ast_ppFM5ppexpv2N10Ast__exp_tR5PP__t(
          _fx_N10Ast__typ_t t_2 = v_24->t0;
          _fx_R9Ast__id_t* n_1 = &vcase_3->t0;
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_2, &v_23, 0), _fx_catch_45);
-         if (FX_REC_VARIANT_TAG(v_23) == 24) {
+         if (FX_REC_VARIANT_TAG(v_23) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_4 = &v_23->u.TypApp;
             if (vcase_4->t0 == 0) {
                bool res_3;
@@ -5837,7 +5848,7 @@ static int _fx_M6Ast_ppFM5ppexpv2N10Ast__exp_tR5PP__t(
          FX_CALL(_fx_M2PPFM3strv2RM1tS(pp_0, &slit_78, 0), _fx_catch_56);
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_31->t0, &v_30, 0), _fx_catch_56);
          if (i_8->tag == 4) {
-            if (FX_REC_VARIANT_TAG(v_30) == 24) {
+            if (FX_REC_VARIANT_TAG(v_30) == 25) {
                _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_10 = &v_30->u.TypApp;
                if (vcase_10->t0 == 0) {
                   _fx_N10Ast__typ_t v_32 = 0;
@@ -5862,7 +5873,7 @@ static int _fx_M6Ast_ppFM5ppexpv2N10Ast__exp_tR5PP__t(
             }
          }
          if (i_8->tag == 5) {
-            if (FX_REC_VARIANT_TAG(v_30) == 24) {
+            if (FX_REC_VARIANT_TAG(v_30) == 25) {
                _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_11 = &v_30->u.TypApp;
                if (vcase_11->t0 == 0) {
                   _fx_N10Ast__typ_t v_35 = 0;
@@ -7222,7 +7233,7 @@ FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(
    FX_COPY_PTR(v_8->df_typ, &df_typ_0);
    _fx_R9Ast__id_t df_name_0 = v_8->df_name;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(df_typ_0, &v_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_0) == 14) {
+   if (FX_REC_VARIANT_TAG(v_0) == 15) {
       _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_0->u.TypFun;
       _fx_make_T2LN10Ast__typ_tN10Ast__typ_t(vcase_0->t0, vcase_0->t1, &v_1);
    }

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -1154,12 +1154,17 @@ typedef struct _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast
    } u;
 } _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t;
 
-typedef struct _fx_Nt6option1rR13Ast__deffun_t {
+typedef struct _fx_T2R9Ast__id_trR13Ast__deffun_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_rR13Ast__deffun_t_data_t* t1;
+} _fx_T2R9Ast__id_trR13Ast__deffun_t;
+
+typedef struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t {
    int tag;
    union {
-      struct _fx_rR13Ast__deffun_t_data_t* Some;
+      struct _fx_T2R9Ast__id_trR13Ast__deffun_t Some;
    } u;
-} _fx_Nt6option1rR13Ast__deffun_t;
+} _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t;
 
 typedef struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t {
    struct _fx_T2R9Ast__id_tN10Ast__typ_t t0;
@@ -1217,11 +1222,11 @@ typedef struct _fx_LT2N10Ast__exp_tB_data_t {
    struct _fx_T2N10Ast__exp_tB hd;
 } _fx_LT2N10Ast__exp_tB_data_t, *_fx_LT2N10Ast__exp_tB;
 
-typedef struct _fx_LrR13Ast__deffun_t_data_t {
+typedef struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t {
    int_ rc;
-   struct _fx_LrR13Ast__deffun_t_data_t* tl;
-   struct _fx_rR13Ast__deffun_t_data_t* hd;
-} _fx_LrR13Ast__deffun_t_data_t, *_fx_LrR13Ast__deffun_t;
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t* tl;
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t hd;
+} _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t, *_fx_LT2R9Ast__id_trR13Ast__deffun_t;
 
 typedef struct _fx_FPN10Ast__typ_t1N10Ast__exp_t {
    int (*fp)(struct _fx_N10Ast__exp_t_data_t*, struct _fx_N10Ast__typ_t_data_t**, void*);
@@ -1369,11 +1374,6 @@ typedef struct _fx_FPNt6option1N10Ast__typ_t1N16Ast__env_entry_t {
    fx_fcv_t* fcv;
 } _fx_FPNt6option1N10Ast__typ_t1N16Ast__env_entry_t;
 
-typedef struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t {
-   int (*fp)(struct _fx_N16Ast__env_entry_t_data_t*, struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t;
-
 typedef struct _fx_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t {
    struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t t0;
    struct _fx_LN16Ast__env_entry_t_data_t* t1;
@@ -1383,6 +1383,12 @@ typedef struct _fx_rLN16Ast__env_entry_t_data_t {
    int_ rc;
    struct _fx_LN16Ast__env_entry_t_data_t* data;
 } _fx_rLN16Ast__env_entry_t_data_t, *_fx_rLN16Ast__env_entry_t;
+
+typedef struct _fx_LrR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_LrR13Ast__deffun_t_data_t* tl;
+   struct _fx_rR13Ast__deffun_t_data_t* hd;
+} _fx_LrR13Ast__deffun_t_data_t, *_fx_LrR13Ast__deffun_t;
 
 typedef struct _fx_Ta2N10Ast__exp_t {
    struct _fx_N10Ast__exp_t_data_t* t0;
@@ -4457,25 +4463,47 @@ static void _fx_copy_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10A
    }
 }
 
-static void _fx_free_Nt6option1rR13Ast__deffun_t(struct _fx_Nt6option1rR13Ast__deffun_t* dst)
+static void _fx_free_T2R9Ast__id_trR13Ast__deffun_t(struct _fx_T2R9Ast__id_trR13Ast__deffun_t* dst)
+{
+   _fx_free_rR13Ast__deffun_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t* src,
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_rR13Ast__deffun_t_data_t* t1,
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t* dst)
 {
    switch (dst->tag) {
    case 2:
-      _fx_free_rR13Ast__deffun_t(&dst->u.Some); break;
+      _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&dst->u.Some); break;
    default:
       ;
    }
    dst->tag = 0;
 }
 
-static void _fx_copy_Nt6option1rR13Ast__deffun_t(
-   struct _fx_Nt6option1rR13Ast__deffun_t* src,
-   struct _fx_Nt6option1rR13Ast__deffun_t* dst)
+static void _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t* src,
+   struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t* dst)
 {
    dst->tag = src->tag;
    switch (src->tag) {
    case 2:
-      FX_COPY_PTR(src->u.Some, &dst->u.Some); break;
+      _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&src->u.Some, &dst->u.Some); break;
    default:
       dst->u = src->u;
    }
@@ -4665,18 +4693,18 @@ static int _fx_cons_LT2N10Ast__exp_tB(
    FX_MAKE_LIST_IMPL(_fx_LT2N10Ast__exp_tB, _fx_copy_T2N10Ast__exp_tB);
 }
 
-static void _fx_free_LrR13Ast__deffun_t(struct _fx_LrR13Ast__deffun_t_data_t** dst)
+static void _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t** dst)
 {
-   FX_FREE_LIST_IMPL(_fx_LrR13Ast__deffun_t, _fx_free_rR13Ast__deffun_t);
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_trR13Ast__deffun_t, _fx_free_T2R9Ast__id_trR13Ast__deffun_t);
 }
 
-static int _fx_cons_LrR13Ast__deffun_t(
-   struct _fx_rR13Ast__deffun_t_data_t* hd,
-   struct _fx_LrR13Ast__deffun_t_data_t* tl,
+static int _fx_cons_LT2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t* hd,
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t* tl,
    bool addref_tl,
-   struct _fx_LrR13Ast__deffun_t_data_t** fx_result)
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t** fx_result)
 {
-   FX_MAKE_LIST_IMPL(_fx_LrR13Ast__deffun_t, FX_COPY_PTR);
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_trR13Ast__deffun_t, _fx_copy_T2R9Ast__id_trR13Ast__deffun_t);
 }
 
 static void _fx_free_T2Nt11Set__tree_t1R9Ast__id_ti(struct _fx_T2Nt11Set__tree_t1R9Ast__id_ti* dst)
@@ -5041,6 +5069,20 @@ static int _fx_make_rLN16Ast__env_entry_t(
    struct _fx_rLN16Ast__env_entry_t_data_t** fx_result)
 {
    FX_MAKE_REF_IMPL(_fx_rLN16Ast__env_entry_t, FX_COPY_PTR);
+}
+
+static void _fx_free_LrR13Ast__deffun_t(struct _fx_LrR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LrR13Ast__deffun_t, _fx_free_rR13Ast__deffun_t);
+}
+
+static int _fx_cons_LrR13Ast__deffun_t(
+   struct _fx_rR13Ast__deffun_t_data_t* hd,
+   struct _fx_LrR13Ast__deffun_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LrR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LrR13Ast__deffun_t, FX_COPY_PTR);
 }
 
 static void _fx_free_Ta2N10Ast__exp_t(struct _fx_Ta2N10Ast__exp_t* dst)
@@ -6090,7 +6132,7 @@ static void _fx_make_T2N10Ast__pat_tB(struct _fx_N10Ast__pat_t_data_t* t0, bool 
 
 _fx_Nt6option1T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t _fx_g19Ast_typecheck__None = { 1 };
 _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t _fx_g21Ast_typecheck__None1_ = { 1 };
-_fx_Nt6option1rR13Ast__deffun_t _fx_g21Ast_typecheck__None2_ = { 1 };
+_fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t _fx_g21Ast_typecheck__None2_ = { 1 };
 _fx_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t _fx_g21Ast_typecheck__None3_ = { 1 };
 _fx_Nt6option1N10Ast__lit_t _fx_g21Ast_typecheck__None4_ = { 1 };
 _fx_Nt6option1LN16Ast__env_entry_t _fx_g21Ast_typecheck__None5_ = { 1 };
@@ -6291,6 +6333,16 @@ FX_EXTERN_C int
 
 FX_EXTERN_C int _fx_M3AstFM14is_constructorB1RM11fun_flags_t(struct _fx_R16Ast__fun_flags_t*, bool*, void*);
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+   struct _fx_rB_data_t*,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
+
+static int _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__typ_t_data_t**,
+   void*);
+
 FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(struct _fx_R10Ast__loc_t*, fx_str_t*, fx_exn_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
@@ -6421,7 +6473,7 @@ FX_EXTERN_C int
 
 FX_EXTERN_C int _fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, void*);
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
    struct _fx_rB_data_t*,
    struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
 
@@ -6463,40 +6515,22 @@ FX_EXTERN_C int _fx_M3AstFM14get_module_envRt6Map__t2RM4id_tLN16Ast__env_entry_t
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    void*);
 
-static int
-   _fx_M13Ast_typecheckFM11search_pathNt6option1T2R9Ast__id_tN10Ast__typ_t8SiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_tLN12Ast__scope_t(
-   fx_str_t*,
-   int_,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
-   struct _fx_R10Ast__loc_t*,
-   int_,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
-   struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t*,
-   struct _fx_LN12Ast__scope_t_data_t*,
-   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*,
-   void*);
-
 FX_EXTERN_C int _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(
    struct _fx_LN10Ast__typ_t_data_t*,
    struct _fx_N10Ast__typ_t_data_t*,
    struct _fx_N10Ast__typ_t_data_t**);
 
-FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
-
-FX_EXTERN_C int _fx_F6stringS1B(bool, fx_str_t*, void*);
-
-FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM7make_fpFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t6Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+static int
+   _fx_M13Ast_typecheckFM7lookup_Nt6option1T2R9Ast__id_tN10Ast__typ_t9R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t*,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
+   int_,
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    struct _fx_R10Ast__loc_t*,
    struct _fx_R9Ast__id_t*,
    struct _fx_rLN16Ast__env_entry_t_data_t*,
    struct _fx_LN12Ast__scope_t_data_t*,
    struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t*);
-
-static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-   struct _fx_N16Ast__env_entry_t_data_t*,
    struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*,
    void*);
 
@@ -6519,6 +6553,27 @@ FX_EXTERN_C int
    struct _fx_R10Ast__loc_t*,
    bool,
    struct _fx_rR13Ast__deffun_t_data_t**,
+   void*);
+
+FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F6stringS1B(bool, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F4joinS2SLS(fx_str_t*, struct _fx_LS_data_t*, fx_str_t*, void*);
+
+static int
+   _fx_M13Ast_typecheckFM12search_path_Nt6option1T2R9Ast__id_tN10Ast__typ_t10SiiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+   fx_str_t*,
+   int_,
+   int_,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
+   struct _fx_R10Ast__loc_t*,
+   struct _fx_R9Ast__id_t*,
+   struct _fx_rLN16Ast__env_entry_t_data_t*,
+   struct _fx_LN12Ast__scope_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t*,
    void*);
 
 FX_EXTERN_C int
@@ -7465,6 +7520,19 @@ FX_EXTERN_C void _fx_free_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_
 typedef struct {
    int_ rc;
    fx_free_t free_f;
+   struct _fx_rB_data_t* t0;
+} _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t;
+
+FX_EXTERN_C void _fx_free_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* dst)
+{
+   FX_FREE_REF_SIMPLE(&dst->t0);
+   fx_free(dst);
+}
+
+typedef struct {
+   int_ rc;
+   fx_free_t free_f;
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t0;
 } _fx_M13Ast_typecheckFM10__lambda__Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_cldata_t;
 
@@ -7502,27 +7570,6 @@ FX_EXTERN_C void _fx_free_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__
    _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* dst)
 {
    FX_FREE_REF_SIMPLE(&dst->t0);
-   fx_free(dst);
-}
-
-typedef struct {
-   int_ rc;
-   fx_free_t free_f;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t0;
-   struct _fx_R10Ast__loc_t t1;
-   struct _fx_R9Ast__id_t t2;
-   struct _fx_rLN16Ast__env_entry_t_data_t* t3;
-   struct _fx_LN12Ast__scope_t_data_t* t4;
-   struct _fx_N10Ast__typ_t_data_t* t5;
-} _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t_cldata_t;
-
-FX_EXTERN_C void _fx_free_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-   _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t_cldata_t* dst)
-{
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->t0);
-   _fx_free_rLN16Ast__env_entry_t(&dst->t3);
-   FX_FREE_LIST_SIMPLE(&dst->t4);
-   _fx_free_N10Ast__typ_t(&dst->t5);
    fx_free(dst);
 }
 
@@ -7644,12 +7691,12 @@ FX_EXTERN_C void
    _fx_copy_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(arg0, &fx_result->u.Some);
 }
 
-FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1rR13Ast__deffun_t1rR13Ast__deffun_t(
-   struct _fx_rR13Ast__deffun_t_data_t* arg0,
-   struct _fx_Nt6option1rR13Ast__deffun_t* fx_result)
+FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_trR13Ast__deffun_t1T2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_T2R9Ast__id_trR13Ast__deffun_t* arg0,
+   struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t* fx_result)
 {
    fx_result->tag = 2;
-   FX_COPY_PTR(arg0, &fx_result->u.Some);
+   _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(arg0, &fx_result->u.Some);
 }
 
 FX_EXTERN_C void
@@ -7817,7 +7864,9 @@ return fx_list_length(l);
 
 }
 
-FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(struct _fx_LrR13Ast__deffun_t_data_t* l, void* fx_fv)
+FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LT2R9Ast__id_trR13Ast__deffun_t(
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t* l,
+   void* fx_fv)
 {
    
 return fx_list_length(l);
@@ -13367,6 +13416,128 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM17typ_has_free_varsB1N10Ast__typ_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   bool* fx_result,
+   void* fx_fv)
+{
+   _fx_rB has_free_ref_0 = 0;
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t check__0 = {0};
+   _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t v_0 = 0;
+   _fx_R16Ast__ast_callb_t callb_0 = {0};
+   _fx_N10Ast__typ_t res_0 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_make_rB(false, &has_free_ref_0), _fx_cleanup);
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(has_free_ref_0, &check__0);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+         &check__0, &v_0), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   FX_CALL(check__0.fp(t_0, &callb_0, &res_0, check__0.fcv), _fx_cleanup);
+   *fx_result = has_free_ref_0->data;
+
+_fx_cleanup: ;
+   FX_FREE_REF_SIMPLE(&has_free_ref_0);
+   FX_FREE_FP(&check__0);
+   if (v_0) {
+      _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&v_0);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_0);
+   if (res_0) {
+      _fx_free_N10Ast__typ_t(&res_0);
+   }
+   return fx_status;
+}
+
+static int _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_R16Ast__ast_callb_t* callb_0,
+   struct _fx_N10Ast__typ_t_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_1 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_2 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_3 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_4 = 0;
+   int fx_status = 0;
+   _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* cv_0 =
+      (_fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
+   bool* has_free_0 = &cv_0->t0->data;
+   if (*has_free_0) {
+      FX_COPY_PTR(t_0, fx_result);
+   }
+   else {
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+      int tag_0 = FX_REC_VARIANT_TAG(v_0);
+      if (tag_0 == 1) {
+         FX_COPY_PTR(v_0->u.TypVar->data, &v_1);
+         if ((v_1 != 0) + 1 == 1) {
+            *has_free_0 = true; FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+         }
+      }
+      if (tag_0 == 1) {
+         FX_COPY_PTR(v_0->u.TypVar->data, &v_2);
+         if ((v_2 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_2->u.Some) == 4) {
+               *has_free_0 = true; FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+            }
+         }
+      }
+      if (tag_0 == 1) {
+         FX_COPY_PTR(v_0->u.TypVar->data, &v_3);
+         if ((v_3 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_3->u.Some) == 2) {
+               *has_free_0 = true; FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+            }
+         }
+      }
+      if (tag_0 == 1) {
+         FX_COPY_PTR(v_0->u.TypVar->data, &v_4);
+         if ((v_4 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_4->u.Some) == 3) {
+               *has_free_0 = true; FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+            }
+         }
+      }
+      FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(v_0, callb_0, fx_result, 0), _fx_catch_0);
+
+   _fx_catch_0: ;
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (v_1) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_1);
+   }
+   if (v_2) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_2);
+   }
+   if (v_3) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_3);
+   }
+   if (v_4) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_4);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+   struct _fx_rB_data_t* arg0,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t* fx_result)
+{
+   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t,
+      _fx_free_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t,
+      _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t);
+   FX_COPY_PTR(arg0, &fcv->t0);
+   return 0;
+}
+
 FX_EXTERN_C int _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(
    struct _fx_N10Ast__typ_t_data_t* t1_0,
    struct _fx_N10Ast__typ_t_data_t* t2_0,
@@ -15928,7 +16099,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
    int fx_status = 0;
    FX_CALL(_fx_make_rB(false, &have_typ_vars_ref_0), _fx_cleanup);
    bool* have_typ_vars_0 = &have_typ_vars_ref_0->data;
-   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(have_typ_vars_ref_0, &is_real_typ__0);
+   _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(have_typ_vars_ref_0, &is_real_typ__0);
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &is_real_typ__0, &v_0), _fx_cleanup);
@@ -16019,7 +16190,7 @@ _fx_endmatch_0: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
    struct _fx_rB_data_t* arg0,
    struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t* fx_result)
 {
@@ -16375,232 +16546,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM10find_firstNt6option1T2R9Ast__id_tN10Ast__typ_t6R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-   struct _fx_R9Ast__id_t* n_0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env0_0,
-   struct _fx_LN12Ast__scope_t_data_t* sc_0,
-   struct _fx_R10Ast__loc_t* loc_0,
-   struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t* pred_0,
-   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
-   void* fx_fv)
-{
-   _fx_LN16Ast__env_entry_t e_all_0 = 0;
-   _fx_LN16Ast__env_entry_t e_all_1 = 0;
-   _fx_N16Ast__env_entry_t v_0 = 0;
-   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_0 = {0};
-   _fx_LN16Ast__env_entry_t elist_0 = 0;
-   fx_str_t n_path_0 = {0};
-   int fx_status = 0;
-   FX_CALL(fx_check_stack(), _fx_cleanup);
-   int_ curr_m_idx_0;
-   FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_0, &curr_m_idx_0, 0), _fx_cleanup);
-   FX_CALL(
-      _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(n_0, env_0,
-         &e_all_0, 0), _fx_cleanup);
-   bool t_0;
-   if (e_all_0 == 0) {
-      FX_CALL(_fx_M3AstFM12is_unique_idB1RM4id_t(n_0, &t_0, 0), _fx_cleanup);
-   }
-   else {
-      t_0 = false;
-   }
-   if (t_0) {
-      FX_CALL(_fx_M3AstFM5EnvIdN16Ast__env_entry_t1RM4id_t(n_0, &v_0), _fx_cleanup);
-      FX_CALL(_fx_cons_LN16Ast__env_entry_t(v_0, 0, true, &e_all_1), _fx_cleanup);
-   }
-   else {
-      FX_COPY_PTR(e_all_0, &e_all_1);
-   }
-   if (e_all_1 != 0) {
-      FX_COPY_PTR(e_all_1, &elist_0);
-      for (;;) {
-         _fx_LN16Ast__env_entry_t elist_1 = 0;
-         FX_COPY_PTR(elist_0, &elist_1);
-         if (elist_1 != 0) {
-            _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t v_1 = {0};
-            FX_CALL(pred_0->fp(elist_1->hd, &v_1, pred_0->fcv), _fx_catch_1);
-            if (v_1.tag == 1) {
-               _fx_LN16Ast__env_entry_t* rest_0 = &elist_1->tl;
-               _fx_free_LN16Ast__env_entry_t(&elist_0);
-               FX_COPY_PTR(*rest_0, &elist_0);
-            }
-            else {
-               _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_1, &result_0);
-               FX_BREAK(_fx_catch_0);
-
-            _fx_catch_0: ;
-            }
-            FX_CHECK_EXN(_fx_catch_1);
-
-         _fx_catch_1: ;
-            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_1);
-         }
-         else {
-            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-            _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
-            FX_BREAK(_fx_catch_2);
-
-         _fx_catch_2: ;
-         }
-         FX_CHECK_EXN(_fx_catch_3);
-
-      _fx_catch_3: ;
-         if (elist_1) {
-            _fx_free_LN16Ast__env_entry_t(&elist_1);
-         }
-         FX_CHECK_BREAK();
-         FX_CHECK_EXN(_fx_cleanup);
-      }
-      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0, fx_result);
-   }
-   else {
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &n_path_0, 0), _fx_cleanup);
-      FX_CALL(
-         _fx_M13Ast_typecheckFM11search_pathNt6option1T2R9Ast__id_tN10Ast__typ_t8SiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_tLN12Ast__scope_t(
-            &n_path_0, FX_STR_LENGTH(n_path_0) - 1, env_0, loc_0, curr_m_idx_0, env0_0, pred_0, sc_0, fx_result, 0),
-         _fx_cleanup);
-   }
-
-_fx_cleanup: ;
-   if (e_all_0) {
-      _fx_free_LN16Ast__env_entry_t(&e_all_0);
-   }
-   if (e_all_1) {
-      _fx_free_LN16Ast__env_entry_t(&e_all_1);
-   }
-   if (v_0) {
-      _fx_free_N16Ast__env_entry_t(&v_0);
-   }
-   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-   if (elist_0) {
-      _fx_free_LN16Ast__env_entry_t(&elist_0);
-   }
-   FX_FREE_STR(&n_path_0);
-   return fx_status;
-}
-
-static int
-   _fx_M13Ast_typecheckFM11search_pathNt6option1T2R9Ast__id_tN10Ast__typ_t8SiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_tLN12Ast__scope_t(
-   fx_str_t* n_path_0,
-   int_ dot_pos_0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
-   struct _fx_R10Ast__loc_t* loc_0,
-   int_ curr_m_idx_0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env0_0,
-   struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t* pred_0,
-   struct _fx_LN12Ast__scope_t_data_t* sc_0,
-   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
-   void* fx_fv)
-{
-   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_0 = {0};
-   fx_str_t n_path_1 = {0};
-   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_1 = {0};
-   int fx_status = 0;
-   FX_CALL(fx_check_stack(), _fx_cleanup);
-   fx_copy_str(n_path_0, &n_path_1);
-   int_ dot_pos_1 = dot_pos_0;
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env_0, &env_1);
-   _fx_R10Ast__loc_t loc_1 = *loc_0;
-   for (;;) {
-      fx_str_t n_path_2 = {0};
-      _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_2 = {0};
-      fx_str_t v_0 = {0};
-      _fx_LN16Ast__env_entry_t v_1 = 0;
-      fx_copy_str(&n_path_1, &n_path_2);
-      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_1, &env_2);
-      _fx_R10Ast__loc_t loc_2 = loc_1;
-      int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
-      if (dot_pos_2 < 0) {
-         _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
-         FX_BREAK(_fx_catch_3);
-      }
-      else {
-         FX_CALL(fx_substr(&n_path_2, 0, dot_pos_2, 1, 1, &v_0), _fx_catch_3);
-         _fx_R9Ast__id_t v_2;
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_0, &v_2, 0), _fx_catch_3);
-         FX_CALL(
-            _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_2,
-               &env_2, &v_1, 0), _fx_catch_3);
-         if (v_1 != 0) {
-            _fx_N16Ast__env_entry_t v_3 = v_1->hd;
-            if (FX_REC_VARIANT_TAG(v_3) == 1) {
-               _fx_N14Ast__id_info_t v_4 = {0};
-               FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_3->u.EnvId, &loc_2, &v_4, 0), _fx_catch_2);
-               if (v_4.tag == 8) {
-                  _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_3 = {0};
-                  fx_str_t v_5 = {0};
-                  _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_1 = {0};
-                  int_ m_idx_0 = v_4.u.IdModule;
-                  if (m_idx_0 == curr_m_idx_0) {
-                     _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env0_0, &env_3);
-                  }
-                  else {
-                     FX_CALL(_fx_M3AstFM14get_module_envRt6Map__t2RM4id_tLN16Ast__env_entry_t1i(m_idx_0, &env_3, 0),
-                        _fx_catch_0);
-                  }
-                  FX_CALL(fx_substr(&n_path_2, dot_pos_2 + 1, 0, 1, 2, &v_5), _fx_catch_0);
-                  _fx_R9Ast__id_t v_6;
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_5, &v_6, 0), _fx_catch_0);
-                  FX_CALL(
-                     _fx_M13Ast_typecheckFM10find_firstNt6option1T2R9Ast__id_tN10Ast__typ_t6R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-                        &v_6, &env_3, env0_0, sc_0, &loc_2, pred_0, &result_1, 0), _fx_catch_0);
-                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1, &result_0);
-                  FX_BREAK(_fx_catch_0);
-
-               _fx_catch_0: ;
-                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1);
-                  FX_FREE_STR(&v_5);
-                  _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_3);
-               }
-               else {
-                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
-                  FX_BREAK(_fx_catch_1);
-
-               _fx_catch_1: ;
-               }
-               FX_CHECK_EXN(_fx_catch_2);
-
-            _fx_catch_2: ;
-               _fx_free_N14Ast__id_info_t(&v_4);
-               goto _fx_endmatch_0;
-            }
-         }
-         FX_FREE_STR(&n_path_1);
-         fx_copy_str(&n_path_2, &n_path_1);
-         dot_pos_1 = dot_pos_2 - 1;
-         _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_1);
-         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_2, &env_1);
-         loc_1 = loc_2;
-
-      _fx_endmatch_0: ;
-         FX_CHECK_EXN(_fx_catch_3);
-      }
-
-   _fx_catch_3: ;
-      if (v_1) {
-         _fx_free_LN16Ast__env_entry_t(&v_1);
-      }
-      FX_FREE_STR(&v_0);
-      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_2);
-      FX_FREE_STR(&n_path_2);
-      FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0, fx_result);
-
-_fx_cleanup: ;
-   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-   FX_FREE_STR(&n_path_1);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_1);
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_rR13Ast__deffun_t_data_t* df_0,
    struct _fx_N10Ast__typ_t_data_t* t_0,
@@ -16805,276 +16750,6 @@ _fx_cleanup: ;
 }
 
 FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM13trace_resolvev5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-   struct _fx_R9Ast__id_t* n_0,
-   struct _fx_N10Ast__typ_t_data_t* t_0,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
-   struct _fx_LN12Ast__scope_t_data_t* sc_0,
-   struct _fx_R10Ast__loc_t* loc_0,
-   void* fx_fv)
-{
-   _fx_N10Ast__typ_t v_0 = 0;
-   _fx_LrR13Ast__deffun_t acc_0 = 0;
-   _fx_LN16Ast__env_entry_t v_1 = 0;
-   _fx_LrR13Ast__deffun_t __fold_result___0 = 0;
-   _fx_LrR13Ast__deffun_t viable_0 = 0;
-   _fx_rR13Ast__deffun_t envwin_0 = 0;
-   _fx_Nt6option1rR13Ast__deffun_t __fold_result___1 = {0};
-   _fx_LrR13Ast__deffun_t viable_1 = 0;
-   _fx_Nt6option1rR13Ast__deffun_t genwin_0 = {0};
-   fx_str_t v_2 = {0};
-   fx_str_t v_3 = {0};
-   fx_str_t v_4 = {0};
-   fx_str_t v_5 = {0};
-   fx_str_t v_6 = {0};
-   fx_str_t v_7 = {0};
-   fx_str_t v_8 = {0};
-   fx_str_t v_9 = {0};
-   fx_str_t v_10 = {0};
-   int fx_status = 0;
-   bool v_11;
-   if (_fx_g12Options__opt.print_resolve) {
-      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
-      if (FX_REC_VARIANT_TAG(v_0) == 14) {
-         v_11 = true;
-      }
-      else {
-         v_11 = false;
-      }
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   else {
-      v_11 = false;
-   }
-   if (v_11) {
-      FX_CALL(
-         _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(n_0, env_0,
-            &v_1, 0), _fx_cleanup);
-      _fx_LN16Ast__env_entry_t lst_0 = v_1;
-      for (; lst_0; lst_0 = lst_0->tl) {
-         _fx_N16Ast__env_entry_t e_0 = lst_0->hd;
-         if (FX_REC_VARIANT_TAG(e_0) == 1) {
-            _fx_N14Ast__id_info_t v_12 = {0};
-            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&e_0->u.EnvId, loc_0, &v_12, 0), _fx_catch_1);
-            if (v_12.tag == 3) {
-               _fx_N10Ast__typ_t v_13 = 0;
-               _fx_LrR13Ast__deffun_t v_14 = 0;
-               _fx_rR13Ast__deffun_t df_0 = v_12.u.IdFun;
-               FX_CALL(_fx_M3AstFM7dup_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_13, 0), _fx_catch_0);
-               bool v_15;
-               FX_CALL(
-                  _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(df_0,
-                     v_13, sc_0, loc_0, &v_15, 0), _fx_catch_0);
-               if (v_15) {
-                  FX_CALL(_fx_cons_LrR13Ast__deffun_t(df_0, acc_0, true, &v_14), _fx_catch_0);
-                  _fx_free_LrR13Ast__deffun_t(&acc_0);
-                  FX_COPY_PTR(v_14, &acc_0);
-               }
-
-            _fx_catch_0: ;
-               if (v_14) {
-                  _fx_free_LrR13Ast__deffun_t(&v_14);
-               }
-               if (v_13) {
-                  _fx_free_N10Ast__typ_t(&v_13);
-               }
-            }
-            FX_CHECK_EXN(_fx_catch_1);
-
-         _fx_catch_1: ;
-            _fx_free_N14Ast__id_info_t(&v_12);
-         }
-         FX_CHECK_EXN(_fx_catch_2);
-
-      _fx_catch_2: ;
-         FX_CHECK_EXN(_fx_cleanup);
-      }
-      _fx_LrR13Ast__deffun_t lst_1 = acc_0;
-      for (; lst_1; lst_1 = lst_1->tl) {
-         _fx_LrR13Ast__deffun_t r_0 = 0;
-         _fx_rR13Ast__deffun_t a_0 = lst_1->hd;
-         FX_COPY_PTR(__fold_result___0, &r_0);
-         FX_CALL(_fx_cons_LrR13Ast__deffun_t(a_0, r_0, false, &r_0), _fx_catch_3);
-         _fx_free_LrR13Ast__deffun_t(&__fold_result___0);
-         FX_COPY_PTR(r_0, &__fold_result___0);
-
-      _fx_catch_3: ;
-         if (r_0) {
-            _fx_free_LrR13Ast__deffun_t(&r_0);
-         }
-         FX_CHECK_EXN(_fx_cleanup);
-      }
-      FX_COPY_PTR(__fold_result___0, &viable_0);
-      int_ v_16 = _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(viable_0, 0);
-      if (v_16 > 1) {
-         if (viable_0 != 0) {
-            FX_COPY_PTR(viable_0->hd, &envwin_0);
-         }
-         else {
-            FX_FAST_THROW(FX_EXN_NullListError, _fx_cleanup);
-         }
-         FX_CHECK_EXN(_fx_cleanup);
-         _fx_copy_Nt6option1rR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___1);
-         FX_COPY_PTR(viable_0, &viable_1);
-         _fx_LrR13Ast__deffun_t lst_2 = viable_1;
-         for (; lst_2; lst_2 = lst_2->tl) {
-            _fx_Nt6option1rR13Ast__deffun_t v_17 = {0};
-            _fx_rR13Ast__deffun_t c_0 = lst_2->hd;
-            bool __fold_result___2 = true;
-            _fx_LrR13Ast__deffun_t lst_3 = viable_0;
-            for (; lst_3; lst_3 = lst_3->tl) {
-               _fx_rR13Ast__deffun_t d_0 = lst_3->hd;
-               bool v_18;
-               if (_fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(c_0, d_0, 0)) {
-                  v_18 = true;
-               }
-               else {
-                  _fx_N24Ast_typecheck__gen_cmp_t v_19;
-                  FX_CALL(
-                     _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__gen_cmp_t2rR13Ast__deffun_trR13Ast__deffun_t(
-                        c_0, d_0, &v_19, 0), _fx_catch_4);
-                  v_18 = v_19.tag == 2;
-               }
-               if (!v_18) {
-                  __fold_result___2 = false; FX_BREAK(_fx_catch_4);
-               }
-
-            _fx_catch_4: ;
-               FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_5);
-            }
-            if (__fold_result___2) {
-               _fx_M13Ast_typecheckFM4SomeNt6option1rR13Ast__deffun_t1rR13Ast__deffun_t(c_0, &v_17);
-               _fx_free_Nt6option1rR13Ast__deffun_t(&__fold_result___1);
-               _fx_copy_Nt6option1rR13Ast__deffun_t(&v_17, &__fold_result___1);
-               FX_BREAK(_fx_catch_5);
-            }
-
-         _fx_catch_5: ;
-            _fx_free_Nt6option1rR13Ast__deffun_t(&v_17);
-            FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_cleanup);
-         }
-         _fx_copy_Nt6option1rR13Ast__deffun_t(&__fold_result___1, &genwin_0);
-         bool agree_0;
-         if (genwin_0.tag == 2) {
-            agree_0 = _fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(genwin_0.u.Some, envwin_0, 0);
-         }
-         else {
-            agree_0 = false;
-         }
-         FX_CHECK_EXN(_fx_cleanup);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_2, 0), _fx_cleanup);
-         FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_3, 0), _fx_cleanup);
-         int_ v_20 = _fx_M13Ast_typecheckFM6lengthi1LrR13Ast__deffun_t(viable_0, 0);
-         FX_CALL(_fx_F6stringS1i(v_20, &v_4, 0), _fx_cleanup);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_5, 0), _fx_cleanup);
-         fx_str_t slit_0 = FX_MAKE_STR("-pr-resolve: \'");
-         fx_str_t slit_1 = FX_MAKE_STR("\' @ ");
-         fx_str_t slit_2 = FX_MAKE_STR(": ");
-         fx_str_t slit_3 = FX_MAKE_STR(" viable for ");
-         fx_str_t slit_4 = FX_MAKE_STR("\n");
-         {
-            const fx_str_t strs_0[] = { slit_0, v_2, slit_1, v_3, slit_2, v_4, slit_3, v_5, slit_4 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_6), _fx_cleanup);
-         }
-         _fx_F12print_stringv1S(&v_6, 0);
-         _fx_LrR13Ast__deffun_t lst_4 = viable_0;
-         for (; lst_4; lst_4 = lst_4->tl) {
-            fx_str_t v_21 = {0};
-            fx_str_t v_22 = {0};
-            _fx_rR13Ast__deffun_t c_1 = lst_4->hd;
-            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(c_1, &v_21, 0), _fx_catch_6);
-            fx_str_t slit_5 = FX_MAKE_STR("    candidate: ");
-            fx_str_t slit_6 = FX_MAKE_STR("\n");
-            {
-               const fx_str_t strs_1[] = { slit_5, v_21, slit_6 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_22), _fx_catch_6);
-            }
-            _fx_F12print_stringv1S(&v_22, 0);
-
-         _fx_catch_6: ;
-            FX_FREE_STR(&v_22);
-            FX_FREE_STR(&v_21);
-            FX_CHECK_EXN(_fx_cleanup);
-         }
-         FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_7, 0), _fx_cleanup);
-         fx_str_t slit_7 = FX_MAKE_STR("    env-order  winner: ");
-         fx_str_t slit_8 = FX_MAKE_STR("\n");
-         {
-            const fx_str_t strs_2[] = { slit_7, v_7, slit_8 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_8), _fx_cleanup);
-         }
-         _fx_F12print_stringv1S(&v_8, 0);
-         if (genwin_0.tag == 2) {
-            fx_str_t v_23 = {0};
-            fx_str_t v_24 = {0};
-            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(genwin_0.u.Some, &v_23, 0), _fx_catch_7);
-            fx_str_t slit_9 = FX_MAKE_STR("    generality winner: ");
-            fx_str_t slit_10 = FX_MAKE_STR("\n");
-            {
-               const fx_str_t strs_3[] = { slit_9, v_23, slit_10 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_24), _fx_catch_7);
-            }
-            _fx_F12print_stringv1S(&v_24, 0);
-
-         _fx_catch_7: ;
-            FX_FREE_STR(&v_24);
-            FX_FREE_STR(&v_23);
-         }
-         else {
-            fx_str_t slit_11 = FX_MAKE_STR("    generality winner: <none: tied or unordered>\n");
-            _fx_F12print_stringv1S(&slit_11, 0);
-         }
-         FX_CHECK_EXN(_fx_cleanup);
-         FX_CALL(_fx_F6stringS1B(agree_0, &v_9, 0), _fx_cleanup);
-         fx_str_t slit_12 = FX_MAKE_STR("    winners agree: ");
-         fx_str_t slit_13 = FX_MAKE_STR("\n");
-         {
-            const fx_str_t strs_4[] = { slit_12, v_9, slit_13 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_10), _fx_cleanup);
-         }
-         _fx_F12print_stringv1S(&v_10, 0);
-      }
-   }
-
-_fx_cleanup: ;
-   if (v_0) {
-      _fx_free_N10Ast__typ_t(&v_0);
-   }
-   if (acc_0) {
-      _fx_free_LrR13Ast__deffun_t(&acc_0);
-   }
-   if (v_1) {
-      _fx_free_LN16Ast__env_entry_t(&v_1);
-   }
-   if (__fold_result___0) {
-      _fx_free_LrR13Ast__deffun_t(&__fold_result___0);
-   }
-   if (viable_0) {
-      _fx_free_LrR13Ast__deffun_t(&viable_0);
-   }
-   if (envwin_0) {
-      _fx_free_rR13Ast__deffun_t(&envwin_0);
-   }
-   _fx_free_Nt6option1rR13Ast__deffun_t(&__fold_result___1);
-   if (viable_1) {
-      _fx_free_LrR13Ast__deffun_t(&viable_1);
-   }
-   _fx_free_Nt6option1rR13Ast__deffun_t(&genwin_0);
-   FX_FREE_STR(&v_2);
-   FX_FREE_STR(&v_3);
-   FX_FREE_STR(&v_4);
-   FX_FREE_STR(&v_5);
-   FX_FREE_STR(&v_6);
-   FX_FREE_STR(&v_7);
-   FX_FREE_STR(&v_8);
-   FX_FREE_STR(&v_9);
-   FX_FREE_STR(&v_10);
-   return fx_status;
-}
-
-FX_EXTERN_C int
    _fx_M13Ast_typecheckFM13lookup_id_optT2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* n_0,
    struct _fx_N10Ast__typ_t_data_t* t_0,
@@ -17085,585 +16760,1305 @@ FX_EXTERN_C int
    void* fx_fv)
 {
    _fx_rLN16Ast__env_entry_t possible_matches_ref_0 = 0;
-   _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t __lambda___0 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t nt_opt_0 = {0};
    int fx_status = 0;
-   FX_CALL(
-      _fx_M13Ast_typecheckFM13trace_resolvev5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-         n_0, t_0, env_0, sc_0, loc_0, 0), _fx_cleanup);
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   int_ curr_m_idx_0;
+   FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_0, &curr_m_idx_0, 0), _fx_cleanup);
    FX_CALL(_fx_make_rLN16Ast__env_entry_t(0, &possible_matches_ref_0), _fx_cleanup);
-   _fx_M13Ast_typecheckFM7make_fpFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t6Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
-      env_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0, &__lambda___0);
    FX_CALL(
-      _fx_M13Ast_typecheckFM10find_firstNt6option1T2R9Ast__id_tN10Ast__typ_t6R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-         n_0, env_0, env_0, sc_0, loc_0, &__lambda___0, &nt_opt_0, 0), _fx_cleanup);
+      _fx_M13Ast_typecheckFM7lookup_Nt6option1T2R9Ast__id_tN10Ast__typ_t9R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+         n_0, env_0, curr_m_idx_0, env_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0, &nt_opt_0, 0), _fx_cleanup);
    _fx_make_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t(&nt_opt_0, possible_matches_ref_0->data, fx_result);
 
 _fx_cleanup: ;
    if (possible_matches_ref_0) {
       _fx_free_rLN16Ast__env_entry_t(&possible_matches_ref_0);
    }
-   FX_FREE_FP(&__lambda___0);
    _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&nt_opt_0);
    return fx_status;
 }
 
-static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t(
-   struct _fx_N16Ast__env_entry_t_data_t* e_0,
+static int
+   _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* i_0,
+   struct _fx_rR13Ast__deffun_t_data_t* df_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
+   void* fx_fv)
+{
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env_0 = {0};
+   _fx_rLR9Ast__id_t df_templ_inst_0 = 0;
+   _fx_N10Ast__typ_t df_typ_0 = 0;
+   _fx_LR9Ast__id_t df_templ_args_0 = 0;
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_N10Ast__typ_t t_1 = 0;
+   _fx_T2R9Ast__id_tN10Ast__typ_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
+   fx_exn_t v_4 = {0};
+   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_5 = {0};
+   _fx_N10Ast__typ_t ftyp_0 = 0;
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
+   fx_str_t v_6 = {0};
+   fx_str_t v_7 = {0};
+   fx_exn_t v_8 = {0};
+   _fx_T2R9Ast__id_tN10Ast__typ_t v_9 = {0};
+   _fx_LR9Ast__id_t v_10 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   _fx_R13Ast__deffun_t* v_11 = &df_0->data;
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_11->df_env, &df_env_0);
+   FX_COPY_PTR(v_11->df_templ_inst, &df_templ_inst_0);
+   _fx_R16Ast__fun_flags_t df_flags_0 = v_11->df_flags;
+   FX_COPY_PTR(v_11->df_typ, &df_typ_0);
+   FX_COPY_PTR(v_11->df_templ_args, &df_templ_args_0);
+   _fx_R9Ast__id_t df_name_0 = v_11->df_name;
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+   if (df_flags_0.fun_flag_have_keywords == true) {
+      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+         _fx_LN10Ast__typ_t argtyps_0 = 0;
+         _fx_N10Ast__typ_t result_0 = 0;
+         _fx_LN10Ast__typ_t __pat___0 = 0;
+         _fx_N10Ast__typ_t v_12 = 0;
+         _fx_N10Ast__typ_t v_13 = 0;
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_14 = {0};
+         _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_0->u.TypFun;
+         _fx_LN10Ast__typ_t argtyps_1 = vcase_0->t0;
+         if (argtyps_1 != 0) {
+            FX_COPY_PTR(argtyps_1, &__pat___0);
+            for (;;) {
+               _fx_LN10Ast__typ_t __pat___1 = 0;
+               FX_COPY_PTR(__pat___0, &__pat___1);
+               if (__pat___1 != 0) {
+                  if (__pat___1->tl == 0) {
+                     _fx_N10Ast__typ_t result_1 = 0;
+                     FX_COPY_PTR(__pat___1->hd, &result_1);
+                     _fx_free_N10Ast__typ_t(&result_0);
+                     FX_COPY_PTR(result_1, &result_0);
+                     FX_BREAK(_fx_catch_0);
+
+                  _fx_catch_0: ;
+                     if (result_1) {
+                        _fx_free_N10Ast__typ_t(&result_1);
+                     }
+                     goto _fx_endmatch_0;
+                  }
+               }
+               if (__pat___1 != 0) {
+                  _fx_LN10Ast__typ_t* rest_0 = &__pat___1->tl;
+                  _fx_free_LN10Ast__typ_t(&__pat___0);
+                  FX_COPY_PTR(*rest_0, &__pat___0);
+                  goto _fx_endmatch_0;
+               }
+               FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_1);
+
+            _fx_endmatch_0: ;
+               FX_CHECK_EXN(_fx_catch_1);
+
+            _fx_catch_1: ;
+               if (__pat___1) {
+                  _fx_free_LN10Ast__typ_t(&__pat___1);
+               }
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_5);
+            }
+            FX_COPY_PTR(result_0, &v_12);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_12, &v_13, 0), _fx_catch_5);
+            bool res_0;
+            if (FX_REC_VARIANT_TAG(v_13) == 20) {
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_13->u.TypRecord->data, &v_14);
+               if (v_14.t1 == false) {
+                  res_0 = true; goto _fx_endmatch_1;
+               }
+            }
+            res_0 = false;
+
+         _fx_endmatch_1: ;
+            FX_CHECK_EXN(_fx_catch_5);
+            if (res_0) {
+               FX_COPY_PTR(argtyps_1, &argtyps_0); goto _fx_endmatch_2;
+            }
+         }
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_15 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = 0;
+         _fx_N10Ast__typ_t v_17 = 0;
+         _fx_LN10Ast__typ_t v_18 = 0;
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_15);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_15, &v_16), _fx_catch_4);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_16, &v_17),
+            _fx_catch_4);
+         FX_CALL(_fx_cons_LN10Ast__typ_t(v_17, 0, true, &v_18), _fx_catch_4);
+         if (argtyps_1 == 0) {
+            FX_COPY_PTR(v_18, &argtyps_0);
+         }
+         else if (v_18 == 0) {
+            FX_COPY_PTR(argtyps_1, &argtyps_0);
+         }
+         else {
+            _fx_LN10Ast__typ_t v_19 = 0;
+            _fx_LN10Ast__typ_t argtyps_2 = 0;
+            _fx_LN10Ast__typ_t lstend_0 = 0;
+            FX_COPY_PTR(argtyps_1, &argtyps_2);
+            _fx_LN10Ast__typ_t lst_0 = argtyps_2;
+            for (; lst_0; lst_0 = lst_0->tl) {
+               _fx_N10Ast__typ_t x_0 = lst_0->hd;
+               _fx_LN10Ast__typ_t node_0 = 0;
+               FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_2);
+               FX_LIST_APPEND(v_19, lstend_0, node_0);
+
+            _fx_catch_2: ;
+               FX_CHECK_EXN(_fx_catch_3);
+            }
+            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_19, v_18, &argtyps_0, 0);
+
+         _fx_catch_3: ;
+            if (argtyps_2) {
+               _fx_free_LN10Ast__typ_t(&argtyps_2);
+            }
+            if (v_19) {
+               _fx_free_LN10Ast__typ_t(&v_19);
+            }
+         }
+         FX_CHECK_EXN(_fx_catch_4);
+
+      _fx_catch_4: ;
+         if (v_18) {
+            _fx_free_LN10Ast__typ_t(&v_18);
+         }
+         if (v_17) {
+            _fx_free_N10Ast__typ_t(&v_17);
+         }
+         if (v_16) {
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
+         }
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_15);
+
+      _fx_endmatch_2: ;
+         FX_CHECK_EXN(_fx_catch_5);
+         FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(argtyps_0, vcase_0->t1, &t_1), _fx_catch_5);
+
+      _fx_catch_5: ;
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_14);
+         if (v_13) {
+            _fx_free_N10Ast__typ_t(&v_13);
+         }
+         if (v_12) {
+            _fx_free_N10Ast__typ_t(&v_12);
+         }
+         if (__pat___0) {
+            _fx_free_LN10Ast__typ_t(&__pat___0);
+         }
+         if (result_0) {
+            _fx_free_N10Ast__typ_t(&result_0);
+         }
+         if (argtyps_0) {
+            _fx_free_LN10Ast__typ_t(&argtyps_0);
+         }
+         goto _fx_endmatch_3;
+      }
+   }
+   FX_COPY_PTR(t_0, &t_1);
+
+_fx_endmatch_3: ;
+   FX_CHECK_EXN(_fx_cleanup);
+   if (df_templ_args_0 == 0) {
+      bool v_20;
+      FX_CALL(
+         _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(df_typ_0, t_1, loc_0, true, &v_20, 0),
+         _fx_cleanup);
+      if (v_20) {
+         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_1, &v_1);
+         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_1, fx_result);
+      }
+      else {
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_2, 0), _fx_cleanup);
+         fx_str_t slit_0 = FX_MAKE_STR("internal error: the winning overload of \'");
+         fx_str_t slit_1 = FX_MAKE_STR("\' failed to re-unify at commit");
+         {
+            const fx_str_t strs_0[] = { slit_0, v_2, slit_1 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_3), _fx_cleanup);
+         }
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_3, &v_4, 0), _fx_cleanup);
+         FX_THROW(&v_4, false, _fx_cleanup);
+      }
+   }
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+            df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_5, 0), _fx_cleanup);
+      FX_COPY_PTR(v_5.t0, &ftyp_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5.t1, &env1_0);
+      bool v_21;
+      FX_CALL(_fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, true, &v_21, 0),
+         _fx_cleanup);
+      if (!v_21) {
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_6, 0), _fx_cleanup);
+         fx_str_t slit_2 = FX_MAKE_STR("internal error: the winning overload of \'");
+         fx_str_t slit_3 = FX_MAKE_STR("\' failed to re-unify at commit");
+         {
+            const fx_str_t strs_1[] = { slit_2, v_6, slit_3 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_7), _fx_cleanup);
+         }
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_7, &v_8, 0), _fx_cleanup);
+         FX_THROW(&v_8, false, _fx_cleanup);
+      }
+      bool res_1;
+      FX_CALL(_fx_M3AstFM14is_constructorB1RM11fun_flags_t(&df_flags_0, &res_1, 0), _fx_cleanup);
+      bool return_orig_0;
+      if (!res_1) {
+         return_orig_0 = false;
+      }
+      else {
+         if (FX_REC_VARIANT_TAG(ftyp_0) == 14) {
+            _fx_N10Ast__typ_t res_2 = 0;
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                  ftyp_0->u.TypFun.t1, &env1_0, sc_0, loc_0, &res_2, 0), _fx_catch_6);
+            return_orig_0 = false;
+
+         _fx_catch_6: ;
+            if (res_2) {
+               _fx_free_N10Ast__typ_t(&res_2);
+            }
+         }
+         else {
+            bool v_22;
+            FX_CALL(_fx_M3AstFM12is_fixed_typB1N10Ast__typ_t(t_1, &v_22, 0), _fx_catch_7);
+            return_orig_0 = !v_22;
+
+         _fx_catch_7: ;
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      if (return_orig_0) {
+         _fx_make_T2R9Ast__id_tN10Ast__typ_t(&df_name_0, t_1, &v_9);
+         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_9, fx_result);
+      }
+      else {
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
+         FX_COPY_PTR(df_templ_inst_0->data, &v_10);
+         _fx_LR9Ast__id_t lst_1 = v_10;
+         for (; lst_1; lst_1 = lst_1->tl) {
+            _fx_N14Ast__id_info_t v_23 = {0};
+            _fx_R9Ast__id_t* inst_0 = &lst_1->hd;
+            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(inst_0, loc_0, &v_23, 0), _fx_catch_10);
+            bool v_24;
+            if (v_23.tag == 3) {
+               _fx_R13Ast__deffun_t v_25 = {0};
+               _fx_copy_R13Ast__deffun_t(&v_23.u.IdFun->data, &v_25);
+               FX_CALL(
+                  _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(v_25.df_typ, t_1, loc_0, true,
+                     &v_24, 0), _fx_catch_8);
+
+            _fx_catch_8: ;
+               _fx_free_R13Ast__deffun_t(&v_25);
+            }
+            else {
+               fx_str_t v_26 = {0};
+               fx_str_t v_27 = {0};
+               fx_str_t v_28 = {0};
+               fx_exn_t v_29 = {0};
+               FX_CALL(_fx_M3AstFM6stringS1RM4id_t(inst_0, &v_26, 0), _fx_catch_9);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&df_name_0, &v_27, 0), _fx_catch_9);
+               fx_str_t slit_4 = FX_MAKE_STR("invalid (non-function) instance ");
+               fx_str_t slit_5 = FX_MAKE_STR(" of template function ");
+               {
+                  const fx_str_t strs_2[] = { slit_4, v_26, slit_5, v_27 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 4, &v_28), _fx_catch_9);
+               }
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_28, &v_29, 0), _fx_catch_9);
+               FX_THROW(&v_29, false, _fx_catch_9);
+
+            _fx_catch_9: ;
+               fx_free_exn(&v_29);
+               FX_FREE_STR(&v_28);
+               FX_FREE_STR(&v_27);
+               FX_FREE_STR(&v_26);
+            }
+            FX_CHECK_EXN(_fx_catch_10);
+            if (v_24) {
+               _fx_Nt6option1R9Ast__id_t v_30;
+               _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(inst_0, &v_30);
+               __fold_result___0 = v_30;
+               FX_BREAK(_fx_catch_10);
+            }
+
+         _fx_catch_10: ;
+            _fx_free_N14Ast__id_info_t(&v_23);
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         _fx_Nt6option1R9Ast__id_t inst_name_opt_0 = __fold_result___0;
+         if (inst_name_opt_0.tag == 2) {
+            _fx_T2R9Ast__id_tN10Ast__typ_t v_31 = {0};
+            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_opt_0.u.Some, t_1, &v_31);
+            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_31, fx_result);
+            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_31);
+         }
+         else {
+            _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t inst_env_0 = {0};
+            _fx_rR13Ast__deffun_t v_32 = 0;
+            _fx_N10Ast__typ_t inst_typ_0 = 0;
+            fx_exn_t v_33 = {0};
+            _fx_T2R9Ast__id_tN10Ast__typ_t v_34 = {0};
+            FX_CALL(
+               _fx_M13Ast_typecheckFM14inst_merge_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t2Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+                  env_0, &env1_0, &inst_env_0, 0), _fx_catch_11);
+            FX_CALL(
+               _fx_M13Ast_typecheckFM15instantiate_funrR13Ast__deffun_t5rR13Ast__deffun_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tB(
+                  df_0, ftyp_0, &inst_env_0, loc_0, true, &v_32, 0), _fx_catch_11);
+            _fx_R13Ast__deffun_t* v_35 = &v_32->data;
+            FX_COPY_PTR(v_35->df_typ, &inst_typ_0);
+            _fx_R9Ast__id_t inst_name_0 = v_35->df_name;
+            bool v_36;
+            FX_CALL(
+               _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(inst_typ_0, t_1, loc_0, true,
+                  &v_36, 0), _fx_catch_11);
+            if (!v_36) {
+               fx_str_t slit_6 = FX_MAKE_STR("inconsistent type of the instantiated function");
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_6, &v_33, 0), _fx_catch_11);
+               FX_THROW(&v_33, false, _fx_catch_11);
+            }
+            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_0, t_1, &v_34);
+            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_34, fx_result);
+
+         _fx_catch_11: ;
+            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_34);
+            fx_free_exn(&v_33);
+            if (inst_typ_0) {
+               _fx_free_N10Ast__typ_t(&inst_typ_0);
+            }
+            if (v_32) {
+               _fx_free_rR13Ast__deffun_t(&v_32);
+            }
+            _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&inst_env_0);
+         }
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+   }
+
+_fx_cleanup: ;
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&df_env_0);
+   if (df_templ_inst_0) {
+      _fx_free_rLR9Ast__id_t(&df_templ_inst_0);
+   }
+   if (df_typ_0) {
+      _fx_free_N10Ast__typ_t(&df_typ_0);
+   }
+   FX_FREE_LIST_SIMPLE(&df_templ_args_0);
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (t_1) {
+      _fx_free_N10Ast__typ_t(&t_1);
+   }
+   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
+   fx_free_exn(&v_4);
+   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5);
+   if (ftyp_0) {
+      _fx_free_N10Ast__typ_t(&ftyp_0);
+   }
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
+   FX_FREE_STR(&v_6);
+   FX_FREE_STR(&v_7);
+   fx_free_exn(&v_8);
+   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_9);
+   FX_FREE_LIST_SIMPLE(&v_10);
+   return fx_status;
+}
+
+static int
+   _fx_M13Ast_typecheckFM15rank_and_commitNt6option1T2R9Ast__id_tN10Ast__typ_t6LT2R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t* viable_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
    struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
    void* fx_fv)
 {
    int fx_status = 0;
-   _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t_cldata_t* cv_0 =
-      (_fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t_cldata_t*)fx_fv;
-   _fx_R10Ast__loc_t* loc_0 = &cv_0->t1;
-   _fx_LN12Ast__scope_t sc_0 = cv_0->t4;
-   _fx_N10Ast__typ_t t_0 = cv_0->t5;
-   _fx_LN16Ast__env_entry_t* possible_matches_0 = &cv_0->t3->data;
-   int tag_0 = FX_REC_VARIANT_TAG(e_0);
-   if (tag_0 == 1) {
-      if (e_0->u.EnvId.m == 0) {
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_5;
-      }
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   if (viable_0 == 0) {
+      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_0;
    }
-   if (tag_0 == 1) {
-      _fx_LN16Ast__env_entry_t v_0 = 0;
-      _fx_N14Ast__id_info_t v_1 = {0};
-      _fx_R9Ast__id_t* i_0 = &e_0->u.EnvId;
-      FX_CALL(_fx_cons_LN16Ast__env_entry_t(e_0, *possible_matches_0, true, &v_0), _fx_catch_18);
-      _fx_free_LN16Ast__env_entry_t(possible_matches_0);
-      FX_COPY_PTR(v_0, possible_matches_0);
-      FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(i_0, loc_0, &v_1, 0), _fx_catch_18);
-      int tag_1 = v_1.tag;
-      if (tag_1 == 2) {
-         fx_str_t v_2 = {0};
-         fx_str_t v_3 = {0};
-         fx_str_t v_4 = {0};
-         fx_str_t v_5 = {0};
-         fx_exn_t v_6 = {0};
-         _fx_T2R9Ast__id_tN10Ast__typ_t v_7 = {0};
-         _fx_N10Ast__typ_t dv_typ_0 = v_1.u.IdDVal.dv_typ;
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&cv_0->t2, &v_2, 0), _fx_catch_0);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_3, 0), _fx_catch_0);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(dv_typ_0, &v_4, 0), _fx_catch_0);
-         fx_str_t slit_0 = FX_MAKE_STR("incorrect type of value \'");
-         fx_str_t slit_1 = FX_MAKE_STR("\': expected=\'");
-         fx_str_t slit_2 = FX_MAKE_STR("\', actual=\'");
-         fx_str_t slit_3 = FX_MAKE_STR("\'");
-         {
-            const fx_str_t strs_0[] = { slit_0, v_2, slit_1, v_3, slit_2, v_4, slit_3 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &v_5), _fx_catch_0);
-         }
-         bool v_8;
+   if (viable_0 != 0) {
+      if (viable_0->tl == 0) {
+         _fx_T2R9Ast__id_trR13Ast__deffun_t* v_0 = &viable_0->hd;
          FX_CALL(
-            _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(dv_typ_0, t_0, loc_0, true, &v_8, 0),
-            _fx_catch_0);
-         if (!v_8) {
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_5, &v_6, 0), _fx_catch_0); FX_THROW(&v_6, false, _fx_catch_0);
-         }
-         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_7);
-         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_7, fx_result);
+            _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+               &v_0->t0, v_0->t1, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_0);
 
       _fx_catch_0: ;
-         _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_7);
-         fx_free_exn(&v_6);
-         FX_FREE_STR(&v_5);
-         FX_FREE_STR(&v_4);
-         FX_FREE_STR(&v_3);
-         FX_FREE_STR(&v_2);
-         goto _fx_endmatch_4;
+         goto _fx_endmatch_0;
       }
-      if (tag_1 == 3) {
-         _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env_0 = {0};
-         _fx_rLR9Ast__id_t df_templ_inst_0 = 0;
-         _fx_N10Ast__typ_t df_typ_0 = 0;
-         _fx_LR9Ast__id_t df_templ_args_0 = 0;
-         _fx_N10Ast__typ_t v_9 = 0;
-         _fx_N10Ast__typ_t t_1 = 0;
-         _fx_T2R9Ast__id_tN10Ast__typ_t v_10 = {0};
-         _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_11 = {0};
-         _fx_N10Ast__typ_t ftyp_0 = 0;
-         _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
-         _fx_T2R9Ast__id_tN10Ast__typ_t v_12 = {0};
-         _fx_LR9Ast__id_t v_13 = 0;
-         _fx_rR13Ast__deffun_t df_0 = v_1.u.IdFun;
-         _fx_R13Ast__deffun_t* v_14 = &df_0->data;
-         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_14->df_env, &df_env_0);
-         FX_COPY_PTR(v_14->df_templ_inst, &df_templ_inst_0);
-         _fx_R16Ast__fun_flags_t df_flags_0 = v_14->df_flags;
-         FX_COPY_PTR(v_14->df_typ, &df_typ_0);
-         FX_COPY_PTR(v_14->df_templ_args, &df_templ_args_0);
-         _fx_R9Ast__id_t df_name_0 = v_14->df_name;
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_9, 0), _fx_catch_13);
-         if (df_flags_0.fun_flag_have_keywords == true) {
-            if (FX_REC_VARIANT_TAG(v_9) == 14) {
-               _fx_LN10Ast__typ_t argtyps_0 = 0;
-               _fx_N10Ast__typ_t result_0 = 0;
-               _fx_LN10Ast__typ_t __pat___0 = 0;
-               _fx_N10Ast__typ_t v_15 = 0;
-               _fx_N10Ast__typ_t v_16 = 0;
-               _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_17 = {0};
-               _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_9->u.TypFun;
-               _fx_LN10Ast__typ_t argtyps_1 = vcase_0->t0;
-               if (argtyps_1 != 0) {
-                  FX_COPY_PTR(argtyps_1, &__pat___0);
-                  for (;;) {
-                     _fx_LN10Ast__typ_t __pat___1 = 0;
-                     FX_COPY_PTR(__pat___0, &__pat___1);
-                     if (__pat___1 != 0) {
-                        if (__pat___1->tl == 0) {
-                           _fx_N10Ast__typ_t result_1 = 0;
-                           FX_COPY_PTR(__pat___1->hd, &result_1);
-                           _fx_free_N10Ast__typ_t(&result_0);
-                           FX_COPY_PTR(result_1, &result_0);
-                           FX_BREAK(_fx_catch_1);
+   }
+   _fx_LrR13Ast__deffun_t cands_0 = 0;
+   _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t __fold_result___0 = {0};
+   _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t genwin_opt_0 = {0};
+   _fx_N10Ast__typ_t v_1 = 0;
+   _fx_T2R9Ast__id_trR13Ast__deffun_t v_2 = {0};
+   _fx_rR13Ast__deffun_t envwin_0 = 0;
+   fx_str_t v_3 = {0};
+   fx_str_t v_4 = {0};
+   fx_str_t v_5 = {0};
+   fx_str_t v_6 = {0};
+   fx_str_t v_7 = {0};
+   fx_str_t v_8 = {0};
+   fx_str_t v_9 = {0};
+   fx_str_t v_10 = {0};
+   fx_str_t v_11 = {0};
+   fx_str_t outcome_0 = {0};
+   fx_str_t v_12 = {0};
+   _fx_LrR13Ast__deffun_t lstend_0 = 0;
+   _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_0 = viable_0;
+   for (; lst_0; lst_0 = lst_0->tl) {
+      _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___0 = &lst_0->hd;
+      _fx_LrR13Ast__deffun_t node_0 = 0;
+      FX_CALL(_fx_cons_LrR13Ast__deffun_t(__pat___0->t1, 0, false, &node_0), _fx_catch_1);
+      FX_LIST_APPEND(cands_0, lstend_0, node_0);
 
-                        _fx_catch_1: ;
-                           if (result_1) {
-                              _fx_free_N10Ast__typ_t(&result_1);
-                           }
-                           goto _fx_endmatch_0;
-                        }
-                     }
-                     if (__pat___1 != 0) {
-                        _fx_LN10Ast__typ_t* rest_0 = &__pat___1->tl;
-                        _fx_free_LN10Ast__typ_t(&__pat___0);
-                        FX_COPY_PTR(*rest_0, &__pat___0);
-                        goto _fx_endmatch_0;
-                     }
-                     FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_2);
-
-                  _fx_endmatch_0: ;
-                     FX_CHECK_EXN(_fx_catch_2);
-
-                  _fx_catch_2: ;
-                     if (__pat___1) {
-                        _fx_free_LN10Ast__typ_t(&__pat___1);
-                     }
-                     FX_CHECK_BREAK();
-                     FX_CHECK_EXN(_fx_catch_6);
-                  }
-                  FX_COPY_PTR(result_0, &v_15);
-                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_15, &v_16, 0), _fx_catch_6);
-                  bool res_0;
-                  if (FX_REC_VARIANT_TAG(v_16) == 20) {
-                     _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16->u.TypRecord->data, &v_17);
-                     if (v_17.t1 == false) {
-                        res_0 = true; goto _fx_endmatch_1;
-                     }
-                  }
-                  res_0 = false;
-
-               _fx_endmatch_1: ;
-                  FX_CHECK_EXN(_fx_catch_6);
-                  if (res_0) {
-                     FX_COPY_PTR(argtyps_1, &argtyps_0); goto _fx_endmatch_2;
-                  }
-               }
-               _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_18 = {0};
-               _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_19 = 0;
-               _fx_N10Ast__typ_t v_20 = 0;
-               _fx_LN10Ast__typ_t v_21 = 0;
-               _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_18);
-               FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_18, &v_19), _fx_catch_5);
-               FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_19, &v_20),
-                  _fx_catch_5);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_20, 0, true, &v_21), _fx_catch_5);
-               if (argtyps_1 == 0) {
-                  FX_COPY_PTR(v_21, &argtyps_0);
-               }
-               else if (v_21 == 0) {
-                  FX_COPY_PTR(argtyps_1, &argtyps_0);
-               }
-               else {
-                  _fx_LN10Ast__typ_t v_22 = 0;
-                  _fx_LN10Ast__typ_t argtyps_2 = 0;
-                  _fx_LN10Ast__typ_t lstend_0 = 0;
-                  FX_COPY_PTR(argtyps_1, &argtyps_2);
-                  _fx_LN10Ast__typ_t lst_0 = argtyps_2;
-                  for (; lst_0; lst_0 = lst_0->tl) {
-                     _fx_N10Ast__typ_t x_0 = lst_0->hd;
-                     _fx_LN10Ast__typ_t node_0 = 0;
-                     FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_3);
-                     FX_LIST_APPEND(v_22, lstend_0, node_0);
-
-                  _fx_catch_3: ;
-                     FX_CHECK_EXN(_fx_catch_4);
-                  }
-                  _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_22, v_21, &argtyps_0, 0);
-
-               _fx_catch_4: ;
-                  if (argtyps_2) {
-                     _fx_free_LN10Ast__typ_t(&argtyps_2);
-                  }
-                  if (v_22) {
-                     _fx_free_LN10Ast__typ_t(&v_22);
-                  }
-               }
-               FX_CHECK_EXN(_fx_catch_5);
-
-            _fx_catch_5: ;
-               if (v_21) {
-                  _fx_free_LN10Ast__typ_t(&v_21);
-               }
-               if (v_20) {
-                  _fx_free_N10Ast__typ_t(&v_20);
-               }
-               if (v_19) {
-                  _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_19);
-               }
-               _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_18);
-
-            _fx_endmatch_2: ;
-               FX_CHECK_EXN(_fx_catch_6);
-               FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(argtyps_0, vcase_0->t1, &t_1), _fx_catch_6);
-
-            _fx_catch_6: ;
-               _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_17);
-               if (v_16) {
-                  _fx_free_N10Ast__typ_t(&v_16);
-               }
-               if (v_15) {
-                  _fx_free_N10Ast__typ_t(&v_15);
-               }
-               if (__pat___0) {
-                  _fx_free_LN10Ast__typ_t(&__pat___0);
-               }
-               if (result_0) {
-                  _fx_free_N10Ast__typ_t(&result_0);
-               }
-               if (argtyps_0) {
-                  _fx_free_LN10Ast__typ_t(&argtyps_0);
-               }
-               goto _fx_endmatch_3;
-            }
-         }
-         FX_COPY_PTR(t_0, &t_1);
-
-      _fx_endmatch_3: ;
-         FX_CHECK_EXN(_fx_catch_13);
-         if (df_templ_args_0 == 0) {
-            bool v_23;
-            FX_CALL(
-               _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(df_typ_0, t_1, loc_0, true, &v_23,
-                  0), _fx_catch_13);
-            if (v_23) {
-               _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_1, &v_10);
-               _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_10, fx_result);
-            }
-            else {
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
-            }
+   _fx_catch_1: ;
+      FX_CHECK_EXN(_fx_catch_12);
+   }
+   _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___0);
+   _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_1 = viable_0;
+   for (; lst_1; lst_1 = lst_1->tl) {
+      _fx_rR13Ast__deffun_t c_0 = 0;
+      _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t v_13 = {0};
+      _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___1 = &lst_1->hd;
+      FX_COPY_PTR(__pat___1->t1, &c_0);
+      bool __fold_result___1 = true;
+      _fx_LrR13Ast__deffun_t lst_2 = cands_0;
+      for (; lst_2; lst_2 = lst_2->tl) {
+         _fx_rR13Ast__deffun_t d_0 = lst_2->hd;
+         bool v_14;
+         if (_fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(c_0, d_0, 0)) {
+            v_14 = true;
          }
          else {
+            _fx_N24Ast_typecheck__gen_cmp_t v_15;
             FX_CALL(
-               _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                  df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_11, 0), _fx_catch_13);
-            FX_COPY_PTR(v_11.t0, &ftyp_0);
-            _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_11.t1, &env1_0);
-            bool v_24;
-            FX_CALL(
-               _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, true, &v_24,
-                  0), _fx_catch_13);
-            if (!v_24) {
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
-            }
-            else {
-               bool res_1;
-               FX_CALL(_fx_M3AstFM14is_constructorB1RM11fun_flags_t(&df_flags_0, &res_1, 0), _fx_catch_13);
-               bool return_orig_0;
-               if (!res_1) {
-                  return_orig_0 = false;
-               }
-               else {
-                  if (FX_REC_VARIANT_TAG(ftyp_0) == 14) {
-                     _fx_N10Ast__typ_t res_2 = 0;
-                     FX_CALL(
-                        _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                           ftyp_0->u.TypFun.t1, &env1_0, sc_0, loc_0, &res_2, 0), _fx_catch_7);
-                     return_orig_0 = false;
-
-                  _fx_catch_7: ;
-                     if (res_2) {
-                        _fx_free_N10Ast__typ_t(&res_2);
-                     }
-                  }
-                  else {
-                     bool v_25;
-                     FX_CALL(_fx_M3AstFM12is_fixed_typB1N10Ast__typ_t(t_1, &v_25, 0), _fx_catch_8);
-                     return_orig_0 = !v_25;
-
-                  _fx_catch_8: ;
-                  }
-                  FX_CHECK_EXN(_fx_catch_13);
-               }
-               if (return_orig_0) {
-                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(&df_name_0, t_1, &v_12);
-                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_12, fx_result);
-               }
-               else {
-                  _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
-                  FX_COPY_PTR(df_templ_inst_0->data, &v_13);
-                  _fx_LR9Ast__id_t lst_1 = v_13;
-                  for (; lst_1; lst_1 = lst_1->tl) {
-                     _fx_N14Ast__id_info_t v_26 = {0};
-                     _fx_R9Ast__id_t* inst_0 = &lst_1->hd;
-                     FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(inst_0, loc_0, &v_26, 0), _fx_catch_11);
-                     bool v_27;
-                     if (v_26.tag == 3) {
-                        _fx_R13Ast__deffun_t v_28 = {0};
-                        _fx_copy_R13Ast__deffun_t(&v_26.u.IdFun->data, &v_28);
-                        FX_CALL(
-                           _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(v_28.df_typ, t_1,
-                              loc_0, true, &v_27, 0), _fx_catch_9);
-
-                     _fx_catch_9: ;
-                        _fx_free_R13Ast__deffun_t(&v_28);
-                     }
-                     else {
-                        fx_str_t v_29 = {0};
-                        fx_str_t v_30 = {0};
-                        fx_str_t v_31 = {0};
-                        fx_exn_t v_32 = {0};
-                        FX_CALL(_fx_M3AstFM6stringS1RM4id_t(inst_0, &v_29, 0), _fx_catch_10);
-                        FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&df_name_0, &v_30, 0), _fx_catch_10);
-                        fx_str_t slit_4 = FX_MAKE_STR("invalid (non-function) instance ");
-                        fx_str_t slit_5 = FX_MAKE_STR(" of template function ");
-                        {
-                           const fx_str_t strs_1[] = { slit_4, v_29, slit_5, v_30 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_1, 4, &v_31), _fx_catch_10);
-                        }
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_31, &v_32, 0), _fx_catch_10);
-                        FX_THROW(&v_32, false, _fx_catch_10);
-
-                     _fx_catch_10: ;
-                        fx_free_exn(&v_32);
-                        FX_FREE_STR(&v_31);
-                        FX_FREE_STR(&v_30);
-                        FX_FREE_STR(&v_29);
-                     }
-                     FX_CHECK_EXN(_fx_catch_11);
-                     if (v_27) {
-                        _fx_Nt6option1R9Ast__id_t v_33;
-                        _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(inst_0, &v_33);
-                        __fold_result___0 = v_33;
-                        FX_BREAK(_fx_catch_11);
-                     }
-
-                  _fx_catch_11: ;
-                     _fx_free_N14Ast__id_info_t(&v_26);
-                     FX_CHECK_BREAK();
-                     FX_CHECK_EXN(_fx_catch_13);
-                  }
-                  _fx_Nt6option1R9Ast__id_t inst_name_opt_0 = __fold_result___0;
-                  if (inst_name_opt_0.tag == 2) {
-                     _fx_T2R9Ast__id_tN10Ast__typ_t v_34 = {0};
-                     _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_opt_0.u.Some, t_1, &v_34);
-                     _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_34,
-                        fx_result);
-                     _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_34);
-                  }
-                  else {
-                     _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t inst_env_0 = {0};
-                     _fx_rR13Ast__deffun_t v_35 = 0;
-                     _fx_N10Ast__typ_t inst_typ_0 = 0;
-                     fx_exn_t v_36 = {0};
-                     _fx_T2R9Ast__id_tN10Ast__typ_t v_37 = {0};
-                     FX_CALL(
-                        _fx_M13Ast_typecheckFM14inst_merge_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t2Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                           &cv_0->t0, &env1_0, &inst_env_0, 0), _fx_catch_12);
-                     FX_CALL(
-                        _fx_M13Ast_typecheckFM15instantiate_funrR13Ast__deffun_t5rR13Ast__deffun_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tB(
-                           df_0, ftyp_0, &inst_env_0, loc_0, true, &v_35, 0), _fx_catch_12);
-                     _fx_R13Ast__deffun_t* v_38 = &v_35->data;
-                     FX_COPY_PTR(v_38->df_typ, &inst_typ_0);
-                     _fx_R9Ast__id_t inst_name_0 = v_38->df_name;
-                     bool v_39;
-                     FX_CALL(
-                        _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(inst_typ_0, t_1, loc_0,
-                           true, &v_39, 0), _fx_catch_12);
-                     if (!v_39) {
-                        fx_str_t slit_6 = FX_MAKE_STR("inconsistent type of the instantiated function");
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_6, &v_36, 0), _fx_catch_12);
-                        FX_THROW(&v_36, false, _fx_catch_12);
-                     }
-                     _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_0, t_1, &v_37);
-                     _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_37,
-                        fx_result);
-
-                  _fx_catch_12: ;
-                     _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_37);
-                     fx_free_exn(&v_36);
-                     if (inst_typ_0) {
-                        _fx_free_N10Ast__typ_t(&inst_typ_0);
-                     }
-                     if (v_35) {
-                        _fx_free_rR13Ast__deffun_t(&v_35);
-                     }
-                     _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&inst_env_0);
-                  }
-                  FX_CHECK_EXN(_fx_catch_13);
-               }
-            }
+               _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__gen_cmp_t2rR13Ast__deffun_trR13Ast__deffun_t(c_0,
+                  d_0, &v_15, 0), _fx_catch_2);
+            v_14 = v_15.tag == 2;
+         }
+         if (!v_14) {
+            __fold_result___1 = false; FX_BREAK(_fx_catch_2);
          }
 
-      _fx_catch_13: ;
-         FX_FREE_LIST_SIMPLE(&v_13);
-         _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_12);
-         _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
-         if (ftyp_0) {
-            _fx_free_N10Ast__typ_t(&ftyp_0);
-         }
-         _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_11);
-         _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_10);
-         if (t_1) {
-            _fx_free_N10Ast__typ_t(&t_1);
-         }
-         if (v_9) {
-            _fx_free_N10Ast__typ_t(&v_9);
-         }
-         FX_FREE_LIST_SIMPLE(&df_templ_args_0);
-         if (df_typ_0) {
-            _fx_free_N10Ast__typ_t(&df_typ_0);
-         }
-         if (df_templ_inst_0) {
-            _fx_free_rLR9Ast__id_t(&df_templ_inst_0);
-         }
-         _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&df_env_0);
-         goto _fx_endmatch_4;
+      _fx_catch_2: ;
+         FX_CHECK_BREAK();
+         FX_CHECK_EXN(_fx_catch_3);
       }
-      if (tag_1 == 8) {
-         fx_exn_t v_40 = {0};
-         _fx_T2R9Ast__id_tN10Ast__typ_t v_41 = {0};
-         bool v_42;
-         FX_CALL(
-            _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(_fx_g24Ast_typecheck__TypModule, t_0,
-               loc_0, true, &v_42, 0), _fx_catch_14);
-         if (!v_42) {
-            fx_str_t slit_7 = FX_MAKE_STR("unexpected module name");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_7, &v_40, 0), _fx_catch_14);
-            FX_THROW(&v_40, false, _fx_catch_14);
-         }
-         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_41);
-         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_41, fx_result);
+      if (__fold_result___1) {
+         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_trR13Ast__deffun_t1T2R9Ast__id_trR13Ast__deffun_t(__pat___1, &v_13);
+         _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0);
+         _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&v_13, &__fold_result___0);
+         FX_BREAK(_fx_catch_3);
+      }
 
-      _fx_catch_14: ;
-         _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_41);
-         fx_free_exn(&v_40);
-         goto _fx_endmatch_4;
+   _fx_catch_3: ;
+      _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&v_13);
+      if (c_0) {
+         _fx_free_rR13Ast__deffun_t(&c_0);
       }
-      if (tag_1 == 4) {
-         _fx_R13Ast__defexn_t v_43 = {0};
-         _fx_N10Ast__typ_t ctyp_0 = 0;
-         fx_exn_t v_44 = {0};
-         _fx_T2R9Ast__id_tN10Ast__typ_t v_45 = {0};
-         _fx_copy_R13Ast__defexn_t(&v_1.u.IdExn->data, &v_43);
-         _fx_N10Ast__typ_t dexn_typ_0 = v_43.dexn_typ;
-         if (FX_REC_VARIANT_TAG(dexn_typ_0) == 13) {
-            FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &ctyp_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_catch_12);
+   }
+   _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0, &genwin_opt_0);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_12);
+   bool fully_determined_0;
+   if (FX_REC_VARIANT_TAG(v_1) == 14) {
+      _fx_LN10Ast__typ_t argtyps_0 = 0;
+      bool __fold_result___2 = true;
+      FX_COPY_PTR(v_1->u.TypFun.t0, &argtyps_0);
+      _fx_LN10Ast__typ_t lst_3 = argtyps_0;
+      for (; lst_3; lst_3 = lst_3->tl) {
+         _fx_N10Ast__typ_t a_0 = lst_3->hd;
+         bool v_16;
+         FX_CALL(_fx_M13Ast_typecheckFM17typ_has_free_varsB1N10Ast__typ_t(a_0, &v_16, 0), _fx_catch_4);
+         if (!!v_16) {
+            __fold_result___2 = false; FX_BREAK(_fx_catch_4);
          }
-         else {
-            _fx_LN10Ast__typ_t v_46 = 0;
-            if (FX_REC_VARIANT_TAG(dexn_typ_0) == 17) {
-               FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_46);
-            }
-            else {
-               FX_CALL(_fx_cons_LN10Ast__typ_t(dexn_typ_0, 0, true, &v_46), _fx_catch_15);  _fx_catch_15: ;
-            }
-            FX_CHECK_EXN(_fx_catch_16);
-            FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_46, _fx_g21Ast_typecheck__TypExn, &ctyp_0),
-               _fx_catch_16);
 
-         _fx_catch_16: ;
-            if (v_46) {
-               _fx_free_LN10Ast__typ_t(&v_46);
-            }
-         }
-         FX_CHECK_EXN(_fx_catch_17);
-         bool v_47;
-         FX_CALL(
-            _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ctyp_0, t_0, loc_0, true, &v_47, 0),
-            _fx_catch_17);
-         if (!v_47) {
-            fx_str_t slit_8 = FX_MAKE_STR("uncorrect type of exception constructor and/or its arguments");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_8, &v_44, 0), _fx_catch_17);
-            FX_THROW(&v_44, false, _fx_catch_17);
-         }
-         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_45);
-         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_45, fx_result);
+      _fx_catch_4: ;
+         FX_CHECK_BREAK();
+         FX_CHECK_EXN(_fx_catch_5);
+      }
+      fully_determined_0 = __fold_result___2;
 
-      _fx_catch_17: ;
-         _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_45);
-         fx_free_exn(&v_44);
-         if (ctyp_0) {
-            _fx_free_N10Ast__typ_t(&ctyp_0);
-         }
-         _fx_free_R13Ast__defexn_t(&v_43);
-         goto _fx_endmatch_4;
+   _fx_catch_5: ;
+      if (argtyps_0) {
+         _fx_free_LN10Ast__typ_t(&argtyps_0);
       }
-      bool res_3;
-      if (tag_1 == 1) {
-         res_3 = true;
-      }
-      else if (tag_1 == 5) {
-         res_3 = true;
-      }
-      else if (tag_1 == 6) {
-         res_3 = true;
-      }
-      else if (tag_1 == 7) {
-         res_3 = true;
+   }
+   else {
+      fully_determined_0 = false;
+   }
+   FX_CHECK_EXN(_fx_catch_12);
+   if (_fx_g12Options__opt.print_resolve) {
+      if (viable_0 != 0) {
+         _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_2);
       }
       else {
-         res_3 = false;
+         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_12);
       }
-      FX_CHECK_EXN(_fx_catch_18);
-      if (res_3) {
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_4;
-      }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_18);
+      FX_CHECK_EXN(_fx_catch_12);
+      _fx_R9Ast__id_t envwin_i_0 = v_2.t0;
+      FX_COPY_PTR(v_2.t1, &envwin_0);
+      bool agree_0;
+      if (genwin_opt_0.tag == 2) {
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&genwin_opt_0.u.Some.t0, &envwin_i_0, &agree_0, 0), _fx_catch_6);
 
-   _fx_endmatch_4: ;
-      FX_CHECK_EXN(_fx_catch_18);
-
-   _fx_catch_18: ;
-      _fx_free_N14Ast__id_info_t(&v_1);
-      if (v_0) {
-         _fx_free_LN16Ast__env_entry_t(&v_0);
+      _fx_catch_6: ;
       }
-      goto _fx_endmatch_5;
+      else {
+         agree_0 = false;
+      }
+      FX_CHECK_EXN(_fx_catch_12);
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_3, 0), _fx_catch_12);
+      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_12);
+      int_ v_17 = _fx_M13Ast_typecheckFM6lengthi1LT2R9Ast__id_trR13Ast__deffun_t(viable_0, 0);
+      FX_CALL(_fx_F6stringS1i(v_17, &v_5, 0), _fx_catch_12);
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_12);
+      fx_str_t slit_0 = FX_MAKE_STR("-pr-resolve: \'");
+      fx_str_t slit_1 = FX_MAKE_STR("\' @ ");
+      fx_str_t slit_2 = FX_MAKE_STR(": ");
+      fx_str_t slit_3 = FX_MAKE_STR(" viable for ");
+      fx_str_t slit_4 = FX_MAKE_STR("\n");
+      {
+         const fx_str_t strs_0[] = { slit_0, v_3, slit_1, v_4, slit_2, v_5, slit_3, v_6, slit_4 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_7), _fx_catch_12);
+      }
+      _fx_F12print_stringv1S(&v_7, 0);
+      _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_4 = viable_0;
+      for (; lst_4; lst_4 = lst_4->tl) {
+         _fx_rR13Ast__deffun_t c_1 = 0;
+         fx_str_t v_18 = {0};
+         fx_str_t v_19 = {0};
+         _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___2 = &lst_4->hd;
+         FX_COPY_PTR(__pat___2->t1, &c_1);
+         FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(c_1, &v_18, 0), _fx_catch_7);
+         fx_str_t slit_5 = FX_MAKE_STR("    candidate: ");
+         fx_str_t slit_6 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_1[] = { slit_5, v_18, slit_6 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_19), _fx_catch_7);
+         }
+         _fx_F12print_stringv1S(&v_19, 0);
+
+      _fx_catch_7: ;
+         FX_FREE_STR(&v_19);
+         FX_FREE_STR(&v_18);
+         if (c_1) {
+            _fx_free_rR13Ast__deffun_t(&c_1);
+         }
+         FX_CHECK_EXN(_fx_catch_12);
+      }
+      FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_8, 0), _fx_catch_12);
+      fx_str_t slit_7 = FX_MAKE_STR("    env-order  winner: ");
+      fx_str_t slit_8 = FX_MAKE_STR("\n");
+      {
+         const fx_str_t strs_2[] = { slit_7, v_8, slit_8 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_9), _fx_catch_12);
+      }
+      _fx_F12print_stringv1S(&v_9, 0);
+      if (genwin_opt_0.tag == 2) {
+         fx_str_t v_20 = {0};
+         fx_str_t v_21 = {0};
+         FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(genwin_opt_0.u.Some.t1, &v_20, 0), _fx_catch_8);
+         fx_str_t slit_9 = FX_MAKE_STR("    generality winner: ");
+         fx_str_t slit_10 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_3[] = { slit_9, v_20, slit_10 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_21), _fx_catch_8);
+         }
+         _fx_F12print_stringv1S(&v_21, 0);
+
+      _fx_catch_8: ;
+         FX_FREE_STR(&v_21);
+         FX_FREE_STR(&v_20);
+      }
+      else {
+         fx_str_t slit_11 = FX_MAKE_STR("    generality winner: <none: tied or unordered>\n");
+         _fx_F12print_stringv1S(&slit_11, 0);
+      }
+      FX_CHECK_EXN(_fx_catch_12);
+      FX_CALL(_fx_F6stringS1B(agree_0, &v_10, 0), _fx_catch_12);
+      fx_str_t slit_12 = FX_MAKE_STR("    winners agree: ");
+      fx_str_t slit_13 = FX_MAKE_STR("\n");
+      {
+         const fx_str_t strs_4[] = { slit_12, v_10, slit_13 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_11), _fx_catch_12);
+      }
+      _fx_F12print_stringv1S(&v_11, 0);
+      if (genwin_opt_0.tag == 2) {
+         fx_str_t slit_14 = FX_MAKE_STR("ranked"); fx_copy_str(&slit_14, &outcome_0);
+      }
+      else if (fully_determined_0) {
+         fx_str_t slit_15 = FX_MAKE_STR("ambiguity error"); fx_copy_str(&slit_15, &outcome_0);
+      }
+      else {
+         fx_str_t slit_16 = FX_MAKE_STR("env-order fallback (under-constrained tie)"); fx_copy_str(&slit_16, &outcome_0);
+      }
+      FX_CHECK_EXN(_fx_catch_12);
+      fx_str_t slit_17 = FX_MAKE_STR("    outcome: ");
+      fx_str_t slit_18 = FX_MAKE_STR("\n");
+      {
+         const fx_str_t strs_5[] = { slit_17, outcome_0, slit_18 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_12);
+      }
+      _fx_F12print_stringv1S(&v_12, 0);
    }
-   if (tag_0 == 2) {
-      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_5;
-   }
-   FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+   if (genwin_opt_0.tag == 2) {
+      _fx_T2R9Ast__id_trR13Ast__deffun_t* v_22 = &genwin_opt_0.u.Some;
+      FX_CALL(
+         _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+            &v_22->t0, v_22->t1, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_9);
 
-_fx_endmatch_5: ;
+   _fx_catch_9: ;
+   }
+   else {
+      _fx_LS v_23 = 0;
+      fx_str_t cand_lines_0 = {0};
+      fx_str_t v_24 = {0};
+      fx_str_t v_25 = {0};
+      fx_str_t v_26 = {0};
+      fx_exn_t v_27 = {0};
+      _fx_T2R9Ast__id_trR13Ast__deffun_t v_28 = {0};
+      _fx_rR13Ast__deffun_t df_0 = 0;
+      if (fully_determined_0) {
+         _fx_LS lstend_1 = 0;
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_5 = viable_0;
+         for (; lst_5; lst_5 = lst_5->tl) {
+            _fx_rR13Ast__deffun_t c_2 = 0;
+            fx_str_t res_0 = {0};
+            _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___3 = &lst_5->hd;
+            FX_COPY_PTR(__pat___3->t1, &c_2);
+            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(c_2, &res_0, 0), _fx_catch_10);
+            _fx_LS node_1 = 0;
+            FX_CALL(_fx_cons_LS(&res_0, 0, false, &node_1), _fx_catch_10);
+            FX_LIST_APPEND(v_23, lstend_1, node_1);
+
+         _fx_catch_10: ;
+            FX_FREE_STR(&res_0);
+            if (c_2) {
+               _fx_free_rR13Ast__deffun_t(&c_2);
+            }
+            FX_CHECK_EXN(_fx_catch_11);
+         }
+         fx_str_t slit_19 =
+            FX_MAKE_STR("\n"
+               U"    ");
+         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_23, &cand_lines_0, 0), _fx_catch_11);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_24, 0), _fx_catch_11);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_25, 0), _fx_catch_11);
+         fx_str_t slit_20 = FX_MAKE_STR("ambiguous call of overloaded \'");
+         fx_str_t slit_21 =
+            FX_MAKE_STR("\': no candidate is more specific than the others. Candidates:\n"
+               U"    ");
+         fx_str_t slit_22 =
+            FX_MAKE_STR("\n"
+               U"consider a module-qualified call (e.g. Module.");
+         fx_str_t slit_23 = FX_MAKE_STR("(...)) to disambiguate");
+         {
+            const fx_str_t strs_6[] = { slit_20, v_24, slit_21, cand_lines_0, slit_22, v_25, slit_23 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_6, 7, &v_26), _fx_catch_11);
+         }
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_26, &v_27, 0), _fx_catch_11);
+         FX_THROW(&v_27, false, _fx_catch_11);
+      }
+      else {
+         if (viable_0 != 0) {
+            _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_28);
+         }
+         else {
+            FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_11);
+         }
+         FX_CHECK_EXN(_fx_catch_11);
+         _fx_R9Ast__id_t i_0 = v_28.t0;
+         FX_COPY_PTR(v_28.t1, &df_0);
+         FX_CALL(
+            _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+               &i_0, df_0, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_11);
+      }
+
+   _fx_catch_11: ;
+      if (df_0) {
+         _fx_free_rR13Ast__deffun_t(&df_0);
+      }
+      _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_28);
+      fx_free_exn(&v_27);
+      FX_FREE_STR(&v_26);
+      FX_FREE_STR(&v_25);
+      FX_FREE_STR(&v_24);
+      FX_FREE_STR(&cand_lines_0);
+      if (v_23) {
+         _fx_free_LS(&v_23);
+      }
+   }
+   FX_CHECK_EXN(_fx_catch_12);
+
+_fx_catch_12: ;
+   FX_FREE_STR(&v_12);
+   FX_FREE_STR(&outcome_0);
+   FX_FREE_STR(&v_11);
+   FX_FREE_STR(&v_10);
+   FX_FREE_STR(&v_9);
+   FX_FREE_STR(&v_8);
+   FX_FREE_STR(&v_7);
+   FX_FREE_STR(&v_6);
+   FX_FREE_STR(&v_5);
+   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_3);
+   if (envwin_0) {
+      _fx_free_rR13Ast__deffun_t(&envwin_0);
+   }
+   _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_2);
+   if (v_1) {
+      _fx_free_N10Ast__typ_t(&v_1);
+   }
+   _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&genwin_opt_0);
+   _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0);
+   if (cands_0) {
+      _fx_free_LrR13Ast__deffun_t(&cands_0);
+   }
+
+_fx_endmatch_0: ;
 
 _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM7make_fpFPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t6Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* arg0,
-   struct _fx_R10Ast__loc_t* arg1,
-   struct _fx_R9Ast__id_t* arg2,
-   struct _fx_rLN16Ast__env_entry_t_data_t* arg3,
-   struct _fx_LN12Ast__scope_t_data_t* arg4,
-   struct _fx_N10Ast__typ_t_data_t* arg5,
-   struct _fx_FPNt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t* fx_result)
+static int
+   _fx_M13Ast_typecheckFM5scan_Nt6option1T2R9Ast__id_tN10Ast__typ_t8LN16Ast__env_entry_tLT2R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+   struct _fx_LN16Ast__env_entry_t_data_t* elist_0,
+   struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t* viable_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_rLN16Ast__env_entry_t_data_t* possible_matches_ref_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
+   void* fx_fv)
 {
-   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t_cldata_t,
-      _fx_free_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t,
-      _fx_M13Ast_typecheckFM10__lambda__Nt6option1T2R9Ast__id_tN10Ast__typ_t1N16Ast__env_entry_t);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(arg0, &fcv->t0);
-   fcv->t1 = *arg1;
-   fcv->t2 = *arg2;
-   FX_COPY_PTR(arg3, &fcv->t3);
-   FX_COPY_PTR(arg4, &fcv->t4);
-   FX_COPY_PTR(arg5, &fcv->t5);
-   return 0;
+   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_0 = {0};
+   _fx_LN16Ast__env_entry_t elist_1 = 0;
+   _fx_LT2R9Ast__id_trR13Ast__deffun_t viable_1 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   _fx_LN16Ast__env_entry_t* possible_matches_0 = &possible_matches_ref_0->data;
+   FX_COPY_PTR(elist_0, &elist_1);
+   FX_COPY_PTR(viable_0, &viable_1);
+   for (;;) {
+      _fx_LN16Ast__env_entry_t elist_2 = 0;
+      _fx_LT2R9Ast__id_trR13Ast__deffun_t viable_2 = 0;
+      FX_COPY_PTR(elist_1, &elist_2);
+      FX_COPY_PTR(viable_1, &viable_2);
+      if (elist_2 != 0) {
+         _fx_LN16Ast__env_entry_t rest_0 = elist_2->tl;
+         _fx_N16Ast__env_entry_t e_0 = elist_2->hd;
+         int tag_0 = FX_REC_VARIANT_TAG(e_0);
+         if (tag_0 == 1) {
+            if (e_0->u.EnvId.m == 0) {
+               _fx_free_LN16Ast__env_entry_t(&elist_1);
+               FX_COPY_PTR(rest_0, &elist_1);
+               _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+               FX_COPY_PTR(viable_2, &viable_1);
+               goto _fx_endmatch_1;
+            }
+         }
+         if (tag_0 == 1) {
+            _fx_LN16Ast__env_entry_t v_0 = 0;
+            _fx_N14Ast__id_info_t v_1 = {0};
+            _fx_R9Ast__id_t* i_0 = &e_0->u.EnvId;
+            FX_CALL(_fx_cons_LN16Ast__env_entry_t(e_0, *possible_matches_0, true, &v_0), _fx_catch_9);
+            _fx_free_LN16Ast__env_entry_t(possible_matches_0);
+            FX_COPY_PTR(v_0, possible_matches_0);
+            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(i_0, loc_0, &v_1, 0), _fx_catch_9);
+            int tag_1 = v_1.tag;
+            if (tag_1 == 3) {
+               _fx_LT2R9Ast__id_trR13Ast__deffun_t viable_3 = 0;
+               _fx_T2R9Ast__id_trR13Ast__deffun_t v_2 = {0};
+               _fx_rR13Ast__deffun_t df_0 = v_1.u.IdFun;
+               bool v_3;
+               FX_CALL(
+                  _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(df_0,
+                     t_0, sc_0, loc_0, &v_3, 0), _fx_catch_0);
+               if (v_3) {
+                  _fx_make_T2R9Ast__id_trR13Ast__deffun_t(i_0, df_0, &v_2);
+                  FX_CALL(_fx_cons_LT2R9Ast__id_trR13Ast__deffun_t(&v_2, viable_2, true, &viable_3), _fx_catch_0);
+               }
+               else {
+                  FX_COPY_PTR(viable_2, &viable_3);
+               }
+               _fx_free_LN16Ast__env_entry_t(&elist_1);
+               FX_COPY_PTR(rest_0, &elist_1);
+               _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+               FX_COPY_PTR(viable_3, &viable_1);
+
+            _fx_catch_0: ;
+               _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_2);
+               if (viable_3) {
+                  _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_3);
+               }
+               goto _fx_endmatch_0;
+            }
+            if (tag_1 == 2) {
+               _fx_N10Ast__typ_t dv_typ_0 = v_1.u.IdDVal.dv_typ;
+               if (viable_2 == 0) {
+                  fx_str_t v_4 = {0};
+                  fx_str_t v_5 = {0};
+                  fx_str_t v_6 = {0};
+                  fx_str_t v_7 = {0};
+                  fx_exn_t v_8 = {0};
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_9 = {0};
+                  _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_1 = {0};
+                  FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_4, 0), _fx_catch_1);
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_5, 0), _fx_catch_1);
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(dv_typ_0, &v_6, 0), _fx_catch_1);
+                  fx_str_t slit_0 = FX_MAKE_STR("incorrect type of value \'");
+                  fx_str_t slit_1 = FX_MAKE_STR("\': expected=\'");
+                  fx_str_t slit_2 = FX_MAKE_STR("\', actual=\'");
+                  fx_str_t slit_3 = FX_MAKE_STR("\'");
+                  {
+                     const fx_str_t strs_0[] = { slit_0, v_4, slit_1, v_5, slit_2, v_6, slit_3 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &v_7), _fx_catch_1);
+                  }
+                  bool v_10;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(dv_typ_0, t_0, loc_0, true,
+                        &v_10, 0), _fx_catch_1);
+                  if (!v_10) {
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_7, &v_8, 0), _fx_catch_1);
+                     FX_THROW(&v_8, false, _fx_catch_1);
+                  }
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_9);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_9, &result_1);
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1, &result_0);
+                  FX_BREAK(_fx_catch_1);
+
+               _fx_catch_1: ;
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_9);
+                  fx_free_exn(&v_8);
+                  FX_FREE_STR(&v_7);
+                  FX_FREE_STR(&v_6);
+                  FX_FREE_STR(&v_5);
+                  FX_FREE_STR(&v_4);
+               }
+               else {
+                  _fx_free_LN16Ast__env_entry_t(&elist_1);
+                  FX_COPY_PTR(rest_0, &elist_1);
+                  _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+                  FX_COPY_PTR(viable_2, &viable_1);
+               }
+               FX_CHECK_EXN(_fx_catch_2);
+
+            _fx_catch_2: ;
+               goto _fx_endmatch_0;
+            }
+            if (tag_1 == 8) {
+               if (viable_2 == 0) {
+                  fx_exn_t v_11 = {0};
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_12 = {0};
+                  _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_2 = {0};
+                  bool v_13;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(
+                        _fx_g24Ast_typecheck__TypModule, t_0, loc_0, true, &v_13, 0), _fx_catch_3);
+                  if (!v_13) {
+                     fx_str_t slit_4 = FX_MAKE_STR("unexpected module name");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_11, 0), _fx_catch_3);
+                     FX_THROW(&v_11, false, _fx_catch_3);
+                  }
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_12);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_12, &result_2);
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_2, &result_0);
+                  FX_BREAK(_fx_catch_3);
+
+               _fx_catch_3: ;
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_2);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_12);
+                  fx_free_exn(&v_11);
+               }
+               else {
+                  _fx_free_LN16Ast__env_entry_t(&elist_1);
+                  FX_COPY_PTR(rest_0, &elist_1);
+                  _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+                  FX_COPY_PTR(viable_2, &viable_1);
+               }
+               FX_CHECK_EXN(_fx_catch_4);
+
+            _fx_catch_4: ;
+               goto _fx_endmatch_0;
+            }
+            if (tag_1 == 4) {
+               _fx_R13Ast__defexn_t v_14 = {0};
+               _fx_copy_R13Ast__defexn_t(&v_1.u.IdExn->data, &v_14);
+               _fx_N10Ast__typ_t dexn_typ_0 = v_14.dexn_typ;
+               if (viable_2 == 0) {
+                  _fx_N10Ast__typ_t ctyp_0 = 0;
+                  fx_exn_t v_15 = {0};
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_16 = {0};
+                  _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_3 = {0};
+                  if (FX_REC_VARIANT_TAG(dexn_typ_0) == 13) {
+                     FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &ctyp_0);
+                  }
+                  else {
+                     _fx_LN10Ast__typ_t v_17 = 0;
+                     if (FX_REC_VARIANT_TAG(dexn_typ_0) == 17) {
+                        FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_17);
+                     }
+                     else {
+                        FX_CALL(_fx_cons_LN10Ast__typ_t(dexn_typ_0, 0, true, &v_17), _fx_catch_5);  _fx_catch_5: ;
+                     }
+                     FX_CHECK_EXN(_fx_catch_6);
+                     FX_CALL(
+                        _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_17, _fx_g21Ast_typecheck__TypExn,
+                           &ctyp_0), _fx_catch_6);
+
+                  _fx_catch_6: ;
+                     if (v_17) {
+                        _fx_free_LN10Ast__typ_t(&v_17);
+                     }
+                  }
+                  FX_CHECK_EXN(_fx_catch_7);
+                  bool v_18;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ctyp_0, t_0, loc_0, true,
+                        &v_18, 0), _fx_catch_7);
+                  if (!v_18) {
+                     fx_str_t slit_5 = FX_MAKE_STR("uncorrect type of exception constructor and/or its arguments");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_5, &v_15, 0), _fx_catch_7);
+                     FX_THROW(&v_15, false, _fx_catch_7);
+                  }
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_16);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_16, &result_3);
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_3, &result_0);
+                  FX_BREAK(_fx_catch_7);
+
+               _fx_catch_7: ;
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_3);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_16);
+                  fx_free_exn(&v_15);
+                  if (ctyp_0) {
+                     _fx_free_N10Ast__typ_t(&ctyp_0);
+                  }
+               }
+               else {
+                  _fx_free_LN16Ast__env_entry_t(&elist_1);
+                  FX_COPY_PTR(rest_0, &elist_1);
+                  _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+                  FX_COPY_PTR(viable_2, &viable_1);
+               }
+               FX_CHECK_EXN(_fx_catch_8);
+
+            _fx_catch_8: ;
+               _fx_free_R13Ast__defexn_t(&v_14);
+               goto _fx_endmatch_0;
+            }
+            bool res_0;
+            if (tag_1 == 1) {
+               res_0 = true;
+            }
+            else if (tag_1 == 5) {
+               res_0 = true;
+            }
+            else if (tag_1 == 6) {
+               res_0 = true;
+            }
+            else if (tag_1 == 7) {
+               res_0 = true;
+            }
+            else {
+               res_0 = false;
+            }
+            FX_CHECK_EXN(_fx_catch_9);
+            if (res_0) {
+               _fx_free_LN16Ast__env_entry_t(&elist_1);
+               FX_COPY_PTR(rest_0, &elist_1);
+               _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+               FX_COPY_PTR(viable_2, &viable_1);
+               goto _fx_endmatch_0;
+            }
+            FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_9);
+
+         _fx_endmatch_0: ;
+            FX_CHECK_EXN(_fx_catch_9);
+
+         _fx_catch_9: ;
+            _fx_free_N14Ast__id_info_t(&v_1);
+            if (v_0) {
+               _fx_free_LN16Ast__env_entry_t(&v_0);
+            }
+            goto _fx_endmatch_1;
+         }
+         if (tag_0 == 2) {
+            _fx_free_LN16Ast__env_entry_t(&elist_1);
+            FX_COPY_PTR(rest_0, &elist_1);
+            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+            FX_COPY_PTR(viable_2, &viable_1);
+            goto _fx_endmatch_1;
+         }
+         FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_10);
+
+      _fx_endmatch_1: ;
+         FX_CHECK_EXN(_fx_catch_10);
+
+      _fx_catch_10: ;
+      }
+      else {
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t __fold_result___0 = 0;
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t v_19 = 0;
+         _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_4 = {0};
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_0 = viable_2;
+         for (; lst_0; lst_0 = lst_0->tl) {
+            _fx_LT2R9Ast__id_trR13Ast__deffun_t r_0 = 0;
+            _fx_T2R9Ast__id_trR13Ast__deffun_t* a_0 = &lst_0->hd;
+            FX_COPY_PTR(__fold_result___0, &r_0);
+            FX_CALL(_fx_cons_LT2R9Ast__id_trR13Ast__deffun_t(a_0, r_0, false, &r_0), _fx_catch_11);
+            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0);
+            FX_COPY_PTR(r_0, &__fold_result___0);
+
+         _fx_catch_11: ;
+            if (r_0) {
+               _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&r_0);
+            }
+            FX_CHECK_EXN(_fx_catch_12);
+         }
+         FX_COPY_PTR(__fold_result___0, &v_19);
+         FX_CALL(
+            _fx_M13Ast_typecheckFM15rank_and_commitNt6option1T2R9Ast__id_tN10Ast__typ_t6LT2R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
+               v_19, env_0, loc_0, n_0, sc_0, t_0, &result_4, 0), _fx_catch_12);
+         _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_4, &result_0);
+         FX_BREAK(_fx_catch_12);
+
+      _fx_catch_12: ;
+         _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_4);
+         if (v_19) {
+            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&v_19);
+         }
+         if (__fold_result___0) {
+            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0);
+         }
+      }
+      FX_CHECK_EXN(_fx_catch_13);
+
+   _fx_catch_13: ;
+      if (viable_2) {
+         _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_2);
+      }
+      if (elist_2) {
+         _fx_free_LN16Ast__env_entry_t(&elist_2);
+      }
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0, fx_result);
+
+_fx_cleanup: ;
+   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+   if (elist_1) {
+      _fx_free_LN16Ast__env_entry_t(&elist_1);
+   }
+   if (viable_1) {
+      _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&viable_1);
+   }
+   return fx_status;
+}
+
+static int
+   _fx_M13Ast_typecheckFM7lookup_Nt6option1T2R9Ast__id_tN10Ast__typ_t9R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* n2_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env2_0,
+   int_ curr_m_idx_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_rLN16Ast__env_entry_t_data_t* possible_matches_ref_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
+   void* fx_fv)
+{
+   _fx_LN16Ast__env_entry_t e_all_0 = 0;
+   _fx_LN16Ast__env_entry_t e_all_1 = 0;
+   _fx_N16Ast__env_entry_t v_0 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(n2_0, env2_0,
+         &e_all_0, 0), _fx_cleanup);
+   bool t_1;
+   if (e_all_0 == 0) {
+      FX_CALL(_fx_M3AstFM12is_unique_idB1RM4id_t(n2_0, &t_1, 0), _fx_cleanup);
+   }
+   else {
+      t_1 = false;
+   }
+   if (t_1) {
+      FX_CALL(_fx_M3AstFM5EnvIdN16Ast__env_entry_t1RM4id_t(n2_0, &v_0), _fx_cleanup);
+      FX_CALL(_fx_cons_LN16Ast__env_entry_t(v_0, 0, true, &e_all_1), _fx_cleanup);
+   }
+   else {
+      FX_COPY_PTR(e_all_0, &e_all_1);
+   }
+   if (e_all_1 == 0) {
+      fx_str_t n_path_0 = {0};
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n2_0, &n_path_0, 0), _fx_catch_0);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM12search_path_Nt6option1T2R9Ast__id_tN10Ast__typ_t10SiiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+            &n_path_0, FX_STR_LENGTH(n_path_0) - 1, curr_m_idx_0, env_0, env2_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0,
+            fx_result, 0), _fx_catch_0);
+
+   _fx_catch_0: ;
+      FX_FREE_STR(&n_path_0);
+   }
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM5scan_Nt6option1T2R9Ast__id_tN10Ast__typ_t8LN16Ast__env_entry_tLT2R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+            e_all_1, 0, env_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0, fx_result, 0), _fx_catch_1);
+
+   _fx_catch_1: ;
+   }
+
+_fx_cleanup: ;
+   if (e_all_0) {
+      _fx_free_LN16Ast__env_entry_t(&e_all_0);
+   }
+   if (e_all_1) {
+      _fx_free_LN16Ast__env_entry_t(&e_all_1);
+   }
+   if (v_0) {
+      _fx_free_N16Ast__env_entry_t(&v_0);
+   }
+   return fx_status;
+}
+
+static int
+   _fx_M13Ast_typecheckFM12search_path_Nt6option1T2R9Ast__id_tN10Ast__typ_t10SiiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+   fx_str_t* n_path_0,
+   int_ dot_pos_0,
+   int_ curr_m_idx_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env2_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_rLN16Ast__env_entry_t_data_t* possible_matches_ref_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t* fx_result,
+   void* fx_fv)
+{
+   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_0 = {0};
+   fx_str_t n_path_1 = {0};
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   fx_copy_str(n_path_0, &n_path_1);
+   int_ dot_pos_1 = dot_pos_0;
+   for (;;) {
+      fx_str_t n_path_2 = {0};
+      fx_str_t v_0 = {0};
+      _fx_LN16Ast__env_entry_t v_1 = 0;
+      fx_copy_str(&n_path_1, &n_path_2);
+      int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
+      if (dot_pos_2 < 0) {
+         _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
+         FX_BREAK(_fx_catch_3);
+      }
+      else {
+         FX_CALL(fx_substr(&n_path_2, 0, dot_pos_2, 1, 1, &v_0), _fx_catch_3);
+         _fx_R9Ast__id_t v_2;
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_0, &v_2, 0), _fx_catch_3);
+         FX_CALL(
+            _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_2,
+               env2_0, &v_1, 0), _fx_catch_3);
+         if (v_1 != 0) {
+            _fx_N16Ast__env_entry_t v_3 = v_1->hd;
+            if (FX_REC_VARIANT_TAG(v_3) == 1) {
+               _fx_N14Ast__id_info_t v_4 = {0};
+               FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_3->u.EnvId, loc_0, &v_4, 0), _fx_catch_2);
+               if (v_4.tag == 8) {
+                  _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env3_0 = {0};
+                  fx_str_t v_5 = {0};
+                  _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_1 = {0};
+                  int_ m_idx_0 = v_4.u.IdModule;
+                  if (m_idx_0 == curr_m_idx_0) {
+                     _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env_0, &env3_0);
+                  }
+                  else {
+                     FX_CALL(_fx_M3AstFM14get_module_envRt6Map__t2RM4id_tLN16Ast__env_entry_t1i(m_idx_0, &env3_0, 0),
+                        _fx_catch_0);
+                  }
+                  FX_CALL(fx_substr(&n_path_2, dot_pos_2 + 1, 0, 1, 2, &v_5), _fx_catch_0);
+                  _fx_R9Ast__id_t v_6;
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_5, &v_6, 0), _fx_catch_0);
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM7lookup_Nt6option1T2R9Ast__id_tN10Ast__typ_t9R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_trLN16Ast__env_entry_tLN12Ast__scope_tN10Ast__typ_t(
+                        &v_6, &env3_0, curr_m_idx_0, env_0, loc_0, n_0, possible_matches_ref_0, sc_0, t_0, &result_1, 0),
+                     _fx_catch_0);
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1, &result_0);
+                  FX_BREAK(_fx_catch_0);
+
+               _fx_catch_0: ;
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1);
+                  FX_FREE_STR(&v_5);
+                  _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env3_0);
+               }
+               else {
+                  _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
+                  FX_BREAK(_fx_catch_1);
+
+               _fx_catch_1: ;
+               }
+               FX_CHECK_EXN(_fx_catch_2);
+
+            _fx_catch_2: ;
+               _fx_free_N14Ast__id_info_t(&v_4);
+               goto _fx_endmatch_0;
+            }
+         }
+         FX_FREE_STR(&n_path_1);
+         fx_copy_str(&n_path_2, &n_path_1);
+         dot_pos_1 = dot_pos_2 - 1;
+
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_catch_3);
+      }
+
+   _fx_catch_3: ;
+      if (v_1) {
+         _fx_free_LN16Ast__env_entry_t(&v_1);
+      }
+      FX_FREE_STR(&v_0);
+      FX_FREE_STR(&n_path_2);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0, fx_result);
+
+_fx_cleanup: ;
+   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
+   FX_FREE_STR(&n_path_1);
+   return fx_status;
 }
 
 FX_EXTERN_C int
@@ -27835,6 +28230,7 @@ static int
    _fx_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t v_0 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t id_n_typ_0 = {0};
    int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
    _fx_LN10Ast__typ_t lstend_0 = 0;
    _fx_LN10Ast__exp_t lst_0 = args_0;
    for (; lst_0; lst_0 = lst_0->tl) {

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -6262,6 +6262,23 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
    struct _fx_N10Ast__typ_t_data_t**,
    void*);
 
+FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t*, struct _fx_R9Ast__id_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM17default_val_flagsRM11val_flags_t0(struct _fx_R16Ast__val_flags_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(
+   struct _fx_LN10Ast__typ_t_data_t*,
+   struct _fx_R9Ast__id_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
+FX_EXTERN_C_VAL(struct _fx_R10Ast__loc_t _fx_g10Ast__noloc)
+FX_EXTERN_C int _fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(struct _fx_R10Ast__loc_t*, struct _fx_N10Ast__exp_t_data_t**);
+
+FX_EXTERN_C int _fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(
+   int_,
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
 FX_EXTERN_C int
    _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_LR9Ast__id_t_data_t*,
@@ -6272,14 +6289,8 @@ FX_EXTERN_C int
    struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    void*);
 
-FX_EXTERN_C int _fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(
-   struct _fx_LN10Ast__typ_t_data_t*,
-   struct _fx_R9Ast__id_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
 FX_EXTERN_C int _fx_M3AstFM14is_constructorB1RM11fun_flags_t(struct _fx_R16Ast__fun_flags_t*, bool*, void*);
 
-FX_EXTERN_C_VAL(struct _fx_R10Ast__loc_t _fx_g10Ast__noloc)
 FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(struct _fx_R10Ast__loc_t*, fx_str_t*, fx_exn_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
@@ -6446,8 +6457,6 @@ static int
    void*);
 
 FX_EXTERN_C int_ _fx_M6StringFM5rfindi3SCi(fx_str_t*, char_, int_, void*);
-
-FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t*, struct _fx_R9Ast__id_t*, void*);
 
 FX_EXTERN_C int _fx_M3AstFM14get_module_envRt6Map__t2RM4id_tLN16Ast__env_entry_t1i(
    int_,
@@ -6709,11 +6718,6 @@ FX_EXTERN_C bool _fx_F6__eq__B2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C void _fx_M3AstFM10IntrinMathN13Ast__intrin_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_N13Ast__intrin_t*);
 
-FX_EXTERN_C int _fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(
-   int_,
-   struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
 FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int
@@ -6756,8 +6760,6 @@ FX_EXTERN_C int
    struct _fx_LN12Ast__scope_t_data_t*,
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    void*);
-
-FX_EXTERN_C int _fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(struct _fx_R10Ast__loc_t*, struct _fx_N10Ast__exp_t_data_t**);
 
 FX_EXTERN_C int _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
    struct _fx_N10Ast__exp_t_data_t*,
@@ -6913,8 +6915,6 @@ FX_EXTERN_C int _fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc
    struct _fx_N10Ast__exp_t_data_t**);
 
 FX_EXTERN_C int _fx_M6StringFM10num_suffixS1i(int_, fx_str_t*, void*);
-
-FX_EXTERN_C int _fx_M3AstFM17default_val_flagsRM11val_flags_t0(struct _fx_R16Ast__val_flags_t*, void*);
 
 FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(
    struct _fx_R9Ast__id_t*,
@@ -12787,6 +12787,349 @@ FX_EXTERN_C int
    return 0;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_R16Ast__ast_callb_t* callb_0,
+   struct _fx_N10Ast__typ_t_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_Nt6option1N10Ast__typ_t v_0 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_1 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_2 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_3 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   int tag_0 = FX_REC_VARIANT_TAG(t_0);
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_0);
+      if ((v_0 != 0) + 1 == 2) {
+         if (FX_REC_VARIANT_TAG(v_0->u.Some) == 4) {
+            _fx_R16Ast__val_flags_t v_4 = {0};
+            _fx_N10Ast__typ_t v_5 = 0;
+            _fx_N10Ast__exp_t v_6 = 0;
+            _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_7 = {0};
+            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_8 = 0;
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_9 = {0};
+            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = 0;
+            _fx_R9Ast__id_t k_0;
+            fx_str_t slit_0 = FX_MAKE_STR("__skolem_rec__");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, &k_0, 0), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_4, 0), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &k_0, &v_5), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&_fx_g10Ast__noloc, &v_6), _fx_catch_0);
+            _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_4, &k_0, v_5, v_6, &v_7);
+            FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_7, 0, true, &v_8), _fx_catch_0);
+            _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_8, true, &v_9);
+            FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9, &v_10), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_10, fx_result),
+               _fx_catch_0);
+
+         _fx_catch_0: ;
+            if (v_10) {
+               _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+            }
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9);
+            if (v_8) {
+               _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_8);
+            }
+            _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_7);
+            if (v_6) {
+               _fx_free_N10Ast__exp_t(&v_6);
+            }
+            if (v_5) {
+               _fx_free_N10Ast__typ_t(&v_5);
+            }
+            _fx_free_R16Ast__val_flags_t(&v_4);
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_1);
+      if ((v_1 != 0) + 1 == 2) {
+         _fx_N10Ast__typ_t v_11 = v_1->u.Some;
+         if (FX_REC_VARIANT_TAG(v_11) == 2) {
+            _fx_Nt6option1N10Ast__typ_t t_opt_0 = v_11->u.TypVarTuple;
+            if ((t_opt_0 != 0) + 1 == 2) {
+               _fx_N10Ast__typ_t v_12 = 0;
+               _fx_LN10Ast__typ_t v_13 = 0;
+               FX_CALL(
+                  _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_opt_0->u.Some, callb_0, &v_12,
+                     0), _fx_catch_1);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_12, 0, true, &v_13), _fx_catch_1);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_13, fx_result), _fx_catch_1);
+
+            _fx_catch_1: ;
+               if (v_13) {
+                  _fx_free_LN10Ast__typ_t(&v_13);
+               }
+               if (v_12) {
+                  _fx_free_N10Ast__typ_t(&v_12);
+               }
+            }
+            else {
+               _fx_N10Ast__typ_t v_14 = 0;
+               _fx_N10Ast__typ_t v_15 = 0;
+               _fx_LN10Ast__typ_t v_16 = 0;
+               _fx_R9Ast__id_t v_17;
+               fx_str_t slit_1 = FX_MAKE_STR("__skolem1__");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, &v_17, 0), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_17, &v_14), _fx_catch_2);
+               _fx_R9Ast__id_t v_18;
+               fx_str_t slit_2 = FX_MAKE_STR("__skolem2__");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, &v_18, 0), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_18, &v_15), _fx_catch_2);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_15, 0, true, &v_16), _fx_catch_2);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_14, v_16, false, &v_16), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_16, fx_result), _fx_catch_2);
+
+            _fx_catch_2: ;
+               if (v_16) {
+                  _fx_free_LN10Ast__typ_t(&v_16);
+               }
+               if (v_15) {
+                  _fx_free_N10Ast__typ_t(&v_15);
+               }
+               if (v_14) {
+                  _fx_free_N10Ast__typ_t(&v_14);
+               }
+            }
+            FX_CHECK_EXN(_fx_catch_3);
+
+         _fx_catch_3: ;
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_2);
+      if ((v_2 != 0) + 1 == 2) {
+         _fx_N10Ast__typ_t v_19 = v_2->u.Some;
+         if (FX_REC_VARIANT_TAG(v_19) == 3) {
+            _fx_N10Ast__typ_t v_20 = 0;
+            FX_CALL(
+               _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_19->u.TypVarArray, callb_0, &v_20,
+                  0), _fx_catch_4);
+            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(-1, v_20, fx_result), _fx_catch_4);
+
+         _fx_catch_4: ;
+            if (v_20) {
+               _fx_free_N10Ast__typ_t(&v_20);
+            }
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_3);
+      if ((v_3 != 0) + 1 == 2) {
+         _fx_N10Ast__typ_t v_21 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_22 = 0;
+         _fx_rNt6option1N10Ast__typ_t v_23 = 0;
+         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_3->u.Some, callb_0, &v_21, 0),
+            _fx_catch_5);
+         FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_21, &v_22), _fx_catch_5);
+         FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_22, &v_23), _fx_catch_5);
+         FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_23, fx_result), _fx_catch_5);
+
+      _fx_catch_5: ;
+         if (v_23) {
+            _fx_free_rNt6option1N10Ast__typ_t(&v_23);
+         }
+         if (v_22) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_22);
+         }
+         if (v_21) {
+            _fx_free_N10Ast__typ_t(&v_21);
+         }
+         goto _fx_endmatch_0;
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+   }
+   if (tag_0 == 20) {
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_24 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_25 = {0};
+      _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_26 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_27 = &t_0->u.TypRecord->data;
+      FX_COPY_PTR(v_27->t0, &relems_0);
+      bool ordered_0 = v_27->t1;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lstend_0 = 0;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_0 = relems_0;
+      for (; lst_0; lst_0 = lst_0->tl) {
+         _fx_R16Ast__val_flags_t fl_0 = {0};
+         _fx_N10Ast__typ_t t_1 = 0;
+         _fx_N10Ast__exp_t v_28 = 0;
+         _fx_N10Ast__typ_t v_29 = 0;
+         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t tup_0 = {0};
+         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_0->hd;
+         _fx_copy_R16Ast__val_flags_t(&__pat___0->t0, &fl_0);
+         _fx_R9Ast__id_t n_0 = __pat___0->t1;
+         FX_COPY_PTR(__pat___0->t2, &t_1);
+         FX_COPY_PTR(__pat___0->t3, &v_28);
+         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_1, callb_0, &v_29, 0),
+            _fx_catch_6);
+         _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&fl_0, &n_0, v_29, v_28, &tup_0);
+         _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t node_0 = 0;
+         FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0, 0, false, &node_0), _fx_catch_6);
+         FX_LIST_APPEND(v_24, lstend_0, node_0);
+
+      _fx_catch_6: ;
+         _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0);
+         if (v_29) {
+            _fx_free_N10Ast__typ_t(&v_29);
+         }
+         if (v_28) {
+            _fx_free_N10Ast__exp_t(&v_28);
+         }
+         if (t_1) {
+            _fx_free_N10Ast__typ_t(&t_1);
+         }
+         _fx_free_R16Ast__val_flags_t(&fl_0);
+         FX_CHECK_EXN(_fx_catch_7);
+      }
+      _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_24, ordered_0, &v_25);
+      FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_25, &v_26), _fx_catch_7);
+      FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_26, fx_result),
+         _fx_catch_7);
+
+   _fx_catch_7: ;
+      if (v_26) {
+         _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_26);
+      }
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_25);
+      if (v_24) {
+         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_24);
+      }
+      if (relems_0) {
+         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
+      }
+      goto _fx_endmatch_0;
+   }
+   FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0, callb_0, fx_result, 0), _fx_catch_8);
+
+_fx_catch_8: ;
+
+_fx_endmatch_0: ;
+
+_fx_cleanup: ;
+   if (v_0) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_0);
+   }
+   if (v_1) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_1);
+   }
+   if (v_2) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_2);
+   }
+   if (v_3) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_3);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM22compare_typ_generalityN24Ast_typecheck__gen_cmp_t4N10Ast__typ_tLR9Ast__id_tN10Ast__typ_tLR9Ast__id_t(
+   struct _fx_N10Ast__typ_t_data_t* t1_0,
+   struct _fx_LR9Ast__id_t_data_t* skolems1_0,
+   struct _fx_N10Ast__typ_t_data_t* t2_0,
+   struct _fx_LR9Ast__id_t_data_t* skolems2_0,
+   struct _fx_N24Ast_typecheck__gen_cmp_t* fx_result,
+   void* fx_fv)
+{
+   _fx_N10Ast__typ_t free1_0 = 0;
+   _fx_N10Ast__typ_t free2_0 = 0;
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t freeze__0 = {0};
+   _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t v_0 = 0;
+   _fx_R16Ast__ast_callb_t callb_0 = {0};
+   _fx_N10Ast__typ_t rigid1_0 = 0;
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t freeze__1 = {0};
+   _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t v_1 = 0;
+   _fx_R16Ast__ast_callb_t callb_1 = {0};
+   _fx_N10Ast__typ_t rigid2_0 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t1_0, skolems1_0, &free1_0, 0),
+      _fx_cleanup);
+   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t2_0, skolems2_0, &free2_0, 0),
+      _fx_cleanup);
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t freeze__fp_0 =
+      { _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t, 0 };
+   FX_COPY_FP(&freeze__fp_0, &freeze__0);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+         &freeze__0, &v_0), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t1_0, &callb_0, &rigid1_0, 0),
+      _fx_cleanup);
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t freeze__fp_1 =
+      { _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t, 0 };
+   FX_COPY_FP(&freeze__fp_1, &freeze__1);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+         &freeze__1, &v_1), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(v_1, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_1);
+   FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t2_0, &callb_1, &rigid2_0, 0),
+      _fx_cleanup);
+   bool covers1_2_0;
+   FX_CALL(
+      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free1_0, rigid2_0, &_fx_g10Ast__noloc,
+         false, &covers1_2_0, 0), _fx_cleanup);
+   bool covers2_1_0;
+   FX_CALL(
+      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free2_0, rigid1_0, &_fx_g10Ast__noloc,
+         false, &covers2_1_0, 0), _fx_cleanup);
+   if (covers2_1_0 == true) {
+      if (covers1_2_0 == true) {
+         *fx_result = _fx_g24Ast_typecheck__EqGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == false) {
+      if (covers1_2_0 == true) {
+         *fx_result = _fx_g26Ast_typecheck__MoreGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == true) {
+      if (covers1_2_0 == false) {
+         *fx_result = _fx_g26Ast_typecheck__LessGeneric; goto _fx_endmatch_0;
+      }
+   }
+   if (covers2_1_0 == false) {
+      if (covers1_2_0 == false) {
+         *fx_result = _fx_g28Ast_typecheck__IncompGeneric; goto _fx_endmatch_0;
+      }
+   }
+   FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+
+_fx_endmatch_0: ;
+
+_fx_cleanup: ;
+   if (free1_0) {
+      _fx_free_N10Ast__typ_t(&free1_0);
+   }
+   if (free2_0) {
+      _fx_free_N10Ast__typ_t(&free2_0);
+   }
+   FX_FREE_FP(&freeze__0);
+   if (v_0) {
+      _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&v_0);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_0);
+   if (rigid1_0) {
+      _fx_free_N10Ast__typ_t(&rigid1_0);
+   }
+   FX_FREE_FP(&freeze__1);
+   if (v_1) {
+      _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&v_1);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_1);
+   if (rigid2_0) {
+      _fx_free_N10Ast__typ_t(&rigid2_0);
+   }
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(
    struct _fx_rR13Ast__deffun_t_data_t* df_0,
    struct _fx_T2N10Ast__typ_tLR9Ast__id_t* fx_result,
@@ -12999,8 +13342,6 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
    _fx_T2N10Ast__typ_tLR9Ast__id_t v_1 = {0};
    _fx_N10Ast__typ_t t2_0 = 0;
    _fx_LR9Ast__id_t sk2_0 = 0;
-   _fx_N10Ast__typ_t free1_0 = 0;
-   _fx_N10Ast__typ_t free2_0 = 0;
    int fx_status = 0;
    FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df1_0, &v_0, 0), _fx_cleanup);
    FX_COPY_PTR(v_0.t0, &t1_0);
@@ -13008,41 +13349,9 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
    FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df2_0, &v_1, 0), _fx_cleanup);
    FX_COPY_PTR(v_1.t0, &t2_0);
    FX_COPY_PTR(v_1.t1, &sk2_0);
-   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t1_0, sk1_0, &free1_0, 0),
-      _fx_cleanup);
-   FX_CALL(_fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ_tLR9Ast__id_t(t2_0, sk2_0, &free2_0, 0),
-      _fx_cleanup);
-   bool covers1_2_0;
    FX_CALL(
-      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free1_0, t2_0, &_fx_g10Ast__noloc, false,
-         &covers1_2_0, 0), _fx_cleanup);
-   bool covers2_1_0;
-   FX_CALL(
-      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(free2_0, t1_0, &_fx_g10Ast__noloc, false,
-         &covers2_1_0, 0), _fx_cleanup);
-   if (covers2_1_0 == true) {
-      if (covers1_2_0 == true) {
-         *fx_result = _fx_g24Ast_typecheck__EqGeneric; goto _fx_endmatch_0;
-      }
-   }
-   if (covers2_1_0 == false) {
-      if (covers1_2_0 == true) {
-         *fx_result = _fx_g26Ast_typecheck__MoreGeneric; goto _fx_endmatch_0;
-      }
-   }
-   if (covers2_1_0 == true) {
-      if (covers1_2_0 == false) {
-         *fx_result = _fx_g26Ast_typecheck__LessGeneric; goto _fx_endmatch_0;
-      }
-   }
-   if (covers2_1_0 == false) {
-      if (covers1_2_0 == false) {
-         *fx_result = _fx_g28Ast_typecheck__IncompGeneric; goto _fx_endmatch_0;
-      }
-   }
-   FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
-
-_fx_endmatch_0: ;
+      _fx_M13Ast_typecheckFM22compare_typ_generalityN24Ast_typecheck__gen_cmp_t4N10Ast__typ_tLR9Ast__id_tN10Ast__typ_tLR9Ast__id_t(
+         t1_0, sk1_0, t2_0, sk2_0, fx_result, 0), _fx_cleanup);
 
 _fx_cleanup: ;
    _fx_free_T2N10Ast__typ_tLR9Ast__id_t(&v_0);
@@ -13055,12 +13364,6 @@ _fx_cleanup: ;
       _fx_free_N10Ast__typ_t(&t2_0);
    }
    FX_FREE_LIST_SIMPLE(&sk2_0);
-   if (free1_0) {
-      _fx_free_N10Ast__typ_t(&free1_0);
-   }
-   if (free2_0) {
-      _fx_free_N10Ast__typ_t(&free2_0);
-   }
    return fx_status;
 }
 

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -1166,6 +1166,26 @@ typedef struct _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t {
    } u;
 } _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t;
 
+typedef struct _fx_Nt6option1LN10Ast__typ_t {
+   int tag;
+   union {
+      struct _fx_LN10Ast__typ_t_data_t* Some;
+   } u;
+} _fx_Nt6option1LN10Ast__typ_t;
+
+typedef struct _fx_T3iN10Ast__typ_tN10Ast__typ_t {
+   int_ t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_N10Ast__typ_t_data_t* t2;
+} _fx_T3iN10Ast__typ_tN10Ast__typ_t;
+
+typedef struct _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t {
+   int tag;
+   union {
+      struct _fx_T3iN10Ast__typ_tN10Ast__typ_t Some;
+   } u;
+} _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t;
+
 typedef struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t {
    struct _fx_T2R9Ast__id_tN10Ast__typ_t t0;
    struct _fx_R9Ast__id_t t1;
@@ -4509,6 +4529,80 @@ static void _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(
    }
 }
 
+static void _fx_free_Nt6option1LN10Ast__typ_t(struct _fx_Nt6option1LN10Ast__typ_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_LN10Ast__typ_t(&dst->u.Some); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_Nt6option1LN10Ast__typ_t(
+   struct _fx_Nt6option1LN10Ast__typ_t* src,
+   struct _fx_Nt6option1LN10Ast__typ_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      FX_COPY_PTR(src->u.Some, &dst->u.Some); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
+static void _fx_free_T3iN10Ast__typ_tN10Ast__typ_t(struct _fx_T3iN10Ast__typ_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+   _fx_free_N10Ast__typ_t(&dst->t2);
+}
+
+static void _fx_copy_T3iN10Ast__typ_tN10Ast__typ_t(
+   struct _fx_T3iN10Ast__typ_tN10Ast__typ_t* src,
+   struct _fx_T3iN10Ast__typ_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3iN10Ast__typ_tN10Ast__typ_t(
+   int_ t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_N10Ast__typ_t_data_t* t2,
+   struct _fx_T3iN10Ast__typ_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(struct _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_T3iN10Ast__typ_tN10Ast__typ_t(&dst->u.Some); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(
+   struct _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t* src,
+   struct _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_T3iN10Ast__typ_tN10Ast__typ_t(&src->u.Some, &dst->u.Some); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
 static void _fx_free_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(struct _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t* dst)
 {
    _fx_free_T2R9Ast__id_tN10Ast__typ_t(&dst->t0);
@@ -6133,16 +6227,18 @@ static void _fx_make_T2N10Ast__pat_tB(struct _fx_N10Ast__pat_t_data_t* t0, bool 
 _fx_Nt6option1T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t _fx_g19Ast_typecheck__None = { 1 };
 _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t _fx_g21Ast_typecheck__None1_ = { 1 };
 _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t _fx_g21Ast_typecheck__None2_ = { 1 };
-_fx_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t _fx_g21Ast_typecheck__None3_ = { 1 };
-_fx_Nt6option1N10Ast__lit_t _fx_g21Ast_typecheck__None4_ = { 1 };
-_fx_Nt6option1LN16Ast__env_entry_t _fx_g21Ast_typecheck__None5_ = { 1 };
-_fx_Nt6option1rRt6Set__t1R9Ast__id_t _fx_g21Ast_typecheck__None6_ = { 1 };
-_fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t _fx_g21Ast_typecheck__None7_ = { 1 };
-_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None8_ = 0;
-_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g21Ast_typecheck__None9_ = 0;
-_fx_Nt6option1R9Ast__id_t _fx_g22Ast_typecheck__None10_ = { 1 };
-_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None11_ = 0;
-_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None12_ = 0;
+_fx_Nt6option1LN10Ast__typ_t _fx_g21Ast_typecheck__None3_ = { 1 };
+_fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t _fx_g21Ast_typecheck__None4_ = { 1 };
+_fx_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t _fx_g21Ast_typecheck__None5_ = { 1 };
+_fx_Nt6option1N10Ast__lit_t _fx_g21Ast_typecheck__None6_ = { 1 };
+_fx_Nt6option1LN16Ast__env_entry_t _fx_g21Ast_typecheck__None7_ = { 1 };
+_fx_Nt6option1rRt6Set__t1R9Ast__id_t _fx_g21Ast_typecheck__None8_ = { 1 };
+_fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t _fx_g21Ast_typecheck__None9_ = { 1 };
+_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g22Ast_typecheck__None10_ = 0;
+_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g22Ast_typecheck__None11_ = 0;
+_fx_Nt6option1R9Ast__id_t _fx_g22Ast_typecheck__None12_ = { 1 };
+_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None13_ = 0;
+_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None14_ = 0;
 _fx_N12Map__color_t _fx_g18Ast_typecheck__Red = { 1 };
 _fx_N12Map__color_t _fx_g20Ast_typecheck__Black = { 2 };
 _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t _fx_g20Ast_typecheck__Empty = 0;
@@ -6483,6 +6579,8 @@ static int _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast
    struct _fx_N10Ast__typ_t_data_t**,
    void*);
 
+FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int _fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc_t(
    struct _fx_N14Ast__id_info_t*,
    struct _fx_R10Ast__loc_t*,
@@ -6554,8 +6652,6 @@ FX_EXTERN_C int
    bool,
    struct _fx_rR13Ast__deffun_t_data_t**,
    void*);
-
-FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_F6stringS1B(bool, fx_str_t*, void*);
 
@@ -7697,6 +7793,22 @@ FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_trR13Ast__deff
 {
    fx_result->tag = 2;
    _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(arg0, &fx_result->u.Some);
+}
+
+FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1LN10Ast__typ_t1LN10Ast__typ_t(
+   struct _fx_LN10Ast__typ_t_data_t* arg0,
+   struct _fx_Nt6option1LN10Ast__typ_t* fx_result)
+{
+   fx_result->tag = 2;
+   FX_COPY_PTR(arg0, &fx_result->u.Some);
+}
+
+FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1T3iN10Ast__typ_tN10Ast__typ_t1T3iN10Ast__typ_tN10Ast__typ_t(
+   struct _fx_T3iN10Ast__typ_tN10Ast__typ_t* arg0,
+   struct _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t* fx_result)
+{
+   fx_result->tag = 2;
+   _fx_copy_T3iN10Ast__typ_tN10Ast__typ_t(arg0, &fx_result->u.Some);
 }
 
 FX_EXTERN_C void
@@ -9006,7 +9118,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___0 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___1 = {0};
    int fx_status = 0;
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &__fold_result___0);
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, &__fold_result___0);
    _fx_LT2R9Ast__id_tN10Ast__typ_t lst_0 = l_0;
    for (; lst_0; lst_0 = lst_0->tl) {
       _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t v_0 = {0};
@@ -9057,7 +9169,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast
    _fx_catch_1: ;
    }
    else {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
    }
 
 _fx_cleanup: ;
@@ -12602,7 +12714,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15unskolemize_typN10Ast__typ_t2N10Ast__typ
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &unskolem__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    FX_CALL(unskolem__0.fp(t_0, &callb_0, fx_result, unskolem__0.fcv), _fx_cleanup);
 
 _fx_cleanup: ;
@@ -12739,7 +12851,7 @@ static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__as
    }
    if (tag_0 == 1) {
       _fx_rNt6option1N10Ast__typ_t v_8 = 0;
-      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None12_, &v_8), _fx_catch_4);
+      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None14_, &v_8), _fx_catch_4);
       FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_8, fx_result), _fx_catch_4);
 
    _fx_catch_4: ;
@@ -13109,7 +13221,7 @@ FX_EXTERN_C int
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &freeze__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t1_0, &callb_0, &rigid1_0, 0),
       _fx_cleanup);
    _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t freeze__fp_1 =
@@ -13118,7 +13230,7 @@ FX_EXTERN_C int
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &freeze__1, &v_1), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_1, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_1);
+   _fx_make_R16Ast__ast_callb_t(v_1, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_1);
    FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t2_0, &callb_1, &rigid2_0, 0),
       _fx_cleanup);
    bool covers1_2_0;
@@ -13268,7 +13380,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__
             }
             else {
                _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
-               _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
+               _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None7_, &result_0);
                FX_BREAK(_fx_catch_1);
 
             _fx_catch_1: ;
@@ -13432,7 +13544,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17typ_has_free_varsB1N10Ast__typ_t(
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &check__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    FX_CALL(check__0.fp(t_0, &callb_0, &res_0, check__0.fcv), _fx_cleanup);
    *fx_result = has_free_ref_0->data;
 
@@ -13605,7 +13717,7 @@ _fx_catch_0: ;
          _fx_free_Nt6option1N10Ast__typ_t(fx_result);
       }
       if (exn_0.tag == _FX_EXN_E17Ast__CompileError) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
       }
       else {
          FX_RETHROW(&exn_0, _fx_cleanup);
@@ -14193,7 +14305,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tR
       }
       else {
          _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
-         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
+         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None7_, &result_0);
          FX_BREAK(_fx_catch_1);
 
       _fx_catch_1: ;
@@ -14644,7 +14756,7 @@ static int
       }
       else {
          _fx_free_Nt6option1LN16Ast__env_entry_t(&result_0);
-         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None5_, &result_0);
+         _fx_copy_Nt6option1LN16Ast__env_entry_t(&_fx_g21Ast_typecheck__None7_, &result_0);
          FX_BREAK(_fx_catch_1);
 
       _fx_catch_1: ;
@@ -15480,12 +15592,12 @@ FX_EXTERN_C int
                         _fx_free_N10Ast__lit_t(&v_12);
                      }
                      else {
-                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
+                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None6_, &v_opt_0);
                      }
                      FX_CHECK_EXN(_fx_catch_0);
                   }
                   else {
-                     _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
+                     _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None6_, &v_opt_0);
                   }
 
                _fx_catch_0: ;
@@ -15525,14 +15637,14 @@ FX_EXTERN_C int
                            _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__lit_t1N10Ast__lit_t(&v_13, &v_opt_0);
                         }
                         else {
-                           _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
+                           _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None6_, &v_opt_0);
                         }
 
                      _fx_catch_1: ;
                         _fx_free_N10Ast__lit_t(&v_13);
                      }
                      else {
-                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
+                        _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None6_, &v_opt_0);
                      }
                      FX_CHECK_EXN(_fx_catch_2);
 
@@ -15540,7 +15652,7 @@ FX_EXTERN_C int
                      goto _fx_endmatch_1;
                   }
                }
-               _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None4_, &v_opt_0);
+               _fx_copy_Nt6option1N10Ast__lit_t(&_fx_g21Ast_typecheck__None6_, &v_opt_0);
 
             _fx_endmatch_1: ;
                FX_CHECK_EXN(_fx_catch_5);
@@ -15693,7 +15805,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             _fx_free_R17Ast__defvariant_t(&v_1);
          }
          FX_CHECK_EXN(_fx_catch_3);
-         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None12_;
          _fx_LR9Ast__id_t lst_0 = inst_list_0;
          for (; lst_0; lst_0 = lst_0->tl) {
             _fx_N14Ast__id_info_t v_2 = {0};
@@ -15738,7 +15850,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
          }
          FX_CHECK_EXN(_fx_catch_3);
       }
@@ -15924,7 +16036,7 @@ FX_EXTERN_C int
 
       _fx_endmatch_1: ;
          FX_CHECK_EXN(_fx_catch_6);
-         _fx_copy_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(&_fx_g21Ast_typecheck__None3_, &__fold_result___0);
+         _fx_copy_Nt6option1T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t(&_fx_g21Ast_typecheck__None5_, &__fold_result___0);
          FX_COPY_PTR(dvar_cases_1, &dvar_cases_0);
          _fx_LT2R9Ast__id_tN10Ast__typ_t lst_0 = dvar_cases_0;
          FX_COPY_PTR(v_17.dvar_ctors, &dvar_ctors_0);
@@ -16103,7 +16215,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &is_real_typ__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
    if (tag_0 == 24) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
@@ -16201,29 +16313,484 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16
    return 0;
 }
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM22report_not_found_typedE4R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tR10Ast__loc_t(
+FX_EXTERN_C int _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(
+   struct _fx_rR13Ast__deffun_t_data_t* df_0,
+   struct _fx_LN10Ast__typ_t_data_t* call_argtyps_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   struct _fx_R10Ast__loc_t* loc_0,
+   fx_str_t* fx_result,
+   void* fx_fv)
+{
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env_0 = {0};
+   _fx_N10Ast__typ_t df_typ_0 = 0;
+   _fx_LR9Ast__id_t df_templ_args_0 = 0;
+   _fx_LN10Ast__typ_t call_argtyps_1 = 0;
+   _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_0 = {0};
+   _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_1 = 0;
+   _fx_N10Ast__typ_t v_2 = 0;
+   _fx_LN10Ast__typ_t v_3 = 0;
+   _fx_N10Ast__typ_t ftyp_0 = 0;
+   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_4 = {0};
+   _fx_N10Ast__typ_t v_5 = 0;
+   _fx_LN10Ast__typ_t ptyps_disp_0 = 0;
+   _fx_N10Ast__typ_t v_6 = 0;
+   int fx_status = 0;
+   _fx_R13Ast__deffun_t* v_7 = &df_0->data;
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_7->df_env, &df_env_0);
+   _fx_R16Ast__fun_flags_t df_flags_0 = v_7->df_flags;
+   FX_COPY_PTR(v_7->df_typ, &df_typ_0);
+   FX_COPY_PTR(v_7->df_templ_args, &df_templ_args_0);
+   bool have_kw_0 = df_flags_0.fun_flag_have_keywords;
+   bool caller_has_kwrec_0;
+   if (call_argtyps_0 != 0) {
+      _fx_N10Ast__typ_t result_0 = 0;
+      _fx_LN10Ast__typ_t __pat___0 = 0;
+      _fx_N10Ast__typ_t v_8 = 0;
+      _fx_N10Ast__typ_t v_9 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = {0};
+      FX_COPY_PTR(call_argtyps_0, &__pat___0);
+      for (;;) {
+         _fx_LN10Ast__typ_t __pat___1 = 0;
+         FX_COPY_PTR(__pat___0, &__pat___1);
+         if (__pat___1 != 0) {
+            if (__pat___1->tl == 0) {
+               _fx_N10Ast__typ_t result_1 = 0;
+               FX_COPY_PTR(__pat___1->hd, &result_1);
+               _fx_free_N10Ast__typ_t(&result_0);
+               FX_COPY_PTR(result_1, &result_0);
+               FX_BREAK(_fx_catch_0);
+
+            _fx_catch_0: ;
+               if (result_1) {
+                  _fx_free_N10Ast__typ_t(&result_1);
+               }
+               goto _fx_endmatch_0;
+            }
+         }
+         if (__pat___1 != 0) {
+            _fx_LN10Ast__typ_t* rest_0 = &__pat___1->tl;
+            _fx_free_LN10Ast__typ_t(&__pat___0);
+            FX_COPY_PTR(*rest_0, &__pat___0);
+            goto _fx_endmatch_0;
+         }
+         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_1);
+
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_catch_1);
+
+      _fx_catch_1: ;
+         if (__pat___1) {
+            _fx_free_LN10Ast__typ_t(&__pat___1);
+         }
+         FX_CHECK_BREAK();
+         FX_CHECK_EXN(_fx_catch_2);
+      }
+      FX_COPY_PTR(result_0, &v_8);
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_8, &v_9, 0), _fx_catch_2);
+      if (FX_REC_VARIANT_TAG(v_9) == 20) {
+         _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9->u.TypRecord->data, &v_10);
+         if (v_10.t1 == false) {
+            caller_has_kwrec_0 = true; goto _fx_endmatch_1;
+         }
+      }
+      caller_has_kwrec_0 = false;
+
+   _fx_endmatch_1: ;
+      FX_CHECK_EXN(_fx_catch_2);
+
+   _fx_catch_2: ;
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+      if (v_9) {
+         _fx_free_N10Ast__typ_t(&v_9);
+      }
+      if (v_8) {
+         _fx_free_N10Ast__typ_t(&v_8);
+      }
+      if (__pat___0) {
+         _fx_free_LN10Ast__typ_t(&__pat___0);
+      }
+      if (result_0) {
+         _fx_free_N10Ast__typ_t(&result_0);
+      }
+   }
+   else {
+      caller_has_kwrec_0 = false;
+   }
+   FX_CHECK_EXN(_fx_cleanup);
+   bool t_0;
+   if (!have_kw_0) {
+      t_0 = caller_has_kwrec_0;
+   }
+   else {
+      t_0 = false;
+   }
+   if (t_0) {
+      fx_str_t slit_0 = FX_MAKE_STR("does not accept keyword arguments");
+      fx_copy_str(&slit_0, fx_result);
+      FX_RETURN(_fx_cleanup);
+   }
+   bool t_1;
+   if (have_kw_0) {
+      t_1 = !caller_has_kwrec_0;
+   }
+   else {
+      t_1 = false;
+   }
+   if (t_1) {
+      _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_0);
+      FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_0, &v_1), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_1, &v_2),
+         _fx_cleanup);
+      FX_CALL(_fx_cons_LN10Ast__typ_t(v_2, 0, true, &v_3), _fx_cleanup);
+      if (call_argtyps_0 == 0) {
+         FX_COPY_PTR(v_3, &call_argtyps_1);
+      }
+      else if (v_3 == 0) {
+         FX_COPY_PTR(call_argtyps_0, &call_argtyps_1);
+      }
+      else {
+         _fx_LN10Ast__typ_t v_11 = 0;
+         _fx_LN10Ast__typ_t lstend_0 = 0;
+         _fx_LN10Ast__typ_t lst_0 = call_argtyps_0;
+         for (; lst_0; lst_0 = lst_0->tl) {
+            _fx_N10Ast__typ_t x_0 = lst_0->hd;
+            _fx_LN10Ast__typ_t node_0 = 0;
+            FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_3);
+            FX_LIST_APPEND(v_11, lstend_0, node_0);
+
+         _fx_catch_3: ;
+            FX_CHECK_EXN(_fx_catch_4);
+         }
+         _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_11, v_3, &call_argtyps_1, 0);
+
+      _fx_catch_4: ;
+         if (v_11) {
+            _fx_free_LN10Ast__typ_t(&v_11);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   else {
+      FX_COPY_PTR(call_argtyps_0, &call_argtyps_1);
+   }
+   if (df_templ_args_0 == 0) {
+      FX_CALL(_fx_M3AstFM7dup_typN10Ast__typ_t1N10Ast__typ_t(df_typ_0, &ftyp_0, 0), _fx_cleanup);
+   }
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+            df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_4, 0), _fx_cleanup);
+      FX_COPY_PTR(v_4.t0, &ftyp_0);
+   }
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(df_typ_0, &v_5, 0), _fx_cleanup);
+   if (FX_REC_VARIANT_TAG(v_5) == 14) {
+      FX_COPY_PTR(v_5->u.TypFun.t0, &ptyps_disp_0);
+   }
+   FX_CHECK_EXN(_fx_cleanup);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(ftyp_0, &v_6, 0), _fx_cleanup);
+   if (FX_REC_VARIANT_TAG(v_6) == 14) {
+      fx_str_t pos_s_0 = {0};
+      fx_str_t v_12 = {0};
+      fx_str_t v_13 = {0};
+      _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t result_2 = {0};
+      _fx_LN10Ast__typ_t ptl_0 = 0;
+      _fx_LN10Ast__typ_t ctl_0 = 0;
+      _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t mism_0 = {0};
+      _fx_LN10Ast__typ_t ptyps_0 = v_6->u.TypFun.t0;
+      int_ np_0 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(ptyps_0, 0);
+      int_ nc_0 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(call_argtyps_1, 0);
+      if (np_0 != nc_0) {
+         int_ kw_extra_0;
+         if (have_kw_0) {
+            kw_extra_0 = 1;
+         }
+         else {
+            kw_extra_0 = 0;
+         }
+         if (have_kw_0) {
+            fx_str_t slit_1 = FX_MAKE_STR("positional "); fx_copy_str(&slit_1, &pos_s_0);
+         }
+         else {
+            fx_str_t slit_2 = FX_MAKE_STR(""); fx_copy_str(&slit_2, &pos_s_0);
+         }
+         FX_CALL(_fx_F6stringS1i(np_0 - kw_extra_0, &v_12, 0), _fx_catch_12);
+         FX_CALL(_fx_F6stringS1i(nc_0 - kw_extra_0, &v_13, 0), _fx_catch_12);
+         fx_str_t slit_3 = FX_MAKE_STR("takes ");
+         fx_str_t slit_4 = FX_MAKE_STR(" ");
+         fx_str_t slit_5 = FX_MAKE_STR("argument(s), but ");
+         fx_str_t slit_6 = FX_MAKE_STR(" given");
+         {
+            const fx_str_t strs_0[] = { slit_3, v_12, slit_4, pos_s_0, slit_5, v_13, slit_6 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, fx_result), _fx_catch_12);
+         }
+      }
+      else {
+         FX_COPY_PTR(ptyps_0, &ptl_0);
+         FX_COPY_PTR(call_argtyps_1, &ctl_0);
+         int_ k_0 = 0;
+         for (;;) {
+            _fx_LN10Ast__typ_t ptl_1 = 0;
+            _fx_LN10Ast__typ_t ctl_1 = 0;
+            FX_COPY_PTR(ptl_0, &ptl_1);
+            FX_COPY_PTR(ctl_0, &ctl_1);
+            int_ k_1 = k_0;
+            if (ctl_1 != 0) {
+               if (ptl_1 != 0) {
+                  _fx_N10Ast__typ_t v_14 = 0;
+                  _fx_T3iN10Ast__typ_tN10Ast__typ_t v_15 = {0};
+                  _fx_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t result_3 = {0};
+                  _fx_N10Ast__typ_t pt_0 = ptl_1->hd;
+                  _fx_N10Ast__typ_t ct_0 = ctl_1->hd;
+                  FX_CALL(_fx_M3AstFM7dup_typN10Ast__typ_t1N10Ast__typ_t(ct_0, &v_14, 0), _fx_catch_5);
+                  bool v_16;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(pt_0, v_14, loc_0, false,
+                        &v_16, 0), _fx_catch_5);
+                  if (!v_16) {
+                     _fx_make_T3iN10Ast__typ_tN10Ast__typ_t(k_1, pt_0, ct_0, &v_15);
+                     _fx_M13Ast_typecheckFM4SomeNt6option1T3iN10Ast__typ_tN10Ast__typ_t1T3iN10Ast__typ_tN10Ast__typ_t(&v_15,
+                        &result_3);
+                     _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_2);
+                     _fx_copy_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_3, &result_2);
+                     FX_BREAK(_fx_catch_5);
+                  }
+                  else {
+                     _fx_LN10Ast__typ_t* ptl_rest_0 = &ptl_1->tl;
+                     _fx_free_LN10Ast__typ_t(&ptl_0);
+                     FX_COPY_PTR(*ptl_rest_0, &ptl_0);
+                     _fx_LN10Ast__typ_t* ctl_rest_0 = &ctl_1->tl;
+                     _fx_free_LN10Ast__typ_t(&ctl_0);
+                     FX_COPY_PTR(*ctl_rest_0, &ctl_0);
+                     k_0 = k_1 + 1;
+                  }
+
+               _fx_catch_5: ;
+                  _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_3);
+                  _fx_free_T3iN10Ast__typ_tN10Ast__typ_t(&v_15);
+                  if (v_14) {
+                     _fx_free_N10Ast__typ_t(&v_14);
+                  }
+                  goto _fx_endmatch_2;
+               }
+            }
+            _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_2);
+            _fx_copy_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None4_, &result_2);
+            FX_BREAK(_fx_catch_6);
+
+         _fx_catch_6: ;
+
+         _fx_endmatch_2: ;
+            FX_CHECK_EXN(_fx_catch_7);
+
+         _fx_catch_7: ;
+            if (ctl_1) {
+               _fx_free_LN10Ast__typ_t(&ctl_1);
+            }
+            if (ptl_1) {
+               _fx_free_LN10Ast__typ_t(&ptl_1);
+            }
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_12);
+         }
+         _fx_copy_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_2, &mism_0);
+         if (mism_0.tag == 2) {
+            _fx_N10Ast__typ_t pt_disp_0 = 0;
+            fx_str_t v_17 = {0};
+            fx_str_t v_18 = {0};
+            fx_str_t v_19 = {0};
+            fx_str_t v_20 = {0};
+            fx_str_t v_21 = {0};
+            _fx_T3iN10Ast__typ_tN10Ast__typ_t* v_22 = &mism_0.u.Some;
+            _fx_N10Ast__typ_t ct_1 = v_22->t2;
+            int_ k_2 = v_22->t0;
+            if (ptyps_disp_0 != 0) {
+               int_ v_23 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(ptyps_disp_0, 0);
+               if (v_23 == np_0) {
+                  _fx_N10Ast__typ_t result_4 = 0;
+                  _fx_LN10Ast__typ_t l_0 = 0;
+                  FX_COPY_PTR(ptyps_disp_0, &l_0);
+                  int_ n_0 = k_2;
+                  for (;;) {
+                     _fx_LN10Ast__typ_t l_1 = 0;
+                     FX_COPY_PTR(l_0, &l_1);
+                     int_ n_1 = n_0;
+                     if (l_1 != 0) {
+                        if (n_1 == 0) {
+                           _fx_N10Ast__typ_t* a_0 = &l_1->hd;
+                           _fx_free_N10Ast__typ_t(&result_4);
+                           FX_COPY_PTR(*a_0, &result_4);
+                           FX_BREAK(_fx_catch_8);
+                        }
+                        else {
+                           _fx_LN10Ast__typ_t* rest_1 = &l_1->tl;
+                           _fx_free_LN10Ast__typ_t(&l_0);
+                           FX_COPY_PTR(*rest_1, &l_0);
+                           n_0 = n_1 - 1;
+                        }
+
+                     _fx_catch_8: ;
+                     }
+                     else {
+                        FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_9);
+                     }
+                     FX_CHECK_EXN(_fx_catch_9);
+
+                  _fx_catch_9: ;
+                     if (l_1) {
+                        _fx_free_LN10Ast__typ_t(&l_1);
+                     }
+                     FX_CHECK_BREAK();
+                     FX_CHECK_EXN(_fx_catch_10);
+                  }
+                  FX_COPY_PTR(result_4, &pt_disp_0);
+
+               _fx_catch_10: ;
+                  if (l_0) {
+                     _fx_free_LN10Ast__typ_t(&l_0);
+                  }
+                  if (result_4) {
+                     _fx_free_N10Ast__typ_t(&result_4);
+                  }
+                  goto _fx_endmatch_3;
+               }
+            }
+            FX_COPY_PTR(v_22->t1, &pt_disp_0);
+
+         _fx_endmatch_3: ;
+            FX_CHECK_EXN(_fx_catch_11);
+            bool t_2;
+            if (have_kw_0) {
+               t_2 = k_2 == np_0 - 1;
+            }
+            else {
+               t_2 = false;
+            }
+            if (t_2) {
+               FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(ct_1, &v_17, 0), _fx_catch_11);
+               FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(pt_disp_0, &v_18, 0), _fx_catch_11);
+               fx_str_t slit_7 = FX_MAKE_STR("keyword arguments \'");
+               fx_str_t slit_8 = FX_MAKE_STR("\' do not match the accepted \'");
+               fx_str_t slit_9 = FX_MAKE_STR("\'");
+               {
+                  const fx_str_t strs_1[] = { slit_7, v_17, slit_8, v_18, slit_9 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 5, fx_result), _fx_catch_11);
+               }
+            }
+            else {
+               FX_CALL(_fx_F6stringS1i(k_2 + 1, &v_19, 0), _fx_catch_11);
+               FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(ct_1, &v_20, 0), _fx_catch_11);
+               FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(pt_disp_0, &v_21, 0), _fx_catch_11);
+               fx_str_t slit_10 = FX_MAKE_STR("argument ");
+               fx_str_t slit_11 = FX_MAKE_STR(" of type \'");
+               fx_str_t slit_12 = FX_MAKE_STR("\' does not match \'");
+               fx_str_t slit_13 = FX_MAKE_STR("\'");
+               {
+                  const fx_str_t strs_2[] = { slit_10, v_19, slit_11, v_20, slit_12, v_21, slit_13 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 7, fx_result), _fx_catch_11);
+               }
+            }
+
+         _fx_catch_11: ;
+            FX_FREE_STR(&v_21);
+            FX_FREE_STR(&v_20);
+            FX_FREE_STR(&v_19);
+            FX_FREE_STR(&v_18);
+            FX_FREE_STR(&v_17);
+            if (pt_disp_0) {
+               _fx_free_N10Ast__typ_t(&pt_disp_0);
+            }
+         }
+         else {
+            fx_str_t slit_14 = FX_MAKE_STR("the return type or the signature as a whole does not match");
+            fx_copy_str(&slit_14, fx_result);
+         }
+         FX_CHECK_EXN(_fx_catch_12);
+      }
+
+   _fx_catch_12: ;
+      _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&mism_0);
+      if (ctl_0) {
+         _fx_free_LN10Ast__typ_t(&ctl_0);
+      }
+      if (ptl_0) {
+         _fx_free_LN10Ast__typ_t(&ptl_0);
+      }
+      _fx_free_Nt6option1T3iN10Ast__typ_tN10Ast__typ_t(&result_2);
+      FX_FREE_STR(&v_13);
+      FX_FREE_STR(&v_12);
+      FX_FREE_STR(&pos_s_0);
+   }
+   else {
+      fx_str_t slit_15 = FX_MAKE_STR("is not a function"); fx_copy_str(&slit_15, fx_result);
+   }
+
+_fx_cleanup: ;
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&df_env_0);
+   if (df_typ_0) {
+      _fx_free_N10Ast__typ_t(&df_typ_0);
+   }
+   FX_FREE_LIST_SIMPLE(&df_templ_args_0);
+   if (call_argtyps_1) {
+      _fx_free_LN10Ast__typ_t(&call_argtyps_1);
+   }
+   _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_0);
+   if (v_1) {
+      _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_1);
+   }
+   if (v_2) {
+      _fx_free_N10Ast__typ_t(&v_2);
+   }
+   if (v_3) {
+      _fx_free_LN10Ast__typ_t(&v_3);
+   }
+   if (ftyp_0) {
+      _fx_free_N10Ast__typ_t(&ftyp_0);
+   }
+   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_4);
+   if (v_5) {
+      _fx_free_N10Ast__typ_t(&v_5);
+   }
+   if (ptyps_disp_0) {
+      _fx_free_LN10Ast__typ_t(&ptyps_disp_0);
+   }
+   if (v_6) {
+      _fx_free_N10Ast__typ_t(&v_6);
+   }
+   return FX_CHECK_RETURN();
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* n_0,
    struct _fx_N10Ast__typ_t_data_t* t_0,
    struct _fx_LN16Ast__env_entry_t_data_t* possible_matches_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
    struct _fx_R10Ast__loc_t* loc_0,
    fx_exn_t* fx_result,
    void* fx_fv)
 {
    fx_str_t nstr_0 = {0};
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_Nt6option1LN10Ast__typ_t call_argtyps_opt_0 = {0};
    _fx_LS strs_0 = 0;
    fx_str_t candidates_msg_0 = {0};
-   fx_str_t v_0 = {0};
    fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &nstr_0, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+   if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      _fx_M13Ast_typecheckFM4SomeNt6option1LN10Ast__typ_t1LN10Ast__typ_t(v_0->u.TypFun.t0, &call_argtyps_opt_0);
+   }
+   else {
+      _fx_copy_Nt6option1LN10Ast__typ_t(&_fx_g21Ast_typecheck__None3_, &call_argtyps_opt_0);
+   }
+   FX_CHECK_EXN(_fx_cleanup);
    _fx_LS lstend_0 = 0;
    _fx_LN16Ast__env_entry_t lst_0 = possible_matches_0;
    for (; lst_0; lst_0 = lst_0->tl) {
       _fx_N14Ast__id_info_t info_0 = {0};
-      _fx_N10Ast__typ_t tj_0 = 0;
-      fx_str_t v_2 = {0};
-      fx_str_t v_3 = {0};
-      fx_str_t concat_str_0 = {0};
+      fx_str_t res_0 = {0};
       _fx_N16Ast__env_entry_t e_0 = lst_0->hd;
       int tag_0 = FX_REC_VARIANT_TAG(e_0);
       _fx_R9Ast__id_t n_1;
@@ -16234,85 +16801,118 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22report_not_found_typedE4R9Ast__id_tN10As
          n_1 = _fx_g9Ast__noid;
       }
       else {
-         FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_0);
+         FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_2);
       }
-      FX_CHECK_EXN(_fx_catch_0);
-      bool res_0;
-      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n_1, &_fx_g9Ast__noid, &res_0, 0), _fx_catch_0);
-      if (res_0) {
-         FX_CONTINUE(_fx_catch_0);
-      }
-      FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&n_1, loc_0, &info_0, 0), _fx_catch_0);
+      FX_CHECK_EXN(_fx_catch_2);
       bool res_1;
+      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n_1, &_fx_g9Ast__noid, &res_1, 0), _fx_catch_2);
+      if (res_1) {
+         FX_CONTINUE(_fx_catch_2);
+      }
+      FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&n_1, loc_0, &info_0, 0), _fx_catch_2);
+      bool res_2;
       if (info_0.tag == 1) {
-         res_1 = true;
+         res_2 = true;
       }
       else {
-         res_1 = false;
+         res_2 = false;
       }
-      FX_CHECK_EXN(_fx_catch_0);
-      if (res_1) {
-         FX_CONTINUE(_fx_catch_0);
+      FX_CHECK_EXN(_fx_catch_2);
+      if (res_2) {
+         FX_CONTINUE(_fx_catch_2);
       }
-      FX_CALL(_fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc_t(&info_0, loc_0, &tj_0, 0), _fx_catch_0);
-      _fx_R10Ast__loc_t locj_0;
-      FX_CALL(_fx_M3AstFM14get_idinfo_locRM5loc_t1N14Ast__id_info_t(&info_0, &locj_0, 0), _fx_catch_0);
-      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(tj_0, &v_2, 0), _fx_catch_0);
-      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&locj_0, &v_3, 0), _fx_catch_0);
-      fx_str_t slit_0 = FX_MAKE_STR("\'");
-      fx_str_t slit_1 = FX_MAKE_STR(": ");
-      fx_str_t slit_2 = FX_MAKE_STR("\' defined at ");
-      {
-         const fx_str_t strs_1[] = { slit_0, nstr_0, slit_1, v_2, slit_2, v_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_1, 6, &concat_str_0), _fx_catch_0);
-      }
-      _fx_LS node_0 = 0;
-      FX_CALL(_fx_cons_LS(&concat_str_0, 0, false, &node_0), _fx_catch_0);
-      FX_LIST_APPEND(strs_0, lstend_0, node_0);
+      if (call_argtyps_opt_0.tag == 2) {
+         if (info_0.tag == 3) {
+            fx_str_t v_3 = {0};
+            fx_str_t v_4 = {0};
+            _fx_rR13Ast__deffun_t df_0 = info_0.u.IdFun;
+            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(df_0, &v_3, 0), _fx_catch_0);
+            FX_CALL(
+               _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(df_0,
+                  call_argtyps_opt_0.u.Some, sc_0, loc_0, &v_4, 0), _fx_catch_0);
+            fx_str_t slit_0 = FX_MAKE_STR(" -- ");
+            {
+               const fx_str_t strs_1[] = { v_3, slit_0, v_4 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &res_0), _fx_catch_0);
+            }
 
-   _fx_catch_0: ;
-      FX_FREE_STR(&concat_str_0);
-      FX_FREE_STR(&v_3);
-      FX_FREE_STR(&v_2);
+         _fx_catch_0: ;
+            FX_FREE_STR(&v_4);
+            FX_FREE_STR(&v_3);
+            goto _fx_endmatch_0;
+         }
+      }
+      _fx_N10Ast__typ_t tj_0 = 0;
+      fx_str_t v_5 = {0};
+      fx_str_t v_6 = {0};
+      FX_CALL(_fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc_t(&info_0, loc_0, &tj_0, 0), _fx_catch_1);
+      _fx_R10Ast__loc_t locj_0;
+      FX_CALL(_fx_M3AstFM14get_idinfo_locRM5loc_t1N14Ast__id_info_t(&info_0, &locj_0, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(tj_0, &v_5, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&locj_0, &v_6, 0), _fx_catch_1);
+      fx_str_t slit_1 = FX_MAKE_STR("\'");
+      fx_str_t slit_2 = FX_MAKE_STR(": ");
+      fx_str_t slit_3 = FX_MAKE_STR("\' defined at ");
+      {
+         const fx_str_t strs_2[] = { slit_1, nstr_0, slit_2, v_5, slit_3, v_6 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 6, &res_0), _fx_catch_1);
+      }
+
+   _fx_catch_1: ;
+      FX_FREE_STR(&v_6);
+      FX_FREE_STR(&v_5);
       if (tj_0) {
          _fx_free_N10Ast__typ_t(&tj_0);
       }
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_catch_2);
+      _fx_LS node_0 = 0;
+      FX_CALL(_fx_cons_LS(&res_0, 0, false, &node_0), _fx_catch_2);
+      FX_LIST_APPEND(strs_0, lstend_0, node_0);
+
+   _fx_catch_2: ;
+      FX_FREE_STR(&res_0);
       _fx_free_N14Ast__id_info_t(&info_0);
       FX_CHECK_CONTINUE();
       FX_CHECK_EXN(_fx_cleanup);
    }
    if (strs_0 == 0) {
-      fx_str_t slit_3 = FX_MAKE_STR(""); fx_copy_str(&slit_3, &candidates_msg_0);
+      fx_str_t slit_4 = FX_MAKE_STR(""); fx_copy_str(&slit_4, &candidates_msg_0);
    }
    else {
-      fx_str_t slit_4 =
+      fx_str_t slit_5 =
          FX_MAKE_STR("\n"
             U"Candidates:\n"
             U"\t");
-      fx_str_t slit_5 = FX_MAKE_STR("\n");
-      fx_str_t slit_6 =
+      fx_str_t slit_6 = FX_MAKE_STR("\n");
+      fx_str_t slit_7 =
          FX_MAKE_STR(",\n"
             U"\t");
-      FX_CALL(_fx_F12join_embraceS4SSSLS(&slit_4, &slit_5, &slit_6, strs_0, &candidates_msg_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F12join_embraceS4SSSLS(&slit_5, &slit_6, &slit_7, strs_0, &candidates_msg_0, 0), _fx_cleanup);
    }
-   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
-   fx_str_t slit_7 = FX_MAKE_STR("the appropriate match for \'");
-   fx_str_t slit_8 = FX_MAKE_STR("\' of type \'");
-   fx_str_t slit_9 = FX_MAKE_STR("\' is not found.");
+   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_1, 0), _fx_cleanup);
+   fx_str_t slit_8 = FX_MAKE_STR("the appropriate match for \'");
+   fx_str_t slit_9 = FX_MAKE_STR("\' of type \'");
+   fx_str_t slit_10 = FX_MAKE_STR("\' is not found.");
    {
-      const fx_str_t strs_2[] = { slit_7, nstr_0, slit_8, v_0, slit_9, candidates_msg_0 };
-      FX_CALL(fx_strjoin(0, 0, 0, strs_2, 6, &v_1), _fx_cleanup);
+      const fx_str_t strs_3[] = { slit_8, nstr_0, slit_9, v_1, slit_10, candidates_msg_0 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_3, 6, &v_2), _fx_cleanup);
    }
-   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_1, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_2, fx_result, 0), _fx_cleanup);
 
 _fx_cleanup: ;
    FX_FREE_STR(&nstr_0);
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   _fx_free_Nt6option1LN10Ast__typ_t(&call_argtyps_opt_0);
    if (strs_0) {
       _fx_free_LS(&strs_0);
    }
    FX_FREE_STR(&candidates_msg_0);
-   FX_FREE_STR(&v_0);
    FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
    return fx_status;
 }
 
@@ -16379,7 +16979,7 @@ FX_EXTERN_C int
          }
          else {
             _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
             FX_BREAK(_fx_catch_2);
 
          _fx_catch_2: ;
@@ -16456,7 +17056,7 @@ static int
       int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
       if (dot_pos_2 < 0) {
          _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
          FX_BREAK(_fx_catch_3);
       }
       else {
@@ -16502,7 +17102,7 @@ static int
                }
                else {
                   _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
@@ -17040,7 +17640,7 @@ _fx_endmatch_3: ;
          _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_9, fx_result);
       }
       else {
-         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None10_;
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None12_;
          FX_COPY_PTR(df_templ_inst_0->data, &v_10);
          _fx_LR9Ast__id_t lst_1 = v_10;
          for (; lst_1; lst_1 = lst_1->tl) {
@@ -17188,7 +17788,7 @@ static int
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
    if (viable_0 == 0) {
-      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result); goto _fx_endmatch_0;
+      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, fx_result); goto _fx_endmatch_0;
    }
    if (viable_0 != 0) {
       if (viable_0->tl == 0) {
@@ -17227,7 +17827,7 @@ static int
       FX_LIST_APPEND(cands_0, lstend_0, node_0);
 
    _fx_catch_1: ;
-      FX_CHECK_EXN(_fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
    }
    _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___0);
    _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_1 = viable_0;
@@ -17272,10 +17872,10 @@ static int
          _fx_free_rR13Ast__deffun_t(&c_0);
       }
       FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
    }
    _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0, &genwin_opt_0);
-   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_12);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_14);
    bool fully_determined_0;
    if (FX_REC_VARIANT_TAG(v_1) == 14) {
       _fx_LN10Ast__typ_t argtyps_0 = 0;
@@ -17304,15 +17904,15 @@ static int
    else {
       fully_determined_0 = false;
    }
-   FX_CHECK_EXN(_fx_catch_12);
+   FX_CHECK_EXN(_fx_catch_14);
    if (_fx_g12Options__opt.print_resolve) {
       if (viable_0 != 0) {
          _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_2);
       }
       else {
-         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_12);
+         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_14);
       }
-      FX_CHECK_EXN(_fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
       _fx_R9Ast__id_t envwin_i_0 = v_2.t0;
       FX_COPY_PTR(v_2.t1, &envwin_0);
       bool agree_0;
@@ -17324,12 +17924,12 @@ static int
       else {
          agree_0 = false;
       }
-      FX_CHECK_EXN(_fx_catch_12);
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_3, 0), _fx_catch_12);
-      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_3, 0), _fx_catch_14);
+      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_14);
       int_ v_17 = _fx_M13Ast_typecheckFM6lengthi1LT2R9Ast__id_trR13Ast__deffun_t(viable_0, 0);
-      FX_CALL(_fx_F6stringS1i(v_17, &v_5, 0), _fx_catch_12);
-      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_12);
+      FX_CALL(_fx_F6stringS1i(v_17, &v_5, 0), _fx_catch_14);
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_14);
       fx_str_t slit_0 = FX_MAKE_STR("-pr-resolve: \'");
       fx_str_t slit_1 = FX_MAKE_STR("\' @ ");
       fx_str_t slit_2 = FX_MAKE_STR(": ");
@@ -17337,7 +17937,7 @@ static int
       fx_str_t slit_4 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_0[] = { slit_0, v_3, slit_1, v_4, slit_2, v_5, slit_3, v_6, slit_4 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_7), _fx_catch_12);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_7), _fx_catch_14);
       }
       _fx_F12print_stringv1S(&v_7, 0);
       _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_4 = viable_0;
@@ -17362,14 +17962,14 @@ static int
          if (c_1) {
             _fx_free_rR13Ast__deffun_t(&c_1);
          }
-         FX_CHECK_EXN(_fx_catch_12);
+         FX_CHECK_EXN(_fx_catch_14);
       }
-      FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_8, 0), _fx_catch_12);
+      FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_8, 0), _fx_catch_14);
       fx_str_t slit_7 = FX_MAKE_STR("    env-order  winner: ");
       fx_str_t slit_8 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_2[] = { slit_7, v_8, slit_8 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_9), _fx_catch_12);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_9), _fx_catch_14);
       }
       _fx_F12print_stringv1S(&v_9, 0);
       if (genwin_opt_0.tag == 2) {
@@ -17392,13 +17992,13 @@ static int
          fx_str_t slit_11 = FX_MAKE_STR("    generality winner: <none: tied or unordered>\n");
          _fx_F12print_stringv1S(&slit_11, 0);
       }
-      FX_CHECK_EXN(_fx_catch_12);
-      FX_CALL(_fx_F6stringS1B(agree_0, &v_10, 0), _fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
+      FX_CALL(_fx_F6stringS1B(agree_0, &v_10, 0), _fx_catch_14);
       fx_str_t slit_12 = FX_MAKE_STR("    winners agree: ");
       fx_str_t slit_13 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_4[] = { slit_12, v_10, slit_13 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_11), _fx_catch_12);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_11), _fx_catch_14);
       }
       _fx_F12print_stringv1S(&v_11, 0);
       if (genwin_opt_0.tag == 2) {
@@ -17410,12 +18010,12 @@ static int
       else {
          fx_str_t slit_16 = FX_MAKE_STR("env-order fallback (under-constrained tie)"); fx_copy_str(&slit_16, &outcome_0);
       }
-      FX_CHECK_EXN(_fx_catch_12);
+      FX_CHECK_EXN(_fx_catch_14);
       fx_str_t slit_17 = FX_MAKE_STR("    outcome: ");
       fx_str_t slit_18 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_5[] = { slit_17, outcome_0, slit_18 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_12);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_14);
       }
       _fx_F12print_stringv1S(&v_12, 0);
    }
@@ -17430,11 +18030,14 @@ static int
    else {
       _fx_LS v_23 = 0;
       fx_str_t cand_lines_0 = {0};
+      fx_str_t why_0 = {0};
+      fx_str_t hint_0 = {0};
       fx_str_t v_24 = {0};
       fx_str_t v_25 = {0};
       fx_str_t v_26 = {0};
-      fx_exn_t v_27 = {0};
-      _fx_T2R9Ast__id_trR13Ast__deffun_t v_28 = {0};
+      fx_str_t v_27 = {0};
+      fx_exn_t v_28 = {0};
+      _fx_T2R9Ast__id_trR13Ast__deffun_t v_29 = {0};
       _fx_rR13Ast__deffun_t df_0 = 0;
       if (fully_determined_0) {
          _fx_LS lstend_1 = 0;
@@ -17454,61 +18057,128 @@ static int
             if (c_2) {
                _fx_free_rR13Ast__deffun_t(&c_2);
             }
-            FX_CHECK_EXN(_fx_catch_11);
+            FX_CHECK_EXN(_fx_catch_13);
          }
          fx_str_t slit_19 =
             FX_MAKE_STR("\n"
                U"    ");
-         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_23, &cand_lines_0, 0), _fx_catch_11);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_24, 0), _fx_catch_11);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_25, 0), _fx_catch_11);
-         fx_str_t slit_20 = FX_MAKE_STR("ambiguous call of overloaded \'");
-         fx_str_t slit_21 =
-            FX_MAKE_STR("\': no candidate is more specific than the others. Candidates:\n"
-               U"    ");
-         fx_str_t slit_22 =
-            FX_MAKE_STR("\n"
-               U"consider a module-qualified call (e.g. Module.");
-         fx_str_t slit_23 = FX_MAKE_STR("(...)) to disambiguate");
-         {
-            const fx_str_t strs_6[] = { slit_20, v_24, slit_21, cand_lines_0, slit_22, v_25, slit_23 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_6, 7, &v_26), _fx_catch_11);
+         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_23, &cand_lines_0, 0), _fx_catch_13);
+         bool __fold_result___3 = true;
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_6 = viable_0;
+         for (; lst_6; lst_6 = lst_6->tl) {
+            _fx_rR13Ast__deffun_t c_3 = 0;
+            _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___4 = &lst_6->hd;
+            FX_COPY_PTR(__pat___4->t1, &c_3);
+            bool __fold_result___4 = true;
+            _fx_LrR13Ast__deffun_t lst_7 = cands_0;
+            for (; lst_7; lst_7 = lst_7->tl) {
+               _fx_rR13Ast__deffun_t d_1 = lst_7->hd;
+               bool v_30;
+               if (_fx_M13Ast_typecheckFM6__eq__B2rR13Ast__deffun_trR13Ast__deffun_t(c_3, d_1, 0)) {
+                  v_30 = true;
+               }
+               else {
+                  _fx_N24Ast_typecheck__gen_cmp_t v_31;
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__gen_cmp_t2rR13Ast__deffun_trR13Ast__deffun_t(
+                        c_3, d_1, &v_31, 0), _fx_catch_11);
+                  v_30 = v_31.tag == 3;
+               }
+               if (!v_30) {
+                  __fold_result___4 = false; FX_BREAK(_fx_catch_11);
+               }
+
+            _fx_catch_11: ;
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_12);
+            }
+            if (!__fold_result___4) {
+               __fold_result___3 = false; FX_BREAK(_fx_catch_12);
+            }
+
+         _fx_catch_12: ;
+            if (c_3) {
+               _fx_free_rR13Ast__deffun_t(&c_3);
+            }
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_13);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_26, &v_27, 0), _fx_catch_11);
-         FX_THROW(&v_27, false, _fx_catch_11);
+         bool all_eq_0 = __fold_result___3;
+         if (all_eq_0) {
+            fx_str_t slit_20 = FX_MAKE_STR("the candidates are equally applicable"); fx_copy_str(&slit_20, &why_0);
+         }
+         else {
+            fx_str_t slit_21 = FX_MAKE_STR("the candidates overlap, but none is the most specific");
+            fx_copy_str(&slit_21, &why_0);
+         }
+         if (all_eq_0) {
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_24, 0), _fx_catch_13);
+            fx_str_t slit_22 = FX_MAKE_STR("use a module-qualified call (e.g. Module.");
+            fx_str_t slit_23 = FX_MAKE_STR("(...)) to select one");
+            {
+               const fx_str_t strs_6[] = { slit_22, v_24, slit_23 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &hint_0), _fx_catch_13);
+            }
+         }
+         else {
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_25, 0), _fx_catch_13);
+            fx_str_t slit_24 =
+               FX_MAKE_STR("define/import a more specific overload, or use a module-qualified call (e.g. Module.");
+            fx_str_t slit_25 = FX_MAKE_STR("(...)) to disambiguate");
+            {
+               const fx_str_t strs_7[] = { slit_24, v_25, slit_25 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &hint_0), _fx_catch_13);
+            }
+         }
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_26, 0), _fx_catch_13);
+         fx_str_t slit_26 = FX_MAKE_STR("ambiguous call of overloaded \'");
+         fx_str_t slit_27 = FX_MAKE_STR("\': ");
+         fx_str_t slit_28 =
+            FX_MAKE_STR(". Candidates:\n"
+               U"    ");
+         fx_str_t slit_29 = FX_MAKE_STR("\n");
+         {
+            const fx_str_t strs_8[] = { slit_26, v_26, slit_27, why_0, slit_28, cand_lines_0, slit_29, hint_0 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_8, 8, &v_27), _fx_catch_13);
+         }
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_27, &v_28, 0), _fx_catch_13);
+         FX_THROW(&v_28, false, _fx_catch_13);
       }
       else {
          if (viable_0 != 0) {
-            _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_28);
+            _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_29);
          }
          else {
-            FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_11);
+            FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_13);
          }
-         FX_CHECK_EXN(_fx_catch_11);
-         _fx_R9Ast__id_t i_0 = v_28.t0;
-         FX_COPY_PTR(v_28.t1, &df_0);
+         FX_CHECK_EXN(_fx_catch_13);
+         _fx_R9Ast__id_t i_0 = v_29.t0;
+         FX_COPY_PTR(v_29.t1, &df_0);
          FX_CALL(
             _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
-               &i_0, df_0, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_11);
+               &i_0, df_0, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_13);
       }
 
-   _fx_catch_11: ;
+   _fx_catch_13: ;
       if (df_0) {
          _fx_free_rR13Ast__deffun_t(&df_0);
       }
-      _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_28);
-      fx_free_exn(&v_27);
+      _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_29);
+      fx_free_exn(&v_28);
+      FX_FREE_STR(&v_27);
       FX_FREE_STR(&v_26);
       FX_FREE_STR(&v_25);
       FX_FREE_STR(&v_24);
+      FX_FREE_STR(&hint_0);
+      FX_FREE_STR(&why_0);
       FX_FREE_STR(&cand_lines_0);
       if (v_23) {
          _fx_free_LS(&v_23);
       }
    }
-   FX_CHECK_EXN(_fx_catch_12);
+   FX_CHECK_EXN(_fx_catch_14);
 
-_fx_catch_12: ;
+_fx_catch_14: ;
    FX_FREE_STR(&v_12);
    FX_FREE_STR(&outcome_0);
    FX_FREE_STR(&v_11);
@@ -17979,7 +18649,7 @@ static int
       int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
       if (dot_pos_2 < 0) {
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
+         _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, &result_0);
          FX_BREAK(_fx_catch_3);
       }
       else {
@@ -18024,7 +18694,7 @@ static int
                }
                else {
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &result_0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
@@ -18096,8 +18766,8 @@ FX_EXTERN_C int
       else {
          fx_exn_t v_2 = {0};
          FX_CALL(
-            _fx_M13Ast_typecheckFM22report_not_found_typedE4R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tR10Ast__loc_t(n_0, t_0,
-               possible_matches_0, loc_0, &v_2, 0), _fx_catch_0);
+            _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+               n_0, t_0, possible_matches_0, sc_0, loc_0, &v_2, 0), _fx_catch_0);
          FX_THROW(&v_2, false, _fx_catch_0);
 
       _fx_catch_0: ;
@@ -18213,7 +18883,7 @@ FX_EXTERN_C int
          }
       }
    }
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, fx_result);
+   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, fx_result);
 
 _fx_endmatch_0: ;
 
@@ -19313,8 +19983,8 @@ FX_EXTERN_C int
                   else {
                      fx_exn_t v_30 = {0};
                      FX_CALL(
-                        _fx_M13Ast_typecheckFM22report_not_found_typedE4R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tR10Ast__loc_t(
-                           n2_1, etyp_0, candidates_0, &eloc_0, &v_30, 0), _fx_catch_15);
+                        _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                           n2_1, etyp_0, candidates_0, sc_2, &eloc_0, &v_30, 0), _fx_catch_15);
                      FX_THROW(&v_30, false, _fx_catch_15);
 
                   _fx_catch_15: ;
@@ -19372,7 +20042,7 @@ FX_EXTERN_C int
             _fx_R9Ast__id_t* n2_2 = &e2_0->u.ExpIdent.t0;
             FX_CALL(
                _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                  &_fx_g22Ast_typecheck__None10_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
+                  &_fx_g22Ast_typecheck__None12_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
             FX_COPY_PTR(v_31.t1, &relems_0);
             _fx_M13Ast_typecheckFM7make_fpFPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(n2_2,
                &__lambda___0);
@@ -19642,7 +20312,7 @@ FX_EXTERN_C int
                FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(new_e2_1, &v_62), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                     v_61, _fx_g22Ast_typecheck__None11_, v_62, &ctx_0, &result_11), _fx_catch_24);
+                     v_61, _fx_g22Ast_typecheck__None13_, v_62, &ctx_0, &result_11), _fx_catch_24);
                _fx_free_N10Ast__exp_t(&result_0);
                FX_COPY_PTR(result_11, &result_0);
                FX_BREAK(_fx_catch_24);
@@ -19850,7 +20520,7 @@ FX_EXTERN_C int
                         }
                         goto _fx_endmatch_2;
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
 
                   _fx_endmatch_2: ;
                      FX_CHECK_EXN(_fx_catch_29);
@@ -19952,7 +20622,7 @@ FX_EXTERN_C int
                            }
                         }
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
 
                   _fx_endmatch_3: ;
                      FX_CHECK_EXN(_fx_catch_32);
@@ -19994,7 +20664,7 @@ FX_EXTERN_C int
                            _fx_catch_33);
                      }
                      else {
-                        FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
+                        FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
                      }
 
                   _fx_catch_33: ;
@@ -20017,7 +20687,7 @@ FX_EXTERN_C int
                      }
                   }
                   else {
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
                   }
                   FX_CHECK_EXN(_fx_catch_34);
 
@@ -20027,7 +20697,7 @@ FX_EXTERN_C int
                   }
                   goto _fx_endmatch_4;
                }
-               FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &result_exp_opt_0);
+               FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
 
             _fx_endmatch_4: ;
                FX_CHECK_EXN(_fx_catch_37);
@@ -20231,7 +20901,7 @@ FX_EXTERN_C int
                         &f_id_1, v_96, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &probably_result_0, 0), _fx_catch_41);
                }
                else {
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &probably_result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &probably_result_0);
                }
                bool v_101;
                FX_CALL(
@@ -20263,7 +20933,7 @@ FX_EXTERN_C int
                   _fx_N10Ast__exp_t v_105 = 0;
                   _fx_N10Ast__exp_t binres_0 = 0;
                   _fx_N10Ast__exp_t v_106 = 0;
-                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None12_, &v_102), _fx_catch_40);
+                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None14_, &v_102), _fx_catch_40);
                   FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_102, &v_103), _fx_catch_40);
                   _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_103, &eloc_0, &v_104);
                   FX_CALL(
@@ -20546,7 +21216,7 @@ FX_EXTERN_C int
                   goto _fx_endmatch_8;
                }
             }
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, &typ_opt_3);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &typ_opt_3);
 
          _fx_endmatch_8: ;
             FX_CHECK_EXN(_fx_catch_50);
@@ -20612,10 +21282,10 @@ FX_EXTERN_C int
                _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, v_120, &v_112);
             }
             else if (FX_REC_VARIANT_TAG(etyp1_6) == 10) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
             }
             else {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
             }
 
          _fx_catch_52: ;
@@ -20648,18 +21318,18 @@ FX_EXTERN_C int
                v_124 = false;
             }
             if (v_124) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
             }
             else {
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_6, &v_122, 0), _fx_catch_53);
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp2_2, &v_123, 0), _fx_catch_53);
                if (FX_REC_VARIANT_TAG(v_122) == 10) {
                   if (FX_REC_VARIANT_TAG(v_123) == 10) {
-                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None12_, &v_112);
+                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
                      goto _fx_endmatch_9;
                   }
                }
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
 
             _fx_endmatch_9: ;
                FX_CHECK_EXN(_fx_catch_53);
@@ -20683,7 +21353,7 @@ FX_EXTERN_C int
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypBool,
                   &eloc_0, &slit_38, 0), _fx_catch_54);
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
 
          _fx_catch_54: ;
             goto _fx_endmatch_10;
@@ -20722,7 +21392,7 @@ FX_EXTERN_C int
             goto _fx_endmatch_10;
          }
          if (tag_6 == 5) {
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None12_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
             goto _fx_endmatch_10;
          }
          FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_61);
@@ -24770,7 +25440,7 @@ FX_EXTERN_C int
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, &v_407);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &v_407);
          }
          FX_CHECK_EXN(_fx_catch_160);
          FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_407, &eloc_0, &result_45), _fx_catch_160);
@@ -25621,7 +26291,7 @@ FX_EXTERN_C int
                r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_184);
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g22Ast_typecheck__None10_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_184);
+               &_fx_g22Ast_typecheck__None12_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_184);
          FX_COPY_PTR(v_481.t1, &relems_2);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_14 = 0;
          FX_COPY_PTR(r_initializers_5, &r_initializers_4);
@@ -26674,7 +27344,7 @@ static int
       fx_exn_t exn_0 = {0};
       FX_CALL(
          _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-            &_fx_g22Ast_typecheck__None10_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
+            &_fx_g22Ast_typecheck__None12_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
 
    _fx_catch_0: ;
       if (fx_status < 0) {
@@ -27509,7 +28179,7 @@ static int
          _fx_LN10Ast__exp_t v_33 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g22Ast_typecheck__None10_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
+               &_fx_g22Ast_typecheck__None12_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
          FX_COPY_PTR(v_18.t1, &relems_0);
          FX_COPY_PTR(relems_0, &l_2);
          int_ n_2 = idx_0;
@@ -28274,7 +28944,7 @@ static int
       _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_1);
    }
    else if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, fx_result);
    }
    else {
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
@@ -28387,7 +29057,7 @@ static int _fx_M13Ast_typecheckFM9is_lvalueB4BN10Ast__exp_tT2N10Ast__typ_tR10Ast
                FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(rec_0, &rtyp_0, 0), _fx_catch_6);
                FX_CALL(
                   _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                     &_fx_g22Ast_typecheck__None10_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
+                     &_fx_g22Ast_typecheck__None12_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
                FX_COPY_PTR(v_2.t1, &relems_0);
                _fx_copy_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g21Ast_typecheck__None1_,
                   &__fold_result___0);
@@ -28540,7 +29210,7 @@ static int
    FX_CALL(fx_check_stack(), _fx_cleanup);
    int tag_0 = (e_opt_0 != 0) + 1;
    if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None11_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, fx_result);
    }
    else if (tag_0 == 2) {
       _fx_T2N10Ast__typ_tR10Ast__loc_t v_0 = {0};
@@ -32210,7 +32880,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 1) {
       if (e_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 1) {
@@ -32296,7 +32966,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
          FX_FREE_STR(&v_4);
          goto _fx_endmatch_0;
       }
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
 
    _fx_endmatch_0: ;
       FX_CHECK_EXN(_fx_catch_3);
@@ -32607,7 +33277,7 @@ FX_EXTERN_C int
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &check_typ__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g21Ast_typecheck__None9_, _fx_g21Ast_typecheck__None8_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    FX_CALL(check_typ__0.fp(t_0, &callb_0, &v_1, check_typ__0.fcv), _fx_cleanup);
    _fx_make_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_1, &r_env_ref_0->data, fx_result);
 
@@ -33012,7 +33682,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
    }
    if (tag_0 == 1) {
       if (entry_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_2;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_2;
       }
    }
    if (tag_0 == 1) {
@@ -33041,7 +33711,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
       }
       FX_CHECK_EXN(_fx_catch_10);
       if (res_0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None12_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_1;
       }
       if (tag_1 == 7) {
          _fx_R19Ast__definterface_t v_4 = {0};
@@ -33253,7 +33923,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
          else if (cv_0->t6) {
             FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(ty_args_0, &dvar_name_0, &t1_0), _fx_catch_9);
             FX_COPY_PTR(dvar_templ_inst_0->data, &v_25);
-            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g22Ast_typecheck__None10_;
+            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g22Ast_typecheck__None12_;
             _fx_LR9Ast__id_t lst_2 = v_25;
             for (; lst_2; lst_2 = lst_2->tl) {
                _fx_N14Ast__id_info_t v_27 = {0};
@@ -33396,7 +34066,7 @@ FX_EXTERN_C int
    int fx_status = 0;
    FX_CALL(
       _fx_M13Ast_typecheckFM30check_typ_and_collect_typ_varsT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tNt6option1rRt6Set__t1R9Ast__id_tLN12Ast__scope_tR10Ast__loc_tB(
-         t_0, env_0, &_fx_g21Ast_typecheck__None6_, sc_0, loc_0, false, &v_0, 0), _fx_cleanup);
+         t_0, env_0, &_fx_g21Ast_typecheck__None8_, sc_0, loc_0, false, &v_0, 0), _fx_cleanup);
    FX_COPY_PTR(v_0.t0, fx_result);
 
 _fx_cleanup: ;
@@ -36301,7 +36971,7 @@ static int
                   _fx_T2LT2R9Ast__id_tN10Ast__typ_tLR9Ast__id_t v_17 = {0};
                   _fx_LT2R9Ast__id_tN10Ast__typ_t v_18 = 0;
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t __fold_result___1 = {0};
-                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None7_, &__fold_result___0);
+                  _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&_fx_g21Ast_typecheck__None9_, &__fold_result___0);
                   FX_CALL(
                      _fx_M13Ast_typecheckFM17get_variant_casesT2LT2R9Ast__id_tN10Ast__typ_tLR9Ast__id_t2N10Ast__typ_tR10Ast__loc_t(
                         t_0, loc_3, &v_17, 0), _fx_catch_9);
@@ -36721,7 +37391,7 @@ static int
          _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(&ctor_0, &v_53);
       }
       else {
-         v_53 = _fx_g22Ast_typecheck__None10_;
+         v_53 = _fx_g22Ast_typecheck__None12_;
       }
       FX_CALL(
          _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&v_53, new_relems_0, loc_4, &v_42),
@@ -36759,7 +37429,7 @@ static int
                      0), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(
-                     &_fx_g22Ast_typecheck__None10_, relems_0, loc_4, &v_54), _fx_catch_24);
+                     &_fx_g22Ast_typecheck__None12_, relems_0, loc_4, &v_54), _fx_catch_24);
                FX_CALL(_fx_cons_LN10Ast__pat_t(v_54, 0, true, &v_55), _fx_catch_24);
                FX_CALL(_fx_M3AstFM10PatVariantN10Ast__pat_t3RM4id_tLN10Ast__pat_tRM5loc_t(&v_57, v_55, loc_4, &v_56),
                   _fx_catch_24);
@@ -36887,7 +37557,7 @@ static int
          _fx_M13Ast_typecheckFM4SomeNt6option1rRt6Set__t1R9Ast__id_t1rRt6Set__t1R9Ast__id_t(r_typ_vars_0, &v_64);
       }
       else {
-         _fx_copy_Nt6option1rRt6Set__t1R9Ast__id_t(&_fx_g21Ast_typecheck__None6_, &v_64);
+         _fx_copy_Nt6option1rRt6Set__t1R9Ast__id_t(&_fx_g21Ast_typecheck__None8_, &v_64);
       }
       FX_CALL(
          _fx_M13Ast_typecheckFM30check_typ_and_collect_typ_varsT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tNt6option1rRt6Set__t1R9Ast__id_tLN12Ast__scope_tR10Ast__loc_tB(

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -3009,21 +3009,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;
@@ -6247,19 +6247,19 @@ _fx_N12Set__color_t _fx_g20Ast_typecheck__Red1_ = { 1 };
 _fx_N12Set__color_t _fx_g22Ast_typecheck__Black1_ = { 2 };
 _fx_Nt11Set__tree_t1R9Ast__id_t _fx_g22Ast_typecheck__Empty2_ = 0;
 _fx_N10Ast__lit_t _fx_g23Ast_typecheck__LitEmpty = { 8 };
-static _fx_N10Ast__typ_t_data_t TypInt_data_2 = { 1, 5 };
+static _fx_N10Ast__typ_t_data_t TypInt_data_2 = { 1, 6 };
 _fx_N10Ast__typ_t _fx_g21Ast_typecheck__TypInt = &TypInt_data_2;
-static _fx_N10Ast__typ_t_data_t TypString_data_2 = { 1, 10 };
+static _fx_N10Ast__typ_t_data_t TypString_data_2 = { 1, 11 };
 _fx_N10Ast__typ_t _fx_g24Ast_typecheck__TypString = &TypString_data_2;
-static _fx_N10Ast__typ_t_data_t TypChar_data_2 = { 1, 11 };
+static _fx_N10Ast__typ_t_data_t TypChar_data_2 = { 1, 12 };
 _fx_N10Ast__typ_t _fx_g22Ast_typecheck__TypChar = &TypChar_data_2;
-static _fx_N10Ast__typ_t_data_t TypBool_data_2 = { 1, 12 };
+static _fx_N10Ast__typ_t_data_t TypBool_data_2 = { 1, 13 };
 _fx_N10Ast__typ_t _fx_g22Ast_typecheck__TypBool = &TypBool_data_2;
-static _fx_N10Ast__typ_t_data_t TypVoid_data_2 = { 1, 13 };
+static _fx_N10Ast__typ_t_data_t TypVoid_data_2 = { 1, 14 };
 _fx_N10Ast__typ_t _fx_g22Ast_typecheck__TypVoid = &TypVoid_data_2;
-static _fx_N10Ast__typ_t_data_t TypExn_data_1 = { 1, 21 };
+static _fx_N10Ast__typ_t_data_t TypExn_data_1 = { 1, 22 };
 _fx_N10Ast__typ_t _fx_g21Ast_typecheck__TypExn = &TypExn_data_1;
-static _fx_N10Ast__typ_t_data_t TypModule_data_1 = { 1, 26 };
+static _fx_N10Ast__typ_t_data_t TypModule_data_1 = { 1, 27 };
 _fx_N10Ast__typ_t _fx_g24Ast_typecheck__TypModule = &TypModule_data_1;
 _fx_N12Ast__cmpop_t _fx_g20Ast_typecheck__CmpEQ = { 1 };
 static _fx_N13Ast__binary_t_data_t OpAdd_data_2 = { 1, 1 };
@@ -8408,24 +8408,24 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 6) {
-         if (FX_REC_VARIANT_TAG(a_2) == 6) {
+      if (FX_REC_VARIANT_TAG(b_2) == 7) {
+         if (FX_REC_VARIANT_TAG(a_2) == 7) {
             result_0 = a_2->u.TypSInt == b_2->u.TypSInt; FX_BREAK(_fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 7) {
-         if (FX_REC_VARIANT_TAG(a_2) == 7) {
+      if (FX_REC_VARIANT_TAG(b_2) == 8) {
+         if (FX_REC_VARIANT_TAG(a_2) == 8) {
             result_0 = a_2->u.TypUInt == b_2->u.TypUInt; FX_BREAK(_fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 9) {
-         if (FX_REC_VARIANT_TAG(a_2) == 9) {
+      if (FX_REC_VARIANT_TAG(b_2) == 10) {
+         if (FX_REC_VARIANT_TAG(a_2) == 10) {
             result_0 = a_2->u.TypFloat == b_2->u.TypFloat; FX_BREAK(_fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 14) {
+      if (FX_REC_VARIANT_TAG(b_2) == 15) {
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &b_2->u.TypFun;
-         if (FX_REC_VARIANT_TAG(a_2) == 14) {
+         if (FX_REC_VARIANT_TAG(a_2) == 15) {
             _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_1 = &a_2->u.TypFun;
             bool v_0;
             FX_CALL(_fx_M13Ast_typecheckFM6__eq__B2LN10Ast__typ_tLN10Ast__typ_t(vcase_1->t0, vcase_0->t0, &v_0, 0),
@@ -8440,8 +8440,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 15) {
-         if (FX_REC_VARIANT_TAG(a_2) == 15) {
+      if (FX_REC_VARIANT_TAG(b_2) == 16) {
+         if (FX_REC_VARIANT_TAG(a_2) == 16) {
             _fx_N10Ast__typ_t* a0_1 = &a_2->u.TypList;
             _fx_free_N10Ast__typ_t(&a_1);
             FX_COPY_PTR(*a0_1, &a_1);
@@ -8451,8 +8451,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 16) {
-         if (FX_REC_VARIANT_TAG(a_2) == 16) {
+      if (FX_REC_VARIANT_TAG(b_2) == 17) {
+         if (FX_REC_VARIANT_TAG(a_2) == 17) {
             _fx_N10Ast__typ_t* a0_2 = &a_2->u.TypVector;
             _fx_free_N10Ast__typ_t(&a_1);
             FX_COPY_PTR(*a0_2, &a_1);
@@ -8462,8 +8462,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 17) {
-         if (FX_REC_VARIANT_TAG(a_2) == 17) {
+      if (FX_REC_VARIANT_TAG(b_2) == 18) {
+         if (FX_REC_VARIANT_TAG(a_2) == 18) {
             bool result_3;
             FX_CALL(_fx_M13Ast_typecheckFM6__eq__B2LN10Ast__typ_tLN10Ast__typ_t(a_2->u.TypTuple, b_2->u.TypTuple, &result_3, 0),
                _fx_catch_6);
@@ -8474,8 +8474,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 18) {
-         if (FX_REC_VARIANT_TAG(a_2) == 18) {
+      if (FX_REC_VARIANT_TAG(b_2) == 19) {
+         if (FX_REC_VARIANT_TAG(a_2) == 19) {
             _fx_N10Ast__typ_t* a0_3 = &a_2->u.TypRef;
             _fx_free_N10Ast__typ_t(&a_1);
             FX_COPY_PTR(*a0_3, &a_1);
@@ -8485,9 +8485,9 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 19) {
+      if (FX_REC_VARIANT_TAG(b_2) == 20) {
          _fx_T2iN10Ast__typ_t* vcase_2 = &b_2->u.TypArray;
-         if (FX_REC_VARIANT_TAG(a_2) == 19) {
+         if (FX_REC_VARIANT_TAG(a_2) == 20) {
             _fx_T2iN10Ast__typ_t* vcase_3 = &a_2->u.TypArray;
             bool v_2;
             FX_CALL(_fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__typ_t(vcase_3->t1, vcase_2->t1, &v_2, 0),
@@ -8499,8 +8499,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 20) {
-         if (FX_REC_VARIANT_TAG(a_2) == 20) {
+      if (FX_REC_VARIANT_TAG(b_2) == 21) {
+         if (FX_REC_VARIANT_TAG(a_2) == 21) {
             bool result_4 =
                _fx_M13Ast_typecheckFM6__eq__B2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBrT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
                   a_2->u.TypRecord, b_2->u.TypRecord, 0);
@@ -8511,9 +8511,9 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(b_2) == 24) {
+      if (FX_REC_VARIANT_TAG(b_2) == 25) {
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_4 = &b_2->u.TypApp;
-         if (FX_REC_VARIANT_TAG(a_2) == 24) {
+         if (FX_REC_VARIANT_TAG(a_2) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_5 = &a_2->u.TypApp;
             _fx_R9Ast__id_t* a1_0 = &vcase_5->t1;
             _fx_R9Ast__id_t* b1_0 = &vcase_4->t1;
@@ -10887,7 +10887,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
       FX_COPY_PTR(r1_1, &r1_2);
       FX_COPY_PTR(t2_1, &t2_2);
       int tag_0 = FX_REC_VARIANT_TAG(t2_2);
-      if (tag_0 == 14) {
+      if (tag_0 == 15) {
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &t2_2->u.TypFun;
          bool res_0;
          FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tLN10Ast__typ_t(r1_2, vcase_0->t0, &res_0, 0),
@@ -10906,7 +10906,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
       _fx_catch_0: ;
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 15) {
+      if (tag_0 == 16) {
          _fx_free_rNt6option1N10Ast__typ_t(&r1_1);
          FX_COPY_PTR(r1_2, &r1_1);
          _fx_N10Ast__typ_t* t2__0 = &t2_2->u.TypList;
@@ -10914,7 +10914,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          FX_COPY_PTR(*t2__0, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 16) {
+      if (tag_0 == 17) {
          _fx_free_rNt6option1N10Ast__typ_t(&r1_1);
          FX_COPY_PTR(r1_2, &r1_1);
          _fx_N10Ast__typ_t* t2__1 = &t2_2->u.TypVector;
@@ -10922,7 +10922,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          FX_COPY_PTR(*t2__1, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          bool result_1;
          FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tLN10Ast__typ_t(r1_2, t2_2->u.TypTuple, &result_1, 0),
             _fx_catch_1);
@@ -10946,7 +10946,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
       if (tag_0 == 2) {
          result_0 = false; FX_BREAK(_fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_0;
       }
-      if (tag_0 == 18) {
+      if (tag_0 == 19) {
          _fx_free_rNt6option1N10Ast__typ_t(&r1_1);
          FX_COPY_PTR(r1_2, &r1_1);
          _fx_N10Ast__typ_t* t2__3 = &t2_2->u.TypRef;
@@ -10954,7 +10954,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          FX_COPY_PTR(*t2__3, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 19) {
+      if (tag_0 == 20) {
          _fx_free_rNt6option1N10Ast__typ_t(&r1_1);
          FX_COPY_PTR(r1_2, &r1_1);
          _fx_N10Ast__typ_t* et2_0 = &t2_2->u.TypArray.t1;
@@ -10970,7 +10970,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          FX_COPY_PTR(*et2_1, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 20) {
+      if (tag_0 == 21) {
          _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_1 = {0};
          _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t2_2->u.TypRecord->data, &v_1);
          bool result_2;
@@ -11012,7 +11012,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          }
          goto _fx_endmatch_0;
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          bool result_3;
          FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tLN10Ast__typ_t(r1_2, t2_2->u.TypApp.t0, &result_3, 0),
             _fx_catch_6);
@@ -11023,19 +11023,16 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
          goto _fx_endmatch_0;
       }
       bool res_1;
-      if (tag_0 == 5) {
+      if (tag_0 == 6) {
          res_1 = true;
       }
-      else if (tag_0 == 8) {
-         res_1 = true;
-      }
-      else if (tag_0 == 6) {
+      else if (tag_0 == 9) {
          res_1 = true;
       }
       else if (tag_0 == 7) {
          res_1 = true;
       }
-      else if (tag_0 == 9) {
+      else if (tag_0 == 8) {
          res_1 = true;
       }
       else if (tag_0 == 10) {
@@ -11050,7 +11047,7 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
       else if (tag_0 == 13) {
          res_1 = true;
       }
-      else if (tag_0 == 21) {
+      else if (tag_0 == 14) {
          res_1 = true;
       }
       else if (tag_0 == 22) {
@@ -11059,13 +11056,19 @@ static int _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(
       else if (tag_0 == 23) {
          res_1 = true;
       }
-      else if (tag_0 == 25) {
+      else if (tag_0 == 24) {
          res_1 = true;
       }
       else if (tag_0 == 26) {
          res_1 = true;
       }
+      else if (tag_0 == 27) {
+         res_1 = true;
+      }
       else if (tag_0 == 4) {
+         res_1 = true;
+      }
+      else if (tag_0 == 5) {
          res_1 = true;
       }
       else {
@@ -11269,10 +11272,10 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
       _fx_Nt6option1N10Ast__typ_t v_5 = 0;
       _fx_Nt6option1N10Ast__typ_t v_6 = 0;
       _fx_Nt6option1N10Ast__typ_t v_7 = 0;
-      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_8 = {0};
-      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_9 = {0};
-      _fx_Nt6option1N10Ast__typ_t v_10 = 0;
-      _fx_Nt6option1N10Ast__typ_t v_11 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_8 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_9 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = {0};
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_11 = {0};
       _fx_Nt6option1N10Ast__typ_t v_12 = 0;
       _fx_Nt6option1N10Ast__typ_t v_13 = 0;
       _fx_Nt6option1N10Ast__typ_t v_14 = 0;
@@ -11281,22 +11284,19 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
       _fx_Nt6option1N10Ast__typ_t v_17 = 0;
       _fx_Nt6option1N10Ast__typ_t v_18 = 0;
       _fx_Nt6option1N10Ast__typ_t v_19 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_20 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_21 = 0;
       FX_COPY_PTR(t1_1, &t1_2);
       FX_COPY_PTR(t2_1, &t2_2);
       _fx_R10Ast__loc_t loc_2 = loc_1;
       bool res_0;
-      if (FX_REC_VARIANT_TAG(t1_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 5) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 6) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 8) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 8) {
-            res_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (FX_REC_VARIANT_TAG(t1_2) == 10) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 10) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 9) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 9) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
@@ -11315,18 +11315,18 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             res_0 = true; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 21) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 21) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 14) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 14) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 23) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 23) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 22) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 22) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 25) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 25) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 24) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 24) {
             res_0 = true; goto _fx_endmatch_0;
          }
       }
@@ -11335,31 +11335,36 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             res_0 = true; goto _fx_endmatch_0;
          }
       }
+      if (FX_REC_VARIANT_TAG(t1_2) == 27) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 27) {
+            res_0 = true; goto _fx_endmatch_0;
+         }
+      }
       res_0 = false;
 
    _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_catch_42);
+      FX_CHECK_EXN(_fx_catch_48);
       if (res_0) {
-         result_0 = true; FX_BREAK(_fx_catch_0);  _fx_catch_0: ; goto _fx_endmatch_7;
-      }
-      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 6) {
-            result_0 = t1_2->u.TypSInt == t2_2->u.TypSInt; FX_BREAK(_fx_catch_1);  _fx_catch_1: ; goto _fx_endmatch_7;
-         }
+         result_0 = true; FX_BREAK(_fx_catch_0);  _fx_catch_0: ; goto _fx_endmatch_9;
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 7) {
          if (FX_REC_VARIANT_TAG(t1_2) == 7) {
-            result_0 = t1_2->u.TypUInt == t2_2->u.TypUInt; FX_BREAK(_fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_7;
+            result_0 = t1_2->u.TypSInt == t2_2->u.TypSInt; FX_BREAK(_fx_catch_1);  _fx_catch_1: ; goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 9) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 9) {
-            result_0 = t1_2->u.TypFloat == t2_2->u.TypFloat; FX_BREAK(_fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_7;
+      if (FX_REC_VARIANT_TAG(t2_2) == 8) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 8) {
+            result_0 = t1_2->u.TypUInt == t2_2->u.TypUInt; FX_BREAK(_fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 14) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 10) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 10) {
+            result_0 = t1_2->u.TypFloat == t2_2->u.TypFloat; FX_BREAK(_fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_9;
+         }
+      }
+      if (FX_REC_VARIANT_TAG(t2_2) == 15) {
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &t2_2->u.TypFun;
-         if (FX_REC_VARIANT_TAG(t1_2) == 14) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 15) {
             _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_1 = &t1_2->u.TypFun;
             bool res_1;
             FX_CALL(
@@ -11379,11 +11384,11 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             }
 
          _fx_catch_4: ;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 15) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 15) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 16) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 16) {
             _fx_N10Ast__typ_t* et1_0 = &t1_2->u.TypList;
             _fx_free_N10Ast__typ_t(&t1_1);
             FX_COPY_PTR(*et1_0, &t1_1);
@@ -11391,11 +11396,11 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             _fx_free_N10Ast__typ_t(&t2_1);
             FX_COPY_PTR(*et2_0, &t2_1);
             loc_1 = loc_2;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 16) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 16) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 17) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 17) {
             _fx_N10Ast__typ_t* et1_1 = &t1_2->u.TypVector;
             _fx_free_N10Ast__typ_t(&t1_1);
             FX_COPY_PTR(*et1_1, &t1_1);
@@ -11403,11 +11408,11 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             _fx_free_N10Ast__typ_t(&t2_1);
             FX_COPY_PTR(*et2_1, &t2_1);
             loc_1 = loc_2;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 17) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 17) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 18) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 18) {
             bool result_1;
             FX_CALL(
                maybe_unify__0.fp(t1_2->u.TypTuple, t2_2->u.TypTuple, &loc_2, rec_undo_stack_ref_0, undo_stack_ref_0, &result_1,
@@ -11416,7 +11421,7 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             FX_BREAK(_fx_catch_5);
 
          _fx_catch_5: ;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
@@ -11424,38 +11429,38 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             _fx_rNt6option1N10Ast__typ_t r1_0 = t1_2->u.TypVar;
             FX_COPY_PTR(r1_0->data, &v_0);
             if ((v_0 != 0) + 1 == 2) {
-               _fx_N10Ast__typ_t v_20 = v_0->u.Some;
-               if (FX_REC_VARIANT_TAG(v_20) == 2) {
-                  _fx_Nt6option1N10Ast__typ_t t1_opt_0 = v_20->u.TypVarTuple;
+               _fx_N10Ast__typ_t v_22 = v_0->u.Some;
+               if (FX_REC_VARIANT_TAG(v_22) == 2) {
+                  _fx_Nt6option1N10Ast__typ_t t1_opt_0 = v_22->u.TypVarTuple;
                   _fx_rNt6option1N10Ast__typ_t r2_0 = t2_2->u.TypVar;
                   FX_COPY_PTR(r2_0->data, &v_1);
                   if ((v_1 != 0) + 1 == 2) {
-                     _fx_N10Ast__typ_t v_21 = v_1->u.Some;
-                     if (FX_REC_VARIANT_TAG(v_21) == 2) {
-                        _fx_Nt6option1N10Ast__typ_t v_22 = 0;
-                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_23 = {0};
-                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_24 = 0;
-                        _fx_Nt6option1N10Ast__typ_t v_25 = 0;
-                        _fx_Nt6option1N10Ast__typ_t t2_opt_0 = v_21->u.TypVarTuple;
-                        bool v_26 =
+                     _fx_N10Ast__typ_t v_23 = v_1->u.Some;
+                     if (FX_REC_VARIANT_TAG(v_23) == 2) {
+                        _fx_Nt6option1N10Ast__typ_t v_24 = 0;
+                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_25 = {0};
+                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_26 = 0;
+                        _fx_Nt6option1N10Ast__typ_t v_27 = 0;
+                        _fx_Nt6option1N10Ast__typ_t t2_opt_0 = v_23->u.TypVarTuple;
+                        bool v_28 =
                            _fx_M13Ast_typecheckFM6__eq__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_0, r2_0, 0);
-                        if (v_26) {
+                        if (v_28) {
                            result_0 = true; FX_BREAK(_fx_catch_7);
                         }
                         else {
-                           bool v_27;
+                           bool v_29;
                            bool res_2;
                            FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_0, t1_2, &res_2, 0),
                               _fx_catch_7);
                            if (res_2) {
-                              v_27 = true;
+                              v_29 = true;
                            }
                            else {
                               FX_CALL(
-                                 _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_0, t2_2, &v_27, 0),
+                                 _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_0, t2_2, &v_29, 0),
                                  _fx_catch_7);
                            }
-                           if (v_27) {
+                           if (v_29) {
                               result_0 = false; FX_BREAK(_fx_catch_7);
                            }
                            else {
@@ -11475,18 +11480,18 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                            _fx_endmatch_1: ;
                               FX_CHECK_EXN(_fx_catch_7);
                               if (ok_0) {
-                                 FX_COPY_PTR(r2_0->data, &v_22);
-                                 _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_0, v_22, &v_23);
+                                 FX_COPY_PTR(r2_0->data, &v_24);
+                                 _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_0, v_24, &v_25);
                                  FX_CALL(
-                                    _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_23, *undo_stack_0, true,
-                                       &v_24), _fx_catch_7);
+                                    _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_25, *undo_stack_0, true,
+                                       &v_26), _fx_catch_7);
                                  _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                                 FX_COPY_PTR(v_24, undo_stack_0);
-                                 FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_25),
+                                 FX_COPY_PTR(v_26, undo_stack_0);
+                                 FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_27),
                                     _fx_catch_7);
-                                 _fx_Nt6option1N10Ast__typ_t* v_28 = &r2_0->data;
-                                 _fx_free_Nt6option1N10Ast__typ_t(v_28);
-                                 FX_COPY_PTR(v_25, v_28);
+                                 _fx_Nt6option1N10Ast__typ_t* v_30 = &r2_0->data;
+                                 _fx_free_Nt6option1N10Ast__typ_t(v_30);
+                                 FX_COPY_PTR(v_27, v_30);
                               }
                               result_0 = ok_0;
                               FX_BREAK(_fx_catch_7);
@@ -11494,17 +11499,17 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                         }
 
                      _fx_catch_7: ;
-                        if (v_25) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_25);
+                        if (v_27) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_27);
                         }
+                        if (v_26) {
+                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_26);
+                        }
+                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_25);
                         if (v_24) {
-                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_24);
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_24);
                         }
-                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_23);
-                        if (v_22) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_22);
-                        }
-                        goto _fx_endmatch_7;
+                        goto _fx_endmatch_9;
                      }
                   }
                }
@@ -11524,14 +11529,14 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                      _fx_free_N10Ast__typ_t(&t2_1);
                      FX_COPY_PTR(t1_2, &t2_1);
                      loc_1 = loc_2;
-                     goto _fx_endmatch_7;
+                     goto _fx_endmatch_9;
                   }
                }
             }
          }
       }
       if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 17) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 18) {
             FX_COPY_PTR(t1_2->u.TypVar->data, &v_4);
             if ((v_4 != 0) + 1 == 2) {
                if (FX_REC_VARIANT_TAG(v_4->u.Some) == 2) {
@@ -11540,28 +11545,28 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                   _fx_free_N10Ast__typ_t(&t2_1);
                   FX_COPY_PTR(t1_2, &t2_1);
                   loc_1 = loc_2;
-                  goto _fx_endmatch_7;
+                  goto _fx_endmatch_9;
                }
             }
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 17) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 18) {
             _fx_LN10Ast__typ_t tl1_0 = t1_2->u.TypTuple;
             _fx_rNt6option1N10Ast__typ_t r2_1 = t2_2->u.TypVar;
             FX_COPY_PTR(r2_1->data, &v_5);
             if ((v_5 != 0) + 1 == 2) {
-               _fx_N10Ast__typ_t v_29 = v_5->u.Some;
-               if (FX_REC_VARIANT_TAG(v_29) == 2) {
-                  _fx_Nt6option1N10Ast__typ_t v_30 = 0;
-                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_31 = {0};
-                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_32 = 0;
-                  _fx_Nt6option1N10Ast__typ_t v_33 = 0;
-                  _fx_Nt6option1N10Ast__typ_t t2_opt_1 = v_29->u.TypVarTuple;
-                  bool v_34;
-                  FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tLN10Ast__typ_t(r2_1, tl1_0, &v_34, 0),
+               _fx_N10Ast__typ_t v_31 = v_5->u.Some;
+               if (FX_REC_VARIANT_TAG(v_31) == 2) {
+                  _fx_Nt6option1N10Ast__typ_t v_32 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_33 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_34 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_35 = 0;
+                  _fx_Nt6option1N10Ast__typ_t t2_opt_1 = v_31->u.TypVarTuple;
+                  bool v_36;
+                  FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tLN10Ast__typ_t(r2_1, tl1_0, &v_36, 0),
                      _fx_catch_9);
-                  if (v_34) {
+                  if (v_36) {
                      result_0 = false; FX_BREAK(_fx_catch_9);
                   }
                   else {
@@ -11582,33 +11587,33 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                      }
                      FX_CHECK_EXN(_fx_catch_9);
                      if (ok_1) {
-                        FX_COPY_PTR(r2_1->data, &v_30);
-                        _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_1, v_30, &v_31);
-                        FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_31, *undo_stack_0, true, &v_32),
+                        FX_COPY_PTR(r2_1->data, &v_32);
+                        _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_1, v_32, &v_33);
+                        FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_33, *undo_stack_0, true, &v_34),
                            _fx_catch_9);
                         _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                        FX_COPY_PTR(v_32, undo_stack_0);
-                        FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_33), _fx_catch_9);
-                        _fx_Nt6option1N10Ast__typ_t* v_35 = &r2_1->data;
-                        _fx_free_Nt6option1N10Ast__typ_t(v_35);
-                        FX_COPY_PTR(v_33, v_35);
+                        FX_COPY_PTR(v_34, undo_stack_0);
+                        FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_35), _fx_catch_9);
+                        _fx_Nt6option1N10Ast__typ_t* v_37 = &r2_1->data;
+                        _fx_free_Nt6option1N10Ast__typ_t(v_37);
+                        FX_COPY_PTR(v_35, v_37);
                      }
                      result_0 = ok_1;
                      FX_BREAK(_fx_catch_9);
                   }
 
                _fx_catch_9: ;
-                  if (v_33) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_33);
+                  if (v_35) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_35);
                   }
+                  if (v_34) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_34);
+                  }
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_33);
                   if (v_32) {
-                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_32);
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_32);
                   }
-                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_31);
-                  if (v_30) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_30);
-                  }
-                  goto _fx_endmatch_7;
+                  goto _fx_endmatch_9;
                }
             }
          }
@@ -11619,49 +11624,49 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
          if ((v_6 != 0) + 1 == 2) {
             if (FX_REC_VARIANT_TAG(v_6->u.Some) == 4) {
                _fx_N10Ast__typ_t t2_3 = 0;
-               _fx_Nt6option1N10Ast__typ_t v_36 = 0;
-               _fx_Nt6option1N10Ast__typ_t v_37 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_38 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_39 = 0;
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_2, &t2_3, 0), _fx_catch_17);
                int tag_0 = FX_REC_VARIANT_TAG(t2_3);
                if (tag_0 == 1) {
                   _fx_rNt6option1N10Ast__typ_t r2_2 = t2_3->u.TypVar;
-                  FX_COPY_PTR(r2_2->data, &v_36);
-                  if ((v_36 != 0) + 1 == 2) {
-                     if (FX_REC_VARIANT_TAG(v_36->u.Some) == 4) {
-                        _fx_Nt6option1N10Ast__typ_t v_38 = 0;
-                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_39 = {0};
-                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_40 = 0;
-                        _fx_Nt6option1N10Ast__typ_t v_41 = 0;
-                        bool v_42;
+                  FX_COPY_PTR(r2_2->data, &v_38);
+                  if ((v_38 != 0) + 1 == 2) {
+                     if (FX_REC_VARIANT_TAG(v_38->u.Some) == 4) {
+                        _fx_Nt6option1N10Ast__typ_t v_40 = 0;
+                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_41 = {0};
+                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_42 = 0;
+                        _fx_Nt6option1N10Ast__typ_t v_43 = 0;
+                        bool v_44;
                         FX_CALL(
-                           _fx_M13Ast_typecheckFM6__ne__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_1, r2_2, &v_42,
+                           _fx_M13Ast_typecheckFM6__ne__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_1, r2_2, &v_44,
                               0), _fx_catch_10);
-                        if (v_42) {
-                           FX_COPY_PTR(r2_2->data, &v_38);
-                           _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_2, v_38, &v_39);
+                        if (v_44) {
+                           FX_COPY_PTR(r2_2->data, &v_40);
+                           _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_2, v_40, &v_41);
                            FX_CALL(
-                              _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_39, *undo_stack_0, true, &v_40),
+                              _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_41, *undo_stack_0, true, &v_42),
                               _fx_catch_10);
                            _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                           FX_COPY_PTR(v_40, undo_stack_0);
-                           FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_41), _fx_catch_10);
-                           _fx_Nt6option1N10Ast__typ_t* v_43 = &r2_2->data;
-                           _fx_free_Nt6option1N10Ast__typ_t(v_43);
-                           FX_COPY_PTR(v_41, v_43);
+                           FX_COPY_PTR(v_42, undo_stack_0);
+                           FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_43), _fx_catch_10);
+                           _fx_Nt6option1N10Ast__typ_t* v_45 = &r2_2->data;
+                           _fx_free_Nt6option1N10Ast__typ_t(v_45);
+                           FX_COPY_PTR(v_43, v_45);
                         }
                         result_0 = true;
                         FX_BREAK(_fx_catch_10);
 
                      _fx_catch_10: ;
-                        if (v_41) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_41);
+                        if (v_43) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_43);
                         }
+                        if (v_42) {
+                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_42);
+                        }
+                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_41);
                         if (v_40) {
-                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_40);
-                        }
-                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_39);
-                        if (v_38) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_38);
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_40);
                         }
                         goto _fx_endmatch_3;
                      }
@@ -11669,110 +11674,110 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                }
                if (tag_0 == 1) {
                   _fx_rNt6option1N10Ast__typ_t r2_3 = t2_3->u.TypVar;
-                  FX_COPY_PTR(r2_3->data, &v_37);
-                  if ((v_37 != 0) + 1 == 1) {
-                     _fx_Nt6option1N10Ast__typ_t v_44 = 0;
-                     _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_45 = {0};
-                     _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_46 = 0;
-                     _fx_Nt6option1N10Ast__typ_t v_47 = 0;
-                     FX_COPY_PTR(r2_3->data, &v_44);
-                     _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_3, v_44, &v_45);
-                     FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_45, *undo_stack_0, true, &v_46),
+                  FX_COPY_PTR(r2_3->data, &v_39);
+                  if ((v_39 != 0) + 1 == 1) {
+                     _fx_Nt6option1N10Ast__typ_t v_46 = 0;
+                     _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_47 = {0};
+                     _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_48 = 0;
+                     _fx_Nt6option1N10Ast__typ_t v_49 = 0;
+                     FX_COPY_PTR(r2_3->data, &v_46);
+                     _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_3, v_46, &v_47);
+                     FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_47, *undo_stack_0, true, &v_48),
                         _fx_catch_11);
                      _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                     FX_COPY_PTR(v_46, undo_stack_0);
-                     FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_47), _fx_catch_11);
-                     _fx_Nt6option1N10Ast__typ_t* v_48 = &r2_3->data;
-                     _fx_free_Nt6option1N10Ast__typ_t(v_48);
-                     FX_COPY_PTR(v_47, v_48);
+                     FX_COPY_PTR(v_48, undo_stack_0);
+                     FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_49), _fx_catch_11);
+                     _fx_Nt6option1N10Ast__typ_t* v_50 = &r2_3->data;
+                     _fx_free_Nt6option1N10Ast__typ_t(v_50);
+                     FX_COPY_PTR(v_49, v_50);
                      result_0 = true;
                      FX_BREAK(_fx_catch_11);
 
                   _fx_catch_11: ;
-                     if (v_47) {
-                        _fx_free_Nt6option1N10Ast__typ_t(&v_47);
+                     if (v_49) {
+                        _fx_free_Nt6option1N10Ast__typ_t(&v_49);
                      }
+                     if (v_48) {
+                        _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_48);
+                     }
+                     _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_47);
                      if (v_46) {
-                        _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_46);
-                     }
-                     _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_45);
-                     if (v_44) {
-                        _fx_free_Nt6option1N10Ast__typ_t(&v_44);
+                        _fx_free_Nt6option1N10Ast__typ_t(&v_46);
                      }
                      goto _fx_endmatch_3;
                   }
                }
-               if (tag_0 == 20) {
-                  _fx_Nt6option1N10Ast__typ_t v_49 = 0;
-                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_50 = {0};
-                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_51 = 0;
-                  _fx_Nt6option1N10Ast__typ_t v_52 = 0;
-                  FX_COPY_PTR(r1_1->data, &v_49);
-                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_1, v_49, &v_50);
-                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_50, *undo_stack_0, true, &v_51),
+               if (tag_0 == 21) {
+                  _fx_Nt6option1N10Ast__typ_t v_51 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_52 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_53 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_54 = 0;
+                  FX_COPY_PTR(r1_1->data, &v_51);
+                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_1, v_51, &v_52);
+                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_52, *undo_stack_0, true, &v_53),
                      _fx_catch_12);
                   _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                  FX_COPY_PTR(v_51, undo_stack_0);
-                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_3, &v_52), _fx_catch_12);
-                  _fx_Nt6option1N10Ast__typ_t* v_53 = &r1_1->data;
-                  _fx_free_Nt6option1N10Ast__typ_t(v_53);
-                  FX_COPY_PTR(v_52, v_53);
+                  FX_COPY_PTR(v_53, undo_stack_0);
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_3, &v_54), _fx_catch_12);
+                  _fx_Nt6option1N10Ast__typ_t* v_55 = &r1_1->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_55);
+                  FX_COPY_PTR(v_54, v_55);
                   result_0 = true;
                   FX_BREAK(_fx_catch_12);
 
                _fx_catch_12: ;
-                  if (v_52) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_52);
+                  if (v_54) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_54);
                   }
+                  if (v_53) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_53);
+                  }
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_52);
                   if (v_51) {
-                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_51);
-                  }
-                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_50);
-                  if (v_49) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_49);
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_51);
                   }
                   goto _fx_endmatch_3;
                }
-               if (tag_0 == 24) {
-                  _fx_N14Ast__id_info_t v_54 = {0};
-                  _fx_R17Ast__defvariant_t v_55 = {0};
-                  FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&t2_3->u.TypApp.t1, &loc_2, &v_54, 0),
+               if (tag_0 == 25) {
+                  _fx_N14Ast__id_info_t v_56 = {0};
+                  _fx_R17Ast__defvariant_t v_57 = {0};
+                  FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&t2_3->u.TypApp.t1, &loc_2, &v_56, 0),
                      _fx_catch_15);
-                  if (v_54.tag == 6) {
-                     _fx_copy_R17Ast__defvariant_t(&v_54.u.IdVariant->data, &v_55);
-                     _fx_LT2R9Ast__id_tN10Ast__typ_t v_56 = v_55.dvar_cases;
-                     if (v_56 != 0) {
-                        if (v_56->tl == 0) {
-                           if (FX_REC_VARIANT_TAG(v_56->hd.t1) == 20) {
-                              _fx_Nt6option1N10Ast__typ_t v_57 = 0;
-                              _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_58 = {0};
-                              _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_59 = 0;
-                              _fx_Nt6option1N10Ast__typ_t v_60 = 0;
-                              FX_COPY_PTR(r1_1->data, &v_57);
-                              _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_1, v_57, &v_58);
+                  if (v_56.tag == 6) {
+                     _fx_copy_R17Ast__defvariant_t(&v_56.u.IdVariant->data, &v_57);
+                     _fx_LT2R9Ast__id_tN10Ast__typ_t v_58 = v_57.dvar_cases;
+                     if (v_58 != 0) {
+                        if (v_58->tl == 0) {
+                           if (FX_REC_VARIANT_TAG(v_58->hd.t1) == 21) {
+                              _fx_Nt6option1N10Ast__typ_t v_59 = 0;
+                              _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_60 = {0};
+                              _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_61 = 0;
+                              _fx_Nt6option1N10Ast__typ_t v_62 = 0;
+                              FX_COPY_PTR(r1_1->data, &v_59);
+                              _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_1, v_59, &v_60);
                               FX_CALL(
-                                 _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_58, *undo_stack_0, true, &v_59),
+                                 _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_60, *undo_stack_0, true, &v_61),
                                  _fx_catch_13);
                               _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                              FX_COPY_PTR(v_59, undo_stack_0);
-                              FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_3, &v_60),
+                              FX_COPY_PTR(v_61, undo_stack_0);
+                              FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_3, &v_62),
                                  _fx_catch_13);
-                              _fx_Nt6option1N10Ast__typ_t* v_61 = &r1_1->data;
-                              _fx_free_Nt6option1N10Ast__typ_t(v_61);
-                              FX_COPY_PTR(v_60, v_61);
+                              _fx_Nt6option1N10Ast__typ_t* v_63 = &r1_1->data;
+                              _fx_free_Nt6option1N10Ast__typ_t(v_63);
+                              FX_COPY_PTR(v_62, v_63);
                               result_0 = true;
                               FX_BREAK(_fx_catch_13);
 
                            _fx_catch_13: ;
-                              if (v_60) {
-                                 _fx_free_Nt6option1N10Ast__typ_t(&v_60);
+                              if (v_62) {
+                                 _fx_free_Nt6option1N10Ast__typ_t(&v_62);
                               }
+                              if (v_61) {
+                                 _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_61);
+                              }
+                              _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_60);
                               if (v_59) {
-                                 _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_59);
-                              }
-                              _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_58);
-                              if (v_57) {
-                                 _fx_free_Nt6option1N10Ast__typ_t(&v_57);
+                                 _fx_free_Nt6option1N10Ast__typ_t(&v_59);
                               }
                               goto _fx_endmatch_2;
                            }
@@ -11788,8 +11793,8 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                   FX_CHECK_EXN(_fx_catch_15);
 
                _fx_catch_15: ;
-                  _fx_free_R17Ast__defvariant_t(&v_55);
-                  _fx_free_N14Ast__id_info_t(&v_54);
+                  _fx_free_R17Ast__defvariant_t(&v_57);
+                  _fx_free_N14Ast__id_info_t(&v_56);
                   goto _fx_endmatch_3;
                }
                result_0 = false;
@@ -11801,16 +11806,16 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                FX_CHECK_EXN(_fx_catch_17);
 
             _fx_catch_17: ;
-               if (v_37) {
-                  _fx_free_Nt6option1N10Ast__typ_t(&v_37);
+               if (v_39) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_39);
                }
-               if (v_36) {
-                  _fx_free_Nt6option1N10Ast__typ_t(&v_36);
+               if (v_38) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_38);
                }
                if (t2_3) {
                   _fx_free_N10Ast__typ_t(&t2_3);
                }
-               goto _fx_endmatch_7;
+               goto _fx_endmatch_9;
             }
          }
       }
@@ -11823,12 +11828,196 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                _fx_free_N10Ast__typ_t(&t2_1);
                FX_COPY_PTR(t1_2, &t2_1);
                loc_1 = loc_2;
-               goto _fx_endmatch_7;
+               goto _fx_endmatch_9;
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 18) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 18) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 1) {
+         _fx_rNt6option1N10Ast__typ_t r1_2 = t1_2->u.TypVar;
+         FX_COPY_PTR(r1_2->data, &v_8);
+         if ((v_8 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_8->u.Some) == 5) {
+               _fx_N10Ast__typ_t t2_4 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_64 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_65 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_66 = 0;
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_2, &t2_4, 0), _fx_catch_23);
+               int tag_1 = FX_REC_VARIANT_TAG(t2_4);
+               if (tag_1 == 1) {
+                  _fx_rNt6option1N10Ast__typ_t r2_4 = t2_4->u.TypVar;
+                  FX_COPY_PTR(r2_4->data, &v_64);
+                  if ((v_64 != 0) + 1 == 2) {
+                     if (FX_REC_VARIANT_TAG(v_64->u.Some) == 5) {
+                        _fx_Nt6option1N10Ast__typ_t v_67 = 0;
+                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_68 = {0};
+                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_69 = 0;
+                        _fx_Nt6option1N10Ast__typ_t v_70 = 0;
+                        bool v_71;
+                        FX_CALL(
+                           _fx_M13Ast_typecheckFM6__ne__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_2, r2_4, &v_71,
+                              0), _fx_catch_18);
+                        if (v_71) {
+                           FX_COPY_PTR(r2_4->data, &v_67);
+                           _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_4, v_67, &v_68);
+                           FX_CALL(
+                              _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_68, *undo_stack_0, true, &v_69),
+                              _fx_catch_18);
+                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
+                           FX_COPY_PTR(v_69, undo_stack_0);
+                           FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_70), _fx_catch_18);
+                           _fx_Nt6option1N10Ast__typ_t* v_72 = &r2_4->data;
+                           _fx_free_Nt6option1N10Ast__typ_t(v_72);
+                           FX_COPY_PTR(v_70, v_72);
+                        }
+                        result_0 = true;
+                        FX_BREAK(_fx_catch_18);
+
+                     _fx_catch_18: ;
+                        if (v_70) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_70);
+                        }
+                        if (v_69) {
+                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_69);
+                        }
+                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_68);
+                        if (v_67) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_67);
+                        }
+                        goto _fx_endmatch_5;
+                     }
+                  }
+               }
+               if (tag_1 == 1) {
+                  _fx_rNt6option1N10Ast__typ_t r2_5 = t2_4->u.TypVar;
+                  FX_COPY_PTR(r2_5->data, &v_65);
+                  if ((v_65 != 0) + 1 == 1) {
+                     _fx_Nt6option1N10Ast__typ_t v_73 = 0;
+                     _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_74 = {0};
+                     _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_75 = 0;
+                     _fx_Nt6option1N10Ast__typ_t v_76 = 0;
+                     FX_COPY_PTR(r2_5->data, &v_73);
+                     _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_5, v_73, &v_74);
+                     FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_74, *undo_stack_0, true, &v_75),
+                        _fx_catch_19);
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
+                     FX_COPY_PTR(v_75, undo_stack_0);
+                     FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_76), _fx_catch_19);
+                     _fx_Nt6option1N10Ast__typ_t* v_77 = &r2_5->data;
+                     _fx_free_Nt6option1N10Ast__typ_t(v_77);
+                     FX_COPY_PTR(v_76, v_77);
+                     result_0 = true;
+                     FX_BREAK(_fx_catch_19);
+
+                  _fx_catch_19: ;
+                     if (v_76) {
+                        _fx_free_Nt6option1N10Ast__typ_t(&v_76);
+                     }
+                     if (v_75) {
+                        _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_75);
+                     }
+                     _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_74);
+                     if (v_73) {
+                        _fx_free_Nt6option1N10Ast__typ_t(&v_73);
+                     }
+                     goto _fx_endmatch_5;
+                  }
+               }
+               bool res_3;
+               if (tag_1 == 16) {
+                  res_3 = true; goto _fx_endmatch_4;
+               }
+               if (tag_1 == 17) {
+                  res_3 = true; goto _fx_endmatch_4;
+               }
+               if (tag_1 == 20) {
+                  res_3 = true; goto _fx_endmatch_4;
+               }
+               if (tag_1 == 1) {
+                  FX_COPY_PTR(t2_4->u.TypVar->data, &v_66);
+                  if ((v_66 != 0) + 1 == 2) {
+                     if (FX_REC_VARIANT_TAG(v_66->u.Some) == 3) {
+                        res_3 = true; goto _fx_endmatch_4;
+                     }
+                  }
+               }
+               res_3 = false;
+
+            _fx_endmatch_4: ;
+               FX_CHECK_EXN(_fx_catch_23);
+               if (res_3) {
+                  _fx_Nt6option1N10Ast__typ_t v_78 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_79 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_80 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_81 = 0;
+                  FX_COPY_PTR(r1_2->data, &v_78);
+                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_2, v_78, &v_79);
+                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_79, *undo_stack_0, true, &v_80),
+                     _fx_catch_20);
+                  _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
+                  FX_COPY_PTR(v_80, undo_stack_0);
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_4, &v_81), _fx_catch_20);
+                  _fx_Nt6option1N10Ast__typ_t* v_82 = &r1_2->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_82);
+                  FX_COPY_PTR(v_81, v_82);
+                  result_0 = true;
+                  FX_BREAK(_fx_catch_20);
+
+               _fx_catch_20: ;
+                  if (v_81) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_81);
+                  }
+                  if (v_80) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_80);
+                  }
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_79);
+                  if (v_78) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_78);
+                  }
+                  goto _fx_endmatch_5;
+               }
+               if (tag_1 == 23) {
+                  result_0 = true; FX_BREAK(_fx_catch_21);  _fx_catch_21: ; goto _fx_endmatch_5;
+               }
+               result_0 = false;
+               FX_BREAK(_fx_catch_22);
+
+            _fx_catch_22: ;
+
+            _fx_endmatch_5: ;
+               FX_CHECK_EXN(_fx_catch_23);
+
+            _fx_catch_23: ;
+               if (v_66) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_66);
+               }
+               if (v_65) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_65);
+               }
+               if (v_64) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_64);
+               }
+               if (t2_4) {
+                  _fx_free_N10Ast__typ_t(&t2_4);
+               }
+               goto _fx_endmatch_9;
+            }
+         }
+      }
+      if (FX_REC_VARIANT_TAG(t2_2) == 1) {
+         FX_COPY_PTR(t2_2->u.TypVar->data, &v_9);
+         if ((v_9 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_9->u.Some) == 5) {
+               _fx_free_N10Ast__typ_t(&t1_1);
+               FX_COPY_PTR(t2_2, &t1_1);
+               _fx_free_N10Ast__typ_t(&t2_1);
+               FX_COPY_PTR(t1_2, &t2_1);
+               loc_1 = loc_2;
+               goto _fx_endmatch_9;
+            }
+         }
+      }
+      if (FX_REC_VARIANT_TAG(t2_2) == 19) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 19) {
             _fx_N10Ast__typ_t* drt1_0 = &t1_2->u.TypRef;
             _fx_free_N10Ast__typ_t(&t1_1);
             FX_COPY_PTR(*drt1_0, &t1_1);
@@ -11836,63 +12025,63 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
             _fx_free_N10Ast__typ_t(&t2_1);
             FX_COPY_PTR(*drt2_0, &t2_1);
             loc_1 = loc_2;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 20) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 20) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 21) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 21) {
             if (_fx_M13Ast_typecheckFM6__eq__B2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBrT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
                    t1_2->u.TypRecord, t2_2->u.TypRecord, 0)) {
-               result_0 = true; FX_BREAK(_fx_catch_18);  _fx_catch_18: ; goto _fx_endmatch_7;
+               result_0 = true; FX_BREAK(_fx_catch_24);  _fx_catch_24: ; goto _fx_endmatch_9;
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 20) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 20) {
-            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t1_2->u.TypRecord->data, &v_8);
-            if (v_8.t1 == false) {
-               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t2_2->u.TypRecord->data, &v_9);
-               if (v_9.t1 == true) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 21) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 21) {
+            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t1_2->u.TypRecord->data, &v_10);
+            if (v_10.t1 == false) {
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t2_2->u.TypRecord->data, &v_11);
+               if (v_11.t1 == true) {
                   _fx_free_N10Ast__typ_t(&t1_1);
                   FX_COPY_PTR(t2_2, &t1_1);
                   _fx_free_N10Ast__typ_t(&t2_1);
                   FX_COPY_PTR(t1_2, &t2_1);
                   loc_1 = loc_2;
-                  goto _fx_endmatch_7;
+                  goto _fx_endmatch_9;
                }
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 20) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 20) {
-            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_62 = {0};
-            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_63 = {0};
-            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_64 = {0};
+      if (FX_REC_VARIANT_TAG(t2_2) == 21) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 21) {
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_83 = {0};
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_84 = {0};
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_85 = {0};
             _fx_T2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB
-               v_65 = {0};
+               v_86 = {0};
             _fx_LT2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB
-               v_66 = 0;
-            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_67 = {0};
-            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB r1_2 = t1_2->u.TypRecord;
-            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB r2_4 = t2_2->u.TypRecord;
-            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r1_2->data, &v_62);
-            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r2_4->data, &v_63);
+               v_87 = 0;
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_88 = {0};
+            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB r1_3 = t1_2->u.TypRecord;
+            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB r2_6 = t2_2->u.TypRecord;
+            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r1_3->data, &v_83);
+            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r2_6->data, &v_84);
             bool ok_2;
-            if (v_63.t1 == true) {
-               if (v_62.t1 == true) {
+            if (v_84.t1 == true) {
+               if (v_83.t1 == true) {
                   _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_0 = 0;
                   _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_0 = 0;
-                  _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_1 = v_62.t0;
-                  _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_1 = v_63.t0;
-                  int_ v_68;
+                  _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_1 = v_83.t0;
+                  _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_1 = v_84.t0;
+                  int_ v_89;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems1_1,
-                        &v_68, 0), _fx_catch_20);
-                  int_ v_69;
+                        &v_89, 0), _fx_catch_26);
+                  int_ v_90;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems2_1,
-                        &v_69, 0), _fx_catch_20);
-                  if (v_68 == v_69) {
+                        &v_90, 0), _fx_catch_26);
+                  if (v_89 == v_90) {
                      bool __fold_result___0 = true;
                      FX_COPY_PTR(relems1_1, &relems1_0);
                      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_0 = relems1_0;
@@ -11902,7 +12091,7 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                         _fx_R16Ast__val_flags_t f1_0 = {0};
                         _fx_N10Ast__typ_t t1_3 = 0;
                         _fx_R16Ast__val_flags_t f2_0 = {0};
-                        _fx_N10Ast__typ_t t2_4 = 0;
+                        _fx_N10Ast__typ_t t2_5 = 0;
                         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_1->hd;
                         _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___1 = &lst_0->hd;
                         _fx_copy_R16Ast__val_flags_t(&__pat___1->t0, &f1_0);
@@ -11910,32 +12099,32 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                         FX_COPY_PTR(__pat___1->t2, &t1_3);
                         _fx_copy_R16Ast__val_flags_t(&__pat___0->t0, &f2_0);
                         _fx_R9Ast__id_t n2_0 = __pat___0->t1;
-                        FX_COPY_PTR(__pat___0->t2, &t2_4);
-                        bool v_70;
-                        bool res_3;
-                        FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_0, &n2_0, &res_3, 0), _fx_catch_19);
+                        FX_COPY_PTR(__pat___0->t2, &t2_5);
+                        bool v_91;
+                        bool res_4;
+                        FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_0, &n2_0, &res_4, 0), _fx_catch_25);
                         bool t_0;
-                        if (res_3) {
+                        if (res_4) {
                            FX_CALL(
-                              _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_3, t2_4, &loc_2,
-                                 &t_0, fx_fv), _fx_catch_19);
+                              _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_3, t2_5, &loc_2,
+                                 &t_0, fx_fv), _fx_catch_25);
                         }
                         else {
                            t_0 = false;
                         }
                         if (t_0) {
-                           v_70 = f1_0.val_flag_mutable == f2_0.val_flag_mutable;
+                           v_91 = f1_0.val_flag_mutable == f2_0.val_flag_mutable;
                         }
                         else {
-                           v_70 = false;
+                           v_91 = false;
                         }
-                        if (!v_70) {
-                           __fold_result___0 = false; FX_BREAK(_fx_catch_19);
+                        if (!v_91) {
+                           __fold_result___0 = false; FX_BREAK(_fx_catch_25);
                         }
 
-                     _fx_catch_19: ;
-                        if (t2_4) {
-                           _fx_free_N10Ast__typ_t(&t2_4);
+                     _fx_catch_25: ;
+                        if (t2_5) {
+                           _fx_free_N10Ast__typ_t(&t2_5);
                         }
                         _fx_free_R16Ast__val_flags_t(&f2_0);
                         if (t1_3) {
@@ -11943,30 +12132,30 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                         }
                         _fx_free_R16Ast__val_flags_t(&f1_0);
                         FX_CHECK_BREAK();
-                        FX_CHECK_EXN(_fx_catch_20);
+                        FX_CHECK_EXN(_fx_catch_26);
                      }
                      int s_0 = !lst_0 + !lst_1;
-                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_20);
+                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_26);
                      ok_2 = __fold_result___0;
                   }
                   else {
                      ok_2 = false;
                   }
 
-               _fx_catch_20: ;
+               _fx_catch_26: ;
                   if (relems2_0) {
                      _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems2_0);
                   }
                   if (relems1_0) {
                      _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems1_0);
                   }
-                  goto _fx_endmatch_4;
+                  goto _fx_endmatch_6;
                }
             }
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_2 = 0;
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_2 = 0;
-            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_3 = v_63.t0;
-            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_3 = v_62.t0;
+            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems2_3 = v_84.t0;
+            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_3 = v_83.t0;
             bool __fold_result___1 = true;
             FX_COPY_PTR(relems1_3, &relems1_2);
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_2 = relems1_2;
@@ -11978,56 +12167,56 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                _fx_R9Ast__id_t n1_1 = __pat___2->t1;
                FX_COPY_PTR(__pat___2->t2, &t1_4);
                FX_COPY_PTR(__pat___2->t3, &v1_0);
-               bool v_71;
-               bool res_4;
+               bool v_92;
+               bool res_5;
                if (FX_REC_VARIANT_TAG(v1_0) == 1) {
-                  res_4 = false;
+                  res_5 = false;
                }
                else {
-                  res_4 = true;
+                  res_5 = true;
                }
-               FX_CHECK_EXN(_fx_catch_22);
-               if (res_4) {
-                  v_71 = true;
+               FX_CHECK_EXN(_fx_catch_28);
+               if (res_5) {
+                  v_92 = true;
                }
                else {
                   bool __fold_result___2 = false;
                   FX_COPY_PTR(relems2_3, &relems2_4);
                   _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_3 = relems2_4;
                   for (; lst_3; lst_3 = lst_3->tl) {
-                     _fx_N10Ast__typ_t t2_5 = 0;
+                     _fx_N10Ast__typ_t t2_6 = 0;
                      _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___3 = &lst_3->hd;
                      _fx_R9Ast__id_t n2_1 = __pat___3->t1;
-                     FX_COPY_PTR(__pat___3->t2, &t2_5);
-                     bool v_72;
-                     bool res_5;
-                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_1, &n2_1, &res_5, 0), _fx_catch_21);
-                     if (res_5) {
+                     FX_COPY_PTR(__pat___3->t2, &t2_6);
+                     bool v_93;
+                     bool res_6;
+                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_1, &n2_1, &res_6, 0), _fx_catch_27);
+                     if (res_6) {
                         FX_CALL(
-                           _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_4, t2_5, &loc_2,
-                              &v_72, fx_fv), _fx_catch_21);
+                           _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_4, t2_6, &loc_2,
+                              &v_93, fx_fv), _fx_catch_27);
                      }
                      else {
-                        v_72 = false;
+                        v_93 = false;
                      }
-                     if (v_72) {
-                        __fold_result___2 = true; FX_BREAK(_fx_catch_21);
+                     if (v_93) {
+                        __fold_result___2 = true; FX_BREAK(_fx_catch_27);
                      }
 
-                  _fx_catch_21: ;
-                     if (t2_5) {
-                        _fx_free_N10Ast__typ_t(&t2_5);
+                  _fx_catch_27: ;
+                     if (t2_6) {
+                        _fx_free_N10Ast__typ_t(&t2_6);
                      }
                      FX_CHECK_BREAK();
-                     FX_CHECK_EXN(_fx_catch_22);
+                     FX_CHECK_EXN(_fx_catch_28);
                   }
-                  v_71 = __fold_result___2;
+                  v_92 = __fold_result___2;
                }
-               if (!v_71) {
-                  __fold_result___1 = false; FX_BREAK(_fx_catch_22);
+               if (!v_92) {
+                  __fold_result___1 = false; FX_BREAK(_fx_catch_28);
                }
 
-            _fx_catch_22: ;
+            _fx_catch_28: ;
                if (relems2_4) {
                   _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems2_4);
                }
@@ -12038,18 +12227,18 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                   _fx_free_N10Ast__typ_t(&t1_4);
                }
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_25);
+               FX_CHECK_EXN(_fx_catch_31);
             }
             bool have_all_matches_0 = __fold_result___1;
             bool __fold_result___3 = true;
             FX_COPY_PTR(relems2_3, &relems2_2);
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_4 = relems2_2;
             for (; lst_4; lst_4 = lst_4->tl) {
-               _fx_N10Ast__typ_t t2_6 = 0;
+               _fx_N10Ast__typ_t t2_7 = 0;
                _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems1_4 = 0;
                _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___4 = &lst_4->hd;
                _fx_R9Ast__id_t n2_2 = __pat___4->t1;
-               FX_COPY_PTR(__pat___4->t2, &t2_6);
+               FX_COPY_PTR(__pat___4->t2, &t2_7);
                bool __fold_result___4 = false;
                FX_COPY_PTR(relems1_3, &relems1_4);
                _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_5 = relems1_4;
@@ -12058,41 +12247,41 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                   _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___5 = &lst_5->hd;
                   _fx_R9Ast__id_t n1_2 = __pat___5->t1;
                   FX_COPY_PTR(__pat___5->t2, &t1_5);
-                  bool v_73;
-                  bool res_6;
-                  FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_2, &n2_2, &res_6, 0), _fx_catch_23);
-                  if (res_6) {
+                  bool v_94;
+                  bool res_7;
+                  FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&n1_2, &n2_2, &res_7, 0), _fx_catch_29);
+                  if (res_7) {
                      FX_CALL(
-                        _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_5, t2_6, &loc_2, &v_73,
-                           fx_fv), _fx_catch_23);
+                        _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(t1_5, t2_7, &loc_2, &v_94,
+                           fx_fv), _fx_catch_29);
                   }
                   else {
-                     v_73 = false;
+                     v_94 = false;
                   }
-                  if (v_73) {
-                     __fold_result___4 = true; FX_BREAK(_fx_catch_23);
+                  if (v_94) {
+                     __fold_result___4 = true; FX_BREAK(_fx_catch_29);
                   }
 
-               _fx_catch_23: ;
+               _fx_catch_29: ;
                   if (t1_5) {
                      _fx_free_N10Ast__typ_t(&t1_5);
                   }
                   FX_CHECK_BREAK();
-                  FX_CHECK_EXN(_fx_catch_24);
+                  FX_CHECK_EXN(_fx_catch_30);
                }
                if (!__fold_result___4) {
-                  __fold_result___3 = false; FX_BREAK(_fx_catch_24);
+                  __fold_result___3 = false; FX_BREAK(_fx_catch_30);
                }
 
-            _fx_catch_24: ;
+            _fx_catch_30: ;
                if (relems1_4) {
                   _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems1_4);
                }
-               if (t2_6) {
-                  _fx_free_N10Ast__typ_t(&t2_6);
+               if (t2_7) {
+                  _fx_free_N10Ast__typ_t(&t2_7);
                }
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_25);
+               FX_CHECK_EXN(_fx_catch_31);
             }
             bool have_all_matches2_0 = __fold_result___3;
             bool t_1;
@@ -12103,21 +12292,21 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                t_1 = false;
             }
             if (t_1) {
-               int_ v_74;
+               int_ v_95;
                FX_CALL(
-                  _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems1_3, &v_74,
-                     0), _fx_catch_25);
-               int_ v_75;
+                  _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems1_3, &v_95,
+                     0), _fx_catch_31);
+               int_ v_96;
                FX_CALL(
-                  _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems2_3, &v_75,
-                     0), _fx_catch_25);
-               ok_2 = v_74 >= v_75;
+                  _fx_M13Ast_typecheckFM8length1_i1LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(relems2_3, &v_96,
+                     0), _fx_catch_31);
+               ok_2 = v_95 >= v_96;
             }
             else {
                ok_2 = false;
             }
 
-         _fx_catch_25: ;
+         _fx_catch_31: ;
             if (relems2_2) {
                _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems2_2);
             }
@@ -12125,43 +12314,43 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems1_2);
             }
 
-         _fx_endmatch_4: ;
-            FX_CHECK_EXN(_fx_catch_26);
+         _fx_endmatch_6: ;
+            FX_CHECK_EXN(_fx_catch_32);
             if (ok_2) {
-               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r2_4->data, &v_64);
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r2_6->data, &v_85);
                _fx_make_T2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
-                  r2_4, &v_64, &v_65);
+                  r2_6, &v_85, &v_86);
                FX_CALL(
                   _fx_cons_LT2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
-                     &v_65, *rec_undo_stack_0, true, &v_66), _fx_catch_26);
+                     &v_86, *rec_undo_stack_0, true, &v_87), _fx_catch_32);
                _fx_free_LT2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
                   rec_undo_stack_0);
-               FX_COPY_PTR(v_66, rec_undo_stack_0);
-               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r1_2->data, &v_67);
-               _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_76 = &r2_4->data;
-               _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_76);
-               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_67, v_76);
+               FX_COPY_PTR(v_87, rec_undo_stack_0);
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&r1_3->data, &v_88);
+               _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_97 = &r2_6->data;
+               _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_97);
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_88, v_97);
             }
             result_0 = ok_2;
-            FX_BREAK(_fx_catch_26);
+            FX_BREAK(_fx_catch_32);
 
-         _fx_catch_26: ;
-            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_67);
-            if (v_66) {
+         _fx_catch_32: ;
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_88);
+            if (v_87) {
                _fx_free_LT2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
-                  &v_66);
+                  &v_87);
             }
             _fx_free_T2rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tBT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
-               &v_65);
-            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_64);
-            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_63);
-            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_62);
-            goto _fx_endmatch_7;
+               &v_86);
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_85);
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_84);
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_83);
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 19) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 20) {
          _fx_T2iN10Ast__typ_t* vcase_2 = &t2_2->u.TypArray;
-         if (FX_REC_VARIANT_TAG(t1_2) == 19) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 20) {
             _fx_T2iN10Ast__typ_t* vcase_3 = &t1_2->u.TypArray;
             if (vcase_3->t0 == vcase_2->t0) {
                _fx_N10Ast__typ_t* et1_2 = &vcase_3->t1;
@@ -12173,89 +12362,89 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
                loc_1 = loc_2;
             }
             else {
-               result_0 = false; FX_BREAK(_fx_catch_27);
+               result_0 = false; FX_BREAK(_fx_catch_33);
             }
 
-         _fx_catch_27: ;
-            goto _fx_endmatch_7;
+         _fx_catch_33: ;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
          if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-            _fx_rNt6option1N10Ast__typ_t r1_3 = t1_2->u.TypVar;
-            FX_COPY_PTR(r1_3->data, &v_10);
-            if ((v_10 != 0) + 1 == 2) {
-               _fx_N10Ast__typ_t v_77 = v_10->u.Some;
-               if (FX_REC_VARIANT_TAG(v_77) == 3) {
-                  _fx_rNt6option1N10Ast__typ_t r2_5 = t2_2->u.TypVar;
-                  FX_COPY_PTR(r2_5->data, &v_11);
-                  if ((v_11 != 0) + 1 == 2) {
-                     _fx_N10Ast__typ_t v_78 = v_11->u.Some;
-                     if (FX_REC_VARIANT_TAG(v_78) == 3) {
-                        _fx_Nt6option1N10Ast__typ_t v_79 = 0;
-                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_80 = {0};
-                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_81 = 0;
-                        _fx_Nt6option1N10Ast__typ_t v_82 = 0;
-                        bool v_83 =
-                           _fx_M13Ast_typecheckFM6__eq__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_3, r2_5, 0);
-                        if (v_83) {
-                           result_0 = true; FX_BREAK(_fx_catch_28);
+            _fx_rNt6option1N10Ast__typ_t r1_4 = t1_2->u.TypVar;
+            FX_COPY_PTR(r1_4->data, &v_12);
+            if ((v_12 != 0) + 1 == 2) {
+               _fx_N10Ast__typ_t v_98 = v_12->u.Some;
+               if (FX_REC_VARIANT_TAG(v_98) == 3) {
+                  _fx_rNt6option1N10Ast__typ_t r2_7 = t2_2->u.TypVar;
+                  FX_COPY_PTR(r2_7->data, &v_13);
+                  if ((v_13 != 0) + 1 == 2) {
+                     _fx_N10Ast__typ_t v_99 = v_13->u.Some;
+                     if (FX_REC_VARIANT_TAG(v_99) == 3) {
+                        _fx_Nt6option1N10Ast__typ_t v_100 = 0;
+                        _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_101 = {0};
+                        _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_102 = 0;
+                        _fx_Nt6option1N10Ast__typ_t v_103 = 0;
+                        bool v_104 =
+                           _fx_M13Ast_typecheckFM6__eq__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(r1_4, r2_7, 0);
+                        if (v_104) {
+                           result_0 = true; FX_BREAK(_fx_catch_34);
                         }
                         else {
-                           bool v_84;
-                           bool res_7;
-                           FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_5, t1_2, &res_7, 0),
-                              _fx_catch_28);
-                           if (res_7) {
-                              v_84 = true;
+                           bool v_105;
+                           bool res_8;
+                           FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_7, t1_2, &res_8, 0),
+                              _fx_catch_34);
+                           if (res_8) {
+                              v_105 = true;
                            }
                            else {
                               FX_CALL(
-                                 _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_3, t2_2, &v_84, 0),
-                                 _fx_catch_28);
+                                 _fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_4, t2_2, &v_105, 0),
+                                 _fx_catch_34);
                            }
-                           if (v_84) {
-                              result_0 = false; FX_BREAK(_fx_catch_28);
+                           if (v_105) {
+                              result_0 = false; FX_BREAK(_fx_catch_34);
                            }
                            else {
-                              bool v_85;
+                              bool v_106;
                               FX_CALL(
                                  _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(
-                                    v_77->u.TypVarArray, v_78->u.TypVarArray, &loc_2, &v_85, fx_fv), _fx_catch_28);
-                              if (v_85) {
-                                 FX_COPY_PTR(r2_5->data, &v_79);
-                                 _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_5, v_79, &v_80);
+                                    v_98->u.TypVarArray, v_99->u.TypVarArray, &loc_2, &v_106, fx_fv), _fx_catch_34);
+                              if (v_106) {
+                                 FX_COPY_PTR(r2_7->data, &v_100);
+                                 _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_7, v_100, &v_101);
                                  FX_CALL(
-                                    _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_80, *undo_stack_0, true,
-                                       &v_81), _fx_catch_28);
+                                    _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_101, *undo_stack_0, true,
+                                       &v_102), _fx_catch_34);
                                  _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                                 FX_COPY_PTR(v_81, undo_stack_0);
-                                 FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_82),
-                                    _fx_catch_28);
-                                 _fx_Nt6option1N10Ast__typ_t* v_86 = &r2_5->data;
-                                 _fx_free_Nt6option1N10Ast__typ_t(v_86);
-                                 FX_COPY_PTR(v_82, v_86);
+                                 FX_COPY_PTR(v_102, undo_stack_0);
+                                 FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_103),
+                                    _fx_catch_34);
+                                 _fx_Nt6option1N10Ast__typ_t* v_107 = &r2_7->data;
+                                 _fx_free_Nt6option1N10Ast__typ_t(v_107);
+                                 FX_COPY_PTR(v_103, v_107);
                                  result_0 = true;
-                                 FX_BREAK(_fx_catch_28);
+                                 FX_BREAK(_fx_catch_34);
                               }
                               else {
-                                 result_0 = false; FX_BREAK(_fx_catch_28);
+                                 result_0 = false; FX_BREAK(_fx_catch_34);
                               }
                            }
                         }
 
-                     _fx_catch_28: ;
-                        if (v_82) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_82);
+                     _fx_catch_34: ;
+                        if (v_103) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_103);
                         }
-                        if (v_81) {
-                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_81);
+                        if (v_102) {
+                           _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_102);
                         }
-                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_80);
-                        if (v_79) {
-                           _fx_free_Nt6option1N10Ast__typ_t(&v_79);
+                        _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_101);
+                        if (v_100) {
+                           _fx_free_Nt6option1N10Ast__typ_t(&v_100);
                         }
-                        goto _fx_endmatch_7;
+                        goto _fx_endmatch_9;
                      }
                   }
                }
@@ -12263,311 +12452,318 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
          }
       }
       if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-         FX_COPY_PTR(t1_2->u.TypVar->data, &v_12);
-         if ((v_12 != 0) + 1 == 2) {
-            if (FX_REC_VARIANT_TAG(v_12->u.Some) == 3) {
+         FX_COPY_PTR(t1_2->u.TypVar->data, &v_14);
+         if ((v_14 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_14->u.Some) == 3) {
                if (FX_REC_VARIANT_TAG(t2_2) == 1) {
-                  FX_COPY_PTR(t2_2->u.TypVar->data, &v_13);
-                  if ((v_13 != 0) + 1 == 2) {
-                     _fx_N10Ast__typ_t* t2__2 = &v_13->u.Some;
+                  FX_COPY_PTR(t2_2->u.TypVar->data, &v_15);
+                  if ((v_15 != 0) + 1 == 2) {
+                     _fx_N10Ast__typ_t* t2__2 = &v_15->u.Some;
                      _fx_free_N10Ast__typ_t(&t1_1);
                      FX_COPY_PTR(*t2__2, &t1_1);
                      _fx_free_N10Ast__typ_t(&t2_1);
                      FX_COPY_PTR(t1_2, &t2_1);
                      loc_1 = loc_2;
-                     goto _fx_endmatch_7;
+                     goto _fx_endmatch_9;
                   }
                }
             }
          }
       }
       if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 19) {
-            FX_COPY_PTR(t1_2->u.TypVar->data, &v_14);
-            if ((v_14 != 0) + 1 == 2) {
-               if (FX_REC_VARIANT_TAG(v_14->u.Some) == 3) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 20) {
+            FX_COPY_PTR(t1_2->u.TypVar->data, &v_16);
+            if ((v_16 != 0) + 1 == 2) {
+               if (FX_REC_VARIANT_TAG(v_16->u.Some) == 3) {
                   _fx_free_N10Ast__typ_t(&t1_1);
                   FX_COPY_PTR(t2_2, &t1_1);
                   _fx_free_N10Ast__typ_t(&t2_1);
                   FX_COPY_PTR(t1_2, &t2_1);
                   loc_1 = loc_2;
-                  goto _fx_endmatch_7;
+                  goto _fx_endmatch_9;
                }
             }
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 19) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 20) {
             _fx_N10Ast__typ_t et1_3 = t1_2->u.TypArray.t1;
-            _fx_rNt6option1N10Ast__typ_t r2_6 = t2_2->u.TypVar;
-            FX_COPY_PTR(r2_6->data, &v_15);
-            if ((v_15 != 0) + 1 == 2) {
-               _fx_N10Ast__typ_t v_87 = v_15->u.Some;
-               if (FX_REC_VARIANT_TAG(v_87) == 3) {
-                  _fx_Nt6option1N10Ast__typ_t v_88 = 0;
-                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_89 = {0};
-                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_90 = 0;
-                  _fx_Nt6option1N10Ast__typ_t v_91 = 0;
-                  bool v_92;
-                  FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_6, et1_3, &v_92, 0),
-                     _fx_catch_29);
-                  if (v_92) {
-                     result_0 = false; FX_BREAK(_fx_catch_29);
+            _fx_rNt6option1N10Ast__typ_t r2_8 = t2_2->u.TypVar;
+            FX_COPY_PTR(r2_8->data, &v_17);
+            if ((v_17 != 0) + 1 == 2) {
+               _fx_N10Ast__typ_t v_108 = v_17->u.Some;
+               if (FX_REC_VARIANT_TAG(v_108) == 3) {
+                  _fx_Nt6option1N10Ast__typ_t v_109 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_110 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_111 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_112 = 0;
+                  bool v_113;
+                  FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_8, et1_3, &v_113, 0),
+                     _fx_catch_35);
+                  if (v_113) {
+                     result_0 = false; FX_BREAK(_fx_catch_35);
                   }
                   else {
-                     bool v_93;
+                     bool v_114;
                      FX_CALL(
                         _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(et1_3,
-                           v_87->u.TypVarArray, &loc_2, &v_93, fx_fv), _fx_catch_29);
-                     if (v_93) {
-                        FX_COPY_PTR(r2_6->data, &v_88);
-                        _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_6, v_88, &v_89);
-                        FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_89, *undo_stack_0, true, &v_90),
-                           _fx_catch_29);
+                           v_108->u.TypVarArray, &loc_2, &v_114, fx_fv), _fx_catch_35);
+                     if (v_114) {
+                        FX_COPY_PTR(r2_8->data, &v_109);
+                        _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_8, v_109, &v_110);
+                        FX_CALL(
+                           _fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_110, *undo_stack_0, true, &v_111),
+                           _fx_catch_35);
                         _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                        FX_COPY_PTR(v_90, undo_stack_0);
-                        FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_91), _fx_catch_29);
-                        _fx_Nt6option1N10Ast__typ_t* v_94 = &r2_6->data;
-                        _fx_free_Nt6option1N10Ast__typ_t(v_94);
-                        FX_COPY_PTR(v_91, v_94);
+                        FX_COPY_PTR(v_111, undo_stack_0);
+                        FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_112), _fx_catch_35);
+                        _fx_Nt6option1N10Ast__typ_t* v_115 = &r2_8->data;
+                        _fx_free_Nt6option1N10Ast__typ_t(v_115);
+                        FX_COPY_PTR(v_112, v_115);
                         result_0 = true;
-                        FX_BREAK(_fx_catch_29);
+                        FX_BREAK(_fx_catch_35);
                      }
                      else {
-                        result_0 = false; FX_BREAK(_fx_catch_29);
+                        result_0 = false; FX_BREAK(_fx_catch_35);
                      }
                   }
 
-               _fx_catch_29: ;
-                  if (v_91) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_91);
+               _fx_catch_35: ;
+                  if (v_112) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_112);
                   }
-                  if (v_90) {
-                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_90);
+                  if (v_111) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_111);
                   }
-                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_89);
-                  if (v_88) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_88);
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_110);
+                  if (v_109) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_109);
                   }
-                  goto _fx_endmatch_7;
+                  goto _fx_endmatch_9;
                }
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 24) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 25) {
          _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_4 = &t2_2->u.TypApp;
-         if (FX_REC_VARIANT_TAG(t1_2) == 24) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 25) {
             _fx_N10Ast__typ_t t1_6 = 0;
-            _fx_N10Ast__typ_t t2_7 = 0;
+            _fx_N10Ast__typ_t t2_8 = 0;
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_5 = &t1_2->u.TypApp;
             _fx_LN10Ast__typ_t args1_0 = vcase_5->t0;
             _fx_LN10Ast__typ_t args2_0 = vcase_4->t0;
-            bool res_8;
-            FX_CALL(_fx_M13Ast_typecheckFM6__ne__B2R9Ast__id_tR9Ast__id_t(&vcase_5->t1, &vcase_4->t1, &res_8, 0), _fx_catch_32);
-            if (res_8) {
-               result_0 = false; FX_BREAK(_fx_catch_32);
+            bool res_9;
+            FX_CALL(_fx_M13Ast_typecheckFM6__ne__B2R9Ast__id_tR9Ast__id_t(&vcase_5->t1, &vcase_4->t1, &res_9, 0), _fx_catch_38);
+            if (res_9) {
+               result_0 = false; FX_BREAK(_fx_catch_38);
             }
             else {
                if (args1_0 == 0) {
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t1_6); goto _fx_endmatch_5;
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t1_6); goto _fx_endmatch_7;
                }
                if (args1_0 != 0) {
                   if (args1_0->tl == 0) {
-                     FX_COPY_PTR(args1_0->hd, &t1_6); goto _fx_endmatch_5;
+                     FX_COPY_PTR(args1_0->hd, &t1_6); goto _fx_endmatch_7;
                   }
                }
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(args1_0, &t1_6), _fx_catch_30);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(args1_0, &t1_6), _fx_catch_36);
 
-            _fx_catch_30: ;
+            _fx_catch_36: ;
 
-            _fx_endmatch_5: ;
-               FX_CHECK_EXN(_fx_catch_32);
+            _fx_endmatch_7: ;
+               FX_CHECK_EXN(_fx_catch_38);
                if (args2_0 == 0) {
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t2_7); goto _fx_endmatch_6;
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t2_8); goto _fx_endmatch_8;
                }
                if (args2_0 != 0) {
                   if (args2_0->tl == 0) {
-                     FX_COPY_PTR(args2_0->hd, &t2_7); goto _fx_endmatch_6;
+                     FX_COPY_PTR(args2_0->hd, &t2_8); goto _fx_endmatch_8;
                   }
                }
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(args2_0, &t2_7), _fx_catch_31);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(args2_0, &t2_8), _fx_catch_37);
 
-            _fx_catch_31: ;
+            _fx_catch_37: ;
 
-            _fx_endmatch_6: ;
-               FX_CHECK_EXN(_fx_catch_32);
+            _fx_endmatch_8: ;
+               FX_CHECK_EXN(_fx_catch_38);
                _fx_free_N10Ast__typ_t(&t1_1);
                FX_COPY_PTR(t1_6, &t1_1);
                _fx_free_N10Ast__typ_t(&t2_1);
-               FX_COPY_PTR(t2_7, &t2_1);
+               FX_COPY_PTR(t2_8, &t2_1);
                loc_1 = loc_2;
             }
 
-         _fx_catch_32: ;
-            if (t2_7) {
-               _fx_free_N10Ast__typ_t(&t2_7);
+         _fx_catch_38: ;
+            if (t2_8) {
+               _fx_free_N10Ast__typ_t(&t2_8);
             }
             if (t1_6) {
                _fx_free_N10Ast__typ_t(&t1_6);
             }
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
          if (FX_REC_VARIANT_TAG(t1_2) == 1) {
             if (_fx_M13Ast_typecheckFM6__eq__B2rNt6option1N10Ast__typ_trNt6option1N10Ast__typ_t(t1_2->u.TypVar, t2_2->u.TypVar,
                    0)) {
-               result_0 = true; FX_BREAK(_fx_catch_33);  _fx_catch_33: ; goto _fx_endmatch_7;
+               result_0 = true; FX_BREAK(_fx_catch_39);  _fx_catch_39: ; goto _fx_endmatch_9;
             }
          }
       }
       if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-         FX_COPY_PTR(t1_2->u.TypVar->data, &v_16);
-         if ((v_16 != 0) + 1 == 2) {
-            _fx_N10Ast__typ_t* t1__0 = &v_16->u.Some;
+         FX_COPY_PTR(t1_2->u.TypVar->data, &v_18);
+         if ((v_18 != 0) + 1 == 2) {
+            _fx_N10Ast__typ_t* t1__0 = &v_18->u.Some;
             _fx_free_N10Ast__typ_t(&t1_1);
             FX_COPY_PTR(*t1__0, &t1_1);
             _fx_free_N10Ast__typ_t(&t2_1);
             FX_COPY_PTR(t2_2, &t2_1);
             loc_1 = loc_2;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
-         FX_COPY_PTR(t2_2->u.TypVar->data, &v_17);
-         if ((v_17 != 0) + 1 == 2) {
+         FX_COPY_PTR(t2_2->u.TypVar->data, &v_19);
+         if ((v_19 != 0) + 1 == 2) {
             _fx_free_N10Ast__typ_t(&t1_1);
             FX_COPY_PTR(t1_2, &t1_1);
-            _fx_N10Ast__typ_t* t2__3 = &v_17->u.Some;
+            _fx_N10Ast__typ_t* t2__3 = &v_19->u.Some;
             _fx_free_N10Ast__typ_t(&t2_1);
             FX_COPY_PTR(*t2__3, &t2_1);
             loc_1 = loc_2;
-            goto _fx_endmatch_7;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t1_2) == 1) {
-         _fx_rNt6option1N10Ast__typ_t r1_4 = t1_2->u.TypVar;
-         FX_COPY_PTR(r1_4->data, &v_18);
-         if ((v_18 != 0) + 1 == 1) {
-            bool v_95;
-            FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_4, t2_2, &v_95, 0), _fx_catch_35);
-            if (v_95) {
-               result_0 = false; FX_BREAK(_fx_catch_35);
+         _fx_rNt6option1N10Ast__typ_t r1_5 = t1_2->u.TypVar;
+         FX_COPY_PTR(r1_5->data, &v_20);
+         if ((v_20 != 0) + 1 == 1) {
+            bool v_116;
+            FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r1_5, t2_2, &v_116, 0), _fx_catch_41);
+            if (v_116) {
+               result_0 = false; FX_BREAK(_fx_catch_41);
             }
             else {
-               if (FX_REC_VARIANT_TAG(t2_2) != 22) {
-                  _fx_Nt6option1N10Ast__typ_t v_96 = 0;
-                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_97 = {0};
-                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_98 = 0;
-                  _fx_Nt6option1N10Ast__typ_t v_99 = 0;
-                  FX_COPY_PTR(r1_4->data, &v_96);
-                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_4, v_96, &v_97);
-                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_97, *undo_stack_0, true, &v_98),
-                     _fx_catch_34);
+               if (FX_REC_VARIANT_TAG(t2_2) != 23) {
+                  _fx_Nt6option1N10Ast__typ_t v_117 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_118 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_119 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_120 = 0;
+                  FX_COPY_PTR(r1_5->data, &v_117);
+                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r1_5, v_117, &v_118);
+                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_118, *undo_stack_0, true, &v_119),
+                     _fx_catch_40);
                   _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                  FX_COPY_PTR(v_98, undo_stack_0);
-                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_2, &v_99), _fx_catch_34);
-                  _fx_Nt6option1N10Ast__typ_t* v_100 = &r1_4->data;
-                  _fx_free_Nt6option1N10Ast__typ_t(v_100);
-                  FX_COPY_PTR(v_99, v_100);
+                  FX_COPY_PTR(v_119, undo_stack_0);
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t2_2, &v_120), _fx_catch_40);
+                  _fx_Nt6option1N10Ast__typ_t* v_121 = &r1_5->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_121);
+                  FX_COPY_PTR(v_120, v_121);
 
-               _fx_catch_34: ;
-                  if (v_99) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_99);
+               _fx_catch_40: ;
+                  if (v_120) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_120);
                   }
-                  if (v_98) {
-                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_98);
+                  if (v_119) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_119);
                   }
-                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_97);
-                  if (v_96) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_96);
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_118);
+                  if (v_117) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_117);
                   }
                }
-               FX_CHECK_EXN(_fx_catch_35);
+               FX_CHECK_EXN(_fx_catch_41);
                result_0 = true;
-               FX_BREAK(_fx_catch_35);
+               FX_BREAK(_fx_catch_41);
             }
 
-         _fx_catch_35: ;
-            goto _fx_endmatch_7;
+         _fx_catch_41: ;
+            goto _fx_endmatch_9;
          }
       }
       if (FX_REC_VARIANT_TAG(t2_2) == 1) {
-         _fx_rNt6option1N10Ast__typ_t r2_7 = t2_2->u.TypVar;
-         FX_COPY_PTR(r2_7->data, &v_19);
-         if ((v_19 != 0) + 1 == 1) {
-            bool v_101;
-            FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_7, t1_2, &v_101, 0), _fx_catch_37);
-            if (v_101) {
-               result_0 = false; FX_BREAK(_fx_catch_37);
+         _fx_rNt6option1N10Ast__typ_t r2_9 = t2_2->u.TypVar;
+         FX_COPY_PTR(r2_9->data, &v_21);
+         if ((v_21 != 0) + 1 == 1) {
+            bool v_122;
+            FX_CALL(_fx_M13Ast_typecheckFM6occursB2rNt6option1N10Ast__typ_tN10Ast__typ_t(r2_9, t1_2, &v_122, 0), _fx_catch_43);
+            if (v_122) {
+               result_0 = false; FX_BREAK(_fx_catch_43);
             }
             else {
-               if (FX_REC_VARIANT_TAG(t1_2) != 22) {
-                  _fx_Nt6option1N10Ast__typ_t v_102 = 0;
-                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_103 = {0};
-                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_104 = 0;
-                  _fx_Nt6option1N10Ast__typ_t v_105 = 0;
-                  FX_COPY_PTR(r2_7->data, &v_102);
-                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_7, v_102, &v_103);
-                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_103, *undo_stack_0, true, &v_104),
-                     _fx_catch_36);
+               if (FX_REC_VARIANT_TAG(t1_2) != 23) {
+                  _fx_Nt6option1N10Ast__typ_t v_123 = 0;
+                  _fx_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_124 = {0};
+                  _fx_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t v_125 = 0;
+                  _fx_Nt6option1N10Ast__typ_t v_126 = 0;
+                  FX_COPY_PTR(r2_9->data, &v_123);
+                  _fx_make_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(r2_9, v_123, &v_124);
+                  FX_CALL(_fx_cons_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_124, *undo_stack_0, true, &v_125),
+                     _fx_catch_42);
                   _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(undo_stack_0);
-                  FX_COPY_PTR(v_104, undo_stack_0);
-                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_105), _fx_catch_36);
-                  _fx_Nt6option1N10Ast__typ_t* v_106 = &r2_7->data;
-                  _fx_free_Nt6option1N10Ast__typ_t(v_106);
-                  FX_COPY_PTR(v_105, v_106);
+                  FX_COPY_PTR(v_125, undo_stack_0);
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(t1_2, &v_126), _fx_catch_42);
+                  _fx_Nt6option1N10Ast__typ_t* v_127 = &r2_9->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_127);
+                  FX_COPY_PTR(v_126, v_127);
 
-               _fx_catch_36: ;
-                  if (v_105) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_105);
+               _fx_catch_42: ;
+                  if (v_126) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_126);
                   }
-                  if (v_104) {
-                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_104);
+                  if (v_125) {
+                     _fx_free_LT2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_125);
                   }
-                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_103);
-                  if (v_102) {
-                     _fx_free_Nt6option1N10Ast__typ_t(&v_102);
+                  _fx_free_T2rNt6option1N10Ast__typ_tNt6option1N10Ast__typ_t(&v_124);
+                  if (v_123) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_123);
                   }
                }
-               FX_CHECK_EXN(_fx_catch_37);
+               FX_CHECK_EXN(_fx_catch_43);
                result_0 = true;
-               FX_BREAK(_fx_catch_37);
+               FX_BREAK(_fx_catch_43);
             }
 
-         _fx_catch_37: ;
-            goto _fx_endmatch_7;
+         _fx_catch_43: ;
+            goto _fx_endmatch_9;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 22) {
-         result_0 = true; FX_BREAK(_fx_catch_38);  _fx_catch_38: ; goto _fx_endmatch_7;
+      if (FX_REC_VARIANT_TAG(t1_2) == 23) {
+         result_0 = true; FX_BREAK(_fx_catch_44);  _fx_catch_44: ; goto _fx_endmatch_9;
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 22) {
-         result_0 = true; FX_BREAK(_fx_catch_39);  _fx_catch_39: ; goto _fx_endmatch_7;
+      if (FX_REC_VARIANT_TAG(t2_2) == 23) {
+         result_0 = true; FX_BREAK(_fx_catch_45);  _fx_catch_45: ; goto _fx_endmatch_9;
       }
-      bool res_9;
-      if (FX_REC_VARIANT_TAG(t1_2) == 25) {
-         res_9 = true;
+      bool res_10;
+      if (FX_REC_VARIANT_TAG(t1_2) == 26) {
+         res_10 = true;
       }
-      else if (FX_REC_VARIANT_TAG(t2_2) == 25) {
-         res_9 = true;
+      else if (FX_REC_VARIANT_TAG(t2_2) == 26) {
+         res_10 = true;
       }
       else {
-         res_9 = false;
+         res_10 = false;
       }
-      FX_CHECK_EXN(_fx_catch_42);
-      if (res_9) {
-         result_0 = false; FX_BREAK(_fx_catch_40);  _fx_catch_40: ; goto _fx_endmatch_7;
+      FX_CHECK_EXN(_fx_catch_48);
+      if (res_10) {
+         result_0 = false; FX_BREAK(_fx_catch_46);  _fx_catch_46: ; goto _fx_endmatch_9;
       }
       result_0 = false;
-      FX_BREAK(_fx_catch_41);
+      FX_BREAK(_fx_catch_47);
 
-   _fx_catch_41: ;
+   _fx_catch_47: ;
 
-   _fx_endmatch_7: ;
-      FX_CHECK_EXN(_fx_catch_42);
+   _fx_endmatch_9: ;
+      FX_CHECK_EXN(_fx_catch_48);
 
-   _fx_catch_42: ;
+   _fx_catch_48: ;
+      if (v_21) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_21);
+      }
+      if (v_20) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_20);
+      }
       if (v_19) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_19);
       }
@@ -12592,14 +12788,14 @@ static int _fx_M13Ast_typecheckFM12maybe_unify_B3N10Ast__typ_tN10Ast__typ_tR10As
       if (v_12) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_12);
       }
-      if (v_11) {
-         _fx_free_Nt6option1N10Ast__typ_t(&v_11);
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11);
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+      if (v_9) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_9);
       }
-      if (v_10) {
-         _fx_free_Nt6option1N10Ast__typ_t(&v_10);
+      if (v_8) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_8);
       }
-      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9);
-      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_8);
       if (v_7) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_7);
       }
@@ -12743,7 +12939,7 @@ static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__as
       (_fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
    _fx_LT2R9Ast__id_tN10Ast__typ_t* subst_0 = &cv_0->t1->data;
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
       if (vcase_0->t0 == 0) {
          _fx_R9Ast__id_t* n_0 = &vcase_0->t1;
@@ -12860,7 +13056,7 @@ static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__as
       }
       goto _fx_endmatch_0;
    }
-   if (tag_0 == 20) {
+   if (tag_0 == 21) {
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_9 = 0;
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = {0};
@@ -12958,6 +13154,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
    _fx_Nt6option1N10Ast__typ_t v_1 = 0;
    _fx_Nt6option1N10Ast__typ_t v_2 = 0;
    _fx_Nt6option1N10Ast__typ_t v_3 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_4 = 0;
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
@@ -12965,42 +13162,42 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
       FX_COPY_PTR(t_0->u.TypVar->data, &v_0);
       if ((v_0 != 0) + 1 == 2) {
          if (FX_REC_VARIANT_TAG(v_0->u.Some) == 4) {
-            _fx_R16Ast__val_flags_t v_4 = {0};
-            _fx_N10Ast__typ_t v_5 = 0;
-            _fx_N10Ast__exp_t v_6 = 0;
-            _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_7 = {0};
-            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_8 = 0;
-            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_9 = {0};
-            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = 0;
+            _fx_R16Ast__val_flags_t v_5 = {0};
+            _fx_N10Ast__typ_t v_6 = 0;
+            _fx_N10Ast__exp_t v_7 = 0;
+            _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_8 = {0};
+            _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_9 = 0;
+            _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_10 = {0};
+            _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_11 = 0;
             _fx_R9Ast__id_t k_0;
             fx_str_t slit_0 = FX_MAKE_STR("__skolem_rec__");
             FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, &k_0, 0), _fx_catch_0);
-            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_4, 0), _fx_catch_0);
-            FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &k_0, &v_5), _fx_catch_0);
-            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&_fx_g10Ast__noloc, &v_6), _fx_catch_0);
-            _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_4, &k_0, v_5, v_6, &v_7);
-            FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_7, 0, true, &v_8), _fx_catch_0);
-            _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_8, true, &v_9);
-            FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9, &v_10), _fx_catch_0);
-            FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_10, fx_result),
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_5, 0), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &k_0, &v_6), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&_fx_g10Ast__noloc, &v_7), _fx_catch_0);
+            _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_5, &k_0, v_6, v_7, &v_8);
+            FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_8, 0, true, &v_9), _fx_catch_0);
+            _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_9, true, &v_10);
+            FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10, &v_11), _fx_catch_0);
+            FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_11, fx_result),
                _fx_catch_0);
 
          _fx_catch_0: ;
-            if (v_10) {
-               _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+            if (v_11) {
+               _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11);
             }
-            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9);
-            if (v_8) {
-               _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_8);
+            _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_10);
+            if (v_9) {
+               _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_9);
             }
-            _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_7);
+            _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_8);
+            if (v_7) {
+               _fx_free_N10Ast__exp_t(&v_7);
+            }
             if (v_6) {
-               _fx_free_N10Ast__exp_t(&v_6);
+               _fx_free_N10Ast__typ_t(&v_6);
             }
-            if (v_5) {
-               _fx_free_N10Ast__typ_t(&v_5);
-            }
-            _fx_free_R16Ast__val_flags_t(&v_4);
+            _fx_free_R16Ast__val_flags_t(&v_5);
             goto _fx_endmatch_0;
          }
       }
@@ -13008,51 +13205,51 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
    if (tag_0 == 1) {
       FX_COPY_PTR(t_0->u.TypVar->data, &v_1);
       if ((v_1 != 0) + 1 == 2) {
-         _fx_N10Ast__typ_t v_11 = v_1->u.Some;
-         if (FX_REC_VARIANT_TAG(v_11) == 2) {
-            _fx_Nt6option1N10Ast__typ_t t_opt_0 = v_11->u.TypVarTuple;
+         _fx_N10Ast__typ_t v_12 = v_1->u.Some;
+         if (FX_REC_VARIANT_TAG(v_12) == 2) {
+            _fx_Nt6option1N10Ast__typ_t t_opt_0 = v_12->u.TypVarTuple;
             if ((t_opt_0 != 0) + 1 == 2) {
-               _fx_N10Ast__typ_t v_12 = 0;
-               _fx_LN10Ast__typ_t v_13 = 0;
+               _fx_N10Ast__typ_t v_13 = 0;
+               _fx_LN10Ast__typ_t v_14 = 0;
                FX_CALL(
-                  _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_opt_0->u.Some, callb_0, &v_12,
+                  _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_opt_0->u.Some, callb_0, &v_13,
                      0), _fx_catch_1);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_12, 0, true, &v_13), _fx_catch_1);
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_13, fx_result), _fx_catch_1);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_13, 0, true, &v_14), _fx_catch_1);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_14, fx_result), _fx_catch_1);
 
             _fx_catch_1: ;
-               if (v_13) {
-                  _fx_free_LN10Ast__typ_t(&v_13);
+               if (v_14) {
+                  _fx_free_LN10Ast__typ_t(&v_14);
                }
-               if (v_12) {
-                  _fx_free_N10Ast__typ_t(&v_12);
+               if (v_13) {
+                  _fx_free_N10Ast__typ_t(&v_13);
                }
             }
             else {
-               _fx_N10Ast__typ_t v_14 = 0;
                _fx_N10Ast__typ_t v_15 = 0;
-               _fx_LN10Ast__typ_t v_16 = 0;
-               _fx_R9Ast__id_t v_17;
-               fx_str_t slit_1 = FX_MAKE_STR("__skolem1__");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, &v_17, 0), _fx_catch_2);
-               FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_17, &v_14), _fx_catch_2);
+               _fx_N10Ast__typ_t v_16 = 0;
+               _fx_LN10Ast__typ_t v_17 = 0;
                _fx_R9Ast__id_t v_18;
-               fx_str_t slit_2 = FX_MAKE_STR("__skolem2__");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, &v_18, 0), _fx_catch_2);
+               fx_str_t slit_1 = FX_MAKE_STR("__skolem1__");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, &v_18, 0), _fx_catch_2);
                FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_18, &v_15), _fx_catch_2);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_15, 0, true, &v_16), _fx_catch_2);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_14, v_16, false, &v_16), _fx_catch_2);
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_16, fx_result), _fx_catch_2);
+               _fx_R9Ast__id_t v_19;
+               fx_str_t slit_2 = FX_MAKE_STR("__skolem2__");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, &v_19, 0), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_19, &v_16), _fx_catch_2);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_16, 0, true, &v_17), _fx_catch_2);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_15, v_17, false, &v_17), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_17, fx_result), _fx_catch_2);
 
             _fx_catch_2: ;
+               if (v_17) {
+                  _fx_free_LN10Ast__typ_t(&v_17);
+               }
                if (v_16) {
-                  _fx_free_LN10Ast__typ_t(&v_16);
+                  _fx_free_N10Ast__typ_t(&v_16);
                }
                if (v_15) {
                   _fx_free_N10Ast__typ_t(&v_15);
-               }
-               if (v_14) {
-                  _fx_free_N10Ast__typ_t(&v_14);
                }
             }
             FX_CHECK_EXN(_fx_catch_3);
@@ -13065,17 +13262,17 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
    if (tag_0 == 1) {
       FX_COPY_PTR(t_0->u.TypVar->data, &v_2);
       if ((v_2 != 0) + 1 == 2) {
-         _fx_N10Ast__typ_t v_19 = v_2->u.Some;
-         if (FX_REC_VARIANT_TAG(v_19) == 3) {
-            _fx_N10Ast__typ_t v_20 = 0;
+         _fx_N10Ast__typ_t v_20 = v_2->u.Some;
+         if (FX_REC_VARIANT_TAG(v_20) == 3) {
+            _fx_N10Ast__typ_t v_21 = 0;
             FX_CALL(
-               _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_19->u.TypVarArray, callb_0, &v_20,
+               _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_20->u.TypVarArray, callb_0, &v_21,
                   0), _fx_catch_4);
-            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(-1, v_20, fx_result), _fx_catch_4);
+            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(-1, v_21, fx_result), _fx_catch_4);
 
          _fx_catch_4: ;
-            if (v_20) {
-               _fx_free_N10Ast__typ_t(&v_20);
+            if (v_21) {
+               _fx_free_N10Ast__typ_t(&v_21);
             }
             goto _fx_endmatch_0;
          }
@@ -13084,24 +13281,38 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
    if (tag_0 == 1) {
       FX_COPY_PTR(t_0->u.TypVar->data, &v_3);
       if ((v_3 != 0) + 1 == 2) {
-         _fx_N10Ast__typ_t v_21 = 0;
-         _fx_Nt6option1N10Ast__typ_t v_22 = 0;
-         _fx_rNt6option1N10Ast__typ_t v_23 = 0;
-         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_3->u.Some, callb_0, &v_21, 0),
-            _fx_catch_5);
-         FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_21, &v_22), _fx_catch_5);
-         FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_22, &v_23), _fx_catch_5);
-         FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_23, fx_result), _fx_catch_5);
+         if (FX_REC_VARIANT_TAG(v_3->u.Some) == 5) {
+            _fx_R9Ast__id_t v_22;
+            fx_str_t slit_3 = FX_MAKE_STR("__skolem_coll__");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_3, &v_22, 0), _fx_catch_5);
+            FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(0, &v_22, fx_result), _fx_catch_5);
 
-      _fx_catch_5: ;
+         _fx_catch_5: ;
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   if (tag_0 == 1) {
+      FX_COPY_PTR(t_0->u.TypVar->data, &v_4);
+      if ((v_4 != 0) + 1 == 2) {
+         _fx_N10Ast__typ_t v_23 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_24 = 0;
+         _fx_rNt6option1N10Ast__typ_t v_25 = 0;
+         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(v_4->u.Some, callb_0, &v_23, 0),
+            _fx_catch_6);
+         FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_23, &v_24), _fx_catch_6);
+         FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_24, &v_25), _fx_catch_6);
+         FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_25, fx_result), _fx_catch_6);
+
+      _fx_catch_6: ;
+         if (v_25) {
+            _fx_free_rNt6option1N10Ast__typ_t(&v_25);
+         }
+         if (v_24) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_24);
+         }
          if (v_23) {
-            _fx_free_rNt6option1N10Ast__typ_t(&v_23);
-         }
-         if (v_22) {
-            _fx_free_Nt6option1N10Ast__typ_t(&v_22);
-         }
-         if (v_21) {
-            _fx_free_N10Ast__typ_t(&v_21);
+            _fx_free_N10Ast__typ_t(&v_23);
          }
          goto _fx_endmatch_0;
       }
@@ -13109,69 +13320,69 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast_
    if (tag_0 == 1) {
       FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
    }
-   if (tag_0 == 20) {
+   if (tag_0 == 21) {
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
-      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_24 = 0;
-      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_25 = {0};
-      _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_26 = 0;
-      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_27 = &t_0->u.TypRecord->data;
-      FX_COPY_PTR(v_27->t0, &relems_0);
-      bool ordered_0 = v_27->t1;
+      _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_26 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_27 = {0};
+      _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_28 = 0;
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB* v_29 = &t_0->u.TypRecord->data;
+      FX_COPY_PTR(v_29->t0, &relems_0);
+      bool ordered_0 = v_29->t1;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lstend_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_0 = relems_0;
       for (; lst_0; lst_0 = lst_0->tl) {
          _fx_R16Ast__val_flags_t fl_0 = {0};
          _fx_N10Ast__typ_t t_1 = 0;
-         _fx_N10Ast__exp_t v_28 = 0;
-         _fx_N10Ast__typ_t v_29 = 0;
+         _fx_N10Ast__exp_t v_30 = 0;
+         _fx_N10Ast__typ_t v_31 = 0;
          _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t tup_0 = {0};
          _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_0->hd;
          _fx_copy_R16Ast__val_flags_t(&__pat___0->t0, &fl_0);
          _fx_R9Ast__id_t n_0 = __pat___0->t1;
          FX_COPY_PTR(__pat___0->t2, &t_1);
-         FX_COPY_PTR(__pat___0->t3, &v_28);
-         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_1, callb_0, &v_29, 0),
-            _fx_catch_6);
-         _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&fl_0, &n_0, v_29, v_28, &tup_0);
+         FX_COPY_PTR(__pat___0->t3, &v_30);
+         FX_CALL(_fx_M13Ast_typecheckFM7freeze_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(t_1, callb_0, &v_31, 0),
+            _fx_catch_7);
+         _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&fl_0, &n_0, v_31, v_30, &tup_0);
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t node_0 = 0;
-         FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0, 0, false, &node_0), _fx_catch_6);
-         FX_LIST_APPEND(v_24, lstend_0, node_0);
+         FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0, 0, false, &node_0), _fx_catch_7);
+         FX_LIST_APPEND(v_26, lstend_0, node_0);
 
-      _fx_catch_6: ;
+      _fx_catch_7: ;
          _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0);
-         if (v_29) {
-            _fx_free_N10Ast__typ_t(&v_29);
+         if (v_31) {
+            _fx_free_N10Ast__typ_t(&v_31);
          }
-         if (v_28) {
-            _fx_free_N10Ast__exp_t(&v_28);
+         if (v_30) {
+            _fx_free_N10Ast__exp_t(&v_30);
          }
          if (t_1) {
             _fx_free_N10Ast__typ_t(&t_1);
          }
          _fx_free_R16Ast__val_flags_t(&fl_0);
-         FX_CHECK_EXN(_fx_catch_7);
+         FX_CHECK_EXN(_fx_catch_8);
       }
-      _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_24, ordered_0, &v_25);
-      FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_25, &v_26), _fx_catch_7);
-      FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_26, fx_result),
-         _fx_catch_7);
+      _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(v_26, ordered_0, &v_27);
+      FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_27, &v_28), _fx_catch_8);
+      FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_28, fx_result),
+         _fx_catch_8);
 
-   _fx_catch_7: ;
-      if (v_26) {
-         _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_26);
+   _fx_catch_8: ;
+      if (v_28) {
+         _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_28);
       }
-      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_25);
-      if (v_24) {
-         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_24);
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_27);
+      if (v_26) {
+         _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_26);
       }
       if (relems_0) {
          _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
       }
       goto _fx_endmatch_0;
    }
-   FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0, callb_0, fx_result, 0), _fx_catch_8);
+   FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(t_0, callb_0, fx_result, 0), _fx_catch_9);
 
-_fx_catch_8: ;
+_fx_catch_9: ;
 
 _fx_endmatch_0: ;
 
@@ -13187,6 +13398,9 @@ _fx_cleanup: ;
    }
    if (v_3) {
       _fx_free_Nt6option1N10Ast__typ_t(&v_3);
+   }
+   if (v_4) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_4);
    }
    return fx_status;
 }
@@ -13452,7 +13666,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__
    bool res_0;
    FX_CALL(_fx_M3AstFM14is_constructorB1RM11fun_flags_t(&df_flags_0, &res_0, 0), _fx_cleanup);
    if (res_0 == false) {
-      if (FX_REC_VARIANT_TAG(v_2) == 14) {
+      if (FX_REC_VARIANT_TAG(v_2) == 15) {
          FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_2->u.TypFun.t0, &cmp_typ_0), _fx_catch_5);
 
       _fx_catch_5: ;
@@ -13521,7 +13735,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
       _fx_make_Ta2N10Ast__typ_t(t1_0, t2_0, &v_2);
    }
    else if (kw1_0) {
-      if (FX_REC_VARIANT_TAG(t2_0) == 17) {
+      if (FX_REC_VARIANT_TAG(t2_0) == 18) {
          _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_5 = {0};
          _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_6 = 0;
          _fx_N10Ast__typ_t v_7 = 0;
@@ -13589,7 +13803,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
       _fx_make_Ta2N10Ast__typ_t(t1_0, v_3, &v_2);
    }
    else {
-      if (FX_REC_VARIANT_TAG(t1_0) == 17) {
+      if (FX_REC_VARIANT_TAG(t1_0) == 18) {
          _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_11 = {0};
          _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_12 = 0;
          _fx_N10Ast__typ_t v_13 = 0;
@@ -13733,6 +13947,7 @@ static int _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_c
    _fx_Nt6option1N10Ast__typ_t v_2 = 0;
    _fx_Nt6option1N10Ast__typ_t v_3 = 0;
    _fx_Nt6option1N10Ast__typ_t v_4 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_5 = 0;
    int fx_status = 0;
    _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* cv_0 =
       (_fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
@@ -13773,6 +13988,14 @@ static int _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_c
             }
          }
       }
+      if (tag_0 == 1) {
+         FX_COPY_PTR(v_0->u.TypVar->data, &v_5);
+         if ((v_5 != 0) + 1 == 2) {
+            if (FX_REC_VARIANT_TAG(v_5->u.Some) == 5) {
+               *has_free_0 = true; FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
+            }
+         }
+      }
       FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(v_0, callb_0, fx_result, 0), _fx_catch_0);
 
    _fx_catch_0: ;
@@ -13796,6 +14019,9 @@ _fx_cleanup: ;
    }
    if (v_4) {
       _fx_free_Nt6option1N10Ast__typ_t(&v_4);
+   }
+   if (v_5) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_5);
    }
    return fx_status;
 }
@@ -13914,8 +14140,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
       _fx_N10Ast__typ_t t2_2 = 0;
       FX_COPY_PTR(t1_1, &t1_2);
       FX_COPY_PTR(t2_1, &t2_2);
-      if (FX_REC_VARIANT_TAG(t1_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 5) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 6) {
             _fx_free_N10Ast__typ_t(&result_0);
             FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, &result_0);
             FX_BREAK(_fx_catch_0);
@@ -13924,8 +14150,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
             _fx_N10Ast__typ_t result_1 = 0;
             int_ b_0 = fx_maxi(t1_2->u.TypSInt, t2_2->u.TypSInt);
             if (b_0 <= 32) {
@@ -13945,8 +14171,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 8) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 8) {
             _fx_N10Ast__typ_t result_2 = 0;
             int_ b_1 = fx_maxi(t1_2->u.TypUInt, t2_2->u.TypUInt);
             if (b_1 <= safe_max_ubits_0) {
@@ -13966,8 +14192,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 7) {
             _fx_N10Ast__typ_t result_3 = 0;
             int_ b_2 = t2_2->u.TypSInt;
             if (b_2 <= 32) {
@@ -13987,8 +14213,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 7) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 8) {
             fx_exn_t v_0 = {0};
             if (t2_2->u.TypUInt <= safe_max_ubits_0) {
                _fx_free_N10Ast__typ_t(&result_0); FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, &result_0); FX_BREAK(_fx_catch_4);
@@ -14005,8 +14231,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
             _fx_N10Ast__typ_t result_4 = 0;
             _fx_N10Ast__typ_t result_5 = 0;
             int_ b_3 = t1_2->u.TypSInt;
@@ -14036,8 +14262,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 8) {
             _fx_N10Ast__typ_t result_6 = 0;
             fx_exn_t v_1 = {0};
             int_ b_4 = t1_2->u.TypUInt;
@@ -14065,9 +14291,9 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 7) {
          if (t1_2->u.TypSInt == 64) {
-            if (FX_REC_VARIANT_TAG(t2_2) == 7) {
+            if (FX_REC_VARIANT_TAG(t2_2) == 8) {
                if (t2_2->u.TypUInt <= 32) {
                   _fx_N10Ast__typ_t result_7 = 0;
                   FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(64, &result_7), _fx_catch_7);
@@ -14084,9 +14310,9 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
          if (t2_2->u.TypSInt == 64) {
-            if (FX_REC_VARIANT_TAG(t1_2) == 7) {
+            if (FX_REC_VARIANT_TAG(t1_2) == 8) {
                if (t1_2->u.TypUInt <= 32) {
                   _fx_N10Ast__typ_t result_8 = 0;
                   FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(64, &result_8), _fx_catch_8);
@@ -14103,8 +14329,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 8) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
             fx_exn_t v_2 = {0};
             bool t_0;
             if (t1_2->u.TypSInt <= 32) {
@@ -14129,8 +14355,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 7) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 8) {
             fx_exn_t v_3 = {0};
             bool t_1;
             if (t1_2->u.TypUInt <= safe_max_ubits_0) {
@@ -14155,8 +14381,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 9) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 10) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_9 = 0;
                int_ max_b_0 = fx_maxi(fx_maxi(t1_2->u.TypFloat, t2_2->u.TypFloat), 32);
@@ -14173,8 +14399,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_10 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t1_2->u.TypFloat, 32), &result_10), _fx_catch_12);
@@ -14190,8 +14416,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 6) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_11 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t1_2->u.TypFloat, 32), &result_11), _fx_catch_13);
@@ -14207,8 +14433,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 7) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 8) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_12 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t1_2->u.TypFloat, 32), &result_12), _fx_catch_14);
@@ -14224,8 +14450,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 5) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_13 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t2_2->u.TypFloat, 32), &result_13), _fx_catch_15);
@@ -14241,8 +14467,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 6) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 7) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_14 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t2_2->u.TypFloat, 32), &result_14), _fx_catch_16);
@@ -14258,8 +14484,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 7) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 9) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 8) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 10) {
             if (allow_fp_0) {
                _fx_N10Ast__typ_t result_15 = 0;
                FX_CALL(_fx_M3AstFM8TypFloatN10Ast__typ_t1i(fx_maxi(t2_2->u.TypFloat, 32), &result_15), _fx_catch_17);
@@ -14275,8 +14501,8 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             }
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 12) {
-         if (FX_REC_VARIANT_TAG(t2_2) == 12) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 13) {
+         if (FX_REC_VARIANT_TAG(t2_2) == 13) {
             _fx_free_N10Ast__typ_t(&result_0);
             FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, &result_0);
             FX_BREAK(_fx_catch_18);
@@ -14285,22 +14511,22 @@ static int _fx_M13Ast_typecheckFM13coerce_types_N10Ast__typ_t7N10Ast__typ_tN10As
             goto _fx_endmatch_0;
          }
       }
-      if (FX_REC_VARIANT_TAG(t1_2) == 12) {
+      if (FX_REC_VARIANT_TAG(t1_2) == 13) {
          _fx_free_N10Ast__typ_t(&t1_1);
          FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, &t1_1);
          _fx_free_N10Ast__typ_t(&t2_1);
          FX_COPY_PTR(t2_2, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 12) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 13) {
          _fx_free_N10Ast__typ_t(&t1_1);
          FX_COPY_PTR(t1_2, &t1_1);
          _fx_free_N10Ast__typ_t(&t2_1);
          FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, &t2_1);
          goto _fx_endmatch_0;
       }
-      if (FX_REC_VARIANT_TAG(t2_2) == 17) {
-         if (FX_REC_VARIANT_TAG(t1_2) == 17) {
+      if (FX_REC_VARIANT_TAG(t2_2) == 18) {
+         if (FX_REC_VARIANT_TAG(t1_2) == 18) {
             fx_exn_t v_4 = {0};
             _fx_LN10Ast__typ_t v_5 = 0;
             _fx_LN10Ast__typ_t tl1_0 = 0;
@@ -15321,60 +15547,60 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM14typ_bounds_intTa2l1N10Ast__typ_t(
 {
    int fx_status = 0;
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (t_0->u.TypSInt == 8) {
          _fx_Ta2l tup_0 = { -128LL, 127LL }; *fx_result = tup_0; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (t_0->u.TypSInt == 16) {
          _fx_Ta2l tup_1 = { -32768LL, 32767LL }; *fx_result = tup_1; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (t_0->u.TypSInt == 32) {
          _fx_Ta2l tup_2 = { -2147483648LL, 2147483647LL }; *fx_result = tup_2; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 6) {
+   if (tag_0 == 7) {
       if (t_0->u.TypSInt == 64) {
          _fx_Ta2l tup_3 = { (-9223372036854775807LL - 1), 9223372036854775807LL }; *fx_result = tup_3; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (t_0->u.TypUInt == 8) {
          _fx_Ta2l tup_4 = { 0LL, 255LL }; *fx_result = tup_4; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (t_0->u.TypUInt == 16) {
          _fx_Ta2l tup_5 = { 0LL, 65535LL }; *fx_result = tup_5; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (t_0->u.TypUInt == 32) {
          _fx_Ta2l tup_6 = { 0LL, 4294967295LL }; *fx_result = tup_6; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 7) {
+   if (tag_0 == 8) {
       if (t_0->u.TypUInt == 64) {
          _fx_Ta2l tup_7 = { 0LL, 9223372036854775807LL }; *fx_result = tup_7; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 8) {
+   if (tag_0 == 9) {
       _fx_Ta2l tup_8 = { (-9223372036854775807LL - 1), 9223372036854775807LL }; *fx_result = tup_8; goto _fx_endmatch_0;
    }
-   if (tag_0 == 9) {
+   if (tag_0 == 10) {
       if (t_0->u.TypFloat == 16) {
          _fx_Ta2l tup_9 = { -4096LL, 4096LL }; *fx_result = tup_9; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 9) {
+   if (tag_0 == 10) {
       if (t_0->u.TypFloat == 32) {
          _fx_Ta2l tup_10 = { -16777216LL, 16777216LL }; *fx_result = tup_10; goto _fx_endmatch_0;
       }
    }
-   if (tag_0 == 9) {
+   if (tag_0 == 10) {
       if (t_0->u.TypFloat == 64) {
          _fx_Ta2l tup_11 = { -9007199254740992LL, 9007199254740992LL }; *fx_result = tup_11; goto _fx_endmatch_0;
       }
@@ -15403,13 +15629,13 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22try_unify_with_literalN10Ast__exp_t3N10A
    FX_COPY_PTR(v_0.t0, &t2_0);
    _fx_R10Ast__loc_t eloc2_0 = v_0.t1;
    bool res_0;
-   if (FX_REC_VARIANT_TAG(t1__0) == 6) {
+   if (FX_REC_VARIANT_TAG(t1__0) == 7) {
       res_0 = true;
    }
-   else if (FX_REC_VARIANT_TAG(t1__0) == 7) {
+   else if (FX_REC_VARIANT_TAG(t1__0) == 8) {
       res_0 = true;
    }
-   else if (FX_REC_VARIANT_TAG(t1__0) == 9) {
+   else if (FX_REC_VARIANT_TAG(t1__0) == 10) {
       res_0 = true;
    }
    else {
@@ -15456,7 +15682,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22try_unify_with_literalN10Ast__exp_t3N10A
                FX_THROW(&v_7, false, _fx_catch_4);
             }
             int tag_0 = FX_REC_VARIANT_TAG(t1__0);
-            if (tag_0 == 6) {
+            if (tag_0 == 7) {
                _fx_N10Ast__lit_t v_9 = {0};
                _fx_T2N10Ast__typ_tR10Ast__loc_t v_10 = {0};
                _fx_M3AstFM7LitSIntN10Ast__lit_t2il(t1__0->u.TypSInt, i_0, &v_9);
@@ -15468,7 +15694,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22try_unify_with_literalN10Ast__exp_t3N10A
                _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_10);
                _fx_free_N10Ast__lit_t(&v_9);
             }
-            else if (tag_0 == 7) {
+            else if (tag_0 == 8) {
                _fx_N10Ast__lit_t v_11 = {0};
                _fx_T2N10Ast__typ_tR10Ast__loc_t v_12 = {0};
                _fx_M3AstFM7LitUIntN10Ast__lit_t2iq(t1__0->u.TypUInt, (uint64_t)i_0, &v_11);
@@ -15480,7 +15706,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22try_unify_with_literalN10Ast__exp_t3N10A
                _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_12);
                _fx_free_N10Ast__lit_t(&v_11);
             }
-            else if (tag_0 == 9) {
+            else if (tag_0 == 10) {
                _fx_N10Ast__lit_t v_13 = {0};
                _fx_T2N10Ast__typ_tR10Ast__loc_t v_14 = {0};
                _fx_M3AstFM8LitFloatN10Ast__lit_t2id(t1__0->u.TypFloat, (double)i_0, &v_13);
@@ -15525,7 +15751,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22try_unify_with_literalN10Ast__exp_t3N10A
       }
    }
    if (FX_REC_VARIANT_TAG(e2_0) == 13) {
-      if (FX_REC_VARIANT_TAG(t1__0) == 17) {
+      if (FX_REC_VARIANT_TAG(t1__0) == 18) {
          fx_str_t v_18 = {0};
          fx_str_t v_19 = {0};
          fx_str_t v_20 = {0};
@@ -15671,7 +15897,7 @@ FX_EXTERN_C int
    FX_CALL(fx_check_stack(), _fx_cleanup);
    FX_CALL(_fx_M3AstFM7dup_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_0, &t_1, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(t_1) == 20) {
+   if (FX_REC_VARIANT_TAG(t_1) == 21) {
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_1 = {0};
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_1 = 0;
@@ -15734,19 +15960,19 @@ FX_EXTERN_C int
                   int64_t b_0 = v_9.t1;
                   if ((bool)((a_0 <= iv_0) & (iv_0 <= b_0))) {
                      int tag_2 = FX_REC_VARIANT_TAG(t_2);
-                     if (tag_2 == 6) {
+                     if (tag_2 == 7) {
                         _fx_N10Ast__lit_t v_10 = {0};
                         _fx_M3AstFM7LitSIntN10Ast__lit_t2il(t_2->u.TypSInt, iv_0, &v_10);
                         _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__lit_t1N10Ast__lit_t(&v_10, &v_opt_0);
                         _fx_free_N10Ast__lit_t(&v_10);
                      }
-                     else if (tag_2 == 7) {
+                     else if (tag_2 == 8) {
                         _fx_N10Ast__lit_t v_11 = {0};
                         _fx_M3AstFM7LitUIntN10Ast__lit_t2iq(t_2->u.TypUInt, (uint64_t)iv_0, &v_11);
                         _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__lit_t1N10Ast__lit_t(&v_11, &v_opt_0);
                         _fx_free_N10Ast__lit_t(&v_11);
                      }
-                     else if (tag_2 == 9) {
+                     else if (tag_2 == 10) {
                         _fx_N10Ast__lit_t v_12 = {0};
                         _fx_M3AstFM8LitFloatN10Ast__lit_t2id(t_2->u.TypFloat, (double)iv_0, &v_12);
                         _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__lit_t1N10Ast__lit_t(&v_12, &v_opt_0);
@@ -15768,16 +15994,16 @@ FX_EXTERN_C int
                   _fx_T2id* vcase_1 = &v_6->u.LitFloat;
                   if (vcase_1->t0 == 64) {
                      double fv_0 = vcase_1->t1;
-                     if (FX_REC_VARIANT_TAG(t_2) == 9) {
+                     if (FX_REC_VARIANT_TAG(t_2) == 10) {
                         _fx_N10Ast__lit_t v_13 = {0};
                         int tag_3 = FX_REC_VARIANT_TAG(t_2);
                         double a_1;
-                        if (tag_3 == 9) {
+                        if (tag_3 == 10) {
                            if (t_2->u.TypFloat == 16) {
                               a_1 = 65504.0; goto _fx_endmatch_0;
                            }
                         }
-                        if (tag_3 == 9) {
+                        if (tag_3 == 10) {
                            if (t_2->u.TypFloat == 32) {
                               a_1 = 3.402823e+38; goto _fx_endmatch_0;
                            }
@@ -15950,7 +16176,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
    _fx_N10Ast__typ_t t_1 = 0;
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &t_1, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(t_1) == 24) {
+   if (FX_REC_VARIANT_TAG(t_1) == 25) {
       _fx_N14Ast__id_info_t v_0 = {0};
       _fx_LR9Ast__id_t inst_list_0 = 0;
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_1->u.TypApp;
@@ -16053,14 +16279,14 @@ FX_EXTERN_C int
    }
    FX_CHECK_EXN(_fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(t_1);
-   if (tag_0 == 20) {
+   if (tag_0 == 21) {
       _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t_1->u.TypRecord->data, &v_0);
       if (v_0.t1 == true) {
          _fx_make_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g9Ast__noid, v_0.t0, fx_result);
          goto _fx_endmatch_4;
       }
    }
-   if (tag_0 == 20) {
+   if (tag_0 == 21) {
       fx_exn_t v_1 = {0};
       fx_str_t slit_0 = FX_MAKE_STR("the records, which elements we request, is not finalized");
       FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_0, &v_1, 0), _fx_catch_1);
@@ -16070,7 +16296,7 @@ FX_EXTERN_C int
       fx_free_exn(&v_1);
       goto _fx_endmatch_4;
    }
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t v_2 = {0};
       _fx_Nt6option1N10Ast__typ_t v_3 = 0;
       _fx_LN10Ast__typ_t new_tyargs_0 = 0;
@@ -16087,7 +16313,7 @@ FX_EXTERN_C int
             _fx_catch_8);
          if ((v_3 != 0) + 1 == 2) {
             _fx_N10Ast__typ_t v_7 = v_3->u.Some;
-            if (FX_REC_VARIANT_TAG(v_7) == 24) {
+            if (FX_REC_VARIANT_TAG(v_7) == 25) {
                _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_1 = &v_7->u.TypApp;
                if (vcase_1->t0 == 0) {
                   _fx_make_T2LN10Ast__typ_tR9Ast__id_t(0, &vcase_1->t1, &v_2); goto _fx_endmatch_0;
@@ -16116,7 +16342,7 @@ FX_EXTERN_C int
             if (v_9->tl == 0) {
                _fx_T2R9Ast__id_tN10Ast__typ_t* v_10 = &v_9->hd;
                _fx_N10Ast__typ_t v_11 = v_10->t1;
-               if (FX_REC_VARIANT_TAG(v_11) == 20) {
+               if (FX_REC_VARIANT_TAG(v_11) == 21) {
                   _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11->u.TypRecord->data, &v_6);
                   if (v_6.t1 == true) {
                      _fx_R9Ast__id_t* vn0_0 = &v_10->t0;
@@ -16243,7 +16469,7 @@ FX_EXTERN_C int
          if (found_case_ctor_0.tag == 2) {
             _fx_T2T2R9Ast__id_tN10Ast__typ_tR9Ast__id_t* v_22 = &found_case_ctor_0.u.Some;
             _fx_N10Ast__typ_t v_23 = v_22->t0.t1;
-            if (FX_REC_VARIANT_TAG(v_23) == 20) {
+            if (FX_REC_VARIANT_TAG(v_23) == 21) {
                _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_23->u.TypRecord->data, &v_18);
                if (v_18.t1 == true) {
                   _fx_make_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_22->t1, v_18.t0,
@@ -16378,7 +16604,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
          &is_real_typ__0, &v_0), _fx_cleanup);
    _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
       if (vcase_0->t0 == 0) {
          if (vcase_0->t1.m == 0) {
@@ -16386,7 +16612,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
          }
       }
    }
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       if (t_0->u.TypApp.t0 == 0) {
          FX_COPY_PTR(t_0, &res_0); goto _fx_endmatch_0;
       }
@@ -16433,7 +16659,7 @@ static int _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast
       (_fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
    bool* have_typ_vars_0 = &cv_0->t0->data;
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_0 = &t_0->u.TypApp;
       if (vcase_0->t0 == 0) {
          if (vcase_0->t1.m == 0) {
@@ -16441,7 +16667,7 @@ static int _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast
          }
       }
    }
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       if (t_0->u.TypApp.t0 == 0) {
          FX_COPY_PTR(t_0, fx_result); goto _fx_endmatch_0;
       }
@@ -16548,7 +16774,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN
       }
       FX_COPY_PTR(result_0, &v_8);
       FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_8, &v_9, 0), _fx_catch_2);
-      if (FX_REC_VARIANT_TAG(v_9) == 20) {
+      if (FX_REC_VARIANT_TAG(v_9) == 21) {
          _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_9->u.TypRecord->data, &v_10);
          if (v_10.t1 == false) {
             caller_has_kwrec_0 = true; goto _fx_endmatch_1;
@@ -16644,12 +16870,12 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN
       FX_COPY_PTR(v_4.t0, &ftyp_0);
    }
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(df_typ_0, &v_5, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_5) == 14) {
+   if (FX_REC_VARIANT_TAG(v_5) == 15) {
       FX_COPY_PTR(v_5->u.TypFun.t0, &ptyps_disp_0);
    }
    FX_CHECK_EXN(_fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(ftyp_0, &v_6, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_6) == 14) {
+   if (FX_REC_VARIANT_TAG(v_6) == 15) {
       fx_str_t pos_s_0 = {0};
       fx_str_t v_12 = {0};
       fx_str_t v_13 = {0};
@@ -16940,7 +17166,7 @@ FX_EXTERN_C int
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &nstr_0, 0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_0) == 14) {
+   if (FX_REC_VARIANT_TAG(v_0) == 15) {
       _fx_M13Ast_typecheckFM4SomeNt6option1LN10Ast__typ_t1LN10Ast__typ_t(v_0->u.TypFun.t0, &call_argtyps_opt_0);
    }
    else {
@@ -17330,7 +17556,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10A
    FX_COPY_PTR(v_2->df_templ_args, &df_templ_args_0);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    if (df_flags_0.fun_flag_have_keywords == true) {
-      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      if (FX_REC_VARIANT_TAG(v_0) == 15) {
          _fx_LN10Ast__typ_t argtyps_0 = 0;
          _fx_N10Ast__typ_t result_0 = 0;
          _fx_LN10Ast__typ_t __pat___0 = 0;
@@ -17380,7 +17606,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17fun_matches_trialB4rR13Ast__deffun_tN10A
             FX_COPY_PTR(result_0, &v_3);
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_3, &v_4, 0), _fx_catch_5);
             bool res_0;
-            if (FX_REC_VARIANT_TAG(v_4) == 20) {
+            if (FX_REC_VARIANT_TAG(v_4) == 21) {
                _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_4->u.TypRecord->data, &v_5);
                if (v_5.t1 == false) {
                   res_0 = true; goto _fx_endmatch_1;
@@ -17581,7 +17807,7 @@ static int
    _fx_R9Ast__id_t df_name_0 = v_11->df_name;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    if (df_flags_0.fun_flag_have_keywords == true) {
-      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      if (FX_REC_VARIANT_TAG(v_0) == 15) {
          _fx_LN10Ast__typ_t argtyps_0 = 0;
          _fx_N10Ast__typ_t result_0 = 0;
          _fx_LN10Ast__typ_t __pat___0 = 0;
@@ -17631,7 +17857,7 @@ static int
             FX_COPY_PTR(result_0, &v_12);
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_12, &v_13, 0), _fx_catch_5);
             bool res_0;
-            if (FX_REC_VARIANT_TAG(v_13) == 20) {
+            if (FX_REC_VARIANT_TAG(v_13) == 21) {
                _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_13->u.TypRecord->data, &v_14);
                if (v_14.t1 == false) {
                   res_0 = true; goto _fx_endmatch_1;
@@ -17775,7 +18001,7 @@ _fx_endmatch_3: ;
          return_orig_0 = false;
       }
       else {
-         if (FX_REC_VARIANT_TAG(ftyp_0) == 14) {
+         if (FX_REC_VARIANT_TAG(ftyp_0) == 15) {
             _fx_N10Ast__typ_t res_2 = 0;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
@@ -18038,7 +18264,7 @@ static int
    _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0, &genwin_opt_0);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_14);
    bool fully_determined_0;
-   if (FX_REC_VARIANT_TAG(v_1) == 14) {
+   if (FX_REC_VARIANT_TAG(v_1) == 15) {
       _fx_LN10Ast__typ_t argtyps_0 = 0;
       bool __fold_result___2 = true;
       FX_COPY_PTR(v_1->u.TypFun.t0, &argtyps_0);
@@ -18545,12 +18771,12 @@ static int
                   fx_exn_t v_15 = {0};
                   _fx_T2R9Ast__id_tN10Ast__typ_t v_16 = {0};
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_3 = {0};
-                  if (FX_REC_VARIANT_TAG(dexn_typ_0) == 13) {
+                  if (FX_REC_VARIANT_TAG(dexn_typ_0) == 14) {
                      FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &ctyp_0);
                   }
                   else {
                      _fx_LN10Ast__typ_t v_17 = 0;
-                     if (FX_REC_VARIANT_TAG(dexn_typ_0) == 17) {
+                     if (FX_REC_VARIANT_TAG(dexn_typ_0) == 18) {
                         FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_17);
                      }
                      else {
@@ -18971,16 +19197,16 @@ FX_EXTERN_C int
    FX_CALL(_fx_M3AstFM13deref_typ_recN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    fx_str_t slit_0 = FX_MAKE_STR("__eq__");
    if (fx_streq(&nstr_0, &slit_0)) {
-      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      if (FX_REC_VARIANT_TAG(v_0) == 15) {
          _fx_LN10Ast__typ_t v_2 = v_0->u.TypFun.t0;
          if (v_2 != 0) {
             _fx_LN10Ast__typ_t v_3 = v_2->tl;
             if (v_3 != 0) {
                if (v_3->tl == 0) {
                   _fx_N10Ast__typ_t v_4 = v_3->hd;
-                  if (FX_REC_VARIANT_TAG(v_4) == 24) {
+                  if (FX_REC_VARIANT_TAG(v_4) == 25) {
                      _fx_N10Ast__typ_t v_5 = v_2->hd;
-                     if (FX_REC_VARIANT_TAG(v_5) == 24) {
+                     if (FX_REC_VARIANT_TAG(v_5) == 25) {
                         _fx_R9Ast__id_t* n1_0 = &v_5->u.TypApp.t1;
                         bool res_0;
                         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(n1_0, &v_4->u.TypApp.t1, &res_0, 0), _fx_cleanup);
@@ -19022,11 +19248,11 @@ FX_EXTERN_C int
    }
    fx_str_t slit_2 = FX_MAKE_STR("string");
    if (fx_streq(&nstr_0, &slit_2)) {
-      if (FX_REC_VARIANT_TAG(v_0) == 14) {
+      if (FX_REC_VARIANT_TAG(v_0) == 15) {
          _fx_LN10Ast__typ_t v_8 = v_0->u.TypFun.t0;
          if (v_8 != 0) {
             if (v_8->tl == 0) {
-               if (FX_REC_VARIANT_TAG(v_8->hd) == 14) {
+               if (FX_REC_VARIANT_TAG(v_8->hd) == 15) {
                   _fx_T2R9Ast__id_tN10Ast__typ_t v_9 = {0};
                   _fx_R9Ast__id_t v_10;
                   fx_str_t slit_3 = FX_MAKE_STR("__fun_string__");
@@ -19298,12 +19524,12 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_v1N14Ast__id_info_t(struct _fx_N1
       bool res_2;
       FX_CALL(_fx_M13Ast_typecheckFM15__eq_variants__B2N12Ast__scope_tN12Ast__scope_t(&v_14, &v_15, &res_2, 0), _fx_catch_3);
       if (res_2) {
-         if (FX_REC_VARIANT_TAG(dexn_typ_0) == 13) {
+         if (FX_REC_VARIANT_TAG(dexn_typ_0) == 14) {
             FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &t_1);
          }
          else {
             _fx_LN10Ast__typ_t v_16 = 0;
-            if (FX_REC_VARIANT_TAG(dexn_typ_0) == 17) {
+            if (FX_REC_VARIANT_TAG(dexn_typ_0) == 18) {
                FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_16);
             }
             else {
@@ -19465,7 +19691,7 @@ FX_EXTERN_C int
       if (actual_ty_args_0 != 0) {
          if (actual_ty_args_0->tl == 0) {
             _fx_N10Ast__typ_t v_0 = actual_ty_args_0->hd;
-            if (FX_REC_VARIANT_TAG(v_0) == 17) {
+            if (FX_REC_VARIANT_TAG(v_0) == 18) {
                _fx_LN10Ast__typ_t tl_0 = v_0->u.TypTuple;
                int_ v_1 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(tl_0, 0);
                if (v_1 == n_templ_args_0) {
@@ -19636,19 +19862,19 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM19check_unary_bitwiseN10Ast__typ_t1N10Ast_
    FX_CALL(fx_check_stack(), _fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(v_0);
-   if (tag_0 == 5) {
+   if (tag_0 == 6) {
       FX_COPY_PTR(_fx_g21Ast_typecheck__TypInt, fx_result);
    }
-   else if (tag_0 == 6) {
+   else if (tag_0 == 7) {
       FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(v_0->u.TypSInt, fx_result), _fx_catch_0);  _fx_catch_0: ;
    }
-   else if (tag_0 == 7) {
+   else if (tag_0 == 8) {
       FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(v_0->u.TypUInt, fx_result), _fx_catch_1);  _fx_catch_1: ;
    }
-   else if (tag_0 == 12) {
+   else if (tag_0 == 13) {
       FX_COPY_PTR(_fx_g22Ast_typecheck__TypBool, fx_result);
    }
-   else if (tag_0 == 17) {
+   else if (tag_0 == 18) {
       _fx_LN10Ast__typ_t v_1 = 0;
       _fx_LN10Ast__typ_t tl_0 = 0;
       _fx_LN10Ast__typ_t lstend_0 = 0;
@@ -19862,7 +20088,7 @@ FX_EXTERN_C int
          FX_COPY_PTR(v_8.t0, &etyp1_0);
          _fx_R10Ast__loc_t eloc1_0 = v_8.t1;
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_0, &etyp1_1, 0), _fx_catch_22);
-         if (FX_REC_VARIANT_TAG(etyp1_1) == 26) {
+         if (FX_REC_VARIANT_TAG(etyp1_1) == 27) {
             if (FX_REC_VARIANT_TAG(e2_0) == 7) {
                if (FX_REC_VARIANT_TAG(new_e1_0) == 7) {
                   _fx_N16Ast__defmodule_t dm_0 = 0;
@@ -19937,7 +20163,7 @@ FX_EXTERN_C int
             _fx_T2N10Ast__lit_tT2N10Ast__typ_tR10Ast__loc_t* vcase_3 = &e2_0->u.ExpLit;
             _fx_N10Ast__lit_t* v_15 = &vcase_3->t0;
             if (v_15->tag == 1) {
-               if (FX_REC_VARIANT_TAG(etyp1_1) == 17) {
+               if (FX_REC_VARIANT_TAG(etyp1_1) == 18) {
                   _fx_N10Ast__typ_t et_0 = 0;
                   fx_exn_t exn_0 = {0};
                   _fx_N10Ast__exp_t result_4 = 0;
@@ -19997,7 +20223,7 @@ FX_EXTERN_C int
             }
          }
          if (FX_REC_VARIANT_TAG(e2_0) == 7) {
-            if (FX_REC_VARIANT_TAG(etyp1_1) == 24) {
+            if (FX_REC_VARIANT_TAG(etyp1_1) == 25) {
                bool res_1;
                FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&e2_0->u.ExpIdent.t0, &_fx_g15Ast__std__tag__, &res_1, 0),
                   _fx_catch_22);
@@ -20041,7 +20267,7 @@ FX_EXTERN_C int
             }
          }
          if (FX_REC_VARIANT_TAG(e2_0) == 7) {
-            if (FX_REC_VARIANT_TAG(etyp1_1) == 24) {
+            if (FX_REC_VARIANT_TAG(etyp1_1) == 25) {
                _fx_R9Ast__id_t* iname_0 = &etyp1_1->u.TypApp.t1;
                _fx_R9Ast__id_t* n2_1 = &e2_0->u.ExpIdent.t0;
                FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(iname_0, &eloc_0, &v_9, 0), _fx_catch_22);
@@ -20169,7 +20395,7 @@ FX_EXTERN_C int
                }
             }
          }
-         if (FX_REC_VARIANT_TAG(etyp1_1) == 21) {
+         if (FX_REC_VARIANT_TAG(etyp1_1) == 22) {
             if (FX_REC_VARIANT_TAG(e2_0) == 7) {
                bool res_3;
                FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&e2_0->u.ExpIdent.t0, &_fx_g15Ast__std__tag__, &res_3, 0),
@@ -20651,7 +20877,7 @@ FX_EXTERN_C int
                   _fx_N10Ast__typ_t v_72 = 0;
                   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_4, &v_72, 0), _fx_catch_34);
                   int tag_2 = FX_REC_VARIANT_TAG(v_72);
-                  if (tag_2 == 15) {
+                  if (tag_2 == 16) {
                      bool res_7;
                      if (FX_REC_VARIANT_TAG(new_e2_3) == 6) {
                         if (new_e2_3->u.ExpLit.t0.tag == 8) {
@@ -20688,7 +20914,7 @@ FX_EXTERN_C int
 
                   _fx_catch_29: ;
                   }
-                  else if (tag_2 == 10) {
+                  else if (tag_2 == 11) {
                      if (FX_REC_VARIANT_TAG(new_e2_3) == 6) {
                         _fx_N10Ast__lit_t* v_74 = &new_e2_3->u.ExpLit.t0;
                         if (v_74->tag == 5) {
@@ -20790,7 +21016,7 @@ FX_EXTERN_C int
 
                   _fx_catch_32: ;
                   }
-                  else if (tag_2 == 24) {
+                  else if (tag_2 == 25) {
                      _fx_LN10Ast__exp_t v_88 = 0;
                      _fx_T2N10Ast__typ_tR10Ast__loc_t v_89 = {0};
                      _fx_N10Ast__exp_t tag1_0 = 0;
@@ -21003,10 +21229,10 @@ FX_EXTERN_C int
                int tag_4 = FX_REC_VARIANT_TAG(v_95);
                bool is_appropriate_type_0;
                bool res_10;
-               if (tag_4 == 19) {
+               if (tag_4 == 20) {
                   res_10 = true;
                }
-               else if (tag_4 == 20) {
+               else if (tag_4 == 21) {
                   res_10 = true;
                }
                else {
@@ -21016,7 +21242,7 @@ FX_EXTERN_C int
                if (res_10) {
                   is_appropriate_type_0 = true; goto _fx_endmatch_6;
                }
-               if (tag_4 == 24) {
+               if (tag_4 == 25) {
                   _fx_N14Ast__id_info_t v_100 = {0};
                   FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_95->u.TypApp.t1, &eloc1_4, &v_100, 0),
                      _fx_catch_38);
@@ -21325,8 +21551,8 @@ FX_EXTERN_C int
             _fx_Nt6option1N10Ast__typ_t typ_opt_3 = 0;
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_6, &v_115, 0), _fx_catch_50);
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp2_2, &v_116, 0), _fx_catch_50);
-            if (FX_REC_VARIANT_TAG(v_115) == 5) {
-               if (FX_REC_VARIANT_TAG(v_116) == 5) {
+            if (FX_REC_VARIANT_TAG(v_115) == 6) {
+               if (FX_REC_VARIANT_TAG(v_116) == 6) {
                   FX_CALL(
                      _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypInt, &typ_opt_3),
                      _fx_catch_46);
@@ -21335,8 +21561,8 @@ FX_EXTERN_C int
                   goto _fx_endmatch_8;
                }
             }
-            if (FX_REC_VARIANT_TAG(v_116) == 6) {
-               if (FX_REC_VARIANT_TAG(v_115) == 6) {
+            if (FX_REC_VARIANT_TAG(v_116) == 7) {
+               if (FX_REC_VARIANT_TAG(v_115) == 7) {
                   int_ b1_0 = v_115->u.TypSInt;
                   if (b1_0 == v_116->u.TypSInt) {
                      _fx_N10Ast__typ_t v_117 = 0;
@@ -21351,8 +21577,8 @@ FX_EXTERN_C int
                   }
                }
             }
-            if (FX_REC_VARIANT_TAG(v_116) == 7) {
-               if (FX_REC_VARIANT_TAG(v_115) == 7) {
+            if (FX_REC_VARIANT_TAG(v_116) == 8) {
+               if (FX_REC_VARIANT_TAG(v_115) == 8) {
                   int_ b1_1 = v_115->u.TypUInt;
                   if (b1_1 == v_116->u.TypUInt) {
                      _fx_N10Ast__typ_t v_118 = 0;
@@ -21367,8 +21593,8 @@ FX_EXTERN_C int
                   }
                }
             }
-            if (FX_REC_VARIANT_TAG(v_115) == 12) {
-               if (FX_REC_VARIANT_TAG(v_116) == 12) {
+            if (FX_REC_VARIANT_TAG(v_115) == 13) {
+               if (FX_REC_VARIANT_TAG(v_116) == 13) {
                   FX_CALL(
                      _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g22Ast_typecheck__TypBool,
                         &typ_opt_3), _fx_catch_49);
@@ -21442,7 +21668,7 @@ FX_EXTERN_C int
                   _fx_catch_52);
                _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, v_120, &v_112);
             }
-            else if (FX_REC_VARIANT_TAG(etyp1_6) == 10) {
+            else if (FX_REC_VARIANT_TAG(etyp1_6) == 11) {
                _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
             }
             else {
@@ -21484,8 +21710,8 @@ FX_EXTERN_C int
             else {
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_6, &v_122, 0), _fx_catch_53);
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp2_2, &v_123, 0), _fx_catch_53);
-               if (FX_REC_VARIANT_TAG(v_122) == 10) {
-                  if (FX_REC_VARIANT_TAG(v_123) == 10) {
+               if (FX_REC_VARIANT_TAG(v_122) == 11) {
+                  if (FX_REC_VARIANT_TAG(v_123) == 11) {
                      _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
                      goto _fx_endmatch_9;
                   }
@@ -21585,14 +21811,7 @@ FX_EXTERN_C int
          }
          bool res_20;
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_113) == 10) {
-               if (FX_REC_VARIANT_TAG(v_114) == 10) {
-                  res_20 = true; goto _fx_endmatch_11;
-               }
-            }
-         }
-         if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_113) == 10) {
+            if (FX_REC_VARIANT_TAG(v_113) == 11) {
                if (FX_REC_VARIANT_TAG(v_114) == 11) {
                   res_20 = true; goto _fx_endmatch_11;
                }
@@ -21600,14 +21819,21 @@ FX_EXTERN_C int
          }
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
             if (FX_REC_VARIANT_TAG(v_113) == 11) {
-               if (FX_REC_VARIANT_TAG(v_114) == 10) {
+               if (FX_REC_VARIANT_TAG(v_114) == 12) {
                   res_20 = true; goto _fx_endmatch_11;
                }
             }
          }
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_113) == 11) {
+            if (FX_REC_VARIANT_TAG(v_113) == 12) {
                if (FX_REC_VARIANT_TAG(v_114) == 11) {
+                  res_20 = true; goto _fx_endmatch_11;
+               }
+            }
+         }
+         if (FX_REC_VARIANT_TAG(bop_2) == 1) {
+            if (FX_REC_VARIANT_TAG(v_113) == 12) {
+               if (FX_REC_VARIANT_TAG(v_114) == 12) {
                   res_20 = true; goto _fx_endmatch_11;
                }
             }
@@ -21637,12 +21863,12 @@ FX_EXTERN_C int
          }
          bool res_21;
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_113) == 16) {
+            if (FX_REC_VARIANT_TAG(v_113) == 17) {
                res_21 = true; goto _fx_endmatch_12;
             }
          }
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_114) == 16) {
+            if (FX_REC_VARIANT_TAG(v_114) == 17) {
                res_21 = true; goto _fx_endmatch_12;
             }
          }
@@ -21713,8 +21939,8 @@ FX_EXTERN_C int
             goto _fx_endmatch_13;
          }
          if (FX_REC_VARIANT_TAG(bop_2) == 1) {
-            if (FX_REC_VARIANT_TAG(v_113) == 15) {
-               if (FX_REC_VARIANT_TAG(v_114) == 15) {
+            if (FX_REC_VARIANT_TAG(v_113) == 16) {
+               if (FX_REC_VARIANT_TAG(v_114) == 16) {
                   if (FX_REC_VARIANT_TAG(e1_0) == 8) {
                      _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_9 = &e1_0->u.ExpBinary;
                      if (FX_REC_VARIANT_TAG(vcase_9->t0) == 1) {
@@ -22433,7 +22659,7 @@ FX_EXTERN_C int
                FX_CHECK_EXN(_fx_catch_85);
             }
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_3, &v_161, 0), _fx_catch_85);
-            if (FX_REC_VARIANT_TAG(v_161) == 9) {
+            if (FX_REC_VARIANT_TAG(v_161) == 10) {
                goto _fx_endmatch_18;
             }
             bool res_25;
@@ -22454,10 +22680,10 @@ FX_EXTERN_C int
          _fx_endmatch_16: ;
             FX_CHECK_EXN(_fx_catch_85);
             if (res_25) {
-               if (FX_REC_VARIANT_TAG(v_161) == 5) {
+               if (FX_REC_VARIANT_TAG(v_161) == 6) {
                   _fx_N10Ast__typ_t v_175 = 0;
                   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(argt_0, &v_175, 0), _fx_catch_83);
-                  if (FX_REC_VARIANT_TAG(v_175) != 9) {
+                  if (FX_REC_VARIANT_TAG(v_175) != 10) {
                      fx_exn_t v_176 = {0};
                      fx_str_t slit_80 = FX_MAKE_STR("floor/ceil/round intrinsics must have a single floating-point argument");
                      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_80, &v_176, 0), _fx_catch_82);
@@ -22489,7 +22715,7 @@ FX_EXTERN_C int
          _fx_endmatch_17: ;
             FX_CHECK_EXN(_fx_catch_85);
             if (res_26) {
-               if (FX_REC_VARIANT_TAG(v_161) == 5) {
+               if (FX_REC_VARIANT_TAG(v_161) == 6) {
                   goto _fx_endmatch_18;
                }
             }
@@ -23097,16 +23323,16 @@ FX_EXTERN_C int
                   &eloc_0, &slit_103, 0), _fx_catch_91);
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_6, &v_233, 0), _fx_catch_91);
             if (idx_0 == 0) {
-               if (FX_REC_VARIANT_TAG(v_233) == 10) {
+               if (FX_REC_VARIANT_TAG(v_233) == 11) {
                   goto _fx_endmatch_20;
                }
             }
             if (idx_0 == 0) {
-               if (FX_REC_VARIANT_TAG(v_233) == 16) {
+               if (FX_REC_VARIANT_TAG(v_233) == 17) {
                   goto _fx_endmatch_20;
                }
             }
-            if (FX_REC_VARIANT_TAG(v_233) == 19) {
+            if (FX_REC_VARIANT_TAG(v_233) == 20) {
                fx_exn_t v_240 = {0};
                bool t_7;
                if (idx_0 < 0) {
@@ -23538,7 +23764,7 @@ FX_EXTERN_C int
                   _fx_R9Ast__id_t* f_4 = &vcase_18->t0;
                   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(vcase_18->t1.t0, &v_267, 0), _fx_catch_107);
                   bool res_34;
-                  if (FX_REC_VARIANT_TAG(v_267) == 14) {
+                  if (FX_REC_VARIANT_TAG(v_267) == 15) {
                      res_34 = true;
                   }
                   else {
@@ -23666,7 +23892,7 @@ FX_EXTERN_C int
                f_2, &env_2, sc_2, &new_f_0, 0), _fx_catch_112);
          FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_f_0, &v_273, 0), _fx_catch_112);
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_273, &v_274, 0), _fx_catch_112);
-         if (FX_REC_VARIANT_TAG(v_274) == 14) {
+         if (FX_REC_VARIANT_TAG(v_274) == 15) {
             _fx_N10Ast__typ_t last_typ_0 = 0;
             _fx_N10Ast__exp_t v_275 = 0;
             _fx_T2N10Ast__typ_tR10Ast__loc_t v_276 = {0};
@@ -23802,22 +24028,22 @@ FX_EXTERN_C int
                      FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(r_0, &r_t_0, 0), _fx_catch_115);
                      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(r_t_0, &v_284, 0), _fx_catch_115);
                      int tag_10 = FX_REC_VARIANT_TAG(v_284);
-                     if (tag_10 == 15) {
+                     if (tag_10 == 16) {
                         fx_str_t slit_114 = FX_MAKE_STR("List"); fx_copy_str(&slit_114, &mstr_0);
                      }
-                     else if (tag_10 == 16) {
+                     else if (tag_10 == 17) {
                         fx_str_t slit_115 = FX_MAKE_STR("Vector"); fx_copy_str(&slit_115, &mstr_0);
                      }
-                     else if (tag_10 == 10) {
+                     else if (tag_10 == 11) {
                         fx_str_t slit_116 = FX_MAKE_STR("String"); fx_copy_str(&slit_116, &mstr_0);
                      }
-                     else if (tag_10 == 11) {
+                     else if (tag_10 == 12) {
                         fx_str_t slit_117 = FX_MAKE_STR("Char"); fx_copy_str(&slit_117, &mstr_0);
                      }
-                     else if (tag_10 == 19) {
+                     else if (tag_10 == 20) {
                         fx_str_t slit_118 = FX_MAKE_STR("Array"); fx_copy_str(&slit_118, &mstr_0);
                      }
-                     else if (tag_10 == 24) {
+                     else if (tag_10 == 25) {
                         _fx_N14Ast__id_info_t v_289 = {0};
                         _fx_R17Ast__defvariant_t v_290 = {0};
                         FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_284->u.TypApp.t1, &eloc_0, &v_289, 0),
@@ -24005,7 +24231,7 @@ FX_EXTERN_C int
                                  v_297, &env_2, sc_2, &new_idx_0, 0), _fx_catch_122);
                            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_298, 0), _fx_catch_122);
                            int tag_11 = FX_REC_VARIANT_TAG(v_298);
-                           if (tag_11 == 19) {
+                           if (tag_11 == 20) {
                               _fx_N10Ast__typ_t v_299 = 0;
                               _fx_LN10Ast__exp_t v_300 = 0;
                               _fx_N10Ast__exp_t result_35 = 0;
@@ -24037,7 +24263,7 @@ FX_EXTERN_C int
                                  _fx_free_N10Ast__typ_t(&v_299);
                               }
                            }
-                           else if (tag_11 == 16) {
+                           else if (tag_11 == 17) {
                               _fx_N10Ast__typ_t v_301 = 0;
                               _fx_LN10Ast__exp_t v_302 = 0;
                               _fx_N10Ast__exp_t result_36 = 0;
@@ -24069,7 +24295,7 @@ FX_EXTERN_C int
                                  _fx_free_N10Ast__typ_t(&v_301);
                               }
                            }
-                           else if (tag_11 == 10) {
+                           else if (tag_11 == 11) {
                               fx_str_t slit_125 =
                                  FX_MAKE_STR("the result of flatten operation ([:]) applied to a string must be string");
                               FX_CALL(
@@ -24278,7 +24504,7 @@ FX_EXTERN_C int
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_305, 0), _fx_catch_133);
          if (nranges_1 == 0) {
             if (ndims_1 == 1) {
-               if (FX_REC_VARIANT_TAG(v_305) == 10) {
+               if (FX_REC_VARIANT_TAG(v_305) == 11) {
                   fx_str_t slit_128 = FX_MAKE_STR("indexing string should give a char");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0,
@@ -24291,7 +24517,7 @@ FX_EXTERN_C int
          }
          if (nranges_1 == 1) {
             if (ndims_1 == 1) {
-               if (FX_REC_VARIANT_TAG(v_305) == 10) {
+               if (FX_REC_VARIANT_TAG(v_305) == 11) {
                   fx_str_t slit_129 = FX_MAKE_STR("indexing string with a range should give a string");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0,
@@ -24304,7 +24530,7 @@ FX_EXTERN_C int
          }
          if (nranges_1 == 0) {
             if (ndims_1 == 1) {
-               if (FX_REC_VARIANT_TAG(v_305) == 16) {
+               if (FX_REC_VARIANT_TAG(v_305) == 17) {
                   fx_str_t slit_130 =
                      FX_MAKE_STR(
                         "incorrect type of the vector element access operation; it gives \'{typ2str(et)}\', but \'{typ2str(etyp)}\' is expected");
@@ -24319,7 +24545,7 @@ FX_EXTERN_C int
          }
          if (nranges_1 == 1) {
             if (ndims_1 == 1) {
-               if (FX_REC_VARIANT_TAG(v_305) == 16) {
+               if (FX_REC_VARIANT_TAG(v_305) == 17) {
                   _fx_N10Ast__typ_t v_324 = 0;
                   FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(v_305->u.TypVector, &v_324), _fx_catch_129);
                   fx_str_t slit_131 =
@@ -25203,7 +25429,7 @@ FX_EXTERN_C int
                if (FX_REC_VARIANT_TAG(v_373) == 1) {
                   FX_COPY_PTR(v_373->u.TypVar->data, &v_374);
                   if ((v_374 != 0) + 1 == 1) {
-                     if (FX_REC_VARIANT_TAG(v_372) == 17) {
+                     if (FX_REC_VARIANT_TAG(v_372) == 18) {
                         _fx_LN10Ast__typ_t colls_0 = 0;
                         _fx_LN10Ast__typ_t b_elems_0 = 0;
                         _fx_N10Ast__typ_t v_394 = 0;
@@ -25249,8 +25475,8 @@ FX_EXTERN_C int
                      }
                   }
                }
-               if (FX_REC_VARIANT_TAG(v_373) == 17) {
-                  if (FX_REC_VARIANT_TAG(v_372) == 17) {
+               if (FX_REC_VARIANT_TAG(v_373) == 18) {
+                  if (FX_REC_VARIANT_TAG(v_372) == 18) {
                      fx_str_t v_395 = {0};
                      fx_str_t v_396 = {0};
                      fx_str_t v_397 = {0};
@@ -25311,10 +25537,10 @@ FX_EXTERN_C int
                   }
                }
                bool res_36;
-               if (FX_REC_VARIANT_TAG(v_372) == 17) {
+               if (FX_REC_VARIANT_TAG(v_372) == 18) {
                   res_36 = true;
                }
-               else if (FX_REC_VARIANT_TAG(v_373) == 17) {
+               else if (FX_REC_VARIANT_TAG(v_373) == 18) {
                   res_36 = true;
                }
                else {
@@ -25364,7 +25590,7 @@ FX_EXTERN_C int
             else {
                FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_body_3, &v_375, 0), _fx_catch_153);
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_375, &v_376, 0), _fx_catch_153);
-               if (FX_REC_VARIANT_TAG(v_376) == 13) {
+               if (FX_REC_VARIANT_TAG(v_376) == 14) {
                   fx_exn_t v_405 = {0};
                   fx_str_t slit_166 = FX_MAKE_STR("comprehension body cannot have \'void\' type");
                   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_166, &v_405, 0), _fx_catch_152);
@@ -25706,16 +25932,16 @@ FX_EXTERN_C int
                            &slit_172, 0), _fx_catch_162);
                      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(arrtyp1_0, &v_443, 0), _fx_catch_162);
                      int tag_12 = FX_REC_VARIANT_TAG(v_443);
-                     if (tag_12 == 19) {
+                     if (tag_12 == 20) {
                         _fx_T2iN10Ast__typ_t* vcase_28 = &v_443->u.TypArray;
                         fx_str_t slit_173 = FX_MAKE_STR("array");
                         _fx_make_T3SiN10Ast__typ_t(&slit_173, vcase_28->t0, vcase_28->t1, &v_444);
                      }
-                     else if (tag_12 == 15) {
+                     else if (tag_12 == 16) {
                         fx_str_t slit_174 = FX_MAKE_STR("list");
                         _fx_make_T3SiN10Ast__typ_t(&slit_174, 1, v_443->u.TypList, &v_444);
                      }
-                     else if (tag_12 == 10) {
+                     else if (tag_12 == 11) {
                         fx_str_t slit_175 = FX_MAKE_STR("string");
                         _fx_make_T3SiN10Ast__typ_t(&slit_175, 1, _fx_g22Ast_typecheck__TypChar, &v_444);
                      }
@@ -26069,7 +26295,7 @@ FX_EXTERN_C int
                         &slit_191, 0), _fx_catch_171);
                   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_11, &v_458, 0), _fx_catch_171);
                   int tag_13 = FX_REC_VARIANT_TAG(v_458);
-                  if (tag_13 == 19) {
+                  if (tag_13 == 20) {
                      _fx_T2iN10Ast__typ_t* vcase_30 = &v_458->u.TypArray;
                      if (vcase_30->t0 == 1) {
                         fx_str_t slit_192 = FX_MAKE_STR("array");
@@ -26077,17 +26303,17 @@ FX_EXTERN_C int
                         goto _fx_endmatch_33;
                      }
                   }
-                  if (tag_13 == 16) {
+                  if (tag_13 == 17) {
                      fx_str_t slit_193 = FX_MAKE_STR("vector");
                      _fx_make_T2SN10Ast__typ_t(&slit_193, v_458->u.TypVector, &v_459);
                      goto _fx_endmatch_33;
                   }
-                  if (tag_13 == 15) {
+                  if (tag_13 == 16) {
                      fx_str_t slit_194 = FX_MAKE_STR("list");
                      _fx_make_T2SN10Ast__typ_t(&slit_194, v_458->u.TypList, &v_459);
                      goto _fx_endmatch_33;
                   }
-                  if (tag_13 == 10) {
+                  if (tag_13 == 11) {
                      fx_str_t slit_195 = FX_MAKE_STR("string");
                      _fx_make_T2SN10Ast__typ_t(&slit_195, _fx_g22Ast_typecheck__TypChar, &v_459);
                      goto _fx_endmatch_33;
@@ -26698,10 +26924,10 @@ FX_EXTERN_C int
             _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_495); goto _fx_endmatch_35;
          }
          bool res_39;
-         if (FX_REC_VARIANT_TAG(v_494) == 17) {
+         if (FX_REC_VARIANT_TAG(v_494) == 18) {
             res_39 = true;
          }
-         else if (FX_REC_VARIANT_TAG(v_493) == 17) {
+         else if (FX_REC_VARIANT_TAG(v_493) == 18) {
             res_39 = true;
          }
          else {
@@ -26761,10 +26987,10 @@ FX_EXTERN_C int
          FX_COPY_PTR(v_495.t1, &code_1);
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_496, 0), _fx_catch_201);
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_497, 0), _fx_catch_201);
-         if (FX_REC_VARIANT_TAG(v_497) == 24) {
+         if (FX_REC_VARIANT_TAG(v_497) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_36 = &v_497->u.TypApp;
             if (vcase_36->t0 == 0) {
-               if (FX_REC_VARIANT_TAG(v_496) == 24) {
+               if (FX_REC_VARIANT_TAG(v_496) == 25) {
                   _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_37 = &v_496->u.TypApp;
                   if (vcase_37->t0 == 0) {
                      _fx_N10Ast__exp_t new_e1_14 = 0;
@@ -27035,8 +27261,8 @@ FX_EXTERN_C int
          if (t_18) {
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_538, 0), _fx_catch_200);
             FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_539, 0), _fx_catch_200);
-            if (FX_REC_VARIANT_TAG(v_538) == 17) {
-               if (FX_REC_VARIANT_TAG(v_539) == 17) {
+            if (FX_REC_VARIANT_TAG(v_538) == 18) {
+               if (FX_REC_VARIANT_TAG(v_539) == 18) {
                   v_547 = false; goto _fx_endmatch_37;
                }
             }
@@ -27501,7 +27727,7 @@ static int
    FX_COPY_PTR(v_0.t0, &etyp_0);
    _fx_R10Ast__loc_t eloc_0 = v_0.t1;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &etyp_1, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(etyp_1) == 24) {
+   if (FX_REC_VARIANT_TAG(etyp_1) == 25) {
       fx_exn_t exn_0 = {0};
       FX_CALL(
          _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
@@ -27530,7 +27756,7 @@ static int
    FX_CHECK_EXN(_fx_cleanup);
    FX_COPY_PTR(v_1.t1, &relems_0);
    if (is_range_0 == false) {
-      if (FX_REC_VARIANT_TAG(etyp_1) == 17) {
+      if (FX_REC_VARIANT_TAG(etyp_1) == 18) {
          _fx_N10Ast__pat_t tup_pat_0 = 0;
          _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_2 = {0};
          _fx_N10Ast__pat_t tup_pat_1 = 0;
@@ -27722,10 +27948,10 @@ static int
    if (FX_REC_VARIANT_TAG(e_1) == 5) {
       _fx_make_T2N10Ast__typ_ti(_fx_g21Ast_typecheck__TypInt, 1, &v_22);
    }
-   else if (FX_REC_VARIANT_TAG(etyp_1) == 19) {
+   else if (FX_REC_VARIANT_TAG(etyp_1) == 20) {
       _fx_T2iN10Ast__typ_t* vcase_0 = &etyp_1->u.TypArray; _fx_make_T2N10Ast__typ_ti(vcase_0->t1, vcase_0->t0, &v_22);
    }
-   else if (FX_REC_VARIANT_TAG(etyp_1) == 15) {
+   else if (FX_REC_VARIANT_TAG(etyp_1) == 16) {
       if (flags_0->for_flag_parallel) {
          fx_str_t slit_4 = FX_MAKE_STR("\'@parallel for\' over a list is not supported");
          FX_CALL(_fx_M3AstFM15compile_warningv2RM5loc_tS(&eloc_0, &slit_4, 0), _fx_catch_10);
@@ -27734,10 +27960,10 @@ static int
 
    _fx_catch_10: ;
    }
-   else if (FX_REC_VARIANT_TAG(etyp_1) == 16) {
+   else if (FX_REC_VARIANT_TAG(etyp_1) == 17) {
       _fx_make_T2N10Ast__typ_ti(etyp_1->u.TypVector, 1, &v_22);
    }
-   else if (FX_REC_VARIANT_TAG(etyp_1) == 10) {
+   else if (FX_REC_VARIANT_TAG(etyp_1) == 11) {
       _fx_make_T2N10Ast__typ_ti(_fx_g22Ast_typecheck__TypChar, 1, &v_22);
    }
    else {
@@ -28197,7 +28423,7 @@ static int
       FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(trj_0, &v_9, 0), _fx_catch_7);
       FX_COPY_PTR(v_9.t0, &ttrj_0);
       _fx_R10Ast__loc_t locj_0 = v_9.t1;
-      if (FX_REC_VARIANT_TAG(ttrj_0) == 17) {
+      if (FX_REC_VARIANT_TAG(ttrj_0) == 18) {
          _fx_N10Ast__typ_t result_0 = 0;
          _fx_LN10Ast__typ_t l_0 = 0;
          _fx_N10Ast__typ_t tj_0 = 0;
@@ -29455,7 +29681,7 @@ static int _fx_M13Ast_typecheckFM14is_simple_ctorB1N10Ast__exp_t(
          _fx_R13Ast__deffun_t v_1 = {0};
          _fx_copy_R13Ast__deffun_t(&v_0.u.IdFun->data, &v_1);
          bool res_0;
-         if (FX_REC_VARIANT_TAG(v_1.df_typ) == 14) {
+         if (FX_REC_VARIANT_TAG(v_1.df_typ) == 15) {
             res_0 = false;
          }
          else {
@@ -29717,7 +29943,7 @@ static int
    _fx_N10Ast__typ_t v_0 = 0;
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(idxtyp_0, &v_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_0) == 17) {
+   if (FX_REC_VARIANT_TAG(v_0) == 18) {
       fx_exn_t v_1 = {0};
       _fx_LN10Ast__typ_t idxtyplst_0 = 0;
       _fx_LN10Ast__typ_t idxtyplst_1 = v_0->u.TypTuple;
@@ -30020,7 +30246,7 @@ static int _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__ty
       goto _fx_endmatch_0;
    }
    if (FX_REC_VARIANT_TAG(e1_0) == 6) {
-      if (FX_REC_VARIANT_TAG(v_1) == 15) {
+      if (FX_REC_VARIANT_TAG(v_1) == 16) {
          _fx_N10Ast__lit_t* v_4 = &e1_0->u.ExpLit.t0;
          if (v_4->tag == 1) {
             if (v_4->u.LitInt == 0LL) {
@@ -30038,7 +30264,7 @@ static int _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__ty
       }
    }
    if (FX_REC_VARIANT_TAG(e1_0) == 6) {
-      if (FX_REC_VARIANT_TAG(v_1) == 10) {
+      if (FX_REC_VARIANT_TAG(v_1) == 11) {
          _fx_N10Ast__lit_t* v_6 = &e1_0->u.ExpLit.t0;
          if (v_6->tag == 1) {
             if (v_6->u.LitInt == 0LL) {
@@ -30058,8 +30284,8 @@ static int _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__ty
          }
       }
    }
-   if (FX_REC_VARIANT_TAG(v_1) == 17) {
-      if (FX_REC_VARIANT_TAG(v_0) == 17) {
+   if (FX_REC_VARIANT_TAG(v_1) == 18) {
+      if (FX_REC_VARIANT_TAG(v_0) == 18) {
          fx_str_t v_9 = {0};
          fx_str_t v_10 = {0};
          fx_str_t v_11 = {0};
@@ -30152,7 +30378,7 @@ static int _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__ty
          goto _fx_endmatch_0;
       }
    }
-   if (FX_REC_VARIANT_TAG(v_0) == 17) {
+   if (FX_REC_VARIANT_TAG(v_0) == 18) {
       _fx_T2LN10Ast__exp_tLN10Ast__typ_t v_18 = {0};
       _fx_LN10Ast__exp_t lst_2 = 0;
       _fx_LN10Ast__typ_t lst_3 = 0;
@@ -30238,7 +30464,7 @@ static int _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__ty
       _fx_free_T2LN10Ast__exp_tLN10Ast__typ_t(&v_18);
       goto _fx_endmatch_0;
    }
-   if (FX_REC_VARIANT_TAG(v_1) == 17) {
+   if (FX_REC_VARIANT_TAG(v_1) == 18) {
       _fx_LN10Ast__exp_t v_25 = 0;
       _fx_LN10Ast__typ_t tl2_3 = 0;
       _fx_T2N10Ast__typ_tR10Ast__loc_t v_26 = {0};
@@ -30798,10 +31024,10 @@ _fx_endmatch_0: ;
       FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_38, 0), _fx_catch_14);
       int tag_3 = FX_REC_VARIANT_TAG(v_38);
       bool res_2;
-      if (tag_3 == 13) {
+      if (tag_3 == 14) {
          res_2 = true;
       }
-      else if (tag_3 == 25) {
+      else if (tag_3 == 26) {
          res_2 = true;
       }
       else {
@@ -31937,7 +32163,7 @@ FX_EXTERN_C int
    }
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(rt_0, &v_0, 0), _fx_cleanup);
    bool is_instance_0;
-   if (FX_REC_VARIANT_TAG(v_0) == 24) {
+   if (FX_REC_VARIANT_TAG(v_0) == 25) {
       if (v_0->u.TypApp.t0 != 0) {
          is_instance_0 = true; goto _fx_endmatch_0;
       }
@@ -32268,7 +32494,7 @@ FX_EXTERN_C int
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
                   v_26, &env_1, sc_0, &di_loc_0, &v_27, 0), _fx_catch_11);
-            if (FX_REC_VARIANT_TAG(v_27) == 24) {
+            if (FX_REC_VARIANT_TAG(v_27) == 25) {
                _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_1 = &v_27->u.TypApp;
                if (vcase_1->t0 == 0) {
                   _fx_rR19Ast__definterface_t v_34 = 0;
@@ -32607,7 +32833,7 @@ FX_EXTERN_C int
    FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_0, &curr_m_idx_0, 0), _fx_cleanup);
    _fx_R9Ast__id_t df_name1_0;
    FX_CALL(_fx_M3AstFM6dup_idRM4id_t2iRM4id_t(curr_m_idx_0, &df_name_0, &df_name1_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(df_typ_0) == 14) {
+   if (FX_REC_VARIANT_TAG(df_typ_0) == 15) {
       FX_COPY_PTR(df_typ_0->u.TypFun.t1, &rt_0);
    }
    else {
@@ -33219,12 +33445,12 @@ _fx_endmatch_0: ;
          t_0, env_0, sc_0, &loc_0, &t_1, 0), _fx_cleanup);
    _fx_R9Ast__id_t n_0;
    FX_CALL(_fx_M3AstFM6dup_idRM4id_t2iRM4id_t(curr_m_idx_0, &n0_0, &n_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(t_1) == 13) {
+   if (FX_REC_VARIANT_TAG(t_1) == 14) {
       FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &ftyp_0);
    }
    else {
       _fx_LN10Ast__typ_t v_7 = 0;
-      if (FX_REC_VARIANT_TAG(t_1) == 17) {
+      if (FX_REC_VARIANT_TAG(t_1) == 18) {
          FX_COPY_PTR(t_1->u.TypTuple, &v_7);
       }
       else {
@@ -33473,7 +33699,7 @@ static int _fx_M13Ast_typecheckFM10check_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__
    _fx_LN12Ast__scope_t sc_0 = cv_0->t5;
    _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_env_0 = &r_env_ref_0->data;
    int tag_0 = FX_REC_VARIANT_TAG(t_0);
-   if (tag_0 == 24) {
+   if (tag_0 == 25) {
       _fx_LN10Ast__typ_t ty_args_0 = 0;
       _fx_LN10Ast__typ_t ty_args_1 = 0;
       _fx_FPNt6option1N10Ast__typ_t1N16Ast__env_entry_t __lambda___0 = {0};
@@ -33658,7 +33884,7 @@ static int _fx_M13Ast_typecheckFM10check_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__
 
    _fx_catch_10: ;
    }
-   else if (tag_0 == 20) {
+   else if (tag_0 == 21) {
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_21 = {0};
       _fx_LR9Ast__id_t v_22 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
@@ -34446,18 +34672,18 @@ FX_EXTERN_C int
    FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__pat_t(df_args_0, &nargs_0, 0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(inst_ftyp_0, &inst_ftyp_1, 0), _fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(inst_ftyp_1);
-   if (tag_0 == 14) {
+   if (tag_0 == 15) {
       _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &inst_ftyp_1->u.TypFun;
       _fx_LN10Ast__typ_t v_19 = vcase_0->t0;
       if (v_19 != 0) {
          if (v_19->tl == 0) {
-            if (FX_REC_VARIANT_TAG(v_19->hd) == 13) {
+            if (FX_REC_VARIANT_TAG(v_19->hd) == 14) {
                _fx_make_T2LN10Ast__typ_tN10Ast__typ_t(0, vcase_0->t1, &v_3); goto _fx_endmatch_0;
             }
          }
       }
    }
-   if (tag_0 == 14) {
+   if (tag_0 == 15) {
       _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_1 = &inst_ftyp_1->u.TypFun;
       _fx_make_T2LN10Ast__typ_tN10Ast__typ_t(vcase_1->t0, vcase_1->t1, &v_3);
       goto _fx_endmatch_0;
@@ -34492,7 +34718,7 @@ _fx_endmatch_0: ;
       if (arg_typs_0 != 0) {
          if (arg_typs_0->tl == 0) {
             _fx_N10Ast__typ_t v_21 = arg_typs_0->hd;
-            if (FX_REC_VARIANT_TAG(v_21) == 17) {
+            if (FX_REC_VARIANT_TAG(v_21) == 18) {
                _fx_LN10Ast__typ_t elems_0 = v_21->u.TypTuple;
                int_ v_22;
                FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(elems_0, &v_22, 0), _fx_cleanup);
@@ -34734,7 +34960,7 @@ _fx_endmatch_3: ;
       }
       if (arg_typs_2 != 0) {
          _fx_N10Ast__typ_t v_38 = arg_typs_2->hd;
-         if (FX_REC_VARIANT_TAG(v_38) == 24) {
+         if (FX_REC_VARIANT_TAG(v_38) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_2 = &v_38->u.TypApp;
             if (vcase_2->t0 == 0) {
                _fx_N14Ast__id_info_t v_39 = {0};
@@ -35153,7 +35379,7 @@ FX_EXTERN_C int
                      if (FX_REC_VARIANT_TAG(v_5) == 9) {
                         _fx_N10Ast__pat_t v_6 = v_5->u.PatTyped.t0;
                         if (FX_REC_VARIANT_TAG(v_6) == 3) {
-                           if (FX_REC_VARIANT_TAG(ftyp_0) == 14) {
+                           if (FX_REC_VARIANT_TAG(ftyp_0) == 15) {
                               _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &ftyp_0->u.TypFun;
                               _fx_LN10Ast__typ_t v_7 = vcase_0->t0;
                               if (v_7 != 0) {
@@ -35161,9 +35387,9 @@ FX_EXTERN_C int
                                  if (v_8 != 0) {
                                     if (v_8->tl == 0) {
                                        _fx_N10Ast__typ_t t2_0 = v_8->hd;
-                                       if (FX_REC_VARIANT_TAG(t2_0) == 24) {
+                                       if (FX_REC_VARIANT_TAG(t2_0) == 25) {
                                           _fx_N10Ast__typ_t t1_0 = v_7->hd;
-                                          if (FX_REC_VARIANT_TAG(t1_0) == 24) {
+                                          if (FX_REC_VARIANT_TAG(t1_0) == 25) {
                                              _fx_R9Ast__id_t* n1_0 = &t1_0->u.TypApp.t1;
                                              bool res_0;
                                              FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(n1_0, &t2_0->u.TypApp.t1, &res_0, 0),
@@ -35228,7 +35454,7 @@ FX_EXTERN_C int
                                                 if (v_9.tag == 6) {
                                                    _fx_copy_R17Ast__defvariant_t(&v_9.u.IdVariant->data, &v_11);
                                                    _fx_N10Ast__typ_t v_19 = v_11.dvar_alias;
-                                                   if (FX_REC_VARIANT_TAG(v_19) == 24) {
+                                                   if (FX_REC_VARIANT_TAG(v_19) == 25) {
                                                       _fx_N14Ast__id_info_t v_20 = {0};
                                                       FX_CALL(
                                                          _fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(
@@ -35288,10 +35514,10 @@ FX_EXTERN_C int
                                                       _fx_M3AstFM13deref_typ_recN10Ast__typ_t1N10Ast__typ_t(t_orig_0, &t_1, 0),
                                                       _fx_catch_8);
                                                    int tag_1 = FX_REC_VARIANT_TAG(t_1);
-                                                   if (tag_1 == 13) {
+                                                   if (tag_1 == 14) {
                                                       FX_COPY_PTR(complex_cases_1, &v_24);
                                                    }
-                                                   else if (tag_1 == 20) {
+                                                   else if (tag_1 == 21) {
                                                       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_25 =
                                                          {0};
                                                       _fx_N10Ast__exp_t v_26 = 0;
@@ -35574,7 +35800,7 @@ FX_EXTERN_C int
                                                       _fx_LN10Ast__pat_t v_59 = 0;
                                                       _fx_N10Ast__pat_t ab_case_pat_1 = 0;
                                                       _fx_T2N10Ast__pat_tN10Ast__exp_t v_60 = {0};
-                                                      if (FX_REC_VARIANT_TAG(t_1) == 17) {
+                                                      if (FX_REC_VARIANT_TAG(t_1) == 18) {
                                                          FX_COPY_PTR(t_1->u.TypTuple, &args_0);
                                                       }
                                                       else {
@@ -36249,7 +36475,7 @@ FX_EXTERN_C int
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
                v_24, &env_1, dvar_scope_0, &dvar_loc_0, &v_25, 0), _fx_catch_8);
-         if (FX_REC_VARIANT_TAG(v_25) == 24) {
+         if (FX_REC_VARIANT_TAG(v_25) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_1 = &v_25->u.TypApp;
             if (vcase_1->t0 == 0) {
                FX_CALL(_fx_M3AstFM9get_ifacerRM14definterface_t2RM4id_tRM5loc_t(&vcase_1->t1, &dvar_loc_0, &iface_0, 0),
@@ -36375,10 +36601,10 @@ FX_EXTERN_C int
       FX_COPY_PTR(__pat___2->t1, &t_0);
       int tag_0 = FX_REC_VARIANT_TAG(t_0);
       int_ nargs_0;
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          nargs_0 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(t_0->u.TypTuple, 0);
       }
-      else if (tag_0 == 13) {
+      else if (tag_0 == 14) {
          nargs_0 = 0;
       }
       else {
@@ -36394,10 +36620,10 @@ FX_EXTERN_C int
             &env_1, t_1, sc_0, loc_0, &t_2, 0), _fx_catch_13);
       int tag_1 = FX_REC_VARIANT_TAG(t_2);
       int_ nrealargs_0;
-      if (tag_1 == 17) {
+      if (tag_1 == 18) {
          nrealargs_0 = _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(t_2->u.TypTuple, 0);
       }
-      else if (tag_1 == 13) {
+      else if (tag_1 == 14) {
          nrealargs_0 = 0;
       }
       else {
@@ -36405,14 +36631,14 @@ FX_EXTERN_C int
       }
       FX_CHECK_EXN(_fx_catch_13);
       if (nargs_0 == 0) {
-         if (FX_REC_VARIANT_TAG(t_2) == 13) {
+         if (FX_REC_VARIANT_TAG(t_2) == 14) {
             goto _fx_endmatch_2;
          }
       }
       if (nargs_0 == 1) {
          FX_CALL(_fx_cons_LN10Ast__typ_t(t_2, 0, true, &argtyps_0), _fx_catch_9);  _fx_catch_9: ; goto _fx_endmatch_2;
       }
-      if (FX_REC_VARIANT_TAG(t_2) == 17) {
+      if (FX_REC_VARIANT_TAG(t_2) == 18) {
          if (nrealargs_0 == nargs_0) {
             FX_COPY_PTR(t_2->u.TypTuple, &argtyps_0); goto _fx_endmatch_2;
          }
@@ -36671,7 +36897,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17get_variant_casesT2LT2R9Ast__id_tN10Ast_
    _fx_N10Ast__typ_t v_0 = 0;
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
-   if (FX_REC_VARIANT_TAG(v_0) == 24) {
+   if (FX_REC_VARIANT_TAG(v_0) == 25) {
       _fx_N14Ast__id_info_t v_1 = {0};
       FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_0->u.TypApp.t1, loc_0, &v_1, 0), _fx_catch_0);
       if (v_1.tag == 6) {
@@ -37163,7 +37389,7 @@ static int
                   if (__fold_result___1.tag == 2) {
                      _fx_N10Ast__typ_t t_2 = __fold_result___1.u.Some.t1;
                      int tag_1 = FX_REC_VARIANT_TAG(t_2);
-                     if (tag_1 == 17) {
+                     if (tag_1 == 18) {
                         _fx_LN10Ast__typ_t tl_2 = 0;
                         _fx_LN10Ast__pat_t lstend_2 = 0;
                         FX_COPY_PTR(t_2->u.TypTuple, &tl_2);
@@ -37188,7 +37414,7 @@ static int
                            _fx_free_LN10Ast__typ_t(&tl_2);
                         }
                      }
-                     else if (tag_1 != 13) {
+                     else if (tag_1 != 14) {
                         FX_COPY_PTR(pl_4, &pl_3);
                      }
                      FX_CHECK_EXN(_fx_catch_8);
@@ -37306,7 +37532,7 @@ static int
                int_ ni_0;
                if (tag_2 == 2) {
                   _fx_N10Ast__typ_t v_31 = v_24->u.Some;
-                  if (FX_REC_VARIANT_TAG(v_31) == 17) {
+                  if (FX_REC_VARIANT_TAG(v_31) == 18) {
                      FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(v_31->u.TypTuple, &ni_0, 0), _fx_catch_14);
 
                   _fx_catch_14: ;
@@ -37314,7 +37540,7 @@ static int
                   }
                }
                if (tag_2 == 2) {
-                  if (FX_REC_VARIANT_TAG(v_24->u.Some) == 13) {
+                  if (FX_REC_VARIANT_TAG(v_24->u.Some) == 14) {
                      fx_str_t v_32 = {0};
                      fx_str_t v_33 = {0};
                      fx_str_t v_34 = {0};

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -1359,6 +1359,11 @@ typedef struct _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t1;
 } _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
+typedef struct _fx_Ta2N10Ast__typ_t {
+   struct _fx_N10Ast__typ_t_data_t* t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_Ta2N10Ast__typ_t;
+
 typedef struct _fx_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* t0;
    bool t1;
@@ -1419,11 +1424,6 @@ typedef struct _fx_T2N13Ast__binary_tNt6option1N10Ast__typ_t {
    struct _fx_N13Ast__binary_t_data_t* t0;
    struct _fx_Nt6option1N10Ast__typ_t_data_t* t1;
 } _fx_T2N13Ast__binary_tNt6option1N10Ast__typ_t;
-
-typedef struct _fx_Ta2N10Ast__typ_t {
-   struct _fx_N10Ast__typ_t_data_t* t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_Ta2N10Ast__typ_t;
 
 typedef struct _fx_T2N10Ast__exp_ti {
    struct _fx_N10Ast__exp_t_data_t* t0;
@@ -5037,6 +5037,27 @@ static void _fx_make_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
    _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(t1, &fx_result->t1);
 }
 
+static void _fx_free_Ta2N10Ast__typ_t(struct _fx_Ta2N10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t0);
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_Ta2N10Ast__typ_t(struct _fx_Ta2N10Ast__typ_t* src, struct _fx_Ta2N10Ast__typ_t* dst)
+{
+   FX_COPY_PTR(src->t0, &dst->t0);
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_Ta2N10Ast__typ_t(
+   struct _fx_N10Ast__typ_t_data_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_Ta2N10Ast__typ_t* fx_result)
+{
+   FX_COPY_PTR(t0, &fx_result->t0);
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
 static void _fx_free_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB(
    struct _fx_T2Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tB* dst)
 {
@@ -5218,27 +5239,6 @@ static void _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(
    struct _fx_N13Ast__binary_t_data_t* t0,
    struct _fx_Nt6option1N10Ast__typ_t_data_t* t1,
    struct _fx_T2N13Ast__binary_tNt6option1N10Ast__typ_t* fx_result)
-{
-   FX_COPY_PTR(t0, &fx_result->t0);
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_Ta2N10Ast__typ_t(struct _fx_Ta2N10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t0);
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_Ta2N10Ast__typ_t(struct _fx_Ta2N10Ast__typ_t* src, struct _fx_Ta2N10Ast__typ_t* dst)
-{
-   FX_COPY_PTR(src->t0, &dst->t0);
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_Ta2N10Ast__typ_t(
-   struct _fx_N10Ast__typ_t_data_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_Ta2N10Ast__typ_t* fx_result)
 {
    FX_COPY_PTR(t0, &fx_result->t0);
    FX_COPY_PTR(t1, &fx_result->t1);
@@ -13503,6 +13503,11 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
    _fx_T2N10Ast__typ_tLR9Ast__id_t v_1 = {0};
    _fx_N10Ast__typ_t t2_0 = 0;
    _fx_LR9Ast__id_t sk2_0 = 0;
+   _fx_Ta2N10Ast__typ_t v_2 = {0};
+   _fx_N10Ast__typ_t v_3 = 0;
+   _fx_N10Ast__typ_t v_4 = 0;
+   _fx_N10Ast__typ_t t1_1 = 0;
+   _fx_N10Ast__typ_t t2_1 = 0;
    int fx_status = 0;
    FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df1_0, &v_0, 0), _fx_cleanup);
    FX_COPY_PTR(v_0.t0, &t1_0);
@@ -13510,9 +13515,152 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM22compare_fun_generalityN24Ast_typecheck__
    FX_CALL(_fx_M13Ast_typecheckFM17skolemize_fun_sigT2N10Ast__typ_tLR9Ast__id_t1rR13Ast__deffun_t(df2_0, &v_1, 0), _fx_cleanup);
    FX_COPY_PTR(v_1.t0, &t2_0);
    FX_COPY_PTR(v_1.t1, &sk2_0);
+   bool kw1_0 = df1_0->data.df_flags.fun_flag_have_keywords;
+   bool kw2_0 = df2_0->data.df_flags.fun_flag_have_keywords;
+   if (kw1_0 == kw2_0) {
+      _fx_make_Ta2N10Ast__typ_t(t1_0, t2_0, &v_2);
+   }
+   else if (kw1_0) {
+      if (FX_REC_VARIANT_TAG(t2_0) == 17) {
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_5 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_6 = 0;
+         _fx_N10Ast__typ_t v_7 = 0;
+         _fx_LN10Ast__typ_t v_8 = 0;
+         _fx_LN10Ast__typ_t v_9 = 0;
+         _fx_LN10Ast__typ_t tl_0 = t2_0->u.TypTuple;
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_5);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_5, &v_6), _fx_catch_2);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_6, &v_7),
+            _fx_catch_2);
+         FX_CALL(_fx_cons_LN10Ast__typ_t(v_7, 0, true, &v_8), _fx_catch_2);
+         if (tl_0 == 0) {
+            FX_COPY_PTR(v_8, &v_9);
+         }
+         else if (v_8 == 0) {
+            FX_COPY_PTR(tl_0, &v_9);
+         }
+         else {
+            _fx_LN10Ast__typ_t v_10 = 0;
+            _fx_LN10Ast__typ_t tl_1 = 0;
+            _fx_LN10Ast__typ_t lstend_0 = 0;
+            FX_COPY_PTR(tl_0, &tl_1);
+            _fx_LN10Ast__typ_t lst_0 = tl_1;
+            for (; lst_0; lst_0 = lst_0->tl) {
+               _fx_N10Ast__typ_t x_0 = lst_0->hd;
+               _fx_LN10Ast__typ_t node_0 = 0;
+               FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_0);
+               FX_LIST_APPEND(v_10, lstend_0, node_0);
+
+            _fx_catch_0: ;
+               FX_CHECK_EXN(_fx_catch_1);
+            }
+            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_10, v_8, &v_9, 0);
+
+         _fx_catch_1: ;
+            if (tl_1) {
+               _fx_free_LN10Ast__typ_t(&tl_1);
+            }
+            if (v_10) {
+               _fx_free_LN10Ast__typ_t(&v_10);
+            }
+         }
+         FX_CHECK_EXN(_fx_catch_2);
+         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_9, &v_3), _fx_catch_2);
+
+      _fx_catch_2: ;
+         if (v_9) {
+            _fx_free_LN10Ast__typ_t(&v_9);
+         }
+         if (v_8) {
+            _fx_free_LN10Ast__typ_t(&v_8);
+         }
+         if (v_7) {
+            _fx_free_N10Ast__typ_t(&v_7);
+         }
+         if (v_6) {
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_6);
+         }
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_5);
+      }
+      else {
+         FX_COPY_PTR(t2_0, &v_3);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      _fx_make_Ta2N10Ast__typ_t(t1_0, v_3, &v_2);
+   }
+   else {
+      if (FX_REC_VARIANT_TAG(t1_0) == 17) {
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_11 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_12 = 0;
+         _fx_N10Ast__typ_t v_13 = 0;
+         _fx_LN10Ast__typ_t v_14 = 0;
+         _fx_LN10Ast__typ_t v_15 = 0;
+         _fx_LN10Ast__typ_t tl_2 = t1_0->u.TypTuple;
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_11);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11, &v_12), _fx_catch_5);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_12, &v_13),
+            _fx_catch_5);
+         FX_CALL(_fx_cons_LN10Ast__typ_t(v_13, 0, true, &v_14), _fx_catch_5);
+         if (tl_2 == 0) {
+            FX_COPY_PTR(v_14, &v_15);
+         }
+         else if (v_14 == 0) {
+            FX_COPY_PTR(tl_2, &v_15);
+         }
+         else {
+            _fx_LN10Ast__typ_t v_16 = 0;
+            _fx_LN10Ast__typ_t tl_3 = 0;
+            _fx_LN10Ast__typ_t lstend_1 = 0;
+            FX_COPY_PTR(tl_2, &tl_3);
+            _fx_LN10Ast__typ_t lst_1 = tl_3;
+            for (; lst_1; lst_1 = lst_1->tl) {
+               _fx_N10Ast__typ_t x_1 = lst_1->hd;
+               _fx_LN10Ast__typ_t node_1 = 0;
+               FX_CALL(_fx_cons_LN10Ast__typ_t(x_1, 0, false, &node_1), _fx_catch_3);
+               FX_LIST_APPEND(v_16, lstend_1, node_1);
+
+            _fx_catch_3: ;
+               FX_CHECK_EXN(_fx_catch_4);
+            }
+            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_16, v_14, &v_15, 0);
+
+         _fx_catch_4: ;
+            if (tl_3) {
+               _fx_free_LN10Ast__typ_t(&tl_3);
+            }
+            if (v_16) {
+               _fx_free_LN10Ast__typ_t(&v_16);
+            }
+         }
+         FX_CHECK_EXN(_fx_catch_5);
+         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(v_15, &v_4), _fx_catch_5);
+
+      _fx_catch_5: ;
+         if (v_15) {
+            _fx_free_LN10Ast__typ_t(&v_15);
+         }
+         if (v_14) {
+            _fx_free_LN10Ast__typ_t(&v_14);
+         }
+         if (v_13) {
+            _fx_free_N10Ast__typ_t(&v_13);
+         }
+         if (v_12) {
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_12);
+         }
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_11);
+      }
+      else {
+         FX_COPY_PTR(t1_0, &v_4);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      _fx_make_Ta2N10Ast__typ_t(v_4, t2_0, &v_2);
+   }
+   FX_COPY_PTR(v_2.t0, &t1_1);
+   FX_COPY_PTR(v_2.t1, &t2_1);
    FX_CALL(
       _fx_M13Ast_typecheckFM22compare_typ_generalityN24Ast_typecheck__gen_cmp_t4N10Ast__typ_tLR9Ast__id_tN10Ast__typ_tLR9Ast__id_t(
-         t1_0, sk1_0, t2_0, sk2_0, fx_result, 0), _fx_cleanup);
+         t1_1, sk1_0, t2_1, sk2_0, fx_result, 0), _fx_cleanup);
 
 _fx_cleanup: ;
    _fx_free_T2N10Ast__typ_tLR9Ast__id_t(&v_0);
@@ -13525,6 +13673,19 @@ _fx_cleanup: ;
       _fx_free_N10Ast__typ_t(&t2_0);
    }
    FX_FREE_LIST_SIMPLE(&sk2_0);
+   _fx_free_Ta2N10Ast__typ_t(&v_2);
+   if (v_3) {
+      _fx_free_N10Ast__typ_t(&v_3);
+   }
+   if (v_4) {
+      _fx_free_N10Ast__typ_t(&v_4);
+   }
+   if (t1_1) {
+      _fx_free_N10Ast__typ_t(&t1_1);
+   }
+   if (t2_1) {
+      _fx_free_N10Ast__typ_t(&t2_1);
+   }
    return fx_status;
 }
 

--- a/compiler/bootstrap/C_form.c
+++ b/compiler/bootstrap/C_form.c
@@ -4357,21 +4357,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -4251,21 +4251,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;

--- a/compiler/bootstrap/K_copy_n_skip.c
+++ b/compiler/bootstrap/K_copy_n_skip.c
@@ -3244,21 +3244,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;

--- a/compiler/bootstrap/K_form.c
+++ b/compiler/bootstrap/K_form.c
@@ -3188,21 +3188,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;

--- a/compiler/bootstrap/K_normalize.c
+++ b/compiler/bootstrap/K_normalize.c
@@ -3406,21 +3406,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;
@@ -7628,7 +7628,7 @@ _fx_Nt6option1N10Ast__exp_t _fx_g19K_normalize__None7_ = 0;
 _fx_N12Set__color_t _fx_g16K_normalize__Red = { 1 };
 _fx_N12Set__color_t _fx_g18K_normalize__Black = { 2 };
 _fx_Nt11Set__tree_t1R9Ast__id_t _fx_g18K_normalize__Empty = 0;
-static _fx_N10Ast__typ_t_data_t TypVoid_data_3 = { 1, 13 };
+static _fx_N10Ast__typ_t_data_t TypVoid_data_3 = { 1, 14 };
 _fx_N10Ast__typ_t _fx_g20K_normalize__TypVoid = &TypVoid_data_3;
 _fx_N12Ast__cmpop_t _fx_g18K_normalize__CmpEQ = { 1 };
 _fx_N12Ast__cmpop_t _fx_g18K_normalize__CmpNE = { 2 };
@@ -10397,7 +10397,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_Nt6option1N10Ast__typ_t v_0 = 0;
       _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_1 = {0};
       FX_COPY_PTR(t_1, &t_2);
-      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_2, &t_3, 0), _fx_catch_36);
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_2, &t_3, 0), _fx_catch_37);
       int tag_0 = FX_REC_VARIANT_TAG(t_3);
       if (tag_0 == 1) {
          FX_COPY_PTR(t_3->u.TypVar->data, &v_0);
@@ -10415,7 +10415,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          fx_free_exn(&v_2);
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 5) {
+      if (tag_0 == 6) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g20K_normalize__KTypInt, &result_0);
          FX_BREAK(_fx_catch_1);
@@ -10423,7 +10423,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_1: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 8) {
+      if (tag_0 == 9) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g21K_normalize__KTypLong, &result_0);
          FX_BREAK(_fx_catch_2);
@@ -10431,7 +10431,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_2: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 6) {
+      if (tag_0 == 7) {
          _fx_N14K_form__ktyp_t result_1 = 0;
          FX_CALL(_fx_M6K_formFM8KTypSIntN14K_form__ktyp_t1i(t_3->u.TypSInt, &result_1), _fx_catch_3);
          _fx_free_N14K_form__ktyp_t(&result_0);
@@ -10444,7 +10444,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 7) {
+      if (tag_0 == 8) {
          _fx_N14K_form__ktyp_t result_2 = 0;
          FX_CALL(_fx_M6K_formFM8KTypUIntN14K_form__ktyp_t1i(t_3->u.TypUInt, &result_2), _fx_catch_4);
          _fx_free_N14K_form__ktyp_t(&result_0);
@@ -10457,7 +10457,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 9) {
+      if (tag_0 == 10) {
          _fx_N14K_form__ktyp_t result_3 = 0;
          FX_CALL(_fx_M6K_formFM9KTypFloatN14K_form__ktyp_t1i(t_3->u.TypFloat, &result_3), _fx_catch_5);
          _fx_free_N14K_form__ktyp_t(&result_0);
@@ -10470,7 +10470,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 10) {
+      if (tag_0 == 11) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g23K_normalize__KTypString, &result_0);
          FX_BREAK(_fx_catch_6);
@@ -10478,7 +10478,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_6: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 11) {
+      if (tag_0 == 12) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g21K_normalize__KTypChar, &result_0);
          FX_BREAK(_fx_catch_7);
@@ -10486,7 +10486,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_7: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 12) {
+      if (tag_0 == 13) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g21K_normalize__KTypBool, &result_0);
          FX_BREAK(_fx_catch_8);
@@ -10494,7 +10494,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_8: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 13) {
+      if (tag_0 == 14) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g21K_normalize__KTypVoid, &result_0);
          FX_BREAK(_fx_catch_9);
@@ -10502,7 +10502,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_9: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 21) {
+      if (tag_0 == 22) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g20K_normalize__KTypExn, &result_0);
          FX_BREAK(_fx_catch_10);
@@ -10510,7 +10510,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_10: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 22) {
+      if (tag_0 == 23) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g20K_normalize__KTypErr, &result_0);
          FX_BREAK(_fx_catch_11);
@@ -10518,7 +10518,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_11: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 23) {
+      if (tag_0 == 24) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g25K_normalize__KTypCPointer, &result_0);
          FX_BREAK(_fx_catch_12);
@@ -10526,7 +10526,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_12: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 25) {
+      if (tag_0 == 26) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g21K_normalize__KTypVoid, &result_0);
          FX_BREAK(_fx_catch_13);
@@ -10534,7 +10534,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_13: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 26) {
+      if (tag_0 == 27) {
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(_fx_g23K_normalize__KTypModule, &result_0);
          FX_BREAK(_fx_catch_14);
@@ -10542,7 +10542,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
       _fx_catch_14: ;
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 15) {
+      if (tag_0 == 16) {
          _fx_N14K_form__ktyp_t v_3 = 0;
          _fx_N14K_form__ktyp_t result_4 = 0;
          FX_CALL(
@@ -10562,7 +10562,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 17) {
+      if (tag_0 == 18) {
          _fx_LN14K_form__ktyp_t v_4 = 0;
          _fx_LN10Ast__typ_t tl_0 = 0;
          _fx_N14K_form__ktyp_t result_5 = 0;
@@ -10612,7 +10612,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          fx_free_exn(&v_5);
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 18) {
+      if (tag_0 == 19) {
          _fx_N14K_form__ktyp_t v_6 = 0;
          _fx_N14K_form__ktyp_t result_6 = 0;
          FX_CALL(
@@ -10632,7 +10632,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 19) {
+      if (tag_0 == 20) {
          _fx_N14K_form__ktyp_t v_7 = 0;
          _fx_N14K_form__ktyp_t result_7 = 0;
          _fx_T2iN10Ast__typ_t* vcase_0 = &t_3->u.TypArray;
@@ -10653,7 +10653,7 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 16) {
+      if (tag_0 == 17) {
          _fx_N14K_form__ktyp_t v_8 = 0;
          _fx_N14K_form__ktyp_t result_8 = 0;
          FX_CALL(
@@ -10693,10 +10693,22 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
          fx_free_exn(&v_10);
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 14) {
-         _fx_LN14K_form__ktyp_t v_11 = 0;
+      if (tag_0 == 5) {
+         fx_exn_t v_11 = {0};
+         fx_str_t slit_4 =
+            FX_MAKE_STR(
+               "[] denotes an empty collection (list, vector or array), but which one cannot be inferenced here; please, use explicit type annotation");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_11, 0), _fx_catch_24);
+         FX_THROW(&v_11, false, _fx_catch_24);
+
+      _fx_catch_24: ;
+         fx_free_exn(&v_11);
+         goto _fx_endmatch_2;
+      }
+      if (tag_0 == 15) {
+         _fx_LN14K_form__ktyp_t v_12 = 0;
          _fx_LN10Ast__typ_t args_0 = 0;
-         _fx_N14K_form__ktyp_t v_12 = 0;
+         _fx_N14K_form__ktyp_t v_13 = 0;
          _fx_N14K_form__ktyp_t result_9 = 0;
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_1 = &t_3->u.TypFun;
          _fx_LN14K_form__ktyp_t lstend_1 = 0;
@@ -10707,45 +10719,45 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
             _fx_N10Ast__typ_t t_6 = lst_1->hd;
             FX_CALL(
                _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast__id_tR10Ast__loc_t(t_6, id_stack_ref_0,
-                  loc_0, &res_1, 0), _fx_catch_24);
+                  loc_0, &res_1, 0), _fx_catch_25);
             _fx_LN14K_form__ktyp_t node_1 = 0;
-            FX_CALL(_fx_cons_LN14K_form__ktyp_t(res_1, 0, false, &node_1), _fx_catch_24);
-            FX_LIST_APPEND(v_11, lstend_1, node_1);
+            FX_CALL(_fx_cons_LN14K_form__ktyp_t(res_1, 0, false, &node_1), _fx_catch_25);
+            FX_LIST_APPEND(v_12, lstend_1, node_1);
 
-         _fx_catch_24: ;
+         _fx_catch_25: ;
             if (res_1) {
                _fx_free_N14K_form__ktyp_t(&res_1);
             }
-            FX_CHECK_EXN(_fx_catch_25);
+            FX_CHECK_EXN(_fx_catch_26);
          }
          FX_CALL(
             _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast__id_tR10Ast__loc_t(vcase_1->t1, id_stack_ref_0,
-               loc_0, &v_12, 0), _fx_catch_25);
-         FX_CALL(_fx_M6K_formFM7KTypFunN14K_form__ktyp_t2LN14K_form__ktyp_tN14K_form__ktyp_t(v_11, v_12, &result_9),
-            _fx_catch_25);
+               loc_0, &v_13, 0), _fx_catch_26);
+         FX_CALL(_fx_M6K_formFM7KTypFunN14K_form__ktyp_t2LN14K_form__ktyp_tN14K_form__ktyp_t(v_12, v_13, &result_9),
+            _fx_catch_26);
          _fx_free_N14K_form__ktyp_t(&result_0);
          FX_COPY_PTR(result_9, &result_0);
-         FX_BREAK(_fx_catch_25);
+         FX_BREAK(_fx_catch_26);
 
-      _fx_catch_25: ;
+      _fx_catch_26: ;
          if (result_9) {
             _fx_free_N14K_form__ktyp_t(&result_9);
          }
-         if (v_12) {
-            _fx_free_N14K_form__ktyp_t(&v_12);
+         if (v_13) {
+            _fx_free_N14K_form__ktyp_t(&v_13);
          }
          if (args_0) {
             _fx_free_LN10Ast__typ_t(&args_0);
          }
-         if (v_11) {
-            _fx_free_LN14K_form__ktyp_t(&v_11);
+         if (v_12) {
+            _fx_free_LN14K_form__ktyp_t(&v_12);
          }
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 20) {
+      if (tag_0 == 21) {
          _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t_3->u.TypRecord->data, &v_1);
          if (v_1.t1 == true) {
-            _fx_LT2R9Ast__id_tN14K_form__ktyp_t v_13 = 0;
+            _fx_LT2R9Ast__id_tN14K_form__ktyp_t v_14 = 0;
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
             _fx_N14K_form__ktyp_t result_10 = 0;
             _fx_LT2R9Ast__id_tN14K_form__ktyp_t lstend_2 = 0;
@@ -10753,94 +10765,94 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_2 = relems_0;
             for (; lst_2; lst_2 = lst_2->tl) {
                _fx_N10Ast__typ_t ti_0 = 0;
-               _fx_N14K_form__ktyp_t v_14 = 0;
+               _fx_N14K_form__ktyp_t v_15 = 0;
                _fx_T2R9Ast__id_tN14K_form__ktyp_t tup_0 = {0};
                _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_2->hd;
                _fx_R9Ast__id_t ni_0 = __pat___0->t1;
                FX_COPY_PTR(__pat___0->t2, &ti_0);
                FX_CALL(
                   _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast__id_tR10Ast__loc_t(ti_0, id_stack_ref_0,
-                     loc_0, &v_14, 0), _fx_catch_26);
-               _fx_make_T2R9Ast__id_tN14K_form__ktyp_t(&ni_0, v_14, &tup_0);
+                     loc_0, &v_15, 0), _fx_catch_27);
+               _fx_make_T2R9Ast__id_tN14K_form__ktyp_t(&ni_0, v_15, &tup_0);
                _fx_LT2R9Ast__id_tN14K_form__ktyp_t node_2 = 0;
-               FX_CALL(_fx_cons_LT2R9Ast__id_tN14K_form__ktyp_t(&tup_0, 0, false, &node_2), _fx_catch_26);
-               FX_LIST_APPEND(v_13, lstend_2, node_2);
+               FX_CALL(_fx_cons_LT2R9Ast__id_tN14K_form__ktyp_t(&tup_0, 0, false, &node_2), _fx_catch_27);
+               FX_LIST_APPEND(v_14, lstend_2, node_2);
 
-            _fx_catch_26: ;
+            _fx_catch_27: ;
                _fx_free_T2R9Ast__id_tN14K_form__ktyp_t(&tup_0);
-               if (v_14) {
-                  _fx_free_N14K_form__ktyp_t(&v_14);
+               if (v_15) {
+                  _fx_free_N14K_form__ktyp_t(&v_15);
                }
                if (ti_0) {
                   _fx_free_N10Ast__typ_t(&ti_0);
                }
-               FX_CHECK_EXN(_fx_catch_27);
+               FX_CHECK_EXN(_fx_catch_28);
             }
             FX_CALL(
-               _fx_M6K_formFM10KTypRecordN14K_form__ktyp_t2R9Ast__id_tLT2R9Ast__id_tN14K_form__ktyp_t(&_fx_g9Ast__noid, v_13,
-                  &result_10), _fx_catch_27);
+               _fx_M6K_formFM10KTypRecordN14K_form__ktyp_t2R9Ast__id_tLT2R9Ast__id_tN14K_form__ktyp_t(&_fx_g9Ast__noid, v_14,
+                  &result_10), _fx_catch_28);
             _fx_free_N14K_form__ktyp_t(&result_0);
             FX_COPY_PTR(result_10, &result_0);
-            FX_BREAK(_fx_catch_27);
+            FX_BREAK(_fx_catch_28);
 
-         _fx_catch_27: ;
+         _fx_catch_28: ;
             if (result_10) {
                _fx_free_N14K_form__ktyp_t(&result_10);
             }
             if (relems_0) {
                _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
             }
-            if (v_13) {
-               _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&v_13);
+            if (v_14) {
+               _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&v_14);
             }
             goto _fx_endmatch_2;
          }
       }
-      if (tag_0 == 20) {
-         fx_exn_t v_15 = {0};
-         fx_str_t slit_4 = FX_MAKE_STR("the record type cannot be inferenced; use explicit type annotation");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_15, 0), _fx_catch_28);
-         FX_THROW(&v_15, false, _fx_catch_28);
+      if (tag_0 == 21) {
+         fx_exn_t v_16 = {0};
+         fx_str_t slit_5 = FX_MAKE_STR("the record type cannot be inferenced; use explicit type annotation");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_5, &v_16, 0), _fx_catch_29);
+         FX_THROW(&v_16, false, _fx_catch_29);
 
-      _fx_catch_28: ;
-         fx_free_exn(&v_15);
+      _fx_catch_29: ;
+         fx_free_exn(&v_16);
          goto _fx_endmatch_2;
       }
-      if (tag_0 == 24) {
+      if (tag_0 == 25) {
          _fx_Nt6option1N10Ast__typ_t t_opt_0 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t2N10Ast__typ_tR10Ast__loc_t(t_3, loc_0, &t_opt_0,
-               0), _fx_catch_35);
+               0), _fx_catch_36);
          if ((t_opt_0 != 0) + 1 == 2) {
-            _fx_N10Ast__typ_t v_16 = t_opt_0->u.Some;
-            if (FX_REC_VARIANT_TAG(v_16) == 24) {
-               _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_2 = &v_16->u.TypApp;
+            _fx_N10Ast__typ_t v_17 = t_opt_0->u.Some;
+            if (FX_REC_VARIANT_TAG(v_17) == 25) {
+               _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_2 = &v_17->u.TypApp;
                if (vcase_2->t0 == 0) {
-                  _fx_N14Ast__id_info_t v_17 = {0};
-                  _fx_R17Ast__defvariant_t v_18 = {0};
-                  _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_19 = {0};
+                  _fx_N14Ast__id_info_t v_18 = {0};
+                  _fx_R17Ast__defvariant_t v_19 = {0};
+                  _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_20 = {0};
                   _fx_R9Ast__id_t* n_0 = &vcase_2->t1;
-                  FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(n_0, loc_0, &v_17, 0), _fx_catch_33);
-                  if (v_17.tag == 6) {
-                     _fx_copy_R17Ast__defvariant_t(&v_17.u.IdVariant->data, &v_18);
-                     _fx_LT2R9Ast__id_tN10Ast__typ_t v_20 = v_18.dvar_cases;
-                     if (v_20 != 0) {
-                        if (v_20->tl == 0) {
-                           _fx_N10Ast__typ_t v_21 = v_20->hd.t1;
-                           if (FX_REC_VARIANT_TAG(v_21) == 20) {
-                              _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_21->u.TypRecord->data,
-                                 &v_19);
-                              if (v_19.t1 == true) {
-                                 if (v_18.dvar_flags.var_flag_record) {
+                  FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(n_0, loc_0, &v_18, 0), _fx_catch_34);
+                  if (v_18.tag == 6) {
+                     _fx_copy_R17Ast__defvariant_t(&v_18.u.IdVariant->data, &v_19);
+                     _fx_LT2R9Ast__id_tN10Ast__typ_t v_21 = v_19.dvar_cases;
+                     if (v_21 != 0) {
+                        if (v_21->tl == 0) {
+                           _fx_N10Ast__typ_t v_22 = v_21->hd.t1;
+                           if (FX_REC_VARIANT_TAG(v_22) == 21) {
+                              _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_22->u.TypRecord->data,
+                                 &v_20);
+                              if (v_20.t1 == true) {
+                                 if (v_19.dvar_flags.var_flag_record) {
                                     _fx_LR9Ast__id_t id_stack_1 = 0;
-                                    fx_str_t v_22 = {0};
                                     fx_str_t v_23 = {0};
-                                    fx_exn_t v_24 = {0};
-                                    _fx_LR9Ast__id_t v_25 = 0;
-                                    _fx_LT2R9Ast__id_tN14K_form__ktyp_t v_26 = 0;
+                                    fx_str_t v_24 = {0};
+                                    fx_exn_t v_25 = {0};
+                                    _fx_LR9Ast__id_t v_26 = 0;
+                                    _fx_LT2R9Ast__id_tN14K_form__ktyp_t v_27 = 0;
                                     _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_1 = 0;
                                     _fx_N14K_form__ktyp_t new_t_0 = 0;
-                                    _fx_LR9Ast__id_t v_27 = 0;
+                                    _fx_LR9Ast__id_t v_28 = 0;
                                     bool __fold_result___0 = false;
                                     FX_COPY_PTR(*id_stack_0, &id_stack_1);
                                     _fx_LR9Ast__id_t lst_3 = id_stack_1;
@@ -10872,34 +10884,34 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
                                        }
                                        __fold_result___1 = t_9;
                                        if (__fold_result___1) {
-                                          __fold_result___0 = true; FX_BREAK(_fx_catch_29);
+                                          __fold_result___0 = true; FX_BREAK(_fx_catch_30);
                                        }
 
-                                    _fx_catch_29: ;
+                                    _fx_catch_30: ;
                                        FX_CHECK_BREAK();
-                                       FX_CHECK_EXN(_fx_catch_31);
+                                       FX_CHECK_EXN(_fx_catch_32);
                                     }
                                     if (__fold_result___0) {
-                                       FX_CALL(_fx_M3AstFM6stringS1RM4id_t(n_0, &v_22, 0), _fx_catch_31);
-                                       fx_str_t slit_5 = FX_MAKE_STR("the record \'");
-                                       fx_str_t slit_6 = FX_MAKE_STR("\' directly or indirectly references itself");
+                                       FX_CALL(_fx_M3AstFM6stringS1RM4id_t(n_0, &v_23, 0), _fx_catch_32);
+                                       fx_str_t slit_6 = FX_MAKE_STR("the record \'");
+                                       fx_str_t slit_7 = FX_MAKE_STR("\' directly or indirectly references itself");
                                        {
-                                          const fx_str_t strs_0[] = { slit_5, v_22, slit_6 };
-                                          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_23), _fx_catch_31);
+                                          const fx_str_t strs_0[] = { slit_6, v_23, slit_7 };
+                                          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_24), _fx_catch_32);
                                        }
-                                       FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_23, &v_24, 0), _fx_catch_31);
-                                       FX_THROW(&v_24, false, _fx_catch_31);
+                                       FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_24, &v_25, 0), _fx_catch_32);
+                                       FX_THROW(&v_25, false, _fx_catch_32);
                                     }
                                     else {
-                                       FX_CALL(_fx_cons_LR9Ast__id_t(n_0, *id_stack_0, true, &v_25), _fx_catch_31);
+                                       FX_CALL(_fx_cons_LR9Ast__id_t(n_0, *id_stack_0, true, &v_26), _fx_catch_32);
                                        FX_FREE_LIST_SIMPLE(id_stack_0);
-                                       FX_COPY_PTR(v_25, id_stack_0);
+                                       FX_COPY_PTR(v_26, id_stack_0);
                                        _fx_LT2R9Ast__id_tN14K_form__ktyp_t lstend_3 = 0;
-                                       FX_COPY_PTR(v_19.t0, &relems_1);
+                                       FX_COPY_PTR(v_20.t0, &relems_1);
                                        _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_4 = relems_1;
                                        for (; lst_4; lst_4 = lst_4->tl) {
                                           _fx_N10Ast__typ_t ti_1 = 0;
-                                          _fx_N14K_form__ktyp_t v_28 = 0;
+                                          _fx_N14K_form__ktyp_t v_29 = 0;
                                           _fx_T2R9Ast__id_tN14K_form__ktyp_t tup_1 = {0};
                                           _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___1 =
                                              &lst_4->hd;
@@ -10907,55 +10919,55 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
                                           FX_COPY_PTR(__pat___1->t2, &ti_1);
                                           FX_CALL(
                                              _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast__id_tR10Ast__loc_t(
-                                                ti_1, id_stack_ref_0, loc_0, &v_28, 0), _fx_catch_30);
-                                          _fx_make_T2R9Ast__id_tN14K_form__ktyp_t(&ni_1, v_28, &tup_1);
+                                                ti_1, id_stack_ref_0, loc_0, &v_29, 0), _fx_catch_31);
+                                          _fx_make_T2R9Ast__id_tN14K_form__ktyp_t(&ni_1, v_29, &tup_1);
                                           _fx_LT2R9Ast__id_tN14K_form__ktyp_t node_3 = 0;
                                           FX_CALL(_fx_cons_LT2R9Ast__id_tN14K_form__ktyp_t(&tup_1, 0, false, &node_3),
-                                             _fx_catch_30);
-                                          FX_LIST_APPEND(v_26, lstend_3, node_3);
+                                             _fx_catch_31);
+                                          FX_LIST_APPEND(v_27, lstend_3, node_3);
 
-                                       _fx_catch_30: ;
+                                       _fx_catch_31: ;
                                           _fx_free_T2R9Ast__id_tN14K_form__ktyp_t(&tup_1);
-                                          if (v_28) {
-                                             _fx_free_N14K_form__ktyp_t(&v_28);
+                                          if (v_29) {
+                                             _fx_free_N14K_form__ktyp_t(&v_29);
                                           }
                                           if (ti_1) {
                                              _fx_free_N10Ast__typ_t(&ti_1);
                                           }
-                                          FX_CHECK_EXN(_fx_catch_31);
+                                          FX_CHECK_EXN(_fx_catch_32);
                                        }
                                        FX_CALL(
                                           _fx_M6K_formFM10KTypRecordN14K_form__ktyp_t2R9Ast__id_tLT2R9Ast__id_tN14K_form__ktyp_t(
-                                             n_0, v_26, &new_t_0), _fx_catch_31);
+                                             n_0, v_27, &new_t_0), _fx_catch_32);
                                        if (*id_stack_0 != 0) {
-                                          FX_COPY_PTR((*id_stack_0)->tl, &v_27);
+                                          FX_COPY_PTR((*id_stack_0)->tl, &v_28);
                                        }
                                        else {
-                                          FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_31);
+                                          FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_32);
                                        }
-                                       FX_CHECK_EXN(_fx_catch_31);
+                                       FX_CHECK_EXN(_fx_catch_32);
                                        FX_FREE_LIST_SIMPLE(id_stack_0);
-                                       FX_COPY_PTR(v_27, id_stack_0);
+                                       FX_COPY_PTR(v_28, id_stack_0);
                                        _fx_free_N14K_form__ktyp_t(&result_0);
                                        FX_COPY_PTR(new_t_0, &result_0);
-                                       FX_BREAK(_fx_catch_31);
+                                       FX_BREAK(_fx_catch_32);
                                     }
 
-                                 _fx_catch_31: ;
-                                    FX_FREE_LIST_SIMPLE(&v_27);
+                                 _fx_catch_32: ;
+                                    FX_FREE_LIST_SIMPLE(&v_28);
                                     if (new_t_0) {
                                        _fx_free_N14K_form__ktyp_t(&new_t_0);
                                     }
                                     if (relems_1) {
                                        _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_1);
                                     }
-                                    if (v_26) {
-                                       _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&v_26);
+                                    if (v_27) {
+                                       _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&v_27);
                                     }
-                                    FX_FREE_LIST_SIMPLE(&v_25);
-                                    fx_free_exn(&v_24);
+                                    FX_FREE_LIST_SIMPLE(&v_26);
+                                    fx_free_exn(&v_25);
+                                    FX_FREE_STR(&v_24);
                                     FX_FREE_STR(&v_23);
-                                    FX_FREE_STR(&v_22);
                                     FX_FREE_LIST_SIMPLE(&id_stack_1);
                                     goto _fx_endmatch_0;
                                  }
@@ -10965,60 +10977,60 @@ static int _fx_M11K_normalizeFM9typ2ktyp_N14K_form__ktyp_t3N10Ast__typ_trLR9Ast_
                      }
                   }
                   _fx_N14K_form__ktyp_t result_11 = 0;
-                  FX_CALL(_fx_M6K_formFM8KTypNameN14K_form__ktyp_t1R9Ast__id_t(n_0, &result_11), _fx_catch_32);
+                  FX_CALL(_fx_M6K_formFM8KTypNameN14K_form__ktyp_t1R9Ast__id_t(n_0, &result_11), _fx_catch_33);
                   _fx_free_N14K_form__ktyp_t(&result_0);
                   FX_COPY_PTR(result_11, &result_0);
-                  FX_BREAK(_fx_catch_32);
+                  FX_BREAK(_fx_catch_33);
 
-               _fx_catch_32: ;
+               _fx_catch_33: ;
                   if (result_11) {
                      _fx_free_N14K_form__ktyp_t(&result_11);
                   }
 
                _fx_endmatch_0: ;
-                  FX_CHECK_EXN(_fx_catch_33);
+                  FX_CHECK_EXN(_fx_catch_34);
 
-               _fx_catch_33: ;
-                  _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_19);
-                  _fx_free_R17Ast__defvariant_t(&v_18);
-                  _fx_free_N14Ast__id_info_t(&v_17);
+               _fx_catch_34: ;
+                  _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_20);
+                  _fx_free_R17Ast__defvariant_t(&v_19);
+                  _fx_free_N14Ast__id_info_t(&v_18);
                   goto _fx_endmatch_1;
                }
             }
          }
-         fx_str_t v_29 = {0};
          fx_str_t v_30 = {0};
-         fx_exn_t v_31 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_3, &v_29, 0), _fx_catch_34);
-         fx_str_t slit_7 = FX_MAKE_STR("the proper instance of the template type \'");
-         fx_str_t slit_8 = FX_MAKE_STR("\' is not found");
+         fx_str_t v_31 = {0};
+         fx_exn_t v_32 = {0};
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_3, &v_30, 0), _fx_catch_35);
+         fx_str_t slit_8 = FX_MAKE_STR("the proper instance of the template type \'");
+         fx_str_t slit_9 = FX_MAKE_STR("\' is not found");
          {
-            const fx_str_t strs_1[] = { slit_7, v_29, slit_8 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_30), _fx_catch_34);
+            const fx_str_t strs_1[] = { slit_8, v_30, slit_9 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_31), _fx_catch_35);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_30, &v_31, 0), _fx_catch_34);
-         FX_THROW(&v_31, false, _fx_catch_34);
-
-      _fx_catch_34: ;
-         fx_free_exn(&v_31);
-         FX_FREE_STR(&v_30);
-         FX_FREE_STR(&v_29);
-
-      _fx_endmatch_1: ;
-         FX_CHECK_EXN(_fx_catch_35);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_31, &v_32, 0), _fx_catch_35);
+         FX_THROW(&v_32, false, _fx_catch_35);
 
       _fx_catch_35: ;
+         fx_free_exn(&v_32);
+         FX_FREE_STR(&v_31);
+         FX_FREE_STR(&v_30);
+
+      _fx_endmatch_1: ;
+         FX_CHECK_EXN(_fx_catch_36);
+
+      _fx_catch_36: ;
          if (t_opt_0) {
             _fx_free_Nt6option1N10Ast__typ_t(&t_opt_0);
          }
          goto _fx_endmatch_2;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_36);
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_37);
 
    _fx_endmatch_2: ;
-      FX_CHECK_EXN(_fx_catch_36);
+      FX_CHECK_EXN(_fx_catch_37);
 
-   _fx_catch_36: ;
+   _fx_catch_37: ;
       _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_1);
       if (v_0) {
          _fx_free_Nt6option1N10Ast__typ_t(&v_0);
@@ -12580,7 +12592,7 @@ FX_EXTERN_C int
          goto _fx_endmatch_6;
       }
       if (FX_REC_VARIANT_TAG(rn_0) == 1) {
-         if (FX_REC_VARIANT_TAG(v_117) == 20) {
+         if (FX_REC_VARIANT_TAG(v_117) == 21) {
             _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_117->u.TypRecord->data, &v_119);
             if (v_119.t1 == true) {
                _fx_make_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g9Ast__noid,
@@ -13753,7 +13765,7 @@ FX_EXTERN_C int
 
    _fx_endmatch_8: ;
       FX_CHECK_EXN(_fx_catch_76);
-      if (FX_REC_VARIANT_TAG(probably_tuple_type_0) == 17) {
+      if (FX_REC_VARIANT_TAG(probably_tuple_type_0) == 18) {
          if (idxlist_0 != 0) {
             _fx_N10Ast__exp_t tupidx_0 = idxlist_0->hd;
             bool res_9;
@@ -15218,7 +15230,7 @@ static int
    }
    if (tag_3 == 9) {
       _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_0 = &idx_pat_0->u.PatTyped;
-      if (FX_REC_VARIANT_TAG(vcase_0->t1) == 5) {
+      if (FX_REC_VARIANT_TAG(vcase_0->t1) == 6) {
          _fx_R16Ast__val_flags_t v_12 = {0};
          _fx_T2R9Ast__id_tLN14K_form__kexp_t v_13 = {0};
          _fx_LN14K_form__kexp_t body_code_4 = 0;
@@ -15247,7 +15259,7 @@ static int
    if (tag_3 == 9) {
       _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_1 = &idx_pat_0->u.PatTyped;
       _fx_N10Ast__typ_t v_15 = vcase_1->t1;
-      if (FX_REC_VARIANT_TAG(v_15) == 17) {
+      if (FX_REC_VARIANT_TAG(v_15) == 18) {
          _fx_N10Ast__pat_t p_0 = 0;
          _fx_LN10Ast__typ_t tl_0 = v_15->u.TypTuple;
          FX_CALL(_fx_M3AstFM14pat_skip_typedN10Ast__pat_t1N10Ast__pat_t(vcase_1->t0, &p_0, 0), _fx_catch_16);
@@ -15287,7 +15299,7 @@ static int
                   _fx_copy_T2LR9Ast__id_tLN14K_form__kexp_t(&__fold_result___2, &v_22);
                   FX_COPY_PTR(v_22.t0, &at_ids_2);
                   FX_COPY_PTR(v_22.t1, &body_code_6);
-                  if (FX_REC_VARIANT_TAG(ti_0) == 5) {
+                  if (FX_REC_VARIANT_TAG(ti_0) == 6) {
                      _fx_R16Ast__val_flags_t v_24 = {0};
                      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_25 = {0};
                      _fx_LN14K_form__kexp_t body_code_7 = 0;
@@ -15402,7 +15414,7 @@ static int
                _fx_copy_T2LR9Ast__id_tLN14K_form__ktyp_t(&__fold_result___4, &v_33);
                FX_COPY_PTR(v_33.t0, &at_ids_5);
                FX_COPY_PTR(v_33.t1, &ktl_1);
-               if (FX_REC_VARIANT_TAG(ti_1) == 5) {
+               if (FX_REC_VARIANT_TAG(ti_1) == 6) {
                   fx_str_t v_35 = {0};
                   fx_str_t v_36 = {0};
                   _fx_R16Ast__val_flags_t v_37 = {0};
@@ -20904,7 +20916,7 @@ FX_EXTERN_C int
                _fx_LT2R9Ast__id_tN10Ast__typ_t dvar_cases_1 = v_10.dvar_cases;
                _fx_R9Ast__id_t* inst_name_0 = &v_10.dvar_name;
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_10.dvar_alias, &v_11, 0), _fx_catch_18);
-               if (FX_REC_VARIANT_TAG(v_11) == 24) {
+               if (FX_REC_VARIANT_TAG(v_11) == 25) {
                   _fx_LN10Ast__typ_t targs_1 = 0;
                   _fx_LN14K_form__ktyp_t lstend_1 = 0;
                   FX_COPY_PTR(v_11->u.TypApp.t0, &targs_1);
@@ -20956,7 +20968,7 @@ FX_EXTERN_C int
                      if (dvar_cases_1 != 0) {
                         if (dvar_cases_1->tl == 0) {
                            _fx_N10Ast__typ_t v_15 = dvar_cases_1->hd.t1;
-                           if (FX_REC_VARIANT_TAG(v_15) == 20) {
+                           if (FX_REC_VARIANT_TAG(v_15) == 21) {
                               _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = {0};
                               _fx_LT2R9Ast__id_tN14K_form__ktyp_t rec_elems_0 = 0;
                               _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
@@ -21183,12 +21195,12 @@ FX_EXTERN_C int
                      _fx_N10Ast__typ_t df_typ_0 = v_39.df_typ;
                      _fx_R9Ast__id_t* df_name_0 = &v_39.df_name;
                      int tag_3 = FX_REC_VARIANT_TAG(df_typ_0);
-                     if (tag_3 == 14) {
+                     if (tag_3 == 15) {
                         _fx_LN10Ast__typ_t v_41 = df_typ_0->u.TypFun.t0;
                         if (v_41 != 0) {
                            if (v_41->tl == 0) {
                               _fx_N10Ast__typ_t v_42 = v_41->hd;
-                              if (FX_REC_VARIANT_TAG(v_42) == 20) {
+                              if (FX_REC_VARIANT_TAG(v_42) == 21) {
                                  _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(
                                     &v_42->u.TypRecord->data, &v_40);
                                  if (v_40.t1 == true) {
@@ -21216,7 +21228,7 @@ FX_EXTERN_C int
                            }
                         }
                      }
-                     if (tag_3 == 14) {
+                     if (tag_3 == 15) {
                         FX_COPY_PTR(df_typ_0->u.TypFun.t0, &argtyps_0); goto _fx_endmatch_0;
                      }
 
@@ -21463,7 +21475,7 @@ FX_EXTERN_C int
          _fx_R9Ast__id_t* dexn_name_0 = &v_56.dexn_name;
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(dexn_typ_1, &v_57, 0), _fx_catch_27);
          bool is_std_0;
-         if (FX_REC_VARIANT_TAG(v_57) == 13) {
+         if (FX_REC_VARIANT_TAG(v_57) == 14) {
             if (dexn_scope_0 != 0) {
                _fx_N12Ast__scope_t* v_74 = &dexn_scope_0->hd;
                if (v_74->tag == 10) {
@@ -21532,7 +21544,7 @@ FX_EXTERN_C int
                   0), _fx_catch_27);
          }
          FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(dexn_typ_1, &v_67, 0), _fx_catch_27);
-         if (FX_REC_VARIANT_TAG(v_67) == 20) {
+         if (FX_REC_VARIANT_TAG(v_67) == 21) {
             _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_67->u.TypRecord->data, &v_68);
             if (v_68.t1 == true) {
                _fx_LN10Ast__typ_t v_78 = 0;

--- a/compiler/bootstrap/Lexer.c
+++ b/compiler/bootstrap/Lexer.c
@@ -3573,81 +3573,81 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
       _fx_T2N14Lexer__token_tTa2i v_5 = {0};
       _fx_T2N14Lexer__token_tTa2i v_6 = {0};
       _fx_LT2N14Lexer__token_tTa2i v_7 = 0;
+      _fx_N10Ast__lit_t zero_0 = {0};
       _fx_N14Lexer__token_t v_8 = {0};
       _fx_T2N14Lexer__token_tTa2i v_9 = {0};
       _fx_N14Lexer__token_t v_10 = {0};
       _fx_T2N14Lexer__token_tTa2i v_11 = {0};
-      _fx_N10Ast__lit_t v_12 = {0};
-      _fx_N14Lexer__token_t v_13 = {0};
+      _fx_N14Lexer__token_t v_12 = {0};
+      _fx_T2N14Lexer__token_tTa2i v_13 = {0};
       _fx_T2N14Lexer__token_tTa2i v_14 = {0};
       _fx_T2N14Lexer__token_tTa2i v_15 = {0};
       _fx_T2N14Lexer__token_tTa2i v_16 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_17 = {0};
-      _fx_LT2N14Lexer__token_tTa2i v_18 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_19 = {0};
+      _fx_LT2N14Lexer__token_tTa2i v_17 = 0;
+      _fx_T2N14Lexer__token_tTa2i v_18 = {0};
       _fx_LT2N14Lexer__token_tTa2i result_1 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_20 = {0};
+      _fx_T2N14Lexer__token_tTa2i v_19 = {0};
       _fx_LT2N14Lexer__token_tTa2i result_2 = 0;
-      fx_str_t v_21 = {0};
+      fx_str_t v_20 = {0};
       fx_str_t tyvar_0 = {0};
-      _fx_N14Lexer__token_t v_22 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_23 = {0};
+      _fx_N14Lexer__token_t v_21 = {0};
+      _fx_T2N14Lexer__token_tTa2i v_22 = {0};
       _fx_LT2N14Lexer__token_tTa2i result_3 = 0;
-      _fx_T4iSiB v_24 = {0};
+      _fx_T4iSiB v_23 = {0};
       fx_str_t res_0 = {0};
-      fx_exn_t v_25 = {0};
-      _fx_N10Ast__lit_t v_26 = {0};
-      _fx_N14Lexer__token_t v_27 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_28 = {0};
+      fx_exn_t v_24 = {0};
+      _fx_N10Ast__lit_t v_25 = {0};
+      _fx_N14Lexer__token_t v_26 = {0};
+      _fx_T2N14Lexer__token_tTa2i v_27 = {0};
       _fx_LT2N14Lexer__token_tTa2i result_4 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_29 = {0};
-      _fx_LT2N14Lexer__token_tTa2i v_30 = 0;
-      _fx_LN14Lexer__token_t v_31 = 0;
+      _fx_T2N14Lexer__token_tTa2i v_28 = {0};
+      _fx_LT2N14Lexer__token_tTa2i v_29 = 0;
+      _fx_LN14Lexer__token_t v_30 = 0;
+      _fx_N14Lexer__token_t v_31 = {0};
       _fx_N14Lexer__token_t v_32 = {0};
-      _fx_N14Lexer__token_t v_33 = {0};
-      _fx_N10Ast__lit_t v_34 = {0};
+      _fx_N10Ast__lit_t v_33 = {0};
+      _fx_N14Lexer__token_t v_34 = {0};
       _fx_N14Lexer__token_t v_35 = {0};
-      _fx_N14Lexer__token_t v_36 = {0};
-      _fx_LN14Lexer__token_t v_37 = 0;
+      _fx_LN14Lexer__token_t v_36 = 0;
+      _fx_N14Lexer__token_t v_37 = {0};
       _fx_N14Lexer__token_t v_38 = {0};
-      _fx_N14Lexer__token_t v_39 = {0};
+      _fx_LN14Lexer__token_t v_39 = 0;
       _fx_LN14Lexer__token_t v_40 = 0;
-      _fx_LN14Lexer__token_t v_41 = 0;
       _fx_LT2N14Lexer__token_tTa2i result_5 = 0;
-      _fx_N10Ast__lit_t v_42 = {0};
-      _fx_N14Lexer__token_t v_43 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_44 = {0};
+      _fx_N10Ast__lit_t v_41 = {0};
+      _fx_N14Lexer__token_t v_42 = {0};
+      _fx_T2N14Lexer__token_tTa2i v_43 = {0};
       _fx_LT2N14Lexer__token_tTa2i result_6 = 0;
-      fx_str_t v_45 = {0};
+      fx_str_t v_44 = {0};
       fx_str_t ident_0 = {0};
-      _fx_Nt6option1T2N14Lexer__token_ti v_46 = {0};
+      _fx_Nt6option1T2N14Lexer__token_ti v_45 = {0};
       fx_copy_str(&strm_0->u.stream_t.t3, &buf_0);
       int_ len_0;
       FX_CALL(_fx_M5LexerFM6lengthi1S(&buf_0, &len_0, 0), _fx_catch_66);
       char_ c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
-      int_ v_47 = *pos_0 + 1;
-      char_ c1_0 = FX_STR_ELEM_ZERO(buf_0, v_47);
-      bool v_48;
+      int_ v_46 = *pos_0 + 1;
+      char_ c1_0 = FX_STR_ELEM_ZERO(buf_0, v_46);
+      bool v_47;
       if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
-         v_48 = true;
+         v_47 = true;
       }
       else if (c_0 == (char_)47) {
          if (c1_0 == (char_)47) {
-            v_48 = true;
+            v_47 = true;
          }
          else {
-            v_48 = c1_0 == (char_)42;
+            v_47 = c1_0 == (char_)42;
          }
       }
       else {
-         v_48 = false;
+         v_47 = false;
       }
-      if (v_48) {
-         _fx_T3CiB v_49;
-         FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_49, 0), _fx_catch_66);
-         char_ c__0 = v_49.t0;
-         int_ p_0 = v_49.t1;
-         bool nl_0 = v_49.t2;
+      if (v_47) {
+         _fx_T3CiB v_48;
+         FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_48, 0), _fx_catch_66);
+         char_ c__0 = v_48.t0;
+         int_ p_0 = v_48.t1;
+         bool nl_0 = v_48.t2;
          c_0 = c__0;
          if (nl_0) {
             FX_COPY_PTR(*paren_stack_0, &paren_stack_1);
@@ -3675,8 +3675,8 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
             FX_CHECK_EXN(_fx_catch_66);
          }
          *pos_0 = p_0;
-         int_ v_50 = *pos_0 + 1;
-         c1_0 = FX_STR_ELEM_ZERO(buf_0, v_50);
+         int_ v_49 = *pos_0 + 1;
+         c1_0 = FX_STR_ELEM_ZERO(buf_0, v_49);
       }
       _fx_Ta2i loc_0;
       FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &loc_0, 0), _fx_catch_66);
@@ -3685,71 +3685,71 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
             _fx_M5LexerFM9getnumberT2iT2N14Lexer__token_tC5SiTa2iBB(&buf_0, *pos_0, &loc_0, *prev_dot_0, !*prev_dot_0, &v_0, 0),
             _fx_catch_66);
          int_ p_1 = v_0.t0;
-         _fx_T2N14Lexer__token_tC* v_51 = &v_0.t1;
-         _fx_copy_N14Lexer__token_t(&v_51->t0, &t_0);
-         char_ c_1 = v_51->t1;
+         _fx_T2N14Lexer__token_tC* v_50 = &v_0.t1;
+         _fx_copy_N14Lexer__token_t(&v_50->t0, &t_0);
+         char_ c_1 = v_50->t1;
          int tag_0 = t_0.tag;
          if (tag_0 == 1) {
-            _fx_N10Ast__lit_t* v_52 = &t_0.u.LITERAL;
-            if (v_52->tag == 1) {
-               fx_exn_t v_53 = {0};
+            _fx_N10Ast__lit_t* v_51 = &t_0.u.LITERAL;
+            if (v_51->tag == 1) {
+               fx_exn_t v_52 = {0};
                bool t_1;
-               if (v_52->u.LitInt < 0LL) {
+               if (v_51->u.LitInt < 0LL) {
                   t_1 = !*expect_neg_number_0;
                }
                else {
                   t_1 = false;
                }
                if (t_1) {
-                  _fx_Ta2i v_54;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_54, 0), _fx_catch_0);
+                  _fx_Ta2i v_53;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_53, 0), _fx_catch_0);
                   fx_str_t slit_0 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_54, &slit_0, &v_53), _fx_catch_0);
-                  FX_THROW(&v_53, true, _fx_catch_0);
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_53, &slit_0, &v_52), _fx_catch_0);
+                  FX_THROW(&v_52, true, _fx_catch_0);
                }
 
             _fx_catch_0: ;
-               fx_free_exn(&v_53);
+               fx_free_exn(&v_52);
                goto _fx_endmatch_2;
             }
          }
          if (tag_0 == 1) {
-            _fx_N10Ast__lit_t* v_55 = &t_0.u.LITERAL;
-            if (v_55->tag == 2) {
-               fx_exn_t v_56 = {0};
+            _fx_N10Ast__lit_t* v_54 = &t_0.u.LITERAL;
+            if (v_54->tag == 2) {
+               fx_exn_t v_55 = {0};
                bool t_2;
-               if (v_55->u.LitSInt.t1 < 0LL) {
+               if (v_54->u.LitSInt.t1 < 0LL) {
                   t_2 = !*expect_neg_number_0;
                }
                else {
                   t_2 = false;
                }
                if (t_2) {
-                  _fx_Ta2i v_57;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_57, 0), _fx_catch_1);
+                  _fx_Ta2i v_56;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_56, 0), _fx_catch_1);
                   fx_str_t slit_1 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_57, &slit_1, &v_56), _fx_catch_1);
-                  FX_THROW(&v_56, true, _fx_catch_1);
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_56, &slit_1, &v_55), _fx_catch_1);
+                  FX_THROW(&v_55, true, _fx_catch_1);
                }
 
             _fx_catch_1: ;
-               fx_free_exn(&v_56);
+               fx_free_exn(&v_55);
                goto _fx_endmatch_2;
             }
          }
          if (tag_0 == 1) {
             if (t_0.u.LITERAL.tag == 3) {
-               fx_exn_t v_58 = {0};
+               fx_exn_t v_57 = {0};
                if (*expect_neg_number_0) {
-                  _fx_Ta2i v_59;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_59, 0), _fx_catch_2);
+                  _fx_Ta2i v_58;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_58, 0), _fx_catch_2);
                   fx_str_t slit_2 = FX_MAKE_STR("\'-\' in front of unsigned integer literal");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_59, &slit_2, &v_58), _fx_catch_2);
-                  FX_THROW(&v_58, true, _fx_catch_2);
+                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_58, &slit_2, &v_57), _fx_catch_2);
+                  FX_THROW(&v_57, true, _fx_catch_2);
                }
 
             _fx_catch_2: ;
-               fx_free_exn(&v_58);
+               fx_free_exn(&v_57);
                goto _fx_endmatch_2;
             }
          }
@@ -3776,30 +3776,39 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
             FX_BREAK(_fx_catch_66);
          }
          else if (c_1 == (char_)99) {
+            if (t_0.tag == 1) {
+               _fx_N10Ast__lit_t* v_59 = &t_0.u.LITERAL;
+               if (v_59->tag == 4) {
+                  _fx_M3AstFM8LitFloatN10Ast__lit_t2id(v_59->u.LitFloat.t0, 0.0, &zero_0); goto _fx_endmatch_3;
+               }
+            }
+            _fx_M3AstFM6LitIntN10Ast__lit_t1l(0LL, &zero_0);
+
+         _fx_endmatch_3: ;
+            FX_CHECK_EXN(_fx_catch_66);
             fx_str_t slit_4 = FX_MAKE_STR("complex");
             _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_4, &v_8);
             _fx_make_T2N14Lexer__token_tTa2i(&v_8, &loc_0, &v_9);
             _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_10);
             _fx_make_T2N14Lexer__token_tTa2i(&v_10, &loc_0, &v_11);
-            _fx_M3AstFM6LitIntN10Ast__lit_t1l(0LL, &v_12);
-            _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_12, &v_13);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_13, &loc_0, &v_14);
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_15);
-            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_16);
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_17);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_17, 0, true, &v_18), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, v_18, false, &v_18), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_18, false, &v_18), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_18, false, &v_18), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_18, false, &v_18), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_18, false, &v_18), _fx_catch_66);
+            _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&zero_0, &v_12);
+            _fx_make_T2N14Lexer__token_tTa2i(&v_12, &loc_0, &v_13);
+            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_14);
+            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_15);
+            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_16);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, 0, true, &v_17), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_17, false, &v_17), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_17, false, &v_17), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_13, v_17, false, &v_17), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_17, false, &v_17), _fx_catch_66);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_17, false, &v_17), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-            FX_COPY_PTR(v_18, &result_0);
+            FX_COPY_PTR(v_17, &result_0);
             FX_BREAK(_fx_catch_66);
          }
          else {
-            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_19);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &result_1), _fx_catch_66);
+            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_18);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_18, 0, true, &result_1), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(result_1, &result_0);
             FX_BREAK(_fx_catch_66);
@@ -3816,8 +3825,8 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
          if (t_3) {
             *prev_dot_0 = false;
             *pos_0 = *pos_0 + 1;
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__APOS, &loc_0, &v_20);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_20, 0, true, &result_2), _fx_catch_66);
+            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__APOS, &loc_0, &v_19);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &result_2), _fx_catch_66);
             _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
             FX_COPY_PTR(result_2, &result_0);
             FX_BREAK(_fx_catch_66);
@@ -3859,14 +3868,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                   FX_CHECK_BREAK();
                   FX_CHECK_EXN(_fx_catch_66);
                }
-               FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_21), _fx_catch_66);
-               FX_CALL(_fx_M6StringFM4copyS1S(&v_21, &tyvar_0, 0), _fx_catch_66);
+               FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_20), _fx_catch_66);
+               FX_CALL(_fx_M6StringFM4copyS1S(&v_20, &tyvar_0, 0), _fx_catch_66);
                *pos_0 = p_2;
                *new_exp_0 = false;
                *prev_dot_0 = false;
-               _fx_M5LexerFM5TYVARN14Lexer__token_t1S(&tyvar_0, &v_22);
-               _fx_make_T2N14Lexer__token_tTa2i(&v_22, &loc_0, &v_23);
-               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_23, 0, true, &result_3), _fx_catch_66);
+               _fx_M5LexerFM5TYVARN14Lexer__token_t1S(&tyvar_0, &v_21);
+               _fx_make_T2N14Lexer__token_tTa2i(&v_21, &loc_0, &v_22);
+               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_22, 0, true, &result_3), _fx_catch_66);
                _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                FX_COPY_PTR(result_3, &result_0);
                FX_BREAK(_fx_catch_66);
@@ -3918,11 +3927,11 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                   FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(termpos_0 + 1, strm_0, &v_63, 0), _fx_catch_66);
                   FX_CALL(
                      _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, termpos_0 + 1, &v_63, term_0, c_0 == (char_)114,
-                        c_0 == (char_)102, &v_24, 0), _fx_catch_66);
-                  int_ p_3 = v_24.t0;
-                  fx_copy_str(&v_24.t1, &res_0);
-                  int_ dl_0 = v_24.t2;
-                  bool inline_exp_0 = v_24.t3;
+                        c_0 == (char_)102, &v_23, 0), _fx_catch_66);
+                  int_ p_3 = v_23.t0;
+                  fx_copy_str(&v_23.t1, &res_0);
+                  int_ dl_0 = v_23.t2;
+                  bool inline_exp_0 = v_23.t3;
                   int_ prev_pos_0 = *pos_0;
                   strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_0;
                   *pos_0 = p_3;
@@ -3935,14 +3944,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         _fx_Ta2i v_64;
                         FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_64, 0), _fx_catch_66);
                         fx_str_t slit_5 = FX_MAKE_STR("character literal should contain exactly one character");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_64, &slit_5, &v_25), _fx_catch_66);
-                        FX_THROW(&v_25, true, _fx_catch_66);
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_64, &slit_5, &v_24), _fx_catch_66);
+                        FX_THROW(&v_24, true, _fx_catch_66);
                      }
                      FX_STR_CHKIDX(res_0, 0, _fx_catch_66);
-                     _fx_M3AstFM7LitCharN10Ast__lit_t1C(FX_STR_ELEM(res_0, 0), &v_26);
-                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_26, &v_27);
-                     _fx_make_T2N14Lexer__token_tTa2i(&v_27, &loc_0, &v_28);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, 0, true, &result_4), _fx_catch_66);
+                     _fx_M3AstFM7LitCharN10Ast__lit_t1C(FX_STR_ELEM(res_0, 0), &v_25);
+                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_25, &v_26);
+                     _fx_make_T2N14Lexer__token_tTa2i(&v_26, &loc_0, &v_27);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_27, 0, true, &result_4), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_4, &result_0);
                      FX_BREAK(_fx_catch_66);
@@ -3950,43 +3959,43 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                   else if (inline_exp_0) {
                      _fx_Ta2i v_65;
                      FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(prev_pos_0, strm_0, &v_65, 0), _fx_catch_66);
-                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_65, &v_29);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_29, *paren_stack_0, true, &v_30), _fx_catch_66);
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_65, &v_28);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, *paren_stack_0, true, &v_29), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                     FX_COPY_PTR(v_30, paren_stack_0);
+                     FX_COPY_PTR(v_29, paren_stack_0);
                      *new_exp_0 = true;
                      *fmt_0 = _fx_g13Lexer__None1_;
                      if (FX_STR_LENGTH(res_0) == 0) {
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_32);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, 0, true, &v_31), _fx_catch_66);
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_31);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_31, 0, true, &v_30), _fx_catch_66);
                      }
                      else {
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_33);
-                        _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_34);
-                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_34, &v_35);
-                        _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_36);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_36, 0, true, &v_37), _fx_catch_66);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, v_37, false, &v_37), _fx_catch_66);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_33, v_37, true, &v_31), _fx_catch_66);
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_32);
+                        _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_33);
+                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_33, &v_34);
+                        _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_35);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, 0, true, &v_36), _fx_catch_66);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_34, v_36, false, &v_36), _fx_catch_66);
+                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, v_36, true, &v_30), _fx_catch_66);
                      }
                      fx_str_t slit_6 = FX_MAKE_STR("string");
-                     _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_6, &v_38);
-                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_39);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_39, 0, true, &v_40), _fx_catch_66);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, v_40, false, &v_40), _fx_catch_66);
-                     FX_CALL(_fx_M5LexerFM7__add__LN14Lexer__token_t2LN14Lexer__token_tLN14Lexer__token_t(v_31, v_40, &v_41, 0),
+                     _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_6, &v_37);
+                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_38);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, 0, true, &v_39), _fx_catch_66);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_37, v_39, false, &v_39), _fx_catch_66);
+                     FX_CALL(_fx_M5LexerFM7__add__LN14Lexer__token_t2LN14Lexer__token_tLN14Lexer__token_t(v_30, v_39, &v_40, 0),
                         _fx_catch_66);
-                     FX_CALL(_fx_M5LexerFM6addlocLT2N14Lexer__token_tTa2i2Ta2iLN14Lexer__token_t(&loc_0, v_41, &result_5, 0),
+                     FX_CALL(_fx_M5LexerFM6addlocLT2N14Lexer__token_tTa2i2Ta2iLN14Lexer__token_t(&loc_0, v_40, &result_5, 0),
                         _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_5, &result_0);
                      FX_BREAK(_fx_catch_66);
                   }
                   else {
-                     _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_42);
-                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_42, &v_43);
-                     _fx_make_T2N14Lexer__token_tTa2i(&v_43, &loc_0, &v_44);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_44, 0, true, &result_6), _fx_catch_66);
+                     _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_41);
+                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_41, &v_42);
+                     _fx_make_T2N14Lexer__token_tTa2i(&v_42, &loc_0, &v_43);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_43, 0, true, &result_6), _fx_catch_66);
                      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                      FX_COPY_PTR(result_6, &result_0);
                      FX_BREAK(_fx_catch_66);
@@ -4032,18 +4041,18 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         FX_CHECK_BREAK();
                         FX_CHECK_EXN(_fx_catch_66);
                      }
-                     FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_45), _fx_catch_66);
-                     FX_CALL(_fx_M6StringFM4copyS1S(&v_45, &ident_0, 0), _fx_catch_66);
+                     FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_44), _fx_catch_66);
+                     FX_CALL(_fx_M6StringFM4copyS1S(&v_44, &ident_0, 0), _fx_catch_66);
                      *pos_0 = p_4;
                      *prev_dot_0 = false;
                      FX_CALL(
                         _fx_M5LexerFM8find_optNt6option1T2N14Lexer__token_ti2Nt10Hashmap__t2ST2N14Lexer__token_tiS(
-                           _fx_g21Lexer__ficus_keywords, &ident_0, &v_46, 0), _fx_catch_66);
-                     if (v_46.tag == 2) {
+                           _fx_g21Lexer__ficus_keywords, &ident_0, &v_45, 0), _fx_catch_66);
+                     if (v_45.tag == 2) {
                         _fx_N14Lexer__token_t t_12 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_68 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_7 = 0;
-                        _fx_T2N14Lexer__token_ti* v_69 = &v_46.u.Some;
+                        _fx_T2N14Lexer__token_ti* v_69 = &v_45.u.Some;
                         int_ n_0 = v_69->t1;
                         _fx_N14Lexer__token_t* t_13 = &v_69->t0;
                         if (t_13->tag == 9) {
@@ -4143,24 +4152,24 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  bool res_3;
                                  if (paren_stack_2 != 0) {
                                     if (paren_stack_2->hd.t0.tag == 44) {
-                                       res_3 = true; goto _fx_endmatch_3;
+                                       res_3 = true; goto _fx_endmatch_4;
                                     }
                                  }
                                  if (paren_stack_2 != 0) {
                                     if (paren_stack_2->hd.t0.tag == 47) {
-                                       res_3 = true; goto _fx_endmatch_3;
+                                       res_3 = true; goto _fx_endmatch_4;
                                     }
                                  }
                                  res_3 = false;
 
-                              _fx_endmatch_3: ;
+                              _fx_endmatch_4: ;
                                  FX_CHECK_EXN(_fx_catch_7);
                                  if (res_3) {
-                                    may_have_arg_0 = true; goto _fx_endmatch_4;
+                                    may_have_arg_0 = true; goto _fx_endmatch_5;
                                  }
                                  may_have_arg_0 = false;
 
-                              _fx_endmatch_4: ;
+                              _fx_endmatch_5: ;
                                  FX_CHECK_EXN(_fx_catch_7);
                               }
                               else {
@@ -4371,7 +4380,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_10);
                               }
                               _fx_free_T2N14Lexer__token_tTa2i(&v_97);
-                              goto _fx_endmatch_5;
+                              goto _fx_endmatch_6;
                            }
                         }
                         fx_exn_t v_98 = {0};
@@ -4382,7 +4391,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                      _fx_catch_16: ;
                         fx_free_exn(&v_98);
 
-                     _fx_endmatch_5: ;
+                     _fx_endmatch_6: ;
                         FX_CHECK_EXN(_fx_catch_17);
 
                      _fx_catch_17: ;
@@ -4472,7 +4481,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_13);
                               }
                               _fx_free_T2N14Lexer__token_tTa2i(&v_107);
-                              goto _fx_endmatch_6;
+                              goto _fx_endmatch_7;
                            }
                         }
                         fx_exn_t v_108 = {0};
@@ -4483,7 +4492,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                      _fx_catch_20: ;
                         fx_free_exn(&v_108);
 
-                     _fx_endmatch_6: ;
+                     _fx_endmatch_7: ;
                         FX_CHECK_EXN(_fx_catch_21);
 
                      _fx_catch_21: ;
@@ -4542,7 +4551,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                     FX_FREE_STR(&v_114);
                                     FX_FREE_STR(&s_0);
                                     _fx_free_T2iS(&v_113);
-                                    goto _fx_endmatch_8;
+                                    goto _fx_endmatch_9;
                                  }
                               }
                            }
@@ -4581,7 +4590,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                     }
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_121);
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_120);
-                                    goto _fx_endmatch_8;
+                                    goto _fx_endmatch_9;
                                  }
                               }
                            }
@@ -4612,12 +4621,12 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_free_LT2N14Lexer__token_tTa2i(&v_129);
                               }
                               _fx_free_T2N14Lexer__token_tTa2i(&v_128);
-                              goto _fx_endmatch_7;
+                              goto _fx_endmatch_8;
                            }
                         }
                         FX_COPY_PTR(v_125, &v_126);
 
-                     _fx_endmatch_7: ;
+                     _fx_endmatch_8: ;
                         FX_CHECK_EXN(_fx_catch_25);
                         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_124, v_126, true, &result_16), _fx_catch_25);
                         _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
@@ -4636,7 +4645,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         }
                         _fx_free_T2N14Lexer__token_tTa2i(&v_124);
 
-                     _fx_endmatch_8: ;
+                     _fx_endmatch_9: ;
                         FX_CHECK_EXN(_fx_catch_26);
 
                      _fx_catch_26: ;
@@ -4792,7 +4801,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               }
                               FX_FREE_STR(&s_1);
                               _fx_free_T4iSiB(&v_131);
-                              goto _fx_endmatch_9;
+                              goto _fx_endmatch_10;
                            }
                         }
                         if (paren_stack_6 != 0) {
@@ -4816,7 +4825,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                        _fx_free_LT2N14Lexer__token_tTa2i(&result_18);
                                     }
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_157);
-                                    goto _fx_endmatch_9;
+                                    goto _fx_endmatch_10;
                                  }
                               }
                            }
@@ -4839,7 +4848,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_free_LT2N14Lexer__token_tTa2i(&result_19);
                               }
                               _fx_free_T2N14Lexer__token_tTa2i(&v_158);
-                              goto _fx_endmatch_9;
+                              goto _fx_endmatch_10;
                            }
                         }
                         fx_exn_t v_159 = {0};
@@ -4850,7 +4859,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                      _fx_catch_30: ;
                         fx_free_exn(&v_159);
 
-                     _fx_endmatch_9: ;
+                     _fx_endmatch_10: ;
                         FX_CHECK_EXN(_fx_catch_31);
 
                      _fx_catch_31: ;
@@ -4902,7 +4911,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                           _fx_free_LT2N14Lexer__token_tTa2i(&result_22);
                                        }
                                        _fx_free_T2N14Lexer__token_tTa2i(&v_164);
-                                       goto _fx_endmatch_10;
+                                       goto _fx_endmatch_11;
                                     }
                                  }
                               }
@@ -4921,7 +4930,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            }
                            _fx_free_T2N14Lexer__token_tTa2i(&v_165);
 
-                        _fx_endmatch_10: ;
+                        _fx_endmatch_11: ;
                            FX_CHECK_EXN(_fx_catch_34);
                         }
 
@@ -5040,7 +5049,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_179);
                                     _fx_free_N14Lexer__token_t(&v_178);
                                     _fx_free_N10Ast__lit_t(&v_177);
-                                    goto _fx_endmatch_11;
+                                    goto _fx_endmatch_12;
                                  }
                               }
                            }
@@ -5070,7 +5079,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_184);
                                     _fx_free_N14Lexer__token_t(&v_183);
                                     _fx_free_N10Ast__lit_t(&v_182);
-                                    goto _fx_endmatch_11;
+                                    goto _fx_endmatch_12;
                                  }
                               }
                            }
@@ -5100,7 +5109,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                     _fx_free_T2N14Lexer__token_tTa2i(&v_189);
                                     _fx_free_N14Lexer__token_t(&v_188);
                                     _fx_free_N10Ast__lit_t(&v_187);
-                                    goto _fx_endmatch_11;
+                                    goto _fx_endmatch_12;
                                  }
                               }
                            }
@@ -5121,7 +5130,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            _fx_free_T2N14Lexer__token_tTa2i(&v_191);
                            _fx_free_N14Lexer__token_t(&v_190);
 
-                        _fx_endmatch_11: ;
+                        _fx_endmatch_12: ;
                            FX_CHECK_EXN(_fx_catch_40);
                         }
 
@@ -5882,7 +5891,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               fx_free_exn(&v_253);
                               fx_free_exn(&v_252);
                               fx_free_exn(&curr_exn_0);
-                              goto _fx_endmatch_12;
+                              goto _fx_endmatch_13;
                            }
                         }
                         _fx_T2N14Lexer__token_tTa2i v_258 = {0};
@@ -5929,7 +5938,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         }
                         _fx_free_T2N14Lexer__token_tTa2i(&v_258);
 
-                     _fx_endmatch_12: ;
+                     _fx_endmatch_13: ;
                         FX_CHECK_EXN(_fx_catch_56);
 
                      _fx_catch_56: ;
@@ -6218,7 +6227,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                                  _fx_LT2N14Lexer__token_tTa2i* rest_6 = &paren_stack_9->tl;
                                  _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
                                  FX_COPY_PTR(*rest_6, paren_stack_0);
-                                 goto _fx_endmatch_13;
+                                 goto _fx_endmatch_14;
                               }
                            }
                            fx_exn_t v_304 = {0};
@@ -6229,7 +6238,7 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         _fx_catch_61: ;
                            fx_free_exn(&v_304);
 
-                        _fx_endmatch_13: ;
+                        _fx_endmatch_14: ;
                            FX_CHECK_EXN(_fx_catch_62);
                            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_287);
                            _fx_M3AstFM9LitStringN10Ast__lit_t1S(&verb_0, &v_288);
@@ -6364,78 +6373,78 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
       }
 
    _fx_catch_66: ;
-      _fx_free_Nt6option1T2N14Lexer__token_ti(&v_46);
+      _fx_free_Nt6option1T2N14Lexer__token_ti(&v_45);
       FX_FREE_STR(&ident_0);
-      FX_FREE_STR(&v_45);
+      FX_FREE_STR(&v_44);
       if (result_6) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_6);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_44);
-      _fx_free_N14Lexer__token_t(&v_43);
-      _fx_free_N10Ast__lit_t(&v_42);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_43);
+      _fx_free_N14Lexer__token_t(&v_42);
+      _fx_free_N10Ast__lit_t(&v_41);
       if (result_5) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_5);
-      }
-      if (v_41) {
-         _fx_free_LN14Lexer__token_t(&v_41);
       }
       if (v_40) {
          _fx_free_LN14Lexer__token_t(&v_40);
       }
-      _fx_free_N14Lexer__token_t(&v_39);
+      if (v_39) {
+         _fx_free_LN14Lexer__token_t(&v_39);
+      }
       _fx_free_N14Lexer__token_t(&v_38);
-      if (v_37) {
-         _fx_free_LN14Lexer__token_t(&v_37);
+      _fx_free_N14Lexer__token_t(&v_37);
+      if (v_36) {
+         _fx_free_LN14Lexer__token_t(&v_36);
       }
-      _fx_free_N14Lexer__token_t(&v_36);
       _fx_free_N14Lexer__token_t(&v_35);
-      _fx_free_N10Ast__lit_t(&v_34);
-      _fx_free_N14Lexer__token_t(&v_33);
+      _fx_free_N14Lexer__token_t(&v_34);
+      _fx_free_N10Ast__lit_t(&v_33);
       _fx_free_N14Lexer__token_t(&v_32);
-      if (v_31) {
-         _fx_free_LN14Lexer__token_t(&v_31);
-      }
+      _fx_free_N14Lexer__token_t(&v_31);
       if (v_30) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&v_30);
+         _fx_free_LN14Lexer__token_t(&v_30);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_29);
+      if (v_29) {
+         _fx_free_LT2N14Lexer__token_tTa2i(&v_29);
+      }
+      _fx_free_T2N14Lexer__token_tTa2i(&v_28);
       if (result_4) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_4);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_28);
-      _fx_free_N14Lexer__token_t(&v_27);
-      _fx_free_N10Ast__lit_t(&v_26);
-      fx_free_exn(&v_25);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_27);
+      _fx_free_N14Lexer__token_t(&v_26);
+      _fx_free_N10Ast__lit_t(&v_25);
+      fx_free_exn(&v_24);
       FX_FREE_STR(&res_0);
-      _fx_free_T4iSiB(&v_24);
+      _fx_free_T4iSiB(&v_23);
       if (result_3) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_3);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_23);
-      _fx_free_N14Lexer__token_t(&v_22);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_22);
+      _fx_free_N14Lexer__token_t(&v_21);
       FX_FREE_STR(&tyvar_0);
-      FX_FREE_STR(&v_21);
+      FX_FREE_STR(&v_20);
       if (result_2) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_2);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_20);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_19);
       if (result_1) {
          _fx_free_LT2N14Lexer__token_tTa2i(&result_1);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_19);
-      if (v_18) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&v_18);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_18);
+      if (v_17) {
+         _fx_free_LT2N14Lexer__token_tTa2i(&v_17);
       }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_17);
       _fx_free_T2N14Lexer__token_tTa2i(&v_16);
       _fx_free_T2N14Lexer__token_tTa2i(&v_15);
       _fx_free_T2N14Lexer__token_tTa2i(&v_14);
-      _fx_free_N14Lexer__token_t(&v_13);
-      _fx_free_N10Ast__lit_t(&v_12);
+      _fx_free_T2N14Lexer__token_tTa2i(&v_13);
+      _fx_free_N14Lexer__token_t(&v_12);
       _fx_free_T2N14Lexer__token_tTa2i(&v_11);
       _fx_free_N14Lexer__token_t(&v_10);
       _fx_free_T2N14Lexer__token_tTa2i(&v_9);
       _fx_free_N14Lexer__token_t(&v_8);
+      _fx_free_N10Ast__lit_t(&zero_0);
       if (v_7) {
          _fx_free_LT2N14Lexer__token_tTa2i(&v_7);
       }

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -2715,21 +2715,21 @@ static void _fx_free_N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t** dst)
          _fx_free_Nt6option1N10Ast__typ_t(&(*dst)->u.TypVarTuple); break;
       case 3:
          _fx_free_N10Ast__typ_t(&(*dst)->u.TypVarArray); break;
-      case 14:
-         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 15:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
+         _fx_free_T2LN10Ast__typ_tN10Ast__typ_t(&(*dst)->u.TypFun); break;
       case 16:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypList); break;
       case 17:
-         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypVector); break;
       case 18:
-         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
+         _fx_free_LN10Ast__typ_t(&(*dst)->u.TypTuple); break;
       case 19:
-         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+         _fx_free_N10Ast__typ_t(&(*dst)->u.TypRef); break;
       case 20:
+         _fx_free_T2iN10Ast__typ_t(&(*dst)->u.TypArray); break;
+      case 21:
          _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&(*dst)->u.TypRecord); break;
-      case 24:
+      case 25:
          _fx_free_T2LN10Ast__typ_tR9Ast__id_t(&(*dst)->u.TypApp); break;
       default:
          ;
@@ -5752,21 +5752,21 @@ _fx_Nt6option1N10Ast__typ_t _fx_g14Parser__None3_ = 0;
 _fx_N10Ast__lit_t _fx_g16Parser__LitEmpty = { 8 };
 static _fx_N10Ast__typ_t_data_t TypVarRecord_data_0 = { 1, 4 };
 _fx_N10Ast__typ_t _fx_g20Parser__TypVarRecord = &TypVarRecord_data_0;
-static _fx_N10Ast__typ_t_data_t TypInt_data_1 = { 1, 5 };
+static _fx_N10Ast__typ_t_data_t TypInt_data_1 = { 1, 6 };
 _fx_N10Ast__typ_t _fx_g14Parser__TypInt = &TypInt_data_1;
-static _fx_N10Ast__typ_t_data_t TypLong_data_0 = { 1, 8 };
+static _fx_N10Ast__typ_t_data_t TypLong_data_0 = { 1, 9 };
 _fx_N10Ast__typ_t _fx_g15Parser__TypLong = &TypLong_data_0;
-static _fx_N10Ast__typ_t_data_t TypString_data_1 = { 1, 10 };
+static _fx_N10Ast__typ_t_data_t TypString_data_1 = { 1, 11 };
 _fx_N10Ast__typ_t _fx_g17Parser__TypString = &TypString_data_1;
-static _fx_N10Ast__typ_t_data_t TypChar_data_1 = { 1, 11 };
+static _fx_N10Ast__typ_t_data_t TypChar_data_1 = { 1, 12 };
 _fx_N10Ast__typ_t _fx_g15Parser__TypChar = &TypChar_data_1;
-static _fx_N10Ast__typ_t_data_t TypBool_data_1 = { 1, 12 };
+static _fx_N10Ast__typ_t_data_t TypBool_data_1 = { 1, 13 };
 _fx_N10Ast__typ_t _fx_g15Parser__TypBool = &TypBool_data_1;
-static _fx_N10Ast__typ_t_data_t TypVoid_data_1 = { 1, 13 };
+static _fx_N10Ast__typ_t_data_t TypVoid_data_1 = { 1, 14 };
 _fx_N10Ast__typ_t _fx_g15Parser__TypVoid = &TypVoid_data_1;
-static _fx_N10Ast__typ_t_data_t TypExn_data_0 = { 1, 21 };
+static _fx_N10Ast__typ_t_data_t TypExn_data_0 = { 1, 22 };
 _fx_N10Ast__typ_t _fx_g14Parser__TypExn = &TypExn_data_0;
-static _fx_N10Ast__typ_t_data_t TypCPointer_data_1 = { 1, 23 };
+static _fx_N10Ast__typ_t_data_t TypCPointer_data_1 = { 1, 24 };
 _fx_N10Ast__typ_t _fx_g19Parser__TypCPointer = &TypCPointer_data_1;
 _fx_N15Ast__op_assoc_t _fx_g17Parser__AssocLeft = { 1 };
 _fx_N15Ast__op_assoc_t _fx_g18Parser__AssocRight = { 2 };
@@ -22481,10 +22481,10 @@ FX_EXTERN_C int
                }
                _fx_LN10Ast__typ_t v_2 = 0;
                int tag_0 = FX_REC_VARIANT_TAG(result_3);
-               if (tag_0 == 17) {
+               if (tag_0 == 18) {
                   FX_COPY_PTR(result_3->u.TypTuple, &v_2);
                }
-               else if (tag_0 != 13) {
+               else if (tag_0 != 14) {
                   FX_CALL(_fx_cons_LN10Ast__typ_t(result_3, 0, true, &v_2), _fx_catch_2);  _fx_catch_2: ;
                }
                FX_CHECK_EXN(_fx_catch_3);
@@ -23196,10 +23196,10 @@ FX_EXTERN_C int
             FX_COPY_PTR(v_30.t0, &ts_5);
             FX_COPY_PTR(v_30.t1, &rt_0);
             int tag_0 = FX_REC_VARIANT_TAG(t_3);
-            if (tag_0 == 17) {
+            if (tag_0 == 18) {
                FX_COPY_PTR(t_3->u.TypTuple, &v_31);
             }
-            else if (tag_0 != 13) {
+            else if (tag_0 != 14) {
                FX_CALL(_fx_cons_LN10Ast__typ_t(t_3, 0, true, &v_31), _fx_catch_17);  _fx_catch_17: ;
             }
             FX_CHECK_EXN(_fx_catch_18);
@@ -23329,10 +23329,10 @@ FX_EXTERN_C int
          FX_COPY_PTR(v_1.t0, &ts_2);
          FX_COPY_PTR(v_1.t1, &rt_0);
          int tag_0 = FX_REC_VARIANT_TAG(t_0);
-         if (tag_0 == 17) {
+         if (tag_0 == 18) {
             FX_COPY_PTR(t_0->u.TypTuple, &v_2);
          }
-         else if (tag_0 != 13) {
+         else if (tag_0 != 14) {
             FX_CALL(_fx_cons_LN10Ast__typ_t(t_0, 0, true, &v_2), _fx_catch_0);  _fx_catch_0: ;
          }
          FX_CHECK_EXN(_fx_catch_1);
@@ -24570,7 +24570,7 @@ _fx_endmatch_4: ;
             _fx_T2R9Ast__id_tN10Ast__typ_t* __pat___0 = &lst_1->hd;
             _fx_N10Ast__typ_t v_24 = __pat___0->t1;
             bool v_25;
-            if (FX_REC_VARIANT_TAG(v_24) == 20) {
+            if (FX_REC_VARIANT_TAG(v_24) == 21) {
                _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_26 = {0};
                _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
                _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_24->u.TypRecord->data, &v_26);
@@ -24726,7 +24726,7 @@ _fx_endmatch_5: ;
          _fx_T2R9Ast__id_tN10Ast__typ_t* __pat___2 = &lst_3->hd;
          _fx_N10Ast__typ_t v_38 = __pat___2->t1;
          bool v_39;
-         if (FX_REC_VARIANT_TAG(v_38) == 20) {
+         if (FX_REC_VARIANT_TAG(v_38) == 21) {
             _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_40 = {0};
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_1 = 0;
             _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_38->u.TypRecord->data, &v_40);

--- a/docs/fancy-inventing-orbit.md
+++ b/docs/fancy-inventing-orbit.md
@@ -1,0 +1,64 @@
+# WP-E tranche A — resolver surgery (draft; WAITING for Vadim's brief)
+
+## Status
+
+- 2026-07-08: reviewed `docs/wpe_tests_report.md`, `docs/overload_resolution_proposal_v2.md`,
+  `docs/wpe_experiments/e1_census.md`, `docs/wpe_tests_handoff.md`, FB-007/016/017 in
+  `docs/found_bugs.md`. WP-E test package is MERGED (PR #30, master 36002f3). Memory from the
+  Opus session ("better_ficus") is shared — same project dir, `project-wpe-tests.md` current.
+- Vadim: strict-error-on-tie is his inclination, but **paused** — a Fable chat (aware of the
+  whole activity) prepares a brief; he passes it here, then we finalize the plan.
+- Assignment widening (§7) deferred to later. New branch needed (wpe-tests-1 deleted after merge).
+
+## Exploration findings (Ast_typecheck.fx, 4032 lines)
+
+Surgery site `lookup_id_opt` **983–1070** (88 lines): `find_first` with COMMITTING
+`maybe_unify(...,true)` inside the predicate — non-generic commit at **1012**, generic at
+**1016** (after `preprocess_templ_typ` 1099–1107); `df_templ_inst` cache scan **1036–1042**
+also commits; new-instance path **1049–1053** (`inst_merge_env` at 1049 → `instantiate_fun`);
+`possible_matches` accumulated at 989. Keyword TypRecord append 999–1010; constructor branch
+1025–1034 (return type participates). Caller `lookup_id` 1072–1083 (`report_not_found_typed`).
+
+Ready-made pieces:
+- `maybe_unify` 106–330; full rollback on `!ok || !update_refs` at **322–328** — trial mode works.
+- FB-017 root: TypVarRecord arms **194–221** — symmetric flip at 221; record-var binds either
+  direction → comparator sees EqGeneric. Fix: skolemize TypVar* family (Record/Tuple/Array) on
+  the rigid side in `skolemize_fun_sig` (423–445; skolem = frozen `TypApp([],id)` at 432),
+  extend `unskolemize_typ` (362–381). maybe_unify itself stays untouched.
+- Comparator `compare_typ_generality` 395–408, `compare_fun_generality` 449–454 (unwired).
+- `fun_matches_trial` **916–936** — already the update_refs=false viability test the collect
+  phase needs; `trace_resolve` 946–981 computes env-order vs generality winner.
+- `find_all` 533–537, `find_first` 852–909 (dotted-module fallback path 883–908 — keep).
+
+## Key data constraints (from E1 census)
+
+- 344 viable>1 sites in compiler; 0 different-concrete-winner disagreements; 227 `<none>`:
+  ~224 = FB-017 (fixable), **2 genuine stdlib duplicate signatures** (`length(string)`,
+  `join(string, string list)` in Builtins.fx AND String.fx) — strict error-on-tie requires
+  de-duplicating String.fx first.
+- Under-constrained args (free TypVar at call): many generics trivially viable (one 21-viable
+  site; container size/string families). Today: env-order first + later narrowing. Strict
+  error-on-tie risk here — must re-run census with fixed comparator to size the problem.
+- S3 mechanism confirmed: `lib/NN/FromOnnx.fx:1012` `rev_more_ops + prog` — list-concat
+  `+('t list,'t list)` (Builtins.fx:181) vs over-general `+('t,'t complex)` are INCOMPARABLE;
+  prog's type still free → ranking alone doesn't fix S3; needs tranche-B deferral, a type
+  annotation in FromOnnx, or keeping Complex ops fenced.
+- S1 fix = add `fun complex(r:'t, i:'t)` to lib/Complex.fx (FB-007 entry sanctions it).
+- FB-007 multi-module repro idea (Vadim: at my discretion): test-local mini `cplx` module with
+  over-general `operator +(a:'t, b:'t cplx)` + consumer building a list with a free-typed
+  accumulator (mimic `rev_more_ops + prog` shape), `.rev()` after — S3-shape without touching
+  lib. S2-shape try: `val c = ref(cplx{...}); *c *= 2` with `*('t cplx, int)` defined.
+
+## Open questions (answers to come from the brief)
+
+1. Tie policy tranche A: strict ambiguity error (Vadim leans; needs String.fx dedup + a story
+   for under-constrained sites) vs staged (rank+env-order-fallback first, census re-run, then
+   flip to strict).
+2. Complex.fx unlock scope in this PR (S3 not fixed by ranking).
+3. PR scope: resolver core + basic ambiguity diagnostics vs full §8 (rich not-found reasons,
+   edit-distance, TypErr recovery/multiple errors) in one PR.
+
+## Next steps when brief arrives
+
+Incorporate brief → finalize plan (steps, tests-to-flip list, acceptance = E1 corpus
+invariance + fixpoint + determinism + sanitize) → ExitPlanMode.

--- a/docs/ficus_todo_2026.md
+++ b/docs/ficus_todo_2026.md
@@ -2,21 +2,21 @@
 
 - [ ] properly resolve instances of generic functions.
       Adjust the type checker not to stop at the first appropriate candidate.
-- [ ] new syntax for generic types and its instances: `t list => list<t>
+- [ ] new syntax for generic types and its instances: `t list => list[t]`
   - [ ] Q: what would be a syntax for generic functions? `fun [u, v] add(a: u, b: v) {...}`?
 - [ ] new syntax for fold: `fold acc = 0 for x <- arr {acc + x}` => `fold acc = 0 for x <- arr {acc += x}`
 - [ ] add syntax to append elements to lists, vectors during fold?
       We already have runtime support for vector writers for vector comprehensions,
-      maybe need to add list writer as well. E.g. fold val l = [] for x <- 1:n {if isprime(n) {l+=x}}.
+      maybe need to add list writer as well. E.g. `fold val l = [] for x <- 1:n {if isprime(n) {l+=x}}`.
       It partially duplicates list comprehensions, but fold is more universal.
       In fact, list comprehensions can then be converted to just fold's that are,
       in their turn, are converted to simple loops.
-- [ ] because of new syntax for generic types, we can get rid of (x :> new_type) type cast syntax and switch to normal new_type(x).
+- [ ] because of new syntax for generic types, we can get rid of `(x :> new_type)` type cast syntax and switch to normal `new_type(x)`.
 - [ ] currently we use Matlab-style .op for elemwise-operations, but it looks weird
       sometimes for those who are not familiar with Matlab. Shall we drop all .op
-      operations and use Python-style '@' for matrix multiplication? We also use @ for
-      preprocessor in Ficus, but we should be able to differentiate between binary @,
-      unary @ and macro interpolation '@{...}'.
+      operations and use Python-style `@` for matrix multiplication? We also use `@` for
+      preprocessor in Ficus, but we should be able to differentiate between binary `@`,
+      unary `@` in front of macros and macro interpolation `@{...}`.
 - [ ] not quite a new syntax: support string literals inside f-strings interpolations (see CLAUDE.md)
 - [ ] revise records:
   - [ ] keep/drop/revise record update syntax?
@@ -28,24 +28,27 @@
         for the particular option: `type employee_t = Engineer: {age: int; computer: string; claude_subscr: string} | Manager: {age: int; tablet: string; team: list[employee_t]}`, how to we take and operate on all Engineer fields as a whole?
         It's suggested to automatically introduce `Engineer.t` type. It should be possible to
         construct employee_t directly from Engineer.t: `val e = Engineer(data: Engineer.t)`
-- [ ] rename half to `hfloat` (as in OpenCV) or `float16`, because half is quite generic name.
-- [ ] add `bfloat` or `bfloat16`.
-- [ ] add more array reductions, e.g. sum(0., for x <- arr {x**2}).
-      Shall we somehow infer automatically the initial value, not to pass explicit '0.'?
+- [ ] rename `half` to `fp16`, because half is quite generic name.
+- [ ] add `bf16`.
+- [ ] add more array reductions, e.g. `sum(0., for x <- arr {x**2})`.
+      Shall we somehow infer automatically the initial value, not to pass explicit `0.` as initializer?
 - [ ] do we want a generic macro-like syntax to define, e.g., new specialized forms of array
-      comprehensions/reductions, e.g. all(for x <- arr {predicate(x)})?
-- [ ] do we want a ternary selection operator? (a ? b : c) (we now use if(a) {b} else {c})
-- [ ] support variadic functions, e.g. println(a, b, c); max(a, b, c, d)
+      comprehensions/reductions, e.g. `all(for x <- arr {predicate(x)})`?
+- [ ] do we want a ternary selection operator? `(a ? b : c)` (we now use `if(a) {b} else {c}`)
+- [ ] support variadic functions, e.g. `println(a, b, c)`; `max(a, b, c, d)`
 - [ ] remove restriction for modules to start with a capital letter; in fact, it's not a mandatory thing already,
-      see examples/fst.fx that imports 'testmod.fx'. But this rule should probably be propagated to std lib
-- [ ] require that complex modules included __init__.fx in the root and any subdirectories,
+      see `examples/fst.fx` that imports `testmod.fx`. But this rule should probably be propagated to std lib
+- [ ] require that complex modules included `__init__.fx` in the root and any subdirectories,
       just like Python. otherwise it's impossible to differentiate between just a tree of
       files and complex hierarchical modules.
 - [ ] support more than 5-dimensional arrays. Maybe 7-dimensional arrays?
 - [ ] shall we add a syntax for saturating +,-,*,/ (including floating-point types)?
 - [ ] syntax like `@parallel_if(condition) for {...}` to run loop as sequential if the problem is small enough.
       Compilers cannot always figure the bounary properly.
-- [ ] implement einsum and support it at compiler level.
+- [ ] implement `einsum` and support it at compiler level. Probably, it should be done in a generic way.
+      there must be a certain class of special functions that compute all elements of the output array independently from each other.
+      the functions should expose certain API. Then we can fuse those functions with subsequent element-wise operations (array comprehensions,
+      where inputs array(s) are outputs of those special functions).
 - [ ] support numpy-style broadcasting, e.g. [@broadcast for a <- A, b <- B {a*b}].
       It makes sense to explicitly specify that we need broadcasting, because in certain scenarios
       size mismatch is undesirable and is an error that must be reported (via exception).
@@ -59,11 +62,11 @@
       e.g. for OpenCV bindings. Maybe we need to add `tensor` type that is a black box, sitting in CPU, GPU or NPU memory and
       there is a set of operations on it (with fusion etc.)
 - [ ] try to accept `(op)` everywhere where `__opname__` is accepted, e.g. `Complex.(*)(a, b)`
-- [ ] introduce infix `++` as concatenation operator. This should solve several problems with incorrect typing.
+- [ ] (maybe not) introduce infix `++` as concatenation operator. This should solve several problems with incorrect typing.
 
 # Code generation, runtime
-- [+] (we now put compiler modification date, its binary size and the compiler flags as the 'signature')
-      put compiler version (git commit?) into __fxbuild__/<something> directories,
+- [x] (we now put compiler modification date, its binary size and the compiler flags as the 'signature')
+      put compiler version (git commit?) into `__fxbuild__/<something>` directories,
       so that after compiler is updated, all the previously generated .c files are discarded.
 - [ ] we now use compact rpmalloc. Shall we replace it with bigger, but hopefully better supported mimalloc?
 - [ ] we use atomic reference counting, and many of ficus data key structures are immutable or have immutable headers,
@@ -79,8 +82,8 @@
 - [ ] better diagnostic of errors. This is too generic request, some details are needed.
   - [ ] for example, when a reserved name/keyword is used as identifier
 - [ ] more convenient error messages, similar to gcc/clang or other compilers when we display code
-      line and put '^' mark below it where the error occured
-- [+] (added tools/update_compiler.py) regenerate bootstrap sources with a special compiler key or
+      line and put `^` mark below it where the error occured
+- [x] (added `tools/update_compiler.py`) regenerate bootstrap sources with a special compiler key or
       at least some python script (tools/update_compiler.py?)
 - [ ] compiler as a library? Currently compiler uses many global variables.
       It would be nice to be able to create a compiler instance and make some experiments with it
@@ -91,7 +94,7 @@
 - [ ] instantiate (not necessarily generic) functions that take callbacks known at compile time.
       The most classic example is qsort — if we pass known comparison function to it,
       we can create a copy of qsort with that function embedded.
-- [ ] compile ficus compiler itself and all programs by default with '-Ofast'.
+- [ ] compile ficus compiler itself and all programs by default with `-Ofast`.
       Currently, it's broken for some reason
 - [ ] extend constant folding to support math functions
 - [ ] generalization of the previous part: can we include some simple k-form interpreter for a subset of

--- a/docs/ficus_todo_2026.md
+++ b/docs/ficus_todo_2026.md
@@ -59,6 +59,7 @@
       e.g. for OpenCV bindings. Maybe we need to add `tensor` type that is a black box, sitting in CPU, GPU or NPU memory and
       there is a set of operations on it (with fusion etc.)
 - [ ] try to accept `(op)` everywhere where `__opname__` is accepted, e.g. `Complex.(*)(a, b)`
+- [ ] introduce infix `++` as concatenation operator. This should solve several problems with incorrect typing.
 
 # Code generation, runtime
 - [+] (we now put compiler modification date, its binary size and the compiler flags as the 'signature')

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -371,6 +371,16 @@ is the whole point of the ladder.
   The `++`/`.`-concatenation idea (§4 of language_changes_brief.md) is now a
   pure language-design question, no longer needed for correctness (Vadim
   demoted it to "maybe not" in ficus_todo_2026.md).
+- **Imaginary-literal follow-up (same day)**: `N.fi`/`N.i`/`N.hi` never
+  actually worked — the lexer desugared them into `complex(0, N)` with an
+  **int** zero (`LitInt(0)`), so the real demo `1 + 1.fi` typed as
+  `complex(int, float)` and no constructor matched (part of the S1 symptom
+  as originally recorded above). Fixed in `Lexer.fx`: the zero real part is
+  a float literal of the same width as the imaginary part. The fst.fx demo
+  is live as `val c = ref (1.f + 1.fi); *c *= 2.f`. Mixed-type operator
+  variants (`'t1 op 't2 complex`) were tried and reverted — their bodies are
+  exactly the S1 shape; scalars must match the complex element type until
+  session-2 deferral lands (`1.f + 1.fi`, not `1 + 1.fi`).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -282,6 +282,32 @@ is the whole point of the ladder.
   (`compare_fun_generality`) already ranks the concrete `complex` operators over
   the generic ones correctly where it can (`-pr-resolve` confirms); the S3
   over-general match is the `int + 't` deferral gap (proposal §5, tranche B).
+- resolve-1 update (2026-07-08, branch `resolve-1`): **PARTIALLY FIXED** by the
+  collect->rank->commit resolver (see FB-016). Per-symptom status:
+  - **S2 — FIXED** (the mis-resolution mechanism): at a determined receiver,
+    `'t cplx * int` now ranks the cplx operator over the array `__mul__`
+    regardless of declaration/import order. Locked as a passing case in
+    `test/test_resolve.fx` (`fb007.s2_cplx_times_int`, mini-cplx module
+    `test/CplxHelper.fx` mirroring the fenced Complex.fx operator shapes).
+    The trial-pollution half of S3 is fixed the same way: a non-winning
+    candidate's unification no longer commits anything.
+  - **S1 — still open (session 2, §5 deferral)**: re-tested with the operators
+    uncommented + a generic `complex(r:'t, i:'t)` ctor added: `1 + 1.fi` still
+    fails — `a + b.re` inside `operator +(a:int, b:'t complex)` is typed `int`
+    at declaration check, so at 't=float the body calls `complex(int, float)`
+    (no match, correctly). Needs instantiation-time re-resolution of operations
+    involving template params.
+  - **S3 commit-half — still open (session 2, deferral of under-constrained
+    calls)**: `vision_classify.fx` still infers `nnop_t list Complex.complex`
+    at `FromOnnx.fx:1012` (`rev_more_ops + prog`, `prog` free): list-concat `+`
+    and `+('t, 't complex)` are genuinely incomparable, so the tie falls back
+    to env-order = the complex one. NEW: this shape now has a SELF-CONTAINED
+    fenced repro (free fold accumulator + `[:: x] + prog`) in
+    `test/test_resolve.fx` — WP-E could not self-contain it; the key is that
+    the accumulator's type must still be fully free at the `+`.
+  `lib/Complex.fx:15-44` + `examples/fst.fx:125-127` therefore STAY FENCED
+  until session 2 (when unfencing, also add the generic `complex(r:'t, i:'t)`
+  constructor — sanctioned above).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the
@@ -526,6 +552,20 @@ is the whole point of the ladder.
   disagreements over 344 viable>1 sites; all 227 disagreements are `<none>` ties
   from under-constrained arguments) -- so this bites user code like the above, not
   the bootstrap.
+- **FIXED** (2026-07-08, branch `resolve-1`, phase 2): `lookup_id_opt` is now
+  collect -> rank -> commit: all candidates are tried side-effect-free
+  (`update_refs=false`), the viable set is ranked by `compare_fun_generality`
+  (unique least-generic wins), and only the winner commits. `f(5)` returns 6
+  (the concrete `f(int)`) regardless of declaration order; the fenced
+  `test/test_resolve.fx` case flipped and is locked as
+  `FB016_fixed.concrete_beats_generic`; the `test/ir/overload_resolve` goldens
+  now show the concrete instances selected. Tie policy (amends proposal §4,
+  per `docs/resolve1_surgery_brief.md`): fully-determined tie -> ambiguity
+  error (negative goldens 012-014); under-constrained tie -> env-order
+  fallback until session-2 deferral. Corpus-invariance proof: bootstrap
+  regeneration through the new resolver changed ONLY the edited
+  `Ast_typecheck.c`; `-pr-resolve` over `compiler/fx.fx`: 350 ranking sites =
+  343 ranked + 7 under-constrained fallbacks + 0 ambiguity errors.
 
 ## FB-017  generality comparator can't order `{...}` (TypVarRecord) auto-generics vs a concrete record
 - discovered: 2026-07-08, WP-E D1/E1. Limitation of the NEW (unwired)
@@ -563,3 +603,13 @@ is the whole point of the ladder.
   package (D1 scope is `df_templ_args` + keyword `TypRecord` + constructor return
   type); documented in `docs/wpe_tests_report.md` and noted in `test/test_gencmp.fx`.
 - status: not fenced (unwired code); tracked here + in the E1 census + the report.
+- **FIXED** (2026-07-08, branch `resolve-1`, phase 1): `compare_typ_generality`
+  now freezes the var-form family on the RIGID side of each trial via the new
+  `freeze_varform_typs` (non-destructive walk): `{...}` -> a record with a
+  unique `__skolem_rec__` field, `(...)` -> a tuple of two distinct opaque
+  constants (so `('t ...)` does not cover it), `('t ...)` -> a 1-tuple of the
+  frozen payload, `'t [+]` -> `TypArray(-1, frozen 't)`. `maybe_unify` itself
+  untouched. +14 verdicts in `test/test_gencmp.fx` (all pre-existing verdicts
+  unchanged). E1 census re-run (`docs/wpe_experiments/e1_census_post_fb017.md`):
+  344/117/227/0 -> 342/341/1/0 (sites/agree/none/concrete-flips); the one
+  remaining `<none>` is the known under-constrained 21-viable `__cmp__` site.

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -377,10 +377,14 @@ is the whole point of the ladder.
   `complex(int, float)` and no constructor matched (part of the S1 symptom
   as originally recorded above). Fixed in `Lexer.fx`: the zero real part is
   a float literal of the same width as the imaginary part. The fst.fx demo
-  is live as `val c = ref (1.f + 1.fi); *c *= 2.f`. Mixed-type operator
-  variants (`'t1 op 't2 complex`) were tried and reverted — their bodies are
-  exactly the S1 shape; scalars must match the complex element type until
-  session-2 deferral lands (`1.f + 1.fi`, not `1 + 1.fi`).
+  is live as `val c = ref (1.f + 1.fi); *c *= 2.f`. Mixed-type variants:
+  `*` and `/` are mixed (`'t1 op 't2`, return type INFERRED — both result
+  components go through a mixed primitive op, so builtin numeric coercion
+  resolves at instantiation; doubles as the widening-cast idiom
+  `1.0 * fcomplex`, and `v *= 2` works with an int scalar). `+`/`-` must
+  stay homogeneous until S1 deferral: one component passes through unchanged
+  (`b.im`), and a mixed variant would build a record with differently-typed
+  fields (`1.f + 1.fi`, not `1 + 1.fi`).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -308,6 +308,38 @@ is the whole point of the ladder.
   `lib/Complex.fx:15-44` + `examples/fst.fx:125-127` therefore STAY FENCED
   until session 2 (when unfencing, also add the generic `complex(r:'t, i:'t)`
   constructor — sanctioned above).
+- **UNFENCED (2026-07-08, resolve-1, follow-up commit)** — the operators are
+  live again, in a simplified, homogeneous form (Vadim), which sidesteps both
+  remaining symptoms without waiting for session-2 deferral:
+  - All operator bodies are now `'t op 't`-homogeneous (the `int`/`'t2` mixed
+    variants removed) => **no cross-type arithmetic inside generic bodies =>
+    S1 never triggers**. The `fst.fx` demo is rewritten accordingly
+    (`ref complex(1.f, 1.f)`, `*c *= 2.f`) and runs; `fst.fx` is in the fxtest
+    corpus, so complex arithmetic is now permanently regression-tested.
+  - The scalar-on-the-LEFT variants `op (a: 't, b: 't complex)` remain FENCED
+    (commented in Complex.fx with an explanation): their unconstrained 't makes
+    them viable at any `known + still-free` call site (the FromOnnx.fx:1012
+    fold-accumulator shape) where they tie incomparably with list-concat `+`
+    and the under-constrained fallback picks by import order. They return with
+    session-2 deferral, or with the concatenation-spelling change below.
+    Until then: `c + s` works, `s + c` does not.
+  - The second collision found on the way (NN/Inference.fx:94
+    `string(tensor)`: `string(nntensor_t, ~border=8, ~braces=true)` vs the
+    ninja record-generic `string({...})`) was resolved properly by the **Q2
+    keyword normalization** in `compare_fun_generality`: when exactly one
+    candidate has keyword params, the keywordless one's tuple gets the same
+    implicit empty keyword record the caller gets, and coverage then ranks an
+    exact keywordless match ABOVE a candidate viable only via all-defaulted
+    keywords (so `sqrt(81.0)` now resolves to `Math.sqrt(double)` over a local
+    `sqrt('t, ~n=2)` instead of erroring; negative golden 014 was repurposed
+    to the identical-signature cross-module case).
+  - **Language-design direction (Vadim), recorded here for follow-up**: drop
+    the functional record-update operator `.{...}` and reuse `.` as the
+    concatenation operator, or spell concatenation `++`. Either way list/string
+    concatenation stops overloading arithmetic `+`; the free-typed-`[]`
+    accumulator collision class disappears, and the fenced scalar-left complex
+    variants can return unconditionally. Tracked in
+    `docs/language_changes_brief.md` §4.
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -340,6 +340,37 @@ is the whole point of the ladder.
     accumulator collision class disappears, and the fenced scalar-left complex
     variants can return unconditionally. Tracked in
     `docs/language_changes_brief.md` §4.
+- **S3 FIXED (2026-07-08, branch `resolve-2`): `TypVarCollection`** — instead of
+  changing the concatenation spelling or waiting for session-2 deferral, the
+  ROOT of the collision was removed: the empty-collection literal `[]`
+  (`LitEmpty`) is no longer typed as a fully free `make_new_typ()`
+  (`Ast.fx: get_lit_typ`) but as a new var-form
+  `TypVar(ref Some(TypVarCollection))` — "some collection: list, vector or
+  array, element type unknown". `maybe_unify` binds it only to
+  `TypList`/`TypVector`/`TypArray`/`'t [+]`/a plain free var/another
+  collection-var; everything else fails. Consequences:
+  - a free-typed `[]` fold accumulator can no longer be captured by an
+    unrelated generic parameter: at `rev_more_ops + prog` (FromOnnx.fx:1012)
+    the scalar-left `+('t, 't complex)` **dies at the viability trial**
+    (`'t := [...]`, then `'t complex` vs `nnop_t list` fails), so only
+    list-concat remains and the under-constrained fallback picks correctly.
+  - the scalar-left variants `op (a: 't, b: 't complex)` are **UNFENCED** in
+    `lib/Complex.fx` (with the latent sign bug in `-` fixed on the way:
+    `s - c` now negates `im`), `examples/fst.fx` exercises `1.f - *c` in the
+    corpus, and the self-contained S3 test in `test/test_resolve.fx` is
+    unfenced and passing (`fb007.s3_free_accumulator`).
+  - `val n: int = []` is now a TYPE CHECKER error (used to pass `-no-c` and
+    only die at K-normalization's "[] is misused"); new negative golden
+    `test/negative/215_empty_collection_scalar.fx`. An unresolvable `[]`
+    still errors at K-normalization, with a clearer message.
+  - `typ2str` renders the new var-form as `[...]`; `typ_has_free_vars` counts
+    it as free (so `[]`-sites remain "under-constrained" for the tie policy);
+    `freeze_varform_typs` freezes it to an opaque constant.
+  Remaining FB-007 tail: **S1 only** (mixed-type arithmetic like `int + 't`
+  inside generic bodies pinned at declaration check — session-2 deferral).
+  The `++`/`.`-concatenation idea (§4 of language_changes_brief.md) is now a
+  pure language-design question, no longer needed for correctness (Vadim
+  demoted it to "maybe not" in ficus_todo_2026.md).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the

--- a/docs/language_changes_brief.md
+++ b/docs/language_changes_brief.md
@@ -111,15 +111,15 @@ Mechanical, automigrator-friendly.
   type positions; matters for function types).
 - **f-strings — CANDIDATE (parser fix)**: allow string literals inside `{}`
   interpolations (`f"{find(\"x\")}"`).
-- **Concatenation operator — CANDIDATE (Vadim, resolve-1 follow-up)**: stop
-  spelling list/string concatenation as arithmetic `+`. Either drop the
-  functional record-update operator `.{...}` and reuse `.` as concatenation,
-  or introduce `++`. Motivation: `+('t list, 't list)` currently competes with
-  every user-defined `+` at under-constrained call sites (a free-typed `[]`
-  fold accumulator being concatenated — the FromOnnx.fx:1012 / FB-007 S3
-  shape), forcing the scalar-left complex operators `op('t, 't complex)` to
-  stay fenced. A dedicated concatenation spelling removes that entire
-  collision class without deferral.
+- **Concatenation operator — CANDIDATE, urgency REMOVED by resolve-2 (Vadim:
+  "maybe not")**: stop spelling list/string concatenation as arithmetic `+`
+  (drop `.{...}` and reuse `.`, or introduce `++`). The original correctness
+  motivation — `+('t list, 't list)` competing with every user-defined `+` at
+  under-constrained call sites (a free-typed `[]` fold accumulator being
+  concatenated, the FromOnnx.fx:1012 / FB-007 S3 shape) — was resolved at the
+  root by `TypVarCollection` (resolve-2): `[]` is now "some collection" and
+  cannot be captured by a non-collection candidate, so the scalar-left complex
+  operators are unfenced. What remains is a pure taste/readability question.
 
 ## 5. Modules
 
@@ -153,15 +153,24 @@ grammar item. Not-found diagnostics list each candidate with a one-line
 rejection reason.
 
 `lib/Complex.fx` operators + the `examples/fst.fx` demo are UNLOCKED in a
-homogeneous form (all bodies `'t op 't` — sidesteps S1; scalar-on-the-left
-variants stay fenced, see FB-007 and the concatenation-operator candidate in
-§4).
+homogeneous form (all bodies `'t op 't` — sidesteps S1).
+
+**resolve-2 (2026-07-08, same day): `TypVarCollection`** — the empty-collection
+literal `[]` is typed as a new var-form "some list/vector/array" instead of a
+fully free type var. It unifies only with a collection type (or a free var),
+so a `[]`-initialized fold accumulator can no longer be captured by an
+unrelated generic candidate: the FB-007/S3 collision class
+(`FromOnnx.fx:1012`) is gone at the root, the scalar-on-the-left complex
+variants are UNFENCED, and `val n: int = []` became a typecheck-time error
+(negative golden 215). DECIDED for the epoch; a possible follow-up
+(post-reform): `[]` = empty *list* only + a dedicated empty-array spelling
+(e.g. `[.]`).
 
 Session 2 (OPEN): deferral — `int + 't` inside generic bodies (S1, for
-mixed-type operator variants) and under-constrained calls (S3 commit-half:
-`FromOnnx.fx:1012` shape; un-fences the scalar-left complex variants and the
-S3 test in `test/test_resolve.fx`); error recovery (TypErr poisoning,
-multiple errors per run); edit-distance "did you mean".
+mixed-type operator variants) and under-constrained calls in general (the
+commit-half: ranking at sites whose arg types are still free, beyond the
+collection case); error recovery (TypErr poisoning, multiple errors per
+run); edit-distance "did you mean".
 
 ## 7. Deferred / additive (post-reform; decide direction only)
 

--- a/docs/language_changes_brief.md
+++ b/docs/language_changes_brief.md
@@ -111,6 +111,15 @@ Mechanical, automigrator-friendly.
   type positions; matters for function types).
 - **f-strings — CANDIDATE (parser fix)**: allow string literals inside `{}`
   interpolations (`f"{find(\"x\")}"`).
+- **Concatenation operator — CANDIDATE (Vadim, resolve-1 follow-up)**: stop
+  spelling list/string concatenation as arithmetic `+`. Either drop the
+  functional record-update operator `.{...}` and reuse `.` as concatenation,
+  or introduce `++`. Motivation: `+('t list, 't list)` currently competes with
+  every user-defined `+` at under-constrained call sites (a free-typed `[]`
+  fold accumulator being concatenated — the FromOnnx.fx:1012 / FB-007 S3
+  shape), forcing the scalar-left complex operators `op('t, 't complex)` to
+  stay fenced. A dedicated concatenation spelling removes that entire
+  collision class without deferral.
 
 ## 5. Modules
 
@@ -131,16 +140,28 @@ is an **ambiguity error** (two flavors: equally-applicable -> qualify the
 call; overlapping-but-unordered -> also possible to add a more specific
 overload); at an **under-constrained** call (free type vars among the args)
 a tie falls back to env-order first-match — today's semantics, kept until
-deferral. No fewer-defaults keyword tie-break (Q2), no scope-proximity
+deferral. Q2 resolved by **keyword normalization** (not a tie-break ladder):
+when exactly one candidate has keyword params, the keywordless one is
+compared with the same implicit empty keyword record the caller gets, so an
+exact keywordless match ranks more specific than a candidate viable only via
+all-defaulted keywords (`string(tensor)` picks `string(nntensor_t, ~kw..)`
+over the record-generic; `sqrt(81.0)` picks `Math.sqrt(double)` over a local
+`sqrt('t, ~n=2)`). No scope-proximity
 ranking (§6 of the proposal). Escape hatch: module-qualified mangled-operator
 call `Module.__op__(a, b)`; a prettier `Module.(op)` spelling is a Brief #3
 grammar item. Not-found diagnostics list each candidate with a one-line
 rejection reason.
 
-Session 2 (OPEN): deferral — `int + 't` inside generic bodies (S1) and
-under-constrained calls (S3 commit-half: `FromOnnx.fx:1012`), then unlock
-`lib/Complex.fx` operators + `examples/fst.fx`; error recovery (TypErr
-poisoning, multiple errors per run); edit-distance "did you mean".
+`lib/Complex.fx` operators + the `examples/fst.fx` demo are UNLOCKED in a
+homogeneous form (all bodies `'t op 't` — sidesteps S1; scalar-on-the-left
+variants stay fenced, see FB-007 and the concatenation-operator candidate in
+§4).
+
+Session 2 (OPEN): deferral — `int + 't` inside generic bodies (S1, for
+mixed-type operator variants) and under-constrained calls (S3 commit-half:
+`FromOnnx.fx:1012` shape; un-fences the scalar-left complex variants and the
+S3 test in `test/test_resolve.fx`); error recovery (TypErr poisoning,
+multiple errors per run); edit-distance "did you mean".
 
 ## 7. Deferred / additive (post-reform; decide direction only)
 

--- a/docs/language_changes_brief.md
+++ b/docs/language_changes_brief.md
@@ -121,15 +121,26 @@ Mechanical, automigrator-friendly.
   tree from a mere directory of files. Interacts with the case-insensitive
   stdlib-shadowing trap (test-file naming caveat in CLAUDE.md).
 
-## 6. Overload resolution (FB-007) — OPEN, gated on its design session
+## 6. Overload resolution (FB-007) — SESSION 1 LANDED (`resolve-1`); deferral pending
 
-Specificity ordering (non-generic > generic; partial order à la C++ partial
-ordering), `int + 't` inside generic bodies, cross-module candidate
-visibility; diagnostic half (edit-distance "did you mean") separately.
-Design against the 3.1 model (type+constructors one entity). Implementation
-split: corpus-invariant hardening (bitwise-identical K-form on everything that
-compiles today, Complex operators unlocked) may land pre-reform; anything that
-changes candidate choice in currently-compiling code rides the reform epoch.
+Session 1 (branch `resolve-1`, 2026-07-08) DECIDED & implemented: resolution
+is collect -> rank -> commit; the **least-generic viable candidate wins**
+(C++-style partial ordering via two one-way skolemized unification trials,
+`compare_fun_generality`); at a **fully-determined** call an unresolvable tie
+is an **ambiguity error** (two flavors: equally-applicable -> qualify the
+call; overlapping-but-unordered -> also possible to add a more specific
+overload); at an **under-constrained** call (free type vars among the args)
+a tie falls back to env-order first-match — today's semantics, kept until
+deferral. No fewer-defaults keyword tie-break (Q2), no scope-proximity
+ranking (§6 of the proposal). Escape hatch: module-qualified mangled-operator
+call `Module.__op__(a, b)`; a prettier `Module.(op)` spelling is a Brief #3
+grammar item. Not-found diagnostics list each candidate with a one-line
+rejection reason.
+
+Session 2 (OPEN): deferral — `int + 't` inside generic bodies (S1) and
+under-constrained calls (S3 commit-half: `FromOnnx.fx:1012`), then unlock
+`lib/Complex.fx` operators + `examples/fst.fx`; error recovery (TypErr
+poisoning, multiple errors per run); edit-distance "did you mean".
 
 ## 7. Deferred / additive (post-reform; decide direction only)
 

--- a/docs/resolve1_report.md
+++ b/docs/resolve1_report.md
@@ -155,6 +155,22 @@ fires on the real path wherever ranking actually happens, so it sees more
 than the old TypFun-gated instrument. All 7 are ties among trivially-viable
 candidates at free-var sites; none changes a winner (bootstrap proof).
 
+## Addendum (`487d30d`) — tuple arithmetic on uniform tuples only
+
+Vadim's review of the phase-2 Builtins change led to the better design, now
+landed: tuple ARITHMETIC (`+ - .+ .- .* ./`) is defined on **uniform tuples
+only** (tuples-as-short-numeric-vectors, the `std::array<T,n>` role) —
+tuple×tuple forms are `('t1 ...) op ('t2 ...)` (operands uniform, element
+types may differ), and the scalar-broadcast forms returned to the original
+`('t ...) op 'ts`. Uniform×uniform is covered by uniform×anything (not
+conversely), so the set is strictly ranked and `tup op tup` picks the
+element-wise form by specificity — the phase-2 `(...)`-broadcast workaround
+is superseded. Structural generics (`==`, `<=>` lexicographic, `===`,
+`string`, `print`, `hash`) keep `(...)` and still accept mixed tuples.
+Mixed-tuple arithmetic is now a clean not-found error (one corpus site
+existed: the `basic.overloaded` showcase, updated). This retires open item 4
+below.
+
 ## Open items for session 2
 
 1. **Deferral** (proposal §5 + under-constrained calls): S1 (`int + 't` in

--- a/docs/resolve1_report.md
+++ b/docs/resolve1_report.md
@@ -1,8 +1,9 @@
 # resolve-1 — overload-resolver surgery, session 1: report
 
-Branch `resolve-1` (4 commits off master `36002f3`), per
+Branch `resolve-1` (off master `36002f3`), per
 `docs/resolve1_surgery_brief.md` (which amends proposal §4's tie policy).
-Not pushed; diffs left for review.
+Pushed; merged to master via the joint resolve-2 PR (see
+`docs/resolve2_report.md` for the follow-up branch).
 
 **Headline: greedy first-match is gone.** Overload resolution is now
 collect → rank → commit: every candidate is tried side-effect-free, the

--- a/docs/resolve1_report.md
+++ b/docs/resolve1_report.md
@@ -1,0 +1,179 @@
+# resolve-1 — overload-resolver surgery, session 1: report
+
+Branch `resolve-1` (4 commits off master `36002f3`), per
+`docs/resolve1_surgery_brief.md` (which amends proposal §4's tie policy).
+Not pushed; diffs left for review.
+
+**Headline: greedy first-match is gone.** Overload resolution is now
+collect → rank → commit: every candidate is tried side-effect-free, the
+viable set is ranked by `compare_fun_generality`, the unique least-generic
+candidate wins and only it commits. FB-016 fixed, FB-017 fixed, FB-007
+S2 + the trial-pollution half of S3 fixed; S1 and S3's commit-half wait for
+session-2 deferral, so `lib/Complex.fx` stays fenced. The whole ladder is
+green and the bootstrap proves corpus-invariance: the compiler compiled
+through the new resolver emits byte-identical C for every module except the
+edited `Ast_typecheck.c`.
+
+## Per-phase summary
+
+### Phase 0 (`f63dbf2`) — stdlib dedupe, corrected en route
+
+The plan said "remove the `length`/`join` re-declarations from String.fx".
+That turned out WRONG: the re-declarations are **load-bearing** — `s.length()`
+method syntax resolves through the object-type fallback
+(`Ast_typecheck.fx`, `some_exp.foo(args)` → `<Module>.foo(some_exp, args)`),
+so the names must exist in module `String`. (`List.fx:8` `length('t list)` is
+the same idiom.) Removing them broke every dot-call on strings.
+
+What was actually needed for the strict tie rule is *zero call sites that see
+an equal-signature pair*, and the E1 census showed both such sites live inside
+String.fx itself (its plain calls see its own wrapper + the star-imported
+Builtins original). Fix: keep the wrappers, qualify the two internal call
+sites (`rfind` → `__intrin_size__`, `format` → `Builtins.join`). Bootstrap
+byte-identical ⇒ perfectly behavior-neutral. A user doing
+`from String import *` and calling plain `length(s)` WILL now get an
+"equally applicable" ambiguity error — correct per policy (star-import is
+opted-in), and the error's hint resolves it.
+
+### Phase 1 (`4a292b7`) — FB-017: the comparator ranks var-form generics
+
+`compare_typ_generality` now freezes the anonymous var-form generics on the
+RIGID side of each one-way trial (new `freeze_varform_typs`, non-destructive,
+`walk_typ`-based like `unskolemize_typ`; `maybe_unify` untouched):
+
+| var-form | rigid sentinel | why |
+|---|---|---|
+| `{...}` | record with one unique `__skolem_rec__` field | no user record unifies with it; a free `{...}`/`'t` still covers it |
+| `(...)` | tuple of two DISTINCT opaque constants | `('t ...)` (uniform) does not cover it; a free `(...)` does |
+| `('t ...)` | 1-tuple of the frozen payload | covered by `(...)`/`('u ...)`, not by `(int ...)` or concrete tuples |
+| `'t [+]` | `TypArray(-1, frozen 't)` | dim −1 matches no concrete array; `'u [+]`/`'u` still cover |
+
+`test/test_gencmp.fx`: +14 verdicts, all pre-existing ones unchanged.
+**E1 census re-run** (`docs/wpe_experiments/e1_census_post_fb017.md`, raw
+alongside): 344/117/227/0 → **342/341/1/0** (sites/agree/`<none>`/concrete
+flips). The one remaining `<none>` is the known under-constrained 21-viable
+`__cmp__` site — exactly the fallback case. Go/no-go for phase 2 confirmed.
+
+### Phase 2 (`e54dec3`) — the restructure
+
+`lookup_id_opt`: per env level (direct hit or dotted-path module search,
+replicated from `find_first`, which survives for its other callers):
+
+1. **Trial** — every `IdFun` via `fun_matches_trial` (`update_refs=false`;
+   the constructor return-type check and the `df_templ_inst` cache scan are
+   commit-only). Non-function entries keep exact first-match semantics: they
+   win immediately iff no viable function precedes them.
+2. **Rank** — size 1 = fast path; else unique least-generic per
+   `compare_fun_generality`. Tie policy (brief): fully-determined call (new
+   `typ_has_free_vars` over the expected arg types; var-forms count as free)
+   → ambiguity error; under-constrained → env-order fallback (counted under
+   `-pr-resolve`).
+3. **Commit** — the old success path (unify `update_refs=true`, ctor return
+   check, instance cache, `instantiate_fun` with `inst_merge_env(env, env1)`
+   — `env` is the ORIGINAL env even for dotted-path hits, as before),
+   executed once.
+
+`-pr-resolve` is now the real decision path (same line format + a new
+`outcome:` line), not a parallel reconstruction; `trace_resolve` deleted.
+
+**Two corpus adjustments, both forced by the decided strict-tie policy and
+worth review attention:**
+
+- `test_basic.fx` keyword_args: `sqrt(81.0)` — a local generic with ALL
+  keywords defaulted ties with the concrete `Math.sqrt(double)`. This is
+  §10.Q2 in the flesh; per the decided no-fewer-defaults-tie-break policy the
+  call is ambiguous. Changed to `sqrt(81.0, n=2)` (explicit intent, same
+  behavior). *Q2 data point #1 for the session-2 review.*
+- `lib/Builtins.fx` `.*`/`./` scalar-broadcast forms: `('t...) op 'ts` was
+  semantically INCOMPARABLE with `(...) op (...)` (uniform first arg spoils
+  the subset relation), so `tup .* tup` — core functionality — became an
+  ambiguity error; only declaration order ever made it work. Changed the
+  broadcast forms to `(a: (...), b: 'ts)` (element-wise independent): the
+  tuple×tuple form is now strictly more specific and ranking picks it with no
+  ordering dependence. Bonus: mixed tuples broadcast (`(1, 2.) .* 3`). Note:
+  the comparison operators (`.>` etc.) never had this problem — their scalar
+  forms constrain the scalar to the ELEMENT type `'t`, which is also the
+  cleaner design the `.*`/`./` pair could adopt in the reform epoch.
+
+Tests: FB-016 fence flipped (`bad(5) == 6`); `test/ir/overload_resolve`
+goldens regenerated (the `pick(int)`/`pick(float)` calls now bind the concrete
+overloads — the generic instances disappeared, previously ALL calls bound the
+generic); new `test/CplxHelper.fx` + S2 lock; **new self-contained S3 fenced
+repro** (see FB-007 below — WP-E couldn't self-contain it; the trick is a
+still-free fold-accumulator type at the `+`).
+
+Perf (typecheck `compiler/fx.fx` via `-no-c`, 3 runs each): master 6.48s →
+resolve-1 6.60s = **+1.8%** — the trial+commit double unification on
+single-candidate sites, as the brief predicted (negligible).
+
+### Phase 3 (`cac02ae`) — diagnostics
+
+- Ambiguity error distinguishes **equally applicable** (all pairs EqGeneric;
+  hint: qualify) from **overlapping but unordered** (hint: qualify or add a
+  more specific overload). Both suggest `Module.__op__(a, b)`-style qualified
+  calls (the Q4-verified spelling).
+- `report_not_found_typed`: candidates render via `fun2sigstr` + a one-line
+  reason from the new `fun_mismatch_reason` — keyword-acceptance / positional
+  arity / first mismatching argument (trial-based, display types from the raw
+  signature so `'t` names survive) / keyword-record mismatch / return-type.
+- New negative goldens `012_overload_ambiguous_incomp`,
+  `013_overload_ambiguous_eq`, `014_overload_ambiguous_xmodule` (local
+  defaulted-keywords generic vs `Math.sqrt` — cross-module attribution; also
+  locks the Q2 policy). Regenerated: 009–011 (richer format), plus
+  108/207/212/703 which also print candidate listings.
+- Deviation from the brief: ambiguity "via two tiny local modules" is not
+  possible under the negative runner (recursive discovery = every `.fx` must
+  produce a diagnostic), so the cross-module case uses the stdlib instead.
+- NOT here (session 2): TypErr recovery / multiple errors, edit-distance.
+
+### Phase 4 (this commit) — bookkeeping
+
+`found_bugs.md`: FB-016 FIXED, FB-017 FIXED, FB-007 PARTIALLY FIXED (S2 ✓,
+S3-trial-half ✓; S1 + S3-commit-half → session 2, re-confirmed live against
+unfenced Complex.fx: `1 + 1.fi` still S1-fails even WITH a generic ctor —
+`a + b.re` is pinned `int` at declaration; `vision_classify` still infers
+`nnop_t list Complex.complex`). `language_changes_brief.md` §6 rewritten
+(session-1 landed / session-2 open). CLAUDE.md: the new resolution rule +
+qualified-call hatch in the gotchas.
+
+## The numbers
+
+| check | result |
+|---|---|
+| `test_all.fx` | 135/135 |
+| `fxtest all` (unit+negative 72+ir 63+cfold+corpus) | green |
+| `fxtest determinism` | PASS=3 |
+| `fxtest sanitize` (ASan+UBSan) | clean |
+| bootstrap fixpoint | holds; ONLY `Ast_typecheck.c` differs |
+| `-pr-resolve` over `compiler/fx.fx` | 350 sites: 343 ranked, **7 fallbacks**, 0 errors |
+| E1 census post-FB-017 | 342 sites: 341 agree, 1 `<none>`, 0 concrete flips |
+| typecheck perf | +1.8% |
+
+The 7 under-constrained fallback sites (vs the census's single `<none>`)
+include lookups whose expected type is not yet a `TypFun` — the new trace
+fires on the real path wherever ranking actually happens, so it sees more
+than the old TypFun-gated instrument. All 7 are ties among trivially-viable
+candidates at free-var sites; none changes a winner (bootstrap proof).
+
+## Open items for session 2
+
+1. **Deferral** (proposal §5 + under-constrained calls): S1 (`int + 't` in
+   generic bodies re-resolved at instantiation, then literal defaulting) and
+   S3's commit-half (`FromOnnx.fx:1012`); then un-fence `lib/Complex.fx:15-44`
+   (+ add the generic `complex(r:'t, i:'t)` ctor), `examples/fst.fx:125-127`,
+   and the S3 fenced block in `test/test_resolve.fx`.
+2. **Error recovery**: TypErr poisoning, multiple errors per run, LSP
+   groundwork; edit-distance suggestions for name misses.
+3. **Q2 watch**: the `sqrt(81.0)` test collision is the first real
+   defaulted-keywords-vs-exact tie; if the pattern recurs in user code,
+   revisit the fewer-defaults tie-break with corpus data.
+4. **`.*`-family cleanup (reform epoch)**: consider constraining the
+   scalar-broadcast scalar to the element type (as the comparison operators
+   already do) instead of free `'ts`.
+5. **E4 ninja lint** (Q5): with FB-017 fixed the equal-specificity lint is no
+   longer swamped by false positives — a cheap permanent fxtest leg is now
+   feasible.
+6. **Curiosity noted, not chased**: in the S1 re-test the candidate listing
+   for `complex(int, float)` did not include the added `complex('t,'t)` —
+   possibly an `inst_merge_env` visibility artifact inside instantiated
+   bodies; worth a look during session 2's deferral work.

--- a/docs/resolve1_report.md
+++ b/docs/resolve1_report.md
@@ -171,6 +171,38 @@ Mixed-tuple arithmetic is now a clean not-found error (one corpus site
 existed: the `basic.overloaded` showcase, updated). This retires open item 4
 below.
 
+## Addendum 2 — Complex.fx UNLOCKED + Q2 keyword normalization
+
+Vadim simplified `lib/Complex.fx` to homogeneous operators (`'t op 't` bodies
+only — no cross-type arithmetic inside generic bodies, so **S1 never
+triggers**), rewrote the `fst.fx` demo (`ref complex(1.f,1.f)`, `*c *= 2.f`),
+and the experiment confirmed the unlock works today:
+
+- The scalar-on-the-LEFT variants `op('t, 't complex)` stay fenced (commented
+  with an explanation in Complex.fx): unconstrained 't makes them viable at
+  `known + still-free` sites (the FromOnnx:1012 fold-accumulator shape), where
+  they tie incomparably with list-concat `+` and the fallback picks by import
+  order. They return with session-2 deferral — or with the new language
+  candidate recorded in `language_changes_brief.md` §4: spell concatenation
+  `++` (or reuse `.` after dropping `.{...}`), which removes the collision
+  class entirely.
+- The second collision surfaced by the unlock (`string(tensor)` in
+  `NN/Inference.fx:94`: `string(nntensor_t, ~border, ~braces)` vs the ninja
+  `string({...})`) is resolved by the **Q2 revision**: `compare_fun_generality`
+  now normalizes the keyword asymmetry (the keywordless candidate's tuple gets
+  the same implicit empty keyword record the caller gets). Coverage semantics
+  then rank an exact keywordless match above a candidate viable only via
+  all-defaulted keywords — NOT a Swift-style tie-break ladder. Effects:
+  `string(tensor)` picks the tensor printer; `sqrt(81.0)` (the phase-2
+  test_basic case) now resolves to `Math.sqrt(double)` instead of erroring;
+  negative golden 014 was repurposed to the identical-signature cross-module
+  case (`length(string)` vs `Builtins.length`); golden 207 gained the two
+  Complex candidates in its listing.
+- `fst.fx` (with live complex arithmetic) and `vision_classify` typecheck are
+  in the corpus — complex is permanently regression-tested from here on.
+- Census after: unchanged — 343 ranked + 7 under-constrained fallbacks + 0
+  ambiguity errors; bootstrap fixpoint again limited to `Ast_typecheck.c`.
+
 ## Open items for session 2
 
 1. **Deferral** (proposal §5 + under-constrained calls): S1 (`int + 't` in

--- a/docs/resolve1_surgery_brief.md
+++ b/docs/resolve1_surgery_brief.md
@@ -1,0 +1,189 @@
+# Brief: overload-resolver surgery, session 1 (WP-E core)
+
+**You are Claude (Fable) running in Claude Code, in the Ficus repo.** This brief
+is self-contained: you were not present for the design discussions, so read the
+context documents before touching anything. The test net and all measurements
+were prepared in a previous session (branch `wpe-tests-1`, merged) specifically
+so that this surgery can be verified step by step.
+
+Read first, in this order:
+1. `docs/overload_resolution_proposal_v2.md` — the design. This brief AMENDS
+   its §4 (see "Tie policy" below) and re-scopes its tranche A.
+2. `docs/wpe_tests_report.md` — what already exists: the generality comparator,
+   the `-pr-resolve` trace, the test suites, experiment results E0–E4.
+3. `docs/wpe_experiments/e1_census.md` — the corpus measurement that proves
+   this change can be behavior-neutral, and the anatomy of the ties.
+4. `docs/found_bugs.md` — entries FB-007 (three symptoms), FB-016 (greedy
+   first-match), FB-017 (comparator vs record-generics).
+5. Repo `CLAUDE.md` — build/test mechanics and Ficus-writing gotchas. The
+   fxtest ladder, `update_compiler.py`, and `.fxstamp` cache invalidation are
+   already in place; trust them.
+
+## What this session does and does not do
+
+DOES: makes `lookup_id_opt` (in `compiler/Ast_typecheck.fx`) collect all viable
+candidates, rank them by the already-implemented-and-tested
+`compare_fun_generality`, and commit the unique least-generic winner —
+replacing today's greedy first-match (`find_first` commits the first candidate
+that `maybe_unify(update_refs=true)`s). Fixes FB-016 and FB-007's symptom S2
+(wrong candidate), and the *trial-pollution half* of S3 (no binding escapes a
+non-winning trial).
+
+**S3 is only half-fixed here — known and accepted.** Its second half is a
+wrong COMMIT at an under-constrained site: at `lib/NN/FromOnnx.fx:1012`
+(`rev_more_ops + prog`, `prog`'s type still free) the list-concat
+`+('t list,'t list)` and an unfenced over-general `+('t,'t complex)` are
+genuinely incomparable, so ranking cannot prefer the right one and the
+fallback reproduces env-order. Consequently `lib/Complex.fx` operators STAY
+FENCED in this session; the real fix is session-2 deferral (resolve
+under-constrained calls once their variables are bound). Encode the S3-shape
+as a fenced test via the sanctioned mini-`cplx` multi-module repro (your
+discretion on the exact form, per the FB-007 entry): over-general
+`operator +(a:'t, b:'t cplx)` + a consumer with a free-typed list accumulator
+mimicking the FromOnnx shape, `.rev()` after; plus the S2-shape
+(`*('t cplx, int)` with `*c *= 2`).
+
+DOES NOT: implement deferral of overloaded ops inside generic bodies OR at
+under-constrained call sites (proposal §5 + the FromOnnx case above) — that is
+session 2; consequently FB-007's S1 (`int + 't` typed too early) and S3's
+commit-half stay open, and `lib/Complex.fx` / `examples/fst.fx` stay fenced
+(the FB-007 entry sanctions adding the generic constructor
+`fun complex(r:'t, i:'t)` to Complex.fx whenever the operators unfence). Does
+not touch the parser (FB-015 stays fenced), the constructor `is_constructor`
+branch's *selection logic* (only its trials get sandboxed), keyword-default
+tie-breaks (Q2: not added), edit-distance suggestions, `TypErr`
+recovery/multiple errors (session 2), or `ExpAssign` widening (§7 — separate
+work item, not yours).
+
+## Ground rules
+
+- Branch `resolve-1` off main. Do not push; final report + diffs for review.
+- Sanity loop before/after every phase: `make -j$(nproc) && bin/ficus -run
+  test/test_all.fx && python3 tools/fxtest/fxtest.py all`, plus
+  `fxtest.py determinism` and `fxtest.py sanitize`.
+- After compiler edits: `python3 tools/update_compiler.py`; the fixpoint must
+  hold. **The bootstrap diff doubles as the corpus-invariance proof**: apart
+  from the modules you edited (`Ast_typecheck.c`, possibly `Ast_pp.c` /
+  `Options.c` and struct-layout propagation per the wpe_tests_report lesson),
+  every other regenerated `bootstrap/*.c` must be byte-identical — the
+  compiler compiling itself through the new resolver must emit the same code.
+  Any unexpected module diff = a resolution flip; stop and investigate.
+- New bugs: minimal repro into `docs/found_bugs.md`, fence, don't chase.
+- Keep `-pr-resolve` truthful: after the restructure it must report the REAL
+  decision path (the actual viable set, ranking, and outcome), not a parallel
+  reconstruction. It is the primary debugging aid for this work.
+
+## Tie policy (AMENDS proposal §4 — read carefully)
+
+The E1 census killed the naive "tie → error" rule: at calls whose argument
+types still contain free type variables, many mutually-incomparable concrete
+overloads are trivially viable (the census's 21-viable `string` site), and
+today's semantics — the first declared viable candidate wins and PINS the
+free variable — is what the whole corpus, including the compiler, is built on.
+The amended policy:
+
+- **Fully-determined call** (no free type vars in the argument positions of
+  the expected `TypFun` at lookup time): unique least-generic candidate wins;
+  `EqGeneric`/`IncompGeneric` at the top → **ambiguity error** listing the
+  tied candidates via `fun2sigstr` + their declaring modules and locations,
+  with the hint to qualify the call (`Module.__mul__(a, b)` — the form the
+  grammar accepts today, per wpe_tests_report Q4).
+- **Under-constrained call** (free vars present): rank; if a unique
+  least-generic exists, commit it; otherwise **fall back to env-order
+  first-match** — today's behavior, now explicit and documented. Proper
+  deferral is session 2; `FromOnnx.fx:1012` is the canonical example of why
+  the fallback (not an error, not a guess by ranking) is the only
+  corpus-safe choice at these sites today. Count fallback occurrences under
+  `-pr-resolve`.
+
+## Phases (each = one commit, ladder green after each)
+
+### Phase 0 — stdlib dedupe (prep)
+
+`String.fx` re-declares two `Builtins.fx` helpers with byte-identical
+signatures: `length(string) -> int` and `join(string, string list) -> string`
+(E4). Under the strict rule these become ambiguity errors on every call.
+Remove the redundant declarations (keep the better-placed one; check which is
+actually referenced/inlined today) so the corpus contains zero
+equal-signature pairs. Re-run the ladder.
+
+### Phase 1 — FB-017: complete the comparator
+
+`compare_typ_generality` reads auto-generated record-generics
+(`TypVarRecord`, i.e. `__eq__(a:{...}, b:{...})`-style) as `EqGeneric`
+against a concrete record, because `maybe_unify` binds a record-var
+symmetrically in both trial directions. Fix per the FB-017 entry's sketch:
+on the rigid (skolemized) side, the `TypVar*` family (`TypVarRecord`,
+`TypVarTuple`, `TypVarArray`, …) must be frozen too, so the concrete overload
+ranks strictly less generic. Extend `test/test_gencmp.fx`: concrete-record
+overload ≻ record-generic; same for the tuple/array var-forms; existing
+verdicts unchanged. Acceptance: re-run the E1 census
+(`bin/ficus -no-c -pr-resolve compiler/fx.fx`, compare against
+`docs/wpe_experiments/e1_census.md`): the ~224 FB-017 `<none>` sites must now
+AGREE with env-order; remaining `<none>` only at under-constrained sites; still
+**zero** different concrete winners. Save the new census alongside the old.
+
+### Phase 2 — the restructure: collect → rank → commit
+
+In `lookup_id_opt`:
+
+1. **Trial**: walk ALL candidates from `find_all` (no early exit), each tried
+   with `update_refs=false` — including the generic path
+   (`preprocess_templ_typ` + `maybe_unify`) and the `df_templ_inst`
+   instance-cache scan (it currently unifies with `update_refs=true` during
+   the scan — in the trial phase it must not bind).
+2. **Rank**: viable set size 1 → fast path, done (the overwhelming majority;
+   perf impact stays negligible). Size >1 → pairwise
+   `compare_fun_generality`; apply the tie policy above.
+3. **Commit**: re-unify the winner with `update_refs=true`, instantiate if
+   generic — today's success path, executed once, for the right candidate.
+
+Non-function/value/constructor lookups keep their current logic; only their
+trials must not leak bindings. The FB-016 behavior flip (concrete beats
+generic regardless of declaration order at determined sites) is a DECIDED
+change (Vadim, this session): expected visible effects are exactly (a) the
+fenced FB-016 case in `test/test_resolve.fx` un-fences and passes, (b) the
+`test/ir/overload_resolve` golden diffs to select the concrete instances
+(regenerate, include the diff in the report), (c) nothing else — per the
+bootstrap-diff rule above.
+
+### Phase 3 — diagnostics
+
+- Ambiguity error (new): per the tie policy — candidates via `fun2sigstr`,
+  declaring module + location each, qualified-call hint. New negative goldens
+  (`test/negative/012_overload_ambiguous*`): a two-way concrete ambiguity and
+  an equal-generics one, exercised via two tiny local modules.
+- Not-found (existing `report_not_found_typed`): upgrade the `Candidates:`
+  listing to `fun2sigstr` rendering with a one-line per-candidate reason
+  (arity / argument-k mismatch / "less specific than <winner>" for rank
+  losers). Goldens 009–011 will diff — update them; every golden change must
+  be reviewable as a deliberate format improvement.
+- Do NOT implement `TypErr` poisoning / multiple-errors-per-run here (that is
+  session 2's error-recovery work); keep today's first-error-stops behavior.
+
+### Phase 4 — bookkeeping
+
+- `docs/found_bugs.md`: FB-016 → fixed (write-up: what flipped, the E1 proof);
+  FB-017 → fixed; FB-007 → partially fixed: S2 fixed, S3's trial-pollution
+  half fixed, S3's commit-half + S1 explicitly pending session 2 (deferral),
+  with the FromOnnx.fx:1012 analysis recorded in the entry. Re-test
+  `lib/Complex.fx` + `examples/fst.fx` and record exactly which symptoms
+  still reproduce.
+- `docs/language_changes_brief.md`: add a short §6 note that resolution is now
+  "least-generic wins; ambiguity errors at determined sites; env-order
+  fallback at under-constrained sites (deferral pending)". Vadim will edit.
+- CLAUDE.md: replace the FB-016-flavored folklore (if any) with two lines on
+  the new rule + the `Module.__op__` disambiguation hatch; add lessons.
+- Final report `docs/resolve1_report.md`: per-phase summary, both census
+  snapshots (before/after FB-017), the golden diffs, fallback-site count,
+  Complex/fst status, open items for session 2 (deferral + literal
+  defaulting, error recovery, under-constrained deferral, Complex unlock).
+
+## Closing checklist
+
+`test_all` + `fxtest all` + `determinism` + `sanitize` + bootstrap fixpoint
+(`update_compiler.py`) all green; bootstrap diff limited to edited modules +
+declared golden/test changes; `-pr-resolve` off → byte-identical output;
+E1-post census attached. If at any point a phase cannot meet its acceptance
+without widening scope — stop, write down why, and leave the decision to
+review rather than improvising a design change.

--- a/docs/resolve2_report.md
+++ b/docs/resolve2_report.md
@@ -68,6 +68,21 @@ var-form; it only enters through `[]`.
   `val n: int = []` is a typecheck-time error now.
 - The `++`/`.`-concatenation candidate (language_changes §4) is demoted from
   "needed for correctness" to a pure taste question (Vadim: "maybe not").
+- **Imaginary literals `N.fi` / `N.i` / `N.hi` work now** (follow-up commit):
+  the lexer desugared them into `complex(0, N)` with an **int** zero
+  (`LitInt(0)`), so the tokens typed as `complex(int, float)` and no
+  constructor matched — one of the reasons the original 2021 demo
+  `val c = ref (1+1.fi)` was fenced. The zero real part is now a float
+  literal of the same width as the imaginary part (`Lexer.fx`, the `c == 'c'`
+  branch). `examples/fst.fx` runs the demo as `1.f + 1.fi` and prints the
+  mathematically correct values (`abs((1+1i)*2)=2.8284271`,
+  `1-(2+2i)=-1.0-2.0i`).
+- Mixed-type operator variants (`op (a: 't1, b: 't2 complex)`) were tried by
+  Vadim and reverted: their bodies do `'t1 op 't2` arithmetic, which is
+  pinned at declaration/instantiation boundaries — exactly FB-007/S1, i.e.
+  session-2 deferral work. Scalar variants stay homogeneous (`'t op
+  't complex`), so `1 + 1.fi` (int + float complex) is correctly rejected;
+  write `1.f + 1.fi`.
 
 FB-007 is now reduced to **S1 only**: mixed-type arithmetic (`int + 't`)
 inside generic bodies is pinned at declaration check — that is genuine

--- a/docs/resolve2_report.md
+++ b/docs/resolve2_report.md
@@ -1,0 +1,112 @@
+# resolve-2: `TypVarCollection` — `[]` is "some collection", not "anything"
+
+Branch `resolve-2` (off `resolve-1`, 2026-07-08). One-evening experiment,
+agreed with Vadim after the `[]`-typing investigation at the end of the
+resolve-1 session; it worked on the first build.
+
+## The problem
+
+The empty-collection literal `[]` (`LitEmpty`, lexed at `Lexer.fx:536`) was
+typed by `Ast.get_lit_typ` as a **fully free** `make_new_typ()`. Consequences:
+
+1. **FB-007/S3**: a `[]`-initialized fold accumulator has a fully free type at
+   its first use, so an over-general overload candidate (`+('t, 't complex)`)
+   could capture it (`'t := nnop_t list`), tie incomparably with list-concat
+   `+('t list, 't list)`, and win by env-order at the under-constrained
+   fallback — the `NN/FromOnnx.fx:1012` / `vision_classify.fx` failure that
+   kept the scalar-left `lib/Complex.fx` operators fenced.
+2. `val n: int = []` **passed the type checker** (`-no-c`); the misuse was
+   caught only at K-normalization ("[] is misused ...") — or at codegen.
+
+## The fix
+
+New var-form in `typ_t` (next to `TypVarTuple`/`TypVarArray`/`TypVarRecord`):
+
+    | TypVarCollection      // "some list, vector or array; elements unknown"
+
+`get_lit_typ(LitEmpty)` now returns `TypVar(ref Some(TypVarCollection))`.
+`maybe_unify` binds a collection-var only to `TypList`/`TypVector`/
+`TypArray`/an array-var `'t [+]`/a plain free var/another collection-var
+(plus the usual `TypErr` escape); **everything else is a unification
+failure**. Since typedef aliases are expanded by `check_typ` before
+unification, `type intlist = int list; val x: intlist = []` still works.
+
+Support arms, mirroring the existing var-form family:
+
+- `Ast.fx`: `typ_t` constructor; `get_lit_typ`; `deref_typ.find_root` stops at
+  it; `typ2str` renders it `[...]`; `walk_typ` identity arm.
+- `Ast_typecheck.fx`: `occurs` (no payload → false); the two `maybe_unify`
+  arms (direct + symmetric flip, placed after the `TypVarRecord` arms);
+  `freeze_varform_typs` freezes it to an opaque constant (neither `'t list`
+  nor `'t [+]` covers "could be list OR vector OR array"; only plain `'t`
+  does); `typ_has_free_vars` counts it as free, so `[]`-sites remain
+  "under-constrained" for the resolve-1 tie policy (no new ambiguity errors).
+- `Ast_pp.fx`: precedence class + `[...]` rendering.
+- `K_normalize.fx`: an unresolved collection-var now gets a dedicated
+  message ("[] denotes an empty collection (list, vector or array), but which
+  one cannot be inferenced here..."); the `lit2klit` "[] is misused" check
+  stays as the backstop.
+
+No parser/lexer changes: there is (for now) no source syntax for the
+var-form; it only enters through `[]`.
+
+## What it unlocked (same branch)
+
+- **`lib/Complex.fx` scalar-on-the-left variants UNFENCED**:
+  `op (a: 't, b: 't complex)` for `+ - * /`. At a list site the candidate now
+  dies at the viability trial (`'t := [...]` collection-var, then
+  `'t complex` vs `nnop_t list` fails), so it never competes with
+  list-concat. The latent sign bug in the fenced `-` body was fixed on the
+  way (`s - c` = `complex(a - b.re, -b.im)` — `im` must be negated).
+  `examples/vision_classify.fx` (the original FB-007 victim) typechecks with
+  the variants live; `examples/fst.fx` now exercises `1.f - *c` in the fxtest
+  corpus.
+- **FB-007/S3 test UNFENCED**: `fb007.s3_free_accumulator` in
+  `test/test_resolve.fx` (free `[]` fold accumulator + `[:: x*x] + prog`
+  with CplxHelper's over-general `+` in scope) passes.
+- **New negative golden** `test/negative/215_empty_collection_scalar.fx`:
+  `val n: int = []` is a typecheck-time error now.
+- The `++`/`.`-concatenation candidate (language_changes §4) is demoted from
+  "needed for correctness" to a pure taste question (Vadim: "maybe not").
+
+FB-007 is now reduced to **S1 only**: mixed-type arithmetic (`int + 't`)
+inside generic bodies is pinned at declaration check — that is genuine
+session-2 deferral work. True deferral of under-constrained calls in general
+also remains session-2 scope; TypVarCollection removes the `[]` collision
+class, not the mechanism.
+
+## Verification
+
+- `make` — clean first build (the exhaustive matches over `typ_t` that needed
+  a new arm were exactly the ones edited).
+- `bin/ficus -run test/test_all.fx` — 135/135.
+- `python3 tools/fxtest/fxtest.py all` — unit + negative(73) + ir + cfold +
+  corpus(O0/O3) green. One deliberate golden diff: `207_add_int_string.err`
+  gained one `Candidates:` line (the unfenced scalar-left `+`, correctly
+  reporting "argument 2 of type 'string' does not match ''t complex'").
+- `determinism`, `sanitize` — green.
+- `python3 tools/update_compiler.py` — **fixpoint holds**. Bootstrap diff = 9
+  modules: the 4 edited ones (Ast, Ast_pp, Ast_typecheck, K_normalize) +
+  Parser/C_form/Compiler/K_copy_n_skip/K_form, whose diffs are pure `typ_t`
+  **constructor-tag renumbering** (TypVarCollection sits mid-type, all later
+  tags shift; the shared runtime destructor switch gains one case). Verified
+  by inspection: the four 16-line diffs are identical mechanical shifts.
+- Census: `-pr-resolve` over `compiler/fx.fx` — **350 sites: 343 ranked, 7
+  under-constrained fallbacks, 0 ambiguity errors — identical to resolve-1**,
+  and the 7 fallback sites are the same (C_pp AssocLeft/AssocRight,
+  adjust_decls; none involves `[]`). Corpus invariance on the compiler holds.
+- Typecheck perf on `compiler/fx.fx`: 6.73s vs 6.60s on resolve-1 (~+2%;
+  the two new `maybe_unify` arms sit after the tuple/record var-form arms,
+  so every non-collection pair pays two extra pattern probes).
+
+## Design notes / follow-ups
+
+- The stronger reform-epoch option stays open (language_changes §6): `[]` =
+  empty *list* only, plus a dedicated empty-array spelling (e.g. `[.]`).
+  TypVarCollection is compatible with it — it would just narrow further.
+- There is no source syntax for "some collection" yet. If generic functions
+  ever want `fun f(a: 't [..])`-style constraints, the var-form is ready.
+- `freeze_varform_typs` freezes a collection-var to an opaque constant — the
+  correct reading ("some specific collection, kind unknown") but it can only
+  matter if a collection-var flows into a *signature* via inference; source
+  signatures cannot contain it.

--- a/docs/resolve2_report.md
+++ b/docs/resolve2_report.md
@@ -77,12 +77,16 @@ var-form; it only enters through `[]`.
   branch). `examples/fst.fx` runs the demo as `1.f + 1.fi` and prints the
   mathematically correct values (`abs((1+1i)*2)=2.8284271`,
   `1-(2+2i)=-1.0-2.0i`).
-- Mixed-type operator variants (`op (a: 't1, b: 't2 complex)`) were tried by
-  Vadim and reverted: their bodies do `'t1 op 't2` arithmetic, which is
-  pinned at declaration/instantiation boundaries — exactly FB-007/S1, i.e.
-  session-2 deferral work. Scalar variants stay homogeneous (`'t op
-  't complex`), so `1 + 1.fi` (int + float complex) is correctly rejected;
-  write `1.f + 1.fi`.
+- Mixed-type operator variants: `*` and `/` ARE mixed (`'t1 (complex) op
+  't2 (complex)`, Vadim) — with NO return-type annotation, both components
+  of the result go through a mixed primitive op (`a * b.re`), so builtin
+  numeric coercion resolves everything at instantiation and the result type
+  is inferred. This doubles as the **widening-cast idiom**:
+  `1.0 * fcomplex_val` is a double complex; even `v *= 2` (int scalar) works.
+  `+`/`-` stay homogeneous: one component passes through unchanged (`b.im`),
+  so a mixed variant would construct a record with differently-typed fields
+  — that needs FB-007/S1 deferral (or explicit casts in the body). So:
+  `1.f + 1.fi`, but `2 * (1.f + 1.fi)` is fine.
 
 FB-007 is now reduced to **S1 only**: mixed-type arithmetic (`int + 't`)
 inside generic bodies is pinned at declaration check — that is genuine

--- a/docs/wpe_experiments/e1_census_post_fb017.md
+++ b/docs/wpe_experiments/e1_census_post_fb017.md
@@ -1,0 +1,39 @@
+# E1 census, re-run after the FB-017 comparator fix (resolve-1, phase 1)
+
+Same instrument and corpus as `e1_census.md` (`bin/ficus -no-c -pr-resolve
+compiler/fx.fx`), regenerated after:
+
+- phase 0: the two genuine identical-signature duplicates (`length(string)`,
+  `join(string, string list)` in both `Builtins.fx` and `String.fx`) were
+  disambiguated at their only exposed call sites (inside `String.fx`), so those
+  two viable>1 sites no longer exist;
+- phase 1: `compare_typ_generality` freezes the var-form generics (`{...}`
+  `TypVarRecord`, `(...)`/`('t ...)` `TypVarTuple`, `'t [+]` `TypVarArray`)
+  into opaque sentinels on the rigid side of each trial
+  (`freeze_varform_typs`), closing FB-017.
+
+Raw dump: `e1_post_fb017_raw.txt`.
+
+## Headline numbers (compiler/fx.fx)
+
+| metric | pre (e1_census.md) | post |
+|---|---|---|
+| call sites with viable set > 1 | 344 | 342 |
+| winners **agree** | 117 | **341** |
+| generality = `<none>` (tie/unordered) | 227 | **1** |
+| generality picks a **different concrete** winner | 0 | **0** |
+
+- The ~224 FB-017 sites (`__eq__` ×141, `string` ×83, ...record/var-form
+  generics vs a concrete overload) now all AGREE with env-order: the concrete
+  candidate ranks strictly less generic, confirming FB-017 was comparator
+  incompleteness, never a resolution flip.
+- The 2 pre-census duplicate sites (`length`, `join`) are gone (phase 0).
+- The single remaining `<none>` is the known **under-constrained** site
+  (`Builtins.fx:128:38`, `__cmp__` with expected type
+  `(<unknown>, <unknown>) -> <unknown>`, 21 trivially-viable candidates) —
+  exactly the case the amended tie policy sends to the env-order fallback
+  (deferral is session 2).
+
+**Go/no-go for phase 2 confirmed**: zero sites where specificity ranking would
+select a different concrete function; ranking + env-order fallback at
+under-constrained ties is corpus-invariant on the compiler.

--- a/docs/wpe_experiments/e1_post_fb017_raw.txt
+++ b/docs/wpe_experiments/e1_post_fb017_raw.txt
@@ -1,0 +1,2071 @@
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:388:47: 2 viable for (char -> <unknown>)
+    candidate: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    generality winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:488:48: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:488:41: 2 viable for ((string, format_t@14) -> <unknown>)
+    candidate: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    candidate: string('t, format_t@14) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:407:1
+    env-order  winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    generality winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:490:52: 2 viable for (char vector -> <unknown>)
+    candidate: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    candidate: string('t vector) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:349:1
+    env-order  winner: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    generality winner: string(char vector) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:351:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:490:45: 2 viable for ((string, format_t@14) -> <unknown>)
+    candidate: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    candidate: string('t, format_t@14) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:407:1
+    env-order  winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    generality winner: string(string, format_t@14) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:436:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:29: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:42: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1041:52: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1042:27: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1042:49: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1117:25: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'float' @ /home/vpisarev/work/ficus/lib/Math.fx:243:5: 2 viable for (Math.RNG@2 -> <unknown>)
+    candidate: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    candidate: float('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:783:1
+    env-order  winner: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    generality winner: float(Math.RNG@2) -> float @ /home/vpisarev/work/ficus/lib/Math.fx:218:1
+    winners agree: true
+-pr-resolve: 'double' @ /home/vpisarev/work/ficus/lib/Math.fx:246:5: 2 viable for (Math.RNG@2 -> <unknown>)
+    candidate: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    candidate: double('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:784:1
+    env-order  winner: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    generality winner: double(Math.RNG@2) -> double @ /home/vpisarev/work/ficus/lib/Math.fx:217:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Filename.fx:51:66: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Filename.fx:100:66: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__cmp__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:128:38: 21 viable for ((<unknown>, <unknown>) -> <unknown>)
+    candidate: __cmp__(string, string) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:732:16
+    candidate: __cmp__('t option@12, 't option@12) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:719:1
+    candidate: __cmp__(long, long) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:598:16
+    candidate: __cmp__(bool, bool) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:597:1
+    candidate: __cmp__(char, char) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:596:1
+    candidate: __cmp__(double, double) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:595:1
+    candidate: __cmp__(float, float) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:594:1
+    candidate: __cmp__(uint64, uint64) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:593:1
+    candidate: __cmp__(int64, int64) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:592:1
+    candidate: __cmp__(uint32, uint32) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:591:1
+    candidate: __cmp__(int32, int32) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:590:1
+    candidate: __cmp__(uint16, uint16) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:589:1
+    candidate: __cmp__(int16, int16) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:588:1
+    candidate: __cmp__(uint8, uint8) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:587:1
+    candidate: __cmp__(int8, int8) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:586:1
+    candidate: __cmp__(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:585:1
+    candidate: __cmp__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:582:1
+    candidate: __cmp__((...), (...)) -> <unknown> [generic: __var_tuple__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:578:1
+    candidate: __cmp__('t [], 't []) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:558:1
+    candidate: __cmp__('t vector, 't vector) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:542:1
+    candidate: __cmp__('t list, 't list) -> int [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:526:1
+    env-order  winner: __cmp__(string, string) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:732:16
+    generality winner: <none: tied or unordered>
+    winners agree: false
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/File.fx:163:5: 2 viable for ((File.t@9, string) -> void)
+    candidate: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    candidate: print(File.t@9, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/File.fx:122:1
+    env-order  winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    generality winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Sys.fx:99:28: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Sys.fx:105:51: 2 viable for ((double, double) -> <unknown>)
+    candidate: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    generality winner: max(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:970:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/Sys.fx:106:47: 2 viable for ((double, double) -> double)
+    candidate: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    generality winner: min(double, double) -> double @ /home/vpisarev/work/ficus/lib/Builtins.fx:969:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1118:22: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/Builtins.fx:1118:32: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:343:68: 2 viable for (string -> <unknown>)
+    candidate: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    generality winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Options.fx:281:23: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Ast.fx:85:23: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Ast.fx:86:22: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast.fx:87:23: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast.fx:88:22: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:513:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:521:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:537:21: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:546:21: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast.fx:567:9: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:747:27: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:748:29: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:749:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1212:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1225:20: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1226:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1295:26: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:127:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1619:14: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast.fx:1621:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:64:11: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:95:21: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/PP.fx:101:33: 2 viable for (char [] -> <unknown>)
+    candidate: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    candidate: string('t []) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:315:1
+    env-order  winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    generality winner: string(char []) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:345:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/lib/PP.fx:109:30: 2 viable for ((File.t@9, string) -> <unknown>)
+    candidate: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    candidate: print(File.t@9, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/File.fx:122:1
+    env-order  winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    generality winner: print(File.t@9, string) -> void @ /home/vpisarev/work/ficus/lib/File.fx:124:1
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/PP.fx:326:30: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:326:26: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/PP.fx:346:27: 2 viable for ((int, int) -> int)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:348:27: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/PP.fx:359:23: 2 viable for ((int, int) -> int)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:18:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:221:21: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:314:34: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:314:34: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:394:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_pp.fx:739:58: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Lexer.fx:275:42: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/compiler/Lexer.fx:517:19: 2 viable for ((int, int) -> int)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:41:54: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashset.fx:175:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:244:49: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Parser.fx:1235:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:1909:36: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2079:50: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2446:25: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2465:47: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2506:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Parser.fx:2509:17: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:55:19: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:58:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:80:28: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:58:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:33: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:76:21: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:80:28: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:230:32: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:237:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:242:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:520:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:523:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:558:73: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:558:69: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:559:59: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:560:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:561:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:562:59: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:563:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:564:62: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:606:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:609:56: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:619:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:659:40: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:668:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:669:40: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:846:37: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:846:77: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:851:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:858:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:889:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:894:36: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1022:47: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1022:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1023:31: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1024:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1026:26: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1027:20: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1029:13: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1091:63: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1142:17: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1166:70: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1174:72: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1187:76: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1203:190: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1373:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1484:73: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1551:47: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1566:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1579:51: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1588:61: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1593:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:1593:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2028:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2028:63: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2132:28: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2600:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2600:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2655:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2955:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:2955:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3174:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3234:21: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3248:51: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3400:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3420:68: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3436:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3436:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3436:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3494:65: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3514:26: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3535:51: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3623:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3631:55: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3631:63: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3662:23: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3753:13: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3853:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3854:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3854:38: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3863:47: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3863:79: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3894:36: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3939:44: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/Ast_typecheck.fx:3983:89: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:398:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:422:19: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:427:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:511:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:522:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:765:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:781:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:809:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:823:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:841:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:858:25: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1244:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1249:43: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1252:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1269:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1451:22: 2 viable for (char -> string)
+    candidate: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    generality winner: repr(char) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:267:7
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1483:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1485:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1489:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/K_form.fx:1491:5: 2 viable for (string -> <unknown>)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:67:48: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:237:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:243:19: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:355:59: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:368:17: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:376:71: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:534:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:537:40: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:557:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:565:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:582:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:669:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:786:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:786:81: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:795:39: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:809:36: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:827:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:833:124: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:935:10: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:988:25: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1087:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1147:43: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1194:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1249:83: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1266:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1363:61: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1363:61: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1377:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1406:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1427:56: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1427:79: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1475:17: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1475:35: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1489:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1506:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1522:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1564:41: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1564:65: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1571:25: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_normalize.fx:1571:46: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_annotate.fx:52:20: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:577:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_mangle.fx:412:29: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:59:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:201:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:267:78: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:292:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_remove_unused.fx:293:55: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'min' @ /home/vpisarev/work/ficus/lib/Hashset.fx:300:21: 2 viable for ((int, int) -> <unknown>)
+    candidate: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    candidate: min('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:963:1
+    env-order  winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    generality winner: min(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:965:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_lift_simple.fx:86:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/K_lift_simple.fx:86:21: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:30:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:131:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:157:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_tailrec.fx:182:22: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:177:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:269:62: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:281:56: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/compiler/K_inline.fx:478:32: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:261:23: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:58: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:344:75: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:348:43: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:352:40: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:352:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:353:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:369:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:473:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:482:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:487:60: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fast_idx.fx:585:26: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_fuse_loops.fx:151:58: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_nothrow_wrappers.fx:43:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:263:28: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:411:39: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:469:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:516:30: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:566:53: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:629:18: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/K_lift.fx:634:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Dynvec.fx:29:18: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/C_form.fx:415:32: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/C_form.fx:424:9: 2 viable for (Ast.id_t@29 -> <unknown>)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:155:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:158:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:180:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:180:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:198:15: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:198:33: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:217:16: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:573:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_types.fx:630:27: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_fdecls.fx:79:37: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:177:24: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: 'max' @ /home/vpisarev/work/ficus/lib/Hashmap.fx:176:19: 2 viable for ((int, int) -> <unknown>)
+    candidate: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    candidate: max('t, 't) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:964:1
+    env-order  winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    generality winner: max(int, int) -> int @ /home/vpisarev/work/ficus/lib/Builtins.fx:966:9
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:714:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:577:45: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/lib/Builtins.fx:750:68: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:592:41: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:1378:57: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'repr' @ /home/vpisarev/work/ficus/lib/Builtins.fx:311:66: 2 viable for (string -> <unknown>)
+    candidate: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    candidate: repr('t) -> string [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:1
+    env-order  winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    generality winner: repr(string) -> string @ /home/vpisarev/work/ficus/lib/Builtins.fx:266:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/lib/Builtins.fx:264:27: 2 viable for (Ast.id_t@29 -> string)
+    candidate: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    generality winner: string(Ast.id_t@29) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:533:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:1946:31: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2028:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2043:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:2973:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3042:42: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3247:69: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3322:46: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3331:34: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3343:32: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3358:80: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: '__eq__' @ /home/vpisarev/work/ficus/compiler/C_gen_code.fx:3441:38: 2 viable for ((Ast.id_t@29, Ast.id_t@29) -> bool)
+    candidate: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    candidate: __eq__({...}, {...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:580:1
+    env-order  winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    generality winner: __eq__(Ast.id_t@29, Ast.id_t@29) -> bool @ /home/vpisarev/work/ficus/compiler/Ast.fx:48:1
+    winners agree: true
+-pr-resolve: 'string' @ /home/vpisarev/work/ficus/compiler/Compiler.fx:220:25: 2 viable for (Ast.loc_t@31 -> <unknown>)
+    candidate: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    candidate: string({...}) -> <unknown> [generic: __var_record__] @ /home/vpisarev/work/ficus/lib/Builtins.fx:312:1
+    env-order  winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    generality winner: string(Ast.loc_t@31) -> string @ /home/vpisarev/work/ficus/compiler/Ast.fx:494:1
+    winners agree: true
+-pr-resolve: 'print' @ /home/vpisarev/work/ficus/compiler/Compiler.fx:600:44: 2 viable for (string -> void)
+    candidate: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    candidate: print('t) -> <unknown> [generic: 't] @ /home/vpisarev/work/ficus/lib/Builtins.fx:984:1
+    env-order  winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    generality winner: print(string) -> void @ /home/vpisarev/work/ficus/lib/Builtins.fx:1039:9
+    winners agree: true

--- a/examples/fst.fx
+++ b/examples/fst.fx
@@ -122,9 +122,9 @@ fun find_idx(a: 't [], f: 't -> bool): int
 val i4 = find_idx(a, fun (i) {i < 0})
 println(f"excepion-based search: negative number in {a}: {gen_msg(i4, a)}")
 
-/*val c = ref (1+1.fi)
-*c *= 2
-println(f"abs((1+1i)*2)={abs(*c)}")*/
+val c = ref complex(1.f, 1.f)
+*c *= 2.f
+println(f"abs((1+1i)*2)={abs(*c)}")
 
 val fixed_choice = "five"
 

--- a/examples/fst.fx
+++ b/examples/fst.fx
@@ -122,7 +122,7 @@ fun find_idx(a: 't [], f: 't -> bool): int
 val i4 = find_idx(a, fun (i) {i < 0})
 println(f"excepion-based search: negative number in {a}: {gen_msg(i4, a)}")
 
-val c = ref complex(1.f, 1.f)
+val c = ref (1.f + 1.fi)
 *c *= 2.f
 val c2 = 1.f - *c   // scalar-on-the-left variant (unfenced by resolve-2)
 println(f"abs((1+1i)*2)={abs(*c)}, 1-(2+2i)={c2}")

--- a/examples/fst.fx
+++ b/examples/fst.fx
@@ -124,7 +124,8 @@ println(f"excepion-based search: negative number in {a}: {gen_msg(i4, a)}")
 
 val c = ref complex(1.f, 1.f)
 *c *= 2.f
-println(f"abs((1+1i)*2)={abs(*c)}")
+val c2 = 1.f - *c   // scalar-on-the-left variant (unfenced by resolve-2)
+println(f"abs((1+1i)*2)={abs(*c)}, 1-(2+2i)={c2}")
 
 val fixed_choice = "five"
 

--- a/examples/fst.fx
+++ b/examples/fst.fx
@@ -123,9 +123,9 @@ val i4 = find_idx(a, fun (i) {i < 0})
 println(f"excepion-based search: negative number in {a}: {gen_msg(i4, a)}")
 
 val c = ref (1.f + 1.fi)
-*c *= 2.f
-val c2 = 1.f - *c   // scalar-on-the-left variant (unfenced by resolve-2)
-println(f"abs((1+1i)*2)={abs(*c)}, 1-(2+2i)={c2}")
+*c -= 2.f
+val c2 = 3. * *c   // scalar-on-the-left variant (unfenced by resolve-2)
+println(f"abs((1+1i)-2)={abs(*c)}, 3*(-1+i)={c2}")
 
 val fixed_choice = "five"
 

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -623,10 +623,18 @@ fun abs(a: long): long
 @pure @nothrow fun sign(a: long): int
 @ccode { return fx_long_sign(a, fx_result) }
 
-operator .* (a: ('t...), b: 'ts) = (for aj <- a {aj * b})
-operator ./ (a: ('t...), b: 'ts) = (for aj <- a {aj / b})
-operator .* (a: 'ts, b: ('t...)) = (for bj <- b {a * bj})
-operator ./ (a: 'ts, b: ('t...)) = (for bj <- b {a / bj})
+// resolve-1: the scalar-broadcast forms take `(...)` (element-wise independent
+// tuple), not `('t...)` (uniform tuple). With `('t...)` they were semantically
+// INCOMPARABLE with the tuple-x-tuple `(...) op (...)` forms below, and only
+// the declaration order made `t1 .* t2` pick the element-wise version; under
+// least-generic overload ranking that was an ambiguity error. With `(...)`
+// the tuple-x-tuple form is strictly more specific, so ranking selects it on
+// (tuple, tuple) calls with no ordering dependence -- and mixed tuples now
+// broadcast too ((1, 2.) .* 3 works).
+operator .* (a: (...), b: 'ts) = (for aj <- a {aj * b})
+operator ./ (a: (...), b: 'ts) = (for aj <- a {aj / b})
+operator .* (a: 'ts, b: (...)) = (for bj <- b {a * bj})
+operator ./ (a: 'ts, b: (...)) = (for bj <- b {a / bj})
 operator + (a: (...), b: (...)) = (for aj <- a, bj <- b {aj + bj})
 operator - (a: (...), b: (...)) = (for aj <- a, bj <- b {aj - bj})
 operator .+ (a: (...), b: (...)) = (for aj <- a, bj <- b {aj + bj})

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -623,24 +623,26 @@ fun abs(a: long): long
 @pure @nothrow fun sign(a: long): int
 @ccode { return fx_long_sign(a, fx_result) }
 
-// resolve-1: the scalar-broadcast forms take `(...)` (element-wise independent
-// tuple), not `('t...)` (uniform tuple). With `('t...)` they were semantically
-// INCOMPARABLE with the tuple-x-tuple `(...) op (...)` forms below, and only
-// the declaration order made `t1 .* t2` pick the element-wise version; under
-// least-generic overload ranking that was an ambiguity error. With `(...)`
-// the tuple-x-tuple form is strictly more specific, so ranking selects it on
-// (tuple, tuple) calls with no ordering dependence -- and mixed tuples now
-// broadcast too ((1, 2.) .* 3 works).
-operator .* (a: (...), b: 'ts) = (for aj <- a {aj * b})
-operator ./ (a: (...), b: 'ts) = (for aj <- a {aj / b})
-operator .* (a: 'ts, b: (...)) = (for bj <- b {a * bj})
-operator ./ (a: 'ts, b: (...)) = (for bj <- b {a / bj})
-operator + (a: (...), b: (...)) = (for aj <- a, bj <- b {aj + bj})
-operator - (a: (...), b: (...)) = (for aj <- a, bj <- b {aj - bj})
-operator .+ (a: (...), b: (...)) = (for aj <- a, bj <- b {aj + bj})
-operator .- (a: (...), b: (...)) = (for aj <- a, bj <- b {aj - bj})
-operator .* (a: (...), b: (...)) = (for aj <- a, bj <- b {aj * bj})
-operator ./ (a: (...), b: (...)) = (for aj <- a, bj <- b {aj / bj})
+// resolve-1: tuple ARITHMETIC is deliberately defined on UNIFORM tuples only
+// (tuples-as-short-numeric-vectors, the std::array<T,n> role); the structural
+// operations (== / <=> / string / hash / ...) stay on `(...)`. The two operands
+// may have different element types ('t1 vs 't2: int-tuple .+ double-tuple is
+// fine), but each operand must be uniform. This also makes the overload set
+// cleanly rankable with no declaration-order dependence:
+//   ('t1...) op ('t2...)  <  ('t...) op 'ts  /  'ts op ('t...)
+// (uniform-x-uniform is covered by uniform-x-anything, not conversely), so on
+// a (tuple, tuple) call the element-wise form wins by specificity, and on a
+// (tuple, scalar) call only the broadcast form is viable.
+operator .* (a: ('t...), b: 'ts) = (for aj <- a {aj * b})
+operator ./ (a: ('t...), b: 'ts) = (for aj <- a {aj / b})
+operator .* (a: 'ts, b: ('t...)) = (for bj <- b {a * bj})
+operator ./ (a: 'ts, b: ('t...)) = (for bj <- b {a / bj})
+operator + (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj + bj})
+operator - (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj - bj})
+operator .+ (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj + bj})
+operator .- (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj - bj})
+operator .* (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj * bj})
+operator ./ (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj / bj})
 operator | (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj | bj})
 operator & (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj & bj})
 operator ^ (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj ^ bj})

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -1000,8 +1000,8 @@ fun print(a: 't) = print_string(string(a))
 @nothrow fun print(a: int16): void = @ccode { printf("%d", (int)a) }
 @nothrow fun print(a: uint32): void = @ccode { printf("%u", a) }
 @nothrow fun print(a: int32): void = @ccode { printf("%d", a) }
-@nothrow fun print(a: uint64): void = @ccode { printf("%llu", a) }
-@nothrow fun print(a: int64): void = @ccode { printf("%lld", a) }
+@nothrow fun print(a: uint64): void = @ccode { printf("%llu", (unsigned long long)a) }
+@nothrow fun print(a: int64): void = @ccode { printf("%lld", (long long)a) }
 fun print(a: long): void = @ccode {
     fx_cstr_t str;
     int fx_status = fx_ltoa_ascii(a, 'd', false, &str);

--- a/lib/Complex.fx
+++ b/lib/Complex.fx
@@ -12,10 +12,13 @@ fun conj(a: 't complex) = complex {re=a.re, im=-a.im}
 fun abs(a: 't complex) = sqrt(a.re*a.re + a.im*a.im)
 fun phase(a: 't complex) = atan2(a.im, a.re)
 
+operator + (a: 't, b: 't complex): 't complex = complex(a + b.re, b.im)
 operator + (a: 't complex, b: 't): 't complex = complex(a.re + b, a.im)
 operator + (a: 't complex, b: 't complex) = complex(a.re + b.re, a.im + b.im)
+operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, -b.im)
 operator - (a: 't complex, b: 't): 't complex = complex(a.re - b, a.im)
 operator - (a: 't complex, b: 't complex) = complex(a.re - b.re, a.im - b.im)
+operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
 operator * (a: 't complex, b: 't): 't complex = complex(a.re * b, a.im * b)
 operator * (a: 't complex, b: 't complex) =
     complex(a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re)
@@ -24,18 +27,6 @@ operator / (a: 't complex, b: 't complex) {
     val denom = b.re*b.re + b.im*b.im
     complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
 }
-
-/* The scalar-on-the-LEFT variants, UNFENCED by resolve-2 (TypVarCollection):
-   `op (a: 't, b: 't complex)` has an unconstrained 't in the first position,
-   so it used to be viable alongside list-concatenation `+('t list, 't list)`
-   at a call site whose second operand was a free-typed `[]` fold accumulator
-   (the NN/FromOnnx.fx:1012 shape, FB-007/S3) -- and the under-constrained-tie
-   fallback could pick it by import order. Now `[]` is typed TypVarCollection
-   ("some list/vector/array"), which refuses to unify with `'t complex`, so
-   these variants are simply not viable at list sites anymore. */
-operator + (a: 't, b: 't complex): 't complex = complex(a + b.re, b.im)
-operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, -b.im)
-operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
 operator / (a: 't, b: 't complex): 't complex {
     val denom = b.re*b.re + b.im*b.im
     complex(a*b.re/denom, -a*b.im/denom)

--- a/lib/Complex.fx
+++ b/lib/Complex.fx
@@ -25,28 +25,21 @@ operator / (a: 't complex, b: 't complex) {
     complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
 }
 
-/* The scalar-on-the-LEFT variants stay FENCED for now (FB-007, S3):
+/* The scalar-on-the-LEFT variants, UNFENCED by resolve-2 (TypVarCollection):
    `op (a: 't, b: 't complex)` has an unconstrained 't in the first position,
-   so at a call site whose SECOND operand's type is still a free inference
-   variable (the canonical case: a fold accumulator initialized with `[]`,
-   as in `rev_more_ops + prog` at NN/FromOnnx.fx:1012) it is viable alongside
-   the list-concatenation `+('t list, 't list)`, the two are genuinely
-   incomparable, and the under-constrained-tie fallback picks by import order
-   -- wrongly. They can return when either (a) session-2 deferral lands
-   (resolution of under-constrained calls is postponed until the variable is
-   bound, at which point these variants stop being viable at list sites), or
-   (b) list concatenation stops being spelled `+` (see the `++` /
-   dot-concatenation idea in docs/language_changes_brief.md), which removes
-   the colliding candidate altogether. Until then: write `c + s`, not `s + c`.
-
+   so it used to be viable alongside list-concatenation `+('t list, 't list)`
+   at a call site whose second operand was a free-typed `[]` fold accumulator
+   (the NN/FromOnnx.fx:1012 shape, FB-007/S3) -- and the under-constrained-tie
+   fallback could pick it by import order. Now `[]` is typed TypVarCollection
+   ("some list/vector/array"), which refuses to unify with `'t complex`, so
+   these variants are simply not viable at list sites anymore. */
 operator + (a: 't, b: 't complex): 't complex = complex(a + b.re, b.im)
-operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, b.im)
+operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, -b.im)
 operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
 operator / (a: 't, b: 't complex): 't complex {
     val denom = b.re*b.re + b.im*b.im
     complex(a*b.re/denom, -a*b.im/denom)
 }
-*/
 
 fun exp(a: 't complex) {
     val er = exp(a.re)

--- a/lib/Complex.fx
+++ b/lib/Complex.fx
@@ -12,36 +12,41 @@ fun conj(a: 't complex) = complex {re=a.re, im=-a.im}
 fun abs(a: 't complex) = sqrt(a.re*a.re + a.im*a.im)
 fun phase(a: 't complex) = atan2(a.im, a.re)
 
-/*operator + (a: int, b: 't complex): 't complex = complex(a + b.re, b.im)
-operator + (a: 't complex, b: int): 't complex = complex(a.re + b, a.im)
-operator + (a: 't, b: 't complex): 't complex = complex(a + b.re, b.im)
 operator + (a: 't complex, b: 't): 't complex = complex(a.re + b, a.im)
-operator + (a: 't complex, b: 't2 complex) = complex(a.re + b.re, a.im + b.im)
-operator - (a: int, b: 't complex): 't complex = complex(a - b.re, b.im)
-operator - (a: 't complex, b: int): 't complex = complex(a.re - b, a.im)
-operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, b.im)
+operator + (a: 't complex, b: 't complex) = complex(a.re + b.re, a.im + b.im)
 operator - (a: 't complex, b: 't): 't complex = complex(a.re - b, a.im)
-operator - (a: 't complex, b: 't2 complex) = complex(a.re - b.re, a.im - b.im)
-operator * (a: int, b: 't complex): 't complex = complex(a * b.re, a * b.im)
-operator * (a: 't complex, b: int): 't complex = complex(a.re * b, a.im * b)
-operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
+operator - (a: 't complex, b: 't complex) = complex(a.re - b.re, a.im - b.im)
 operator * (a: 't complex, b: 't): 't complex = complex(a.re * b, a.im * b)
-operator * (a: 't complex, b: 't2 complex) =
+operator * (a: 't complex, b: 't complex) =
     complex(a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re)
-operator / (a: int, b: 't complex): 't complex {
+operator / (a: 't complex, b: 't): 't complex = complex(a.re/b, a.im/b)
+operator / (a: 't complex, b: 't complex) {
     val denom = b.re*b.re + b.im*b.im
-    complex(a*b.re/denom, -a*b.im/denom)
+    complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
 }
-operator / (a: 't complex, b: int): 't complex = complex(a.re/b, a.im/b)
+
+/* The scalar-on-the-LEFT variants stay FENCED for now (FB-007, S3):
+   `op (a: 't, b: 't complex)` has an unconstrained 't in the first position,
+   so at a call site whose SECOND operand's type is still a free inference
+   variable (the canonical case: a fold accumulator initialized with `[]`,
+   as in `rev_more_ops + prog` at NN/FromOnnx.fx:1012) it is viable alongside
+   the list-concatenation `+('t list, 't list)`, the two are genuinely
+   incomparable, and the under-constrained-tie fallback picks by import order
+   -- wrongly. They can return when either (a) session-2 deferral lands
+   (resolution of under-constrained calls is postponed until the variable is
+   bound, at which point these variants stop being viable at list sites), or
+   (b) list concatenation stops being spelled `+` (see the `++` /
+   dot-concatenation idea in docs/language_changes_brief.md), which removes
+   the colliding candidate altogether. Until then: write `c + s`, not `s + c`.
+
+operator + (a: 't, b: 't complex): 't complex = complex(a + b.re, b.im)
+operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, b.im)
+operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
 operator / (a: 't, b: 't complex): 't complex {
     val denom = b.re*b.re + b.im*b.im
     complex(a*b.re/denom, -a*b.im/denom)
 }
-operator / (a: 't complex, b: 't): 't complex = complex(a.re/b, a.im/b)
-operator / (a: 't complex, b: 't2 complex) {
-    val denom = b.re*b.re + b.im*b.im
-    complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
-}*/
+*/
 
 fun exp(a: 't complex) {
     val er = exp(a.re)

--- a/lib/Complex.fx
+++ b/lib/Complex.fx
@@ -18,16 +18,16 @@ operator + (a: 't complex, b: 't complex) = complex(a.re + b.re, a.im + b.im)
 operator - (a: 't, b: 't complex): 't complex = complex(a - b.re, -b.im)
 operator - (a: 't complex, b: 't): 't complex = complex(a.re - b, a.im)
 operator - (a: 't complex, b: 't complex) = complex(a.re - b.re, a.im - b.im)
-operator * (a: 't, b: 't complex): 't complex = complex(a * b.re, a * b.im)
-operator * (a: 't complex, b: 't): 't complex = complex(a.re * b, a.im * b)
-operator * (a: 't complex, b: 't complex) =
+operator * (a: 't1, b: 't2 complex) = complex(a * b.re, a * b.im)
+operator * (a: 't1 complex, b: 't2) = complex(a.re * b, a.im * b)
+operator * (a: 't1 complex, b: 't2 complex) =
     complex(a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re)
-operator / (a: 't complex, b: 't): 't complex = complex(a.re/b, a.im/b)
-operator / (a: 't complex, b: 't complex) {
+operator / (a: 't1 complex, b: 't2) = complex(a.re/b, a.im/b)
+operator / (a: 't1 complex, b: 't2 complex) {
     val denom = b.re*b.re + b.im*b.im
     complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
 }
-operator / (a: 't, b: 't complex): 't complex {
+operator / (a: 't1, b: 't2 complex) {
     val denom = b.re*b.re + b.im*b.im
     complex(a*b.re/denom, -a*b.im/denom)
 }

--- a/lib/String.fx
+++ b/lib/String.fx
@@ -7,6 +7,11 @@
 
 @ccode { #include <string.h> }
 
+// NOTE: length/join re-declare Builtins helpers with identical signatures.
+// They are NOT redundant: `s.length()` method syntax resolves through the
+// object-type fallback to `String.length(s)`, so the names must exist in this
+// module. Inside this file, call the Builtins versions QUALIFIED to keep every
+// call site unambiguous under least-generic overload ranking (resolve-1).
 @inline fun length(s: string) = __intrin_size__(s)
 @inline fun join(sep: string, strs: string []) = Builtins.join(sep, strs)
 @inline fun join(sep: string, strs: string list) = Builtins.join(sep, strs)
@@ -81,7 +86,7 @@
     return i;
 }
 
-@inline fun rfind(s: string, part: string): int = rfind(s, part, s.length()-1)
+@inline fun rfind(s: string, part: string): int = rfind(s, part, __intrin_size__(s)-1)
 
 @pure @nothrow fun rfind(s: string, c: char): int
 @ccode {
@@ -344,5 +349,5 @@ fun escaped(s: string, ~quotes: bool=true)
             else { (ll, verb) }
         }
     }
-    join("", (q :: s[verb:] :: ll).rev())
+    Builtins.join("", (q :: s[verb:] :: ll).rev())
 }

--- a/test/CplxHelper.fx
+++ b/test/CplxHelper.fx
@@ -1,0 +1,29 @@
+/*
+    Helper module for test_resolve.fx (resolve-1): a mini generic complex-like
+    class with the SAME over-general operator shapes as the fenced
+    lib/Complex.fx:15-44 block (FB-007). The operators are ninja names, so a
+    plain `import CplxHelper` makes them visible at every call site of the
+    importing module -- exactly how the real Complex.fx operators leak into NN
+    code and trigger FB-007's symptom S3.
+*/
+
+class 't cplx = {re: 't; im: 't}
+
+fun cplx(r: 't, i: 't) = cplx {re=r, im=i}
+
+// the over-general shapes from lib/Complex.fx (S3's culprit is `+('t, 't cplx)`)
+operator + (a: 't, b: 't cplx): 't cplx = cplx(a + b.re, b.im)
+operator + (a: 't cplx, b: 't): 't cplx = cplx(a.re + b, a.im)
+operator + (a: 't cplx, b: 't2 cplx) = cplx(a.re + b.re, a.im + b.im)
+operator - (a: 't cplx, b: 't2 cplx) = cplx(a.re - b.re, a.im - b.im)
+// S2's shape: 't cplx * int (the real Complex.fx `c * 2` resolved to the
+// ARRAY __mul__ under greedy first-match)
+operator * (a: int, b: 't cplx): 't cplx = cplx(a * b.re, a * b.im)
+operator * (a: 't cplx, b: int): 't cplx = cplx(a.re * b, a.im * b)
+operator * (a: 't cplx, b: 't2 cplx) =
+    cplx(a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re)
+
+fun string(a: 't cplx) {
+    val s = if a.im >= (0 :> 't) {"+"} else {""}
+    f"{a.re}{s}{a.im}i"
+}

--- a/test/ir/overload_resolve.ast.golden
+++ b/test/ir/overload_resolve.ast.golden
@@ -16,17 +16,13 @@ template<'t> fun overload_resolve.pick@g4(x: 't): ('t -> int) = { 0 }
 
    @instance fun overload_resolve.pick@g7(overload_resolve.x@g8: string): (string -> int) = { 0 }
 
-   @instance fun overload_resolve.pick@g9(overload_resolve.x@g10: float): (float -> int) = { 0 }
-
-   @instance fun overload_resolve.pick@g11(overload_resolve.x@g12: int): (int -> int) = { 0 }
-
    ]]
-val overload_resolve.a@g13: int = <(int -> int)>overload_resolve.pick@g11(5)
-val overload_resolve.b@g14: int = <(float -> int)>overload_resolve.pick@g9(3.0f)
-val overload_resolve.c@g15: int = <(string -> int)>overload_resolve.pick@g7("hi")
-val overload_resolve.d@g16: int = <(int list -> int)>overload_resolve.pick@g5((1 :: 2 :: []))
+val overload_resolve.a@g9: int = <(int -> int)>overload_resolve.pick@g0(5)
+val overload_resolve.b@g10: int = <(float -> int)>overload_resolve.pick@g2(3.0f)
+val overload_resolve.c@g11: int = <(string -> int)>overload_resolve.pick@g7("hi")
+val overload_resolve.d@g12: int = <(int list -> int)>overload_resolve.pick@g5((1 :: 2 :: []))
 <(string ->
-    void)>Builtins.println@g17(((((((<(int -> string)>Builtins.string@g18(<int>overload_resolve.a@g13) + " ") +
-                                      <(int -> string)>Builtins.string@g18(<int>overload_resolve.b@g14)) + " ") +
-                                    <(int -> string)>Builtins.string@g18(<int>overload_resolve.c@g15)) + " ") +
-                                  <(int -> string)>Builtins.string@g18(<int>overload_resolve.d@g16)))
+    void)>Builtins.println@g13(((((((<(int -> string)>Builtins.string@g14(<int>overload_resolve.a@g9) + " ") +
+                                      <(int -> string)>Builtins.string@g14(<int>overload_resolve.b@g10)) + " ") +
+                                    <(int -> string)>Builtins.string@g14(<int>overload_resolve.c@g11)) + " ") +
+                                  <(int -> string)>Builtins.string@g14(<int>overload_resolve.d@g12)))

--- a/test/ir/overload_resolve.k.golden
+++ b/test/ir/overload_resolve.k.golden
@@ -1,5 +1,5 @@
-@temp val v@g0: string = _fx_F6stringS1i(0)
-@temp val v@g1: string = _fx_F6stringS1i(0)
+@temp val v@g0: string = _fx_F6stringS1i(6)
+@temp val v@g1: string = _fx_F6stringS1i(2)
 @temp val v@g2: string = _fx_F6stringS1i(0)
 @temp val v@g3: string = _fx_F6stringS1i(0)
 @temp val v@g4: string = __intrin_str_concat__(v@g0, " ", v@g1, " ", v@g2, " ", v@g3)

--- a/test/ir/overload_resolve.k0.golden
+++ b/test/ir/overload_resolve.k0.golden
@@ -6,25 +6,21 @@ fun overload_resolve.pick@g2(x@g3: float): int { 2 }
 
 @instance fun overload_resolve.pick@g6(x@g7: string): int { 0 }
 
-@instance fun overload_resolve.pick@g8(x@g9: float): int { 0 }
-
-@instance fun overload_resolve.pick@g10(x@g11: int): int { 0 }
-
-@global val overload_resolve.a@g12: int = overload_resolve.pick@g10(5)
-@global val overload_resolve.b@g13: int = overload_resolve.pick@g8(3.0f)
-@global val overload_resolve.c@g14: int = overload_resolve.pick@g6("hi")
-@temp val z@g15: int list = null
-@temp val v@g16: int list = 2 :: z@g15
-@temp val v@g17: int list = 1 :: v@g16
-@global val overload_resolve.d@g18: int = overload_resolve.pick@g4(v@g17)
-@temp val v@g19: string = string@g20(overload_resolve.a@g12)
-@temp val v@g21: string = __intrin_str_concat__(v@g19, " ")
-@temp val v@g22: string = string@g20(overload_resolve.b@g13)
-@temp val v@g23: string = __intrin_str_concat__(v@g21, v@g22)
-@temp val v@g24: string = __intrin_str_concat__(v@g23, " ")
-@temp val v@g25: string = string@g20(overload_resolve.c@g14)
-@temp val v@g26: string = __intrin_str_concat__(v@g24, v@g25)
-@temp val v@g27: string = __intrin_str_concat__(v@g26, " ")
-@temp val v@g28: string = string@g20(overload_resolve.d@g18)
-@temp val v@g29: string = __intrin_str_concat__(v@g27, v@g28)
-println@g30(v@g29)
+@global val overload_resolve.a@g8: int = overload_resolve.pick@g0(5)
+@global val overload_resolve.b@g9: int = overload_resolve.pick@g2(3.0f)
+@global val overload_resolve.c@g10: int = overload_resolve.pick@g6("hi")
+@temp val z@g11: int list = null
+@temp val v@g12: int list = 2 :: z@g11
+@temp val v@g13: int list = 1 :: v@g12
+@global val overload_resolve.d@g14: int = overload_resolve.pick@g4(v@g13)
+@temp val v@g15: string = string@g16(overload_resolve.a@g8)
+@temp val v@g17: string = __intrin_str_concat__(v@g15, " ")
+@temp val v@g18: string = string@g16(overload_resolve.b@g9)
+@temp val v@g19: string = __intrin_str_concat__(v@g17, v@g18)
+@temp val v@g20: string = __intrin_str_concat__(v@g19, " ")
+@temp val v@g21: string = string@g16(overload_resolve.c@g10)
+@temp val v@g22: string = __intrin_str_concat__(v@g20, v@g21)
+@temp val v@g23: string = __intrin_str_concat__(v@g22, " ")
+@temp val v@g24: string = string@g16(overload_resolve.d@g14)
+@temp val v@g25: string = __intrin_str_concat__(v@g23, v@g24)
+println@g26(v@g25)

--- a/test/negative/009_overload_arity.err
+++ b/test/negative/009_overload_arity.err
@@ -1,6 +1,6 @@
 009_overload_arity.fx:5:9: error: the appropriate match for 'ff' of type '(int -> <unknown>)' is not found.
 Candidates:
- 'ff: ((int, int) -> int)' defined at 009_overload_arity.fx:4:1
+ ff(int, int) -> int @ 009_overload_arity.fx:4:1 -- takes 2 argument(s), but 1 given
 
 
 1 errors occured during type checking.

--- a/test/negative/010_overload_keyword.err
+++ b/test/negative/010_overload_keyword.err
@@ -1,6 +1,6 @@
 010_overload_keyword.fx:4:9: error: the appropriate match for 'kk' of type '({z: int} -> <unknown>)' is not found.
 Candidates:
- 'kk: ({a: int} -> int)' defined at 010_overload_keyword.fx:3:1
+ kk({a: int}) -> int @ 010_overload_keyword.fx:3:1 -- keyword arguments '{z: int}' do not match the accepted '{a: int}'
 
 
 1 errors occured during type checking.

--- a/test/negative/011_overload_not_found_candidates.err
+++ b/test/negative/011_overload_not_found_candidates.err
@@ -1,7 +1,7 @@
 011_overload_not_found_candidates.fx:6:9: error: the appropriate match for 'oo' of type '(string -> <unknown>)' is not found.
 Candidates:
- 'oo: (int -> int)' defined at 011_overload_not_found_candidates.fx:4:1,
- 'oo: (float -> int)' defined at 011_overload_not_found_candidates.fx:5:1
+ oo(int) -> int @ 011_overload_not_found_candidates.fx:4:1 -- argument 1 of type 'string' does not match 'int',
+ oo(float) -> int @ 011_overload_not_found_candidates.fx:5:1 -- argument 1 of type 'string' does not match 'float'
 
 
 1 errors occured during type checking.

--- a/test/negative/012_overload_ambiguous_incomp.err
+++ b/test/negative/012_overload_ambiguous_incomp.err
@@ -1,0 +1,6 @@
+012_overload_ambiguous_incomp.fx:7:9: error: ambiguous call of overloaded 'amb': the candidates overlap, but none is the most specific. Candidates:
+ amb(int, 't) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:6:1
+ amb('t, int) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:5:1
+define/import a more specific overload, or use a module-qualified call (e.g. Module.amb(...)) to disambiguate
+
+1 errors occured during type checking.

--- a/test/negative/012_overload_ambiguous_incomp.fx
+++ b/test/negative/012_overload_ambiguous_incomp.fx
@@ -1,0 +1,8 @@
+// expect: ambiguous call
+// resolve-1: amb('t, int) and amb(int, 't) on an (int, int) call are both
+// viable and genuinely incomparable (neither is more specific); the call is
+// fully determined -> hard ambiguity error, "overlapping but unordered" flavor.
+fun amb(x: 't, y: int) = 1
+fun amb(x: int, y: 't) = 2
+val r = amb(1, 2)
+println(r)

--- a/test/negative/013_overload_ambiguous_eq.err
+++ b/test/negative/013_overload_ambiguous_eq.err
@@ -1,0 +1,6 @@
+013_overload_ambiguous_eq.fx:7:9: error: ambiguous call of overloaded 'g': the candidates are equally applicable. Candidates:
+ g('u) -> <unknown> [generic: 'u] @ 013_overload_ambiguous_eq.fx:6:1
+ g('t) -> <unknown> [generic: 't] @ 013_overload_ambiguous_eq.fx:5:1
+use a module-qualified call (e.g. Module.g(...)) to select one
+
+1 errors occured during type checking.

--- a/test/negative/013_overload_ambiguous_eq.fx
+++ b/test/negative/013_overload_ambiguous_eq.fx
@@ -1,0 +1,8 @@
+// expect: ambiguous call
+// resolve-1: two byte-identical generic signatures are both viable and
+// EqGeneric -> hard ambiguity error, "equally applicable" flavor (the hint is
+// to qualify the call, since no more-specific overload can break an Eq tie).
+fun g(x: 't) = 1
+fun g(x: 'u) = 2
+val r = g(5)
+println(r)

--- a/test/negative/014_overload_ambiguous_xmodule.err
+++ b/test/negative/014_overload_ambiguous_xmodule.err
@@ -1,6 +1,6 @@
-014_overload_ambiguous_xmodule.fx:8:9: error: ambiguous call of overloaded 'sqrt': the candidates overlap, but none is the most specific. Candidates:
- sqrt('t, {n: int}) -> <unknown> [generic: 't] @ 014_overload_ambiguous_xmodule.fx:7:1
- sqrt(double) -> double @ Math.fx:L:C
-define/import a more specific overload, or use a module-qualified call (e.g. Module.sqrt(...)) to disambiguate
+014_overload_ambiguous_xmodule.fx:13:9: error: ambiguous call of overloaded 'length': the candidates are equally applicable. Candidates:
+ length(string) -> int @ 014_overload_ambiguous_xmodule.fx:12:1
+ length(string) -> int @ Builtins.fx:L:C
+use a module-qualified call (e.g. Module.length(...)) to select one
 
 1 errors occured during type checking.

--- a/test/negative/014_overload_ambiguous_xmodule.err
+++ b/test/negative/014_overload_ambiguous_xmodule.err
@@ -1,0 +1,6 @@
+014_overload_ambiguous_xmodule.fx:8:9: error: ambiguous call of overloaded 'sqrt': the candidates overlap, but none is the most specific. Candidates:
+ sqrt('t, {n: int}) -> <unknown> [generic: 't] @ 014_overload_ambiguous_xmodule.fx:7:1
+ sqrt(double) -> double @ Math.fx:L:C
+define/import a more specific overload, or use a module-qualified call (e.g. Module.sqrt(...)) to disambiguate
+
+1 errors occured during type checking.

--- a/test/negative/014_overload_ambiguous_xmodule.fx
+++ b/test/negative/014_overload_ambiguous_xmodule.fx
@@ -1,9 +1,14 @@
 // expect: ambiguous call
-// resolve-1: a local generic whose keywords are all defaulted ties with the
-// concrete Math.sqrt(double) from the preamble: per proposal §10.Q2 there is
-// deliberately NO "fewer defaults preferred" tie-break, so the fully-determined
-// call errors, and the candidate listing attributes each signature to its
-// defining module/location (the cross-module case).
-fun sqrt(a: 't, ~n: int=2) = a
-val r = sqrt(81.0)
+// resolve-1: a local function re-declaring a stdlib helper with a
+// byte-identical signature (Builtins.length(string), star-imported by the
+// preamble) is EqGeneric with it -- neither can be more specific -- so a
+// fully-determined call that sees both is a hard ambiguity error, and the
+// candidate listing attributes each signature to its defining module/location
+// (the cross-module case). The hint (qualify the call) is the resolution.
+// NB: the original 014 case (local all-keywords-defaulted generic vs
+// Math.sqrt(double)) stopped being ambiguous when keyword normalization
+// landed in compare_fun_generality: the exact keywordless match now ranks
+// more specific and wins.
+fun length(s: string) = 42
+val r = length("abc")
 println(r)

--- a/test/negative/014_overload_ambiguous_xmodule.fx
+++ b/test/negative/014_overload_ambiguous_xmodule.fx
@@ -1,0 +1,9 @@
+// expect: ambiguous call
+// resolve-1: a local generic whose keywords are all defaulted ties with the
+// concrete Math.sqrt(double) from the preamble: per proposal §10.Q2 there is
+// deliberately NO "fewer defaults preferred" tie-break, so the fully-determined
+// call errors, and the candidate listing attributes each signature to its
+// defining module/location (the cross-module case).
+fun sqrt(a: 't, ~n: int=2) = a
+val r = sqrt(81.0)
+println(r)

--- a/test/negative/108_positional_after_named.err
+++ b/test/negative/108_positional_after_named.err
@@ -1,6 +1,6 @@
 108_positional_after_named.fx:3:9: error: the appropriate match for 'g' of type '((int, {a: int}) -> <unknown>)' is not found.
 Candidates:
- 'g: ({a: int; b: int} -> int)' defined at 108_positional_after_named.fx:2:1
+ g({a: int; b: int}) -> int @ 108_positional_after_named.fx:2:1 -- takes 0 positional argument(s), but 1 given
 
 
 1 errors occured during type checking.

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -7,6 +7,8 @@ Candidates:
  __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
  __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
  __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
+ __add__('t Complex.complex@3, 't) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
+ __add__('t Complex.complex@3, 't Complex.complex@3) -> <unknown> [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
  __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -1,13 +1,13 @@
 207_add_int_string.fx:2:11: error: the appropriate match for '__add__' of type '((int, string) -> <unknown>)' is not found.
 Candidates:
- '__add__: ((string, string) -> string)' defined at Builtins.fx:L:C,
- '__add__: ((string, char) -> string)' defined at Builtins.fx:L:C,
- '__add__: ((char, string) -> string)' defined at Builtins.fx:L:C,
- '__add__: ((char, char) -> string)' defined at Builtins.fx:L:C,
- '__add__: (('t list, 't list) -> <unknown>)' defined at Builtins.fx:L:C,
- '__add__: ((long, long) -> long)' defined at Builtins.fx:L:C,
- '__add__: (((...), (...)) -> <unknown>)' defined at Builtins.fx:L:C,
- '__add__: (('ta [+], 'tb [+]) -> <unknown>)' defined at Array.fx:L:C
+ __add__(string, string) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'string',
+ __add__(string, char) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'string',
+ __add__(char, string) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'char',
+ __add__(char, char) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'char',
+ __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
+ __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
+ __add__((...), (...)) -> <unknown> [generic: __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '(...)',
+ __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 
 1 errors occured during type checking.

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -7,9 +7,9 @@ Candidates:
  __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
  __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
  __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
+ __add__('t, 't Complex.complex@3) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t Complex.complex@3',
  __add__('t Complex.complex@3, 't) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
  __add__('t Complex.complex@3, 't Complex.complex@3) -> <unknown> [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
- __add__('t, 't Complex.complex@3) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t Complex.complex@3',
  __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -6,7 +6,7 @@ Candidates:
  __add__(char, char) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'char',
  __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
  __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
- __add__((...), (...)) -> <unknown> [generic: __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '(...)',
+ __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
  __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -9,6 +9,7 @@ Candidates:
  __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
  __add__('t Complex.complex@3, 't) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
  __add__('t Complex.complex@3, 't Complex.complex@3) -> <unknown> [generic: 't] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t Complex.complex@3',
+ __add__('t, 't Complex.complex@3) -> 't Complex.complex@3 [generic: 't] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t Complex.complex@3',
  __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 

--- a/test/negative/212_negate_string.err
+++ b/test/negative/212_negate_string.err
@@ -1,7 +1,7 @@
 212_negate_string.fx:2:9: error: the appropriate match for '__negate__' of type '(string -> <unknown>)' is not found.
 Candidates:
- '__negate__: (long -> long)' defined at Builtins.fx:L:C,
- '__negate__: ('t [+] -> <unknown>)' defined at Array.fx:L:C
+ __negate__(long) -> long @ Builtins.fx:L:C -- argument 1 of type 'string' does not match 'long',
+ __negate__('t [+]) -> <unknown> [generic: 't, __var_array__] @ Array.fx:L:C -- argument 1 of type 'string' does not match ''t [+]'
 
 
 1 errors occured during type checking.

--- a/test/negative/215_empty_collection_scalar.err
+++ b/test/negative/215_empty_collection_scalar.err
@@ -1,0 +1,4 @@
+215_empty_collection_scalar.fx:7:6: error: explicit type specification of the defined value does not match the assigned expression type
+215_empty_collection_scalar.fx:8:9: error: the appropriate match for 'n' of type '<unknown>' is not found.
+
+2 errors occured during type checking.

--- a/test/negative/215_empty_collection_scalar.fx
+++ b/test/negative/215_empty_collection_scalar.fx
@@ -1,0 +1,8 @@
+// expect: does not match
+// resolve-2: [] is typed TypVarCollection ("some list/vector/array"), so
+// assigning it to a scalar is now a TYPE CHECKER error. Before, [] was a
+// fully free type var, `val n: int = []` passed -no-c, and the misuse was
+// only caught at K-normalization ("[] is misused...") -- or, worse, the free
+// var made bogus overload candidates viable (FB-007/S3).
+val n: int = []
+println(n)

--- a/test/negative/703_variant_pat_nonvariant.err
+++ b/test/negative/703_variant_pat_nonvariant.err
@@ -1,6 +1,6 @@
 703_variant_pat_nonvariant.fx:2:21: error: the appropriate match for 'Some' of type '(<unknown> -> int)' is not found.
 Candidates:
- 'Some: ('t -> 't option@12)' defined at Builtins.fx:L:C
+ Some('t) -> 't option@12 [generic: 't] @ Builtins.fx:L:C -- the return type or the signature as a whole does not match
 
 
 1 errors occured during type checking.

--- a/test/test_basic.fx
+++ b/test/test_basic.fx
@@ -707,8 +707,11 @@ TEST("basic.loop.squares", fun()
 
 TEST("basic.overloaded", fun()
 {
-    val t = (1, "abc") + (0.125, "def")
-    EXPECT_EQ(t, (1.125, "abcdef"))
+    // resolve-1: tuple arithmetic is defined on UNIFORM tuples only
+    // (tuples-as-short-vectors); the operands may still have different
+    // element types. Mixed tuples like (1, "abc") no longer support `+`.
+    val t = (1, 2) + (0.125, 0.25)
+    EXPECT_EQ(t, (1.125, 2.25))
     type 't point_t = {x: 't; y: 't}
 
     operator + (p1: 't point_t, p2: 't point_t) =

--- a/test/test_basic.fx
+++ b/test/test_basic.fx
@@ -801,7 +801,11 @@ TEST("basic.keyword_args", fun()
         }
     }
 
-    EXPECT_NEAR(`sqrt(81.0)`, 9.0, 1e-10)
+    // resolve-1: `sqrt(81.0)` (all keywords defaulted) ties with the concrete
+    // Math.sqrt(double) under least-generic ranking -> ambiguity error, per the
+    // decided policy (proposal §4/§10.Q2: no "fewer defaults" tie-break).
+    // Passing a keyword makes the intent explicit and only the local sqrt viable.
+    EXPECT_NEAR(`sqrt(81.0, n=2)`, 9.0, 1e-10)
     EXPECT_NEAR(`sqrt(-81.0, use_abs=true, n=4)`, 3.0, 1e-10)
     EXPECT_NEAR(`sqrt(-27.f, n=3)`, -3.f, 1e-6f)
 })

--- a/test/test_gencmp.fx
+++ b/test/test_gencmp.fx
@@ -76,6 +76,36 @@ val recAB_clsd = recf([:: (get_id("a"), TypInt), (get_id("b"), TypInt)], true)
 check("kw_open_a_vs_closed_ab",   compare_typ_generality(recA_open, [], recAB_clsd, []), IncompGeneric) // FIXME(WP-E Q2)
 check("kw_closed_a_vs_closed_ab", compare_typ_generality(recA_clsd, [], recAB_clsd, []), IncompGeneric) // FIXME(WP-E Q2)
 
+// ---- var-form generics: {...} / (...) / ('t ...) / 't [+]  (FB-017 fix) ------
+// The rigid side of a trial freezes var-forms into opaque sentinels
+// (freeze_varform_typs), so a concrete type now ranks strictly more specific
+// than a var-form generic, while identical var-forms stay mutually applicable.
+fun vrec(): typ_t = TypVar(ref Some(TypVarRecord))                // {...}
+fun vtup(p: typ_t?): typ_t = TypVar(ref Some(TypVarTuple(p)))     // (...) / (p ...)
+fun varr(et: typ_t): typ_t = TypVar(ref Some(TypVarArray(et)))    // et [+]
+
+check("rec_vs_varrec", compare_typ_generality(recA_clsd, [], vrec(), []), LessGeneric)
+check("varrec_vs_rec", compare_typ_generality(vrec(), [], recA_clsd, []), MoreGeneric)
+check("varrec_vs_varrec", compare_typ_generality(vrec(), [], vrec(), []), EqGeneric)
+// {...} accepts only records, plain 't accepts everything
+check("varrec_vs_t", compare_typ_generality(vrec(), [], skT, [:: t_id]), LessGeneric)
+check("t_vs_varrec", compare_typ_generality(skT, [:: t_id], vrec(), []), MoreGeneric)
+
+val tup_ii = TypTuple([:: TypInt, TypInt])
+check("tup_vs_vartup", compare_typ_generality(tup_ii, [], vtup(None), []), LessGeneric)
+check("vartup_vs_vartup", compare_typ_generality(vtup(None), [], vtup(None), []), EqGeneric)
+// ('t ...) (all elements equal) is strictly less generic than (...)
+check("ttup_vs_vartup", compare_typ_generality(vtup(Some(skT)), [:: t_id], vtup(None), []), LessGeneric)
+check("vartup_vs_ttup", compare_typ_generality(vtup(None), [], vtup(Some(skT)), [:: t_id]), MoreGeneric)
+check("inttup_vs_ttup", compare_typ_generality(vtup(Some(TypInt)), [],
+                                               vtup(Some(skT)), [:: t_id]), LessGeneric)
+
+val arr1_int = TypArray(1, TypInt)
+check("intarr_vs_tvararr", compare_typ_generality(arr1_int, [], varr(skT), [:: t_id]), LessGeneric)
+check("tvararr_vs_intarr", compare_typ_generality(varr(skT), [:: t_id], arr1_int, []), MoreGeneric)
+check("vararr_vs_vararr", compare_typ_generality(varr(skT), [:: t_id], varr(skU), [:: u_id]), EqGeneric)
+check("intvararr_vs_tvararr", compare_typ_generality(varr(TypInt), [], varr(skT), [:: t_id]), LessGeneric)
+
 // ---- interface direction: FENCED --------------------------------------------
 // §3 wants "concrete class less generic than its interface" and "child iface
 // less generic than parent". That needs UPCAST-AWARE unification (same_or_parent

--- a/test/test_resolve.fx
+++ b/test/test_resolve.fx
@@ -1,17 +1,21 @@
 /*
-    WP-E / D3 — T-res positive suite. Locks CURRENT overload-resolution behavior
-    so the later resolver surgery flips each change deliberately (a failing
-    assertion here == a reviewed decision, not an accident).
+    WP-E / D3 — T-res positive suite. Locks overload-resolution behavior so any
+    change flips a case deliberately (a failing assertion here == a reviewed
+    decision, not an accident).
 
     Self-asserting program (no UTest, no compiler-internal imports): it prints
     each check and throws on the first wrong value, so the fxtest O0/O3
     differential doubles as an assertion at both opt levels.
 
-    Cases marked FIXME(FB-016)/FIXME(FB-007) lock behavior that is WRONG today and
-    is expected to change when tranche A of the resolver surgery lands; when it
-    does, the corresponding assertion fails loudly and is updated in review.
+    resolve-1 status: resolution is collect->rank->commit (least-generic viable
+    candidate wins; ties error at fully-determined sites and fall back to
+    env-order at under-constrained ones). FB-016 is fixed and locked below;
+    FB-007's S2 shape is fixed and locked below (mini-cplx, CplxHelper.fx);
+    FB-007's S3 shape (under-constrained commit) stays FENCED until session 2's
+    deferral.
 
-    See docs/overload_resolution_proposal_v2.md and docs/wpe_tests_report.md.
+    See docs/overload_resolution_proposal_v2.md, docs/resolve1_surgery_brief.md
+    and docs/wpe_tests_report.md.
 */
 import ResHelper
 from ResHelper import *
@@ -62,31 +66,50 @@ check("xmodule.instance_sees_local_eq",
 // FENCED — behavior that is WRONG today; flips when the surgery lands
 // ---------------------------------------------------------------------------
 
-// FIXME(FB-016): greedy first-match. A concrete overload declared BEFORE a
-// generic one LOSES to the generic (env-list is most-recent-first). So bad(5)
-// calls the generic identity and yields 5; a specificity resolver yields 6.
-// When tranche A lands, this assertion fails -> change 5 to 6 and drop the fence.
+// FB-016 FIXED by resolve-1: least-generic ranking picks the concrete overload
+// regardless of declaration order. Before the surgery the generic identity won
+// here (env-list is most-recent-first) and this yielded 5.
 fun bad(x: int) = x + 1
 fun bad(x: 't) = x
-check("FIXME_FB016.generic_beats_concrete", bad(5), 5)   // want-after-fix: 6
+check("FB016_fixed.concrete_beats_generic", bad(5), 6)
+
+// ---------------------------------------------------------------------------
+// FB-007 shapes via the mini-cplx module (CplxHelper.fx mirrors the fenced
+// lib/Complex.fx:15-44 operator shapes; its operators are ninja names, so the
+// plain `import CplxHelper` above... see below -- imported here explicitly)
+// ---------------------------------------------------------------------------
+import CplxHelper
+from CplxHelper import *
+
+// S2-shape (FB-007): `'t cplx * int` on a fully-determined receiver must pick
+// CplxHelper's `*('t cplx, int)`, not the array `__mul__` broadcast. resolve-1
+// ranks the viable set, so this holds regardless of import/declaration order.
+val c = ref (cplx(1, 1))
+*c *= 2
+check("fb007.s2_cplx_times_int", c->re + c->im, 4)
 
 /*
-   FIXME(FB-007): the three generic-`complex` resolution symptoms are NOT
-   reproducible in a self-contained mini-class — they require the real
-   lib/Complex.fx operators (uncommented) plus the `N.fi` imaginary literal and
-   the NN library's generic `+` on `nnop_t list`. Ground-truthed in this WP-E
-   (see docs/found_bugs.md FB-007 and docs/wpe_tests_report.md):
+   FIXME(FB-007, S3-shape) -- STILL FENCED after resolve-1 (session 2 flips it).
+   The commit-half of S3 is an under-constrained call: below, at
+   `[:: x*x] + prog` the fold accumulator `prog` still has a fully free type,
+   so BOTH the list-concat `+('t list, 't list)` (Builtins) and the
+   over-general `+('t, 't cplx)` (CplxHelper, mimicking lib/Complex.fx:17) are
+   viable, and the two are genuinely incomparable. Ranking cannot help; the
+   env-order fallback picks the most recently imported candidate = the cplx
+   one, inferring `prog: int list cplx`, and `.rev()` then fails to match --
+   the exact FromOnnx.fx:1012 / vision_classify.fx failure in miniature.
+   Session 2 (deferral of under-constrained calls) resolves the `+` once
+   `prog`'s type is pinned by the fold result; then this un-fences:
 
-   - S2 (operator mis-resolution): with Complex.fx ops uncommented,
-       val c = ref (1 + 1.fi); *c *= 2
-     resolves `__mul__` to the ARRAY multiply
-     (lib/Array.fx:341: "unsupported iteration domain").
-   - S3 (inference pollution): compiling examples/vision_classify.fx with those
-     ops on infers `nnop_t list Complex.complex` for a plain `nnop_t list`
-     (lib/Complex.fx:17), cascading to NN/FromOnnx.fx:1018.
+   fun build(l: int list) {
+       val fold prog = [] for x <- l { [:: x*x] + prog }
+       prog.rev()
+   }
+   check("fb007.s3_free_accumulator", build([:: 1, 2, 3]).hd(), 1)
 
-   These flip to pass when tranche A lands; they are fenced by keeping
-   lib/Complex.fx:15-44 and examples/fst.fx:125-127 commented in-tree.
+   The real-library reproductions (lib/Complex.fx:15-44 uncommented + the
+   `N.fi` literal in examples/fst.fx:125-127 / examples/vision_classify.fx)
+   stay fenced in-tree for the same reason; see docs/found_bugs.md FB-007.
 */
 
 println(f"\ntest_resolve: {fails} failure(s)")

--- a/test/test_resolve.fx
+++ b/test/test_resolve.fx
@@ -10,9 +10,9 @@
     resolve-1 status: resolution is collect->rank->commit (least-generic viable
     candidate wins; ties error at fully-determined sites and fall back to
     env-order at under-constrained ones). FB-016 is fixed and locked below;
-    FB-007's S2 shape is fixed and locked below (mini-cplx, CplxHelper.fx);
-    FB-007's S3 shape (under-constrained commit) stays FENCED until session 2's
-    deferral.
+    FB-007's S2 shape is fixed and locked below (mini-cplx, CplxHelper.fx).
+    resolve-2 status: [] is typed TypVarCollection, which un-fenced FB-007's
+    S3 shape (free []-accumulator + over-general scalar-left operator) below.
 
     See docs/overload_resolution_proposal_v2.md, docs/resolve1_surgery_brief.md
     and docs/wpe_tests_report.md.
@@ -88,29 +88,23 @@ val c = ref (cplx(1, 1))
 *c *= 2
 check("fb007.s2_cplx_times_int", c->re + c->im, 4)
 
-/*
-   FIXME(FB-007, S3-shape) -- STILL FENCED after resolve-1 (session 2 flips it).
-   The commit-half of S3 is an under-constrained call: below, at
-   `[:: x*x] + prog` the fold accumulator `prog` still has a fully free type,
-   so BOTH the list-concat `+('t list, 't list)` (Builtins) and the
-   over-general `+('t, 't cplx)` (CplxHelper, mimicking lib/Complex.fx:17) are
-   viable, and the two are genuinely incomparable. Ranking cannot help; the
-   env-order fallback picks the most recently imported candidate = the cplx
-   one, inferring `prog: int list cplx`, and `.rev()` then fails to match --
-   the exact FromOnnx.fx:1012 / vision_classify.fx failure in miniature.
-   Session 2 (deferral of under-constrained calls) resolves the `+` once
-   `prog`'s type is pinned by the fold result; then this un-fences:
-
-   fun build(l: int list) {
-       val fold prog = [] for x <- l { [:: x*x] + prog }
-       prog.rev()
-   }
-   check("fb007.s3_free_accumulator", build([:: 1, 2, 3]).hd(), 1)
-
-   The real-library reproductions (lib/Complex.fx:15-44 uncommented + the
-   `N.fi` literal in examples/fst.fx:125-127 / examples/vision_classify.fx)
-   stay fenced in-tree for the same reason; see docs/found_bugs.md FB-007.
-*/
+// FB-007 S3-shape, UNFENCED by resolve-2 (TypVarCollection). The fold
+// accumulator `prog` is initialized with `[]`, whose type is now
+// TypVarCollection ("some list/vector/array") instead of a fully free var.
+// At `[:: x*x] + prog` the over-general `+('t, 't cplx)` (CplxHelper,
+// mimicking lib/Complex.fx) dies at the viability trial -- a collection-var
+// cannot become `'t cplx` -- so only the list-concat `+('t list, 't list)`
+// remains and the call resolves correctly even though it is still
+// under-constrained. (Before resolve-2 the env-order fallback picked the
+// most recently imported cplx candidate, inferring `prog: int list cplx`,
+// and `.rev()` failed -- the FromOnnx.fx:1012 / vision_classify.fx failure
+// in miniature.) The true deferral of under-constrained calls is still
+// session-2 scope; TypVarCollection removes this particular collision class.
+fun build(l: int list) {
+    val fold prog = [] for x <- l { [:: x*x] + prog }
+    prog.rev()
+}
+check("fb007.s3_free_accumulator", build([:: 1, 2, 3]).hd(), 1)
 
 println(f"\ntest_resolve: {fails} failure(s)")
 if fails > 0 { throw Fail("test_resolve failed") }


### PR DESCRIPTION
In brief, ficus compiler now checks _all_ candidates during name resolution (when calling functions, methods) rather than simply choosing the first appropriate match.

## resolve-1 — overload resolution is collect → rank → commit

`lookup_id_opt` no longer commits the first env-order candidate that unifies. All candidates are trialed side-effect-free, ranked by a generality comparator (`compare_fun_generality`, C++-style partial ordering via two one-way skolemized unification trials), and the **unique least-generic viable candidate wins**, independent of declaration/import order.

- **Tie policy** (per `docs/resolve1_surgery_brief.md`): at a fully-determined call an unresolvable tie is an **ambiguity error** (two flavors: equally-applicable / overlapping-but-unordered, with a full candidate listing and a qualify-the-call hint); at an under-constrained call (free type vars among the args) ties fall back to env-order first-match — today's semantics, kept until session-2 deferral.
- **Q2 keyword normalization**: an exact keywordless match ranks above a candidate viable only via all-defaulted keyword args (`sqrt(81.0)` → `Math.sqrt(double)`, not a local `sqrt('t, ~n=2)`).
- **FB-016 fixed** (declaration-order-dependent resolution), **FB-017 fixed** (comparator now ranks var-form generics `{...}`/`(...)`/`('t ...)`/`'t [+]` vs concrete types via freeze sentinels).
- Richer diagnostics: "not found" errors list every candidate with a one-line rejection reason; `-pr-resolve` traces the real decision path.
- Tuple arithmetic (`+ - .+ .- .* ./`) redefined on **uniform tuples only** (tuples-as-short-numeric-vectors, `std::array<T,n>` role); structural generics (`<=>`, `==`, `hash`, `string`, `print`) still accept mixed tuples.

## resolve-2 — `TypVarCollection`: `[]` is "some collection", not "anything"

The empty-collection literal `[]` (`LitEmpty`) is no longer typed as a fully free type var but as a new var-form `TypVar(ref Some(TypVarCollection))`, which unifies **only** with a list/vector/array (or an array-var / a plain free var / another collection-var).

- **FB-007/S3 killed at the root**: a `[]`-initialized fold accumulator can no longer be captured by an unrelated generic candidate (the `NN/FromOnnx.fx:1012` / `vision_classify` failure shape). The over-general candidate now dies at the viability trial.
- **`lib/Complex.fx` fully unlocked**: all `+ - * /` operator variants live, including scalar-on-the-left; `*`/`/` are mixed-type (`1.0 * fcomplex` → `double complex` — the widening-cast idiom; `v *= 2` works with an int scalar). `+`/`-` stay homogeneous until S1 deferral (one result component passes through unchanged).
- **Imaginary literals `N.fi`/`N.i`/`N.hi` actually work now** (the lexer used to desugar them with an int zero real part, so `complex(int,float)` never matched a constructor). The 2021-era fenced `fst.fx` complex demo is live and prints mathematically correct values.
- `val n: int = []` is now a **typecheck-time** error (used to pass `-no-c` and die only at K-normalization); new negative golden 215.

Remaining FB-007 tail: **S1 only** (mixed-type arithmetic inside generic bodies pinned at declaration check) — session-2 deferral scope, see `docs/language_changes_brief.md` §6.

## Verification

- `fxtest.py all` (unit 135/135 + negative 73 + IR + cfold + corpus O0/O3), `determinism` (PASS=3), `sanitize` (ASan+UBSan clean) — all green at every commit.
- `tools/update_compiler.py` **self-hosting fixpoint holds**; the bootstrap diff of non-edited modules is pure `typ_t` constructor-tag renumbering (verified by inspection).
- `-pr-resolve` census over `compiler/fx.fx`: **350 sites = 343 ranked + 7 under-constrained fallbacks + 0 ambiguity errors**, byte-identical winner set before/after resolve-2 — corpus invariance on the compiler itself.
- Typecheck perf: +2% over resolve-1 (which was +1.8% over master).

Reports: `docs/resolve1_report.md`, `docs/resolve2_report.md`. Both branches to be deleted after merge (`resolve-1` is fully contained in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
