### PR TITLE
hotfix: ':t3 complex' return annotations on Complex's mixed operators…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,21 @@ bin/ficus -no-c file.fx                   # parse + typecheck only (fast)
   pass `-o output_name`. ficus will put app `output_name` and all
   intermediate files (.c; (.k, .ast) if requested) to
   `<ficus_root>/__fxbuild__/output_name`.
-- **Regenerating the bootstrap** (after editing any `compiler/*.fx`): run
-  `python3 tools/update_compiler.py`. It rebuilds the compiler, regenerates the
-  pre-gen C in `compiler/bootstrap/*.c`, copies over only the changed modules,
-  and asserts the self-hosting **fixpoint** — the freshly-built compiler must
-  regenerate its own bootstrap byte-for-byte, else it's a determinism
-  regression (`fxtest.py determinism`). `--check` is a CI-friendly dry run
-  (exit 1 if the bootstrap is stale); `--no-make` skips the initial build.
+- **Regenerating the bootstrap** — required after editing any `compiler/*.fx`
+  **or any stdlib module the compiler pulls in** (`compiler/bootstrap/` has 54
+  modules incl. `Builtins.c`, `Complex.c`, `String.c`, ... — `ls` it when in
+  doubt): run `python3 tools/update_compiler.py`. It rebuilds the compiler,
+  regenerates the pre-gen C in `compiler/bootstrap/*.c`, copies over only the
+  changed modules, and asserts the self-hosting **fixpoint** — the
+  freshly-built compiler must regenerate its own bootstrap byte-for-byte, else
+  it's a determinism regression (`fxtest.py determinism`). `--check` is a
+  CI-friendly dry run (exit 1 if the bootstrap is stale); `--no-make` skips
+  the initial build. **CI runs `--check` on every push that touches
+  compiler/lib/runtime** — a lib-only commit with a stale bootstrap is a red
+  master (learned 2026-07-08: lib/Complex.fx edit, forgotten regen). The regen
+  doubles as the ONLY routine self-build of the compiler, so it also catches
+  stdlib changes that break compiling the compiler itself — `fxtest all` does
+  NOT rebuild the compiler and cannot catch that class.
 
 ## Testing — the fxtest ladder (see tools/fxtest/README.md)
 
@@ -117,6 +125,15 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
   `val n: int = []` is a typecheck error and a `[]`-initialized fold
   accumulator can't be captured by a non-collection overload. If the
   collection kind is never pinned, K-normalization asks for an annotation.
+- **Return-type annotations on generic operators are viability filters, not
+  decoration.** A generic `operator` whose return type is left to inference
+  returns a free var that unifies with ANY expected type, so the candidate
+  stays viable at under-constrained call sites (free fold/recursion
+  accumulators) and can steal them via the env-order fallback — dropping
+  `: 't complex` from Complex's mixed operators broke the compiler's own
+  build (C_gen_code.fx:1328). Annotate with a FRESH var (`: 't3 complex`,
+  "returns SOME complex") to reject non-complex contexts while keeping
+  mixed-type widening.
 
 ### Build/run & measurement traps (Brief #2)
 

--- a/docs/ficus_todo_2026.md
+++ b/docs/ficus_todo_2026.md
@@ -1,6 +1,6 @@
 # Syntax and semantics
 
-- [ ] properly resolve instances of generic functions.
+- [x] properly resolve instances of generic functions.
       Adjust the type checker not to stop at the first appropriate candidate.
 - [ ] new syntax for generic types and its instances: `t list => list[t]`
   - [ ] Q: what would be a syntax for generic functions? `fun [u, v] add(a: u, b: v) {...}`?

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -392,6 +392,22 @@ is the whole point of the ladder.
   (`fun h(a: int, b: 't) = a + b; h(2, 1.5) == 3.5` works); the morning
   mixed-type failure was a stray free-var return annotation (`: 't complex`
   with an unbound 't) plus the pass-through component, NOT deferral.
+- **NEAR-MISS (same evening, hotfix-1): mixed `+`/`-` without return
+  annotations broke the compiler's own build** (caught by
+  `update_compiler.py --check` on CI; `fxtest all` does NOT rebuild the
+  compiler and stayed green). Mechanism: the homogeneous operators' return
+  annotation `: 't complex` was a LOAD-BEARING viability filter — at
+  `C_gen_code.fx:1328` (`val ai_ccode: cstmt_t list = ai_ccode + prologue`,
+  RHS `ai_ccode` still free — a recursion-typed accumulator, the S3 shape
+  with a free var instead of `[]`) the expected result type `cstmt_t list`
+  refused to unify with `'t complex`, killing the candidate at the trial.
+  The annotation-less mixed variants return a free var that unifies with
+  anything → viable → env-order fallback picked complex-+ over list-concat
+  → cascade. Fix: `: 't3 complex` return annotations with a FRESH type var
+  ("returns SOME complex") on ALL mixed variants — rejects non-complex
+  contexts, keeps widening (`2.0 + fcomplex` → double complex). Bisect
+  proof: 861a988 OK (homogeneous), 4096963 OK (mixed `*`/`/` — no
+  list-`*` competitor exists), 7e10f29 BREAKS (mixed `+`/`-`).
 
 ## FB-008  [UNCONFIRMED] non-deterministic-looking `.c`: unstable under unrelated changes
 - symptom (Vadim, seen several times over development, not a bit-flip): the

--- a/docs/resolve2_report.md
+++ b/docs/resolve2_report.md
@@ -87,6 +87,26 @@ var-form; it only enters through `[]`.
   **Vadim's `r - r` pattern** (`val r = a + b.re; complex(r, b.im + (r-r))`):
   constant folding provably erases it at both -O0 and -O3, leaving a bare
   `:>` cast in the K-form (verified) — no runtime cost, no inf/nan artifacts.
+  All mixed variants carry a `: 't3 complex` return annotation with a FRESH
+  type var — a load-bearing viability filter, see the near-miss below.
+
+**Near-miss (hotfix-1, same evening)**: the first mixed `+`/`-` commit
+(7e10f29) omitted the return annotations and BROKE the compiler's own build
+— red master. The homogeneous `: 't complex` annotation had been a silent
+viability filter: at `C_gen_code.fx:1328` a recursion-typed (still free)
+accumulator is concatenated into an annotated `cstmt_t list`, and the
+expected result type rejected the complex candidate at the trial; without
+the annotation the candidate's free return type unified with anything and
+env-order picked it over list-concat. This is the FB-007/S3 shape with a
+plain free var instead of `[]` — TypVarCollection cannot guard it; the
+return annotation does. Caught by `update_compiler.py --check` (the only
+routine self-build of the compiler — `fxtest all` never rebuilds it);
+bisect: homogeneous OK, mixed `*`/`/` OK (no list-`*` competitor), mixed
+`+`/`-` broke. Fix: `: 't3 complex` fresh-var return annotations on all
+mixed variants. Two process rules recorded in CLAUDE.md: bootstrap regen is
+required for stdlib edits too (Complex.c is one of 54 bootstrap modules),
+and generic operators should annotate their return type as a viability
+filter.
 
 FB-007 post-mortem: the S1 mechanism turned out to be already dead after
 resolve-1 — generic bodies re-resolve per instantiation (verified:

--- a/lib/Complex.fx
+++ b/lib/Complex.fx
@@ -12,42 +12,55 @@ fun conj(a: 't complex) = complex {re=a.re, im=-a.im}
 fun abs(a: 't complex) = sqrt(a.re*a.re + a.im*a.im)
 fun phase(a: 't complex) = atan2(a.im, a.re)
 
-/* All operators are mixed-type ('t1 op 't2): the result type is INFERRED
+/* All operators are mixed-type ('t1 op 't2): the result type is inferred
    from the body, where builtin numeric coercion combines the two types at
    instantiation -- so `1 + 1.fi` works and `1.0 * fcomplex` widens to
    double complex (the widening-cast idiom). For + and - one component of
    the result does not naturally pass through a mixed operation; it is
    nudged to the coerced type by adding `r - r` (Vadim's pattern), which
    constant folding provably erases at BOTH -O0 and -O3, leaving a bare
-   cast in the K-form -- so no runtime cost and no inf/nan artifacts. */
-operator + (a: 't1, b: 't2 complex) {
+   cast in the K-form -- so no runtime cost and no inf/nan artifacts.
+
+   The `: 't3 complex` return annotations (a FRESH type var: "the result is
+   SOME complex") are LOAD-BEARING, not decoration: at a call site whose
+   result type is already expected to be a non-complex (e.g. a still-free
+   fold/recursion accumulator concatenated into an annotated list, the
+   FB-007/S3 shape -- C_gen_code.fx:1328 in the compiler itself), the
+   return-type unification fails and the candidate is rejected at the
+   viability trial, so it cannot steal the call from list-concatenation
+   via the under-constrained env-order fallback. Without them the mixed
+   variants (whose inferred return is a free var that unifies with
+   anything) broke the compiler's own build. */
+operator + (a: 't1, b: 't2 complex): 't3 complex {
     val r = a + b.re
     complex(r, b.im + (r - r))
 }
-operator + (a: 't1 complex, b: 't2) {
+operator + (a: 't1 complex, b: 't2): 't3 complex {
     val r = a.re + b
     complex(r, a.im + (r - r))
 }
-operator + (a: 't1 complex, b: 't2 complex) = complex(a.re + b.re, a.im + b.im)
-operator - (a: 't1, b: 't2 complex) {
+operator + (a: 't1 complex, b: 't2 complex): 't3 complex =
+    complex(a.re + b.re, a.im + b.im)
+operator - (a: 't1, b: 't2 complex): 't3 complex {
     val r = a - b.re
     complex(r, (r - r) - b.im)
 }
-operator - (a: 't1 complex, b: 't2) {
+operator - (a: 't1 complex, b: 't2): 't3 complex {
     val r = a.re - b
     complex(r, a.im + (r - r))
 }
-operator - (a: 't1 complex, b: 't2 complex) = complex(a.re - b.re, a.im - b.im)
-operator * (a: 't1, b: 't2 complex) = complex(a * b.re, a * b.im)
-operator * (a: 't1 complex, b: 't2) = complex(a.re * b, a.im * b)
-operator * (a: 't1 complex, b: 't2 complex) =
+operator - (a: 't1 complex, b: 't2 complex): 't3 complex =
+    complex(a.re - b.re, a.im - b.im)
+operator * (a: 't1, b: 't2 complex): 't3 complex = complex(a * b.re, a * b.im)
+operator * (a: 't1 complex, b: 't2): 't3 complex = complex(a.re * b, a.im * b)
+operator * (a: 't1 complex, b: 't2 complex): 't3 complex =
     complex(a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re)
-operator / (a: 't1 complex, b: 't2) = complex(a.re/b, a.im/b)
-operator / (a: 't1 complex, b: 't2 complex) {
+operator / (a: 't1 complex, b: 't2): 't3 complex = complex(a.re/b, a.im/b)
+operator / (a: 't1 complex, b: 't2 complex): 't3 complex {
     val denom = b.re*b.re + b.im*b.im
     complex((a.re*b.re + a.im*b.im)/denom, (a.im*b.re - a.re*b.im)/denom)
 }
-operator / (a: 't1, b: 't2 complex) {
+operator / (a: 't1, b: 't2 complex): 't3 complex {
     val denom = b.re*b.re + b.im*b.im
     complex(a*b.re/denom, -a*b.im/denom)
 }

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -7,9 +7,9 @@ Candidates:
  __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
  __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
  __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
- __add__('t1, 't2 Complex.complex@3) -> <unknown> [generic: 't1, 't2] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t2 Complex.complex@3',
- __add__('t1 Complex.complex@3, 't2) -> <unknown> [generic: 't1, 't2] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
- __add__('t1 Complex.complex@3, 't2 Complex.complex@3) -> <unknown> [generic: 't1, 't2] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
+ __add__('t1, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t2 Complex.complex@3',
+ __add__('t1 Complex.complex@3, 't2) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
+ __add__('t1 Complex.complex@3, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
  __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 


### PR DESCRIPTION
… -- they are viability filters

Commit 7e10f29 (mixed +/- via the r-r pattern) broke the compiler's own build: red master on the CI bootstrap check (update_compiler.py --check is the only routine SELF-build of the compiler; fxtest all never rebuilds it and stayed green).

Mechanism: the old homogeneous operators' ': 't complex' return annotation was a load-bearing viability filter. At C_gen_code.fx:1328 a recursion-typed (still free) accumulator is concatenated into an annotated cstmt_t list; the expected result type refused to unify with ''t complex', rejecting the complex candidate at the trial. The annotation-less mixed variants return a free var that unifies with anything -> viable -> the under-constrained env-order fallback picked complex-+ over list-concat -> cascade. This is the FB-007/S3 shape with a plain free var instead of [] -- TypVarCollection cannot guard it; the return annotation does.

Fix: ': 't3 complex' (a FRESH var -- 'returns SOME complex') on ALL mixed variants: rejects non-complex contexts, keeps mixed-type widening (2.0 + fcomplex -> double complex; 1 + 1.fi still works). Bisect proof: homogeneous OK, mixed */ OK (no list-* competitor), mixed +/- broke.

Also: CLAUDE.md -- bootstrap regen is required for stdlib edits too (Complex.c is one of 54 bootstrap modules; the forgotten regen is why master went red), and the return-annotation lesson. Golden 207 re-recorded ('t3 in signatures). found_bugs/resolve2_report near-miss entries.

Verified: compiler self-build OK, bootstrap at clean fixpoint (generic operators emit no C until instantiated -- zero bootstrap churn), test_all 136/136, fxtest all, determinism, sanitize, vision_classify, census unchanged (343 ranked + 7 fallbacks + 0 errors).