### PR TITLE
annotate-1: return-type annotations on ALL 106 generic stdlib operato…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
           fi
           python3 tools/update_compiler.py --check --no-make
 
+      # Guard: stdlib generic operators must annotate their return type -- the
+      # annotation is a viability filter for overload resolution (FB-007
+      # near-miss: dropping it broke the compiler's own build). <1s, one leg.
+      - name: Operator return-annotation lint
+        if: matrix.cc == 'gcc' && matrix.os == 'ubuntu-latest'
+        run: python3 tools/lint_op_returns.py lib
+
       - name: Determine run mode
         id: mode
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,10 @@ intuition**. Read `doc/ficustut.md` and existing files (`test/test_basic.fx`,
   accumulators) and can steal them via the env-order fallback — dropping
   `: 't complex` from Complex's mixed operators broke the compiler's own
   build (C_gen_code.fx:1328). Annotate with a FRESH var (`: 't3 complex`,
-  "returns SOME complex") to reject non-complex contexts while keeping
-  mixed-type widening.
+  `: 't3 [+]`, `: ('t3 ...)` — "returns SOME complex/array/tuple") to reject
+  foreign contexts while keeping mixed-type widening. **Enforced by
+  `python3 tools/lint_op_returns.py lib` (CI, gcc leg)**; its `--funs` mode
+  is the (not yet clean) worklist for overloaded generic functions.
 
 ### Build/run & measurement traps (Brief #2)
 

--- a/docs/language_changes_brief.md
+++ b/docs/language_changes_brief.md
@@ -177,6 +177,17 @@ variants are UNFENCED, and `val n: int = []` became a typecheck-time error
 (post-reform): `[]` = empty *list* only + a dedicated empty-array spelling
 (e.g. `[.]`).
 
+**Operator return annotations = viability filters (annotate-1, follow-up to
+the hotfix-1 near-miss)**: every generic stdlib operator now annotates its
+return type (exact where the signature pins it, fresh-var `: 't3 [+]` /
+`: ('t3 ...)` / `: 't3 vector` for the mixed elementwise families in
+Builtins/Array/Vector/Date/Deque — 106 signatures), so no operator is
+viable at an under-constrained call site whose expected result type is
+foreign. Enforced by `tools/lint_op_returns.py lib` on CI. Its `--funs`
+mode flags overloaded generic FUNCTIONS without return annotations
+(~276 across Builtins/UTest/Array/Math/OpenCV/Map/Set/...) — the worklist
+for a follow-up sweep.
+
 **Deferral: REJECTED as a near-term item (2026-07-08 evening, with Vadim).**
 Re-measured after TypVarCollection: generic bodies already re-resolve per
 instantiation (`fun h(a: int, b: 't) = a + b` works — the recorded S1

--- a/lib/Array.fx
+++ b/lib/Array.fx
@@ -82,88 +82,88 @@ fun sat_int8(a: 't [+]) = [for x <- a {sat_int8(x)}]
 fun sat_uint16(a: 't [+]) = [for x <- a {sat_uint16(x)}]
 fun sat_int16(a: 't [+]) = [for x <- a {sat_int16(x)}]
 
-operator .+ (a: 'ta [+], b: 'tb) =
+operator .+ (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x .+ b}]
-operator .- (a: 'ta [+], b: 'tb) =
+operator .- (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x .- b}]
-operator .* (a: 'ta [+], b: 'tb) =
+operator .* (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x .* b}]
-operator ./ (a: 'ta [+], b: 'tb) =
+operator ./ (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x ./ b}]
-operator .% (a: 'ta [+], b: 'tb) =
+operator .% (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x .% b}]
-operator .** (a: 'ta [+], b: 'tb) =
+operator .** (a: 'ta [+], b: 'tb): 't3 [+] =
     [for x <- a {x .** b}]
 
-operator .+ (a: 'ta, b: 'tb [+]) =
+operator .+ (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a .+ y}]
-operator .- (a: 'ta, b: 'tb [+]) =
+operator .- (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a .- y}]
-operator .* (a: 'ta, b: 'tb [+]) =
+operator .* (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a .* y}]
-operator ./ (a: 'ta, b: 'tb [+]) =
+operator ./ (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a ./ y}]
-operator .% (a: 'ta, b: 'tb [+]) =
+operator .% (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a .% y}]
-operator .** (a: 'ta, b: 'tb [+]) =
+operator .** (a: 'ta, b: 'tb [+]): 't3 [+] =
     [for y <- b {a .** y}]
 
-operator + (a: 'ta [+], b: 'tb [+]) =
+operator + (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x + y}]
-operator - (a: 'ta [+], b: 'tb [+]) =
+operator - (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x - y}]
-operator .+ (a: 'ta [+], b: 'tb [+]) =
+operator .+ (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x + y}]
-operator .- (a: 'ta [+], b: 'tb [+]) =
+operator .- (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x - y}]
-operator .* (a: 'ta [+], b: 'tb [+]) =
+operator .* (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x .* y}]
-operator ./ (a: 'ta [+], b: 'tb [+]) =
+operator ./ (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x ./ y}]
-operator .% (a: 'ta [+], b: 'tb [+]) =
+operator .% (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x .% y}]
-operator .** (a: 'ta [+], b: 'tb [+]) =
+operator .** (a: 'ta [+], b: 'tb [+]): 't3 [+] =
     [for x <- a, y <- b {x .** y}]
 
-operator += (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x + b} }
-operator -= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x - b} }
-operator .*= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x * b} }
-operator ./= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x / b} }
-operator .%= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x % b} }
+operator += (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x + b} }
+operator -= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x - b} }
+operator .*= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x * b} }
+operator ./= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x / b} }
+operator .%= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x % b} }
 
-operator += (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x + y} }
-operator -= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x - y} }
-operator .*= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x * y} }
-operator ./= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x / y} }
-operator .%= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x % y} }
+operator += (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x + y} }
+operator -= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x - y} }
+operator .*= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x * y} }
+operator ./= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x / y} }
+operator .%= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x % y} }
 
-operator & (a: 't, b: 't [+]) =
+operator & (a: 't, b: 't [+]): 't [+] =
     [for y <- b {a & y}]
-operator | (a: 't, b: 't [+]) =
+operator | (a: 't, b: 't [+]): 't [+] =
     [for y <- b {a | y}]
-operator ^ (a: 't, b: 't [+]) =
+operator ^ (a: 't, b: 't [+]): 't [+] =
     [for y <- b {a ^ y}]
-operator & (a: 't [+], b: 't) =
+operator & (a: 't [+], b: 't): 't [+] =
     [for x <- a {x & b}]
-operator | (a: 't [+], b: 't) =
+operator | (a: 't [+], b: 't): 't [+] =
     [for x <- a {x | b}]
-operator ^ (a: 't [+], b: 't) =
+operator ^ (a: 't [+], b: 't): 't [+] =
     [for x <- a {x ^ b}]
 
-operator & (a: 't [+], b: 't [+]) =
+operator & (a: 't [+], b: 't [+]): 't [+] =
     [for x <- a, y <- b {x & y}]
-operator | (a: 't [+], b: 't [+]) =
+operator | (a: 't [+], b: 't [+]): 't [+] =
     [for x <- a, y <- b {x | y}]
-operator ^ (a: 't [+], b: 't [+]) =
+operator ^ (a: 't [+], b: 't [+]): 't [+] =
     [for x <- a, y <- b {x ^ y}]
 
-operator &= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x & b} }
-operator |= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x | b} }
-operator ^= (a: 'ta [+], b: 'tb) { for x@idx <- a { a[idx] = x ^ b} }
+operator &= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x & b} }
+operator |= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x | b} }
+operator ^= (a: 'ta [+], b: 'tb): void { for x@idx <- a { a[idx] = x ^ b} }
 
-operator &= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x & y} }
-operator |= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x | y} }
-operator ^= (a: 'ta [+], b: 'tb [+]) { for x@idx <- a, y <- b { a[idx] = x ^ y} }
+operator &= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x & y} }
+operator |= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x | y} }
+operator ^= (a: 'ta [+], b: 'tb [+]): void { for x@idx <- a, y <- b { a[idx] = x ^ y} }
 
 operator .<=> (a: 't [+], b: 't [+]): int [+] =
     [for x <- a, y <- b {x <=> y}]
@@ -171,7 +171,7 @@ operator .== (a: 't [+], b: 't [+]): bool [+] =
     [for x <- a, y <- b {x == y}]
 operator .!= (a: 't [+], b: 't [+]): bool [+] =
     [for x <- a, y <- b {!(x == y)}]
-operator .< (a: 't [+], b: 't [+]) =
+operator .< (a: 't [+], b: 't [+]): bool [+] =
     [for x <- a, y <- b {x < y}]
 operator .<= (a: 't [+], b: 't [+]): bool [+] =
     [for x <- a, y <- b {!(y < x)}]
@@ -186,7 +186,7 @@ operator .== (x: 't, b: 't [+]): bool [+] =
     [for y <- b {x == y}]
 operator .!= (x: 't, b: 't [+]): bool [+] =
     [for y <- b {!(x == y)}]
-operator .< (x: 't, b: 't [+]) =
+operator .< (x: 't, b: 't [+]): bool [+] =
     [for y <- b {x < y}]
 operator .<= (x: 't, b: 't [+]): bool [+] =
     [for y <- b {!(y < x)}]
@@ -201,7 +201,7 @@ operator .== (a: 't [+], y: 't): bool [+] =
     [for x <- a {x == y}]
 operator .!= (a: 't [+], y: 't): bool [+] =
     [for x <- a {!(x == y)}]
-operator .< (a: 't [+], y: 't) =
+operator .< (a: 't [+], y: 't): bool [+] =
     [for x <- a {x < y}]
 operator .<= (a: 't [+], y: 't): bool [+] =
     [for x <- a {!(y < x)}]
@@ -281,20 +281,20 @@ fun maxindex(a: 't []): ('t, int) =
         }
     }
 
-operator ' (a: 't [,])
+operator ' (a: 't [,]): 't [,]
 {
     val (m, n) = size(a)
     [for j <- 0:n for i <- 0:m {a[i, j]}]
 }
 
-operator ' (a: 't [])
+operator ' (a: 't []): 't [,]
 {
     val n = size(a)
     [for j <- 0:n for i <- 0:1 {a[j]}]
 }
 
 // matrix product: not very efficient and is put here for now just as a placeholder
-operator * (a: 't [,], b: 't [,])
+operator * (a: 't [,], b: 't [,]): 't [,]
 {
     val (ma, na) = size(a), (mb, nb) = size(b)
     assert(na == mb)
@@ -321,10 +321,10 @@ operator * (a: 't [,], b: 't [,])
     c
 }
 
-operator * (a: float [,], b: float [,]) = __intrin_gemm__(a, false, 0, -1, 1, 0, -1, 1, b, false, 0, -1, 1, 0, -1, 1)
-operator * (a: double [,], b: double [,]) = __intrin_gemm__(a, false, 0, -1, 1, 0, -1, 1, b, false, 0, -1, 1, 0, -1, 1)
+operator * (a: float [,], b: float [,]): 't3 [,] = __intrin_gemm__(a, false, 0, -1, 1, 0, -1, 1, b, false, 0, -1, 1, 0, -1, 1)
+operator * (a: double [,], b: double [,]): 't3 [,] = __intrin_gemm__(a, false, 0, -1, 1, 0, -1, 1, b, false, 0, -1, 1, 0, -1, 1)
 
-operator *= (a: 't [,], b: 't [,]) {
+operator *= (a: 't [,], b: 't [,]): void {
     val temp = a*b
     a[:,:] = temp
 }
@@ -335,11 +335,11 @@ fun row2matrix(a: 't [])
     [for i <- 0:1 for j <- 0:n {a[j]}]
 }
 
-operator * (a: 't [], b: 't [,]) = row2matrix(a)*b
-operator * (a: 't [,], b: 't []) = a*row2matrix(b)
+operator * (a: 't [], b: 't [,]): 't [,] = row2matrix(a)*b
+operator * (a: 't [,], b: 't []): 't [,] = a*row2matrix(b)
 
-operator * (a: 't [+], alpha: 't) = [for x <- a {x*alpha}]
-operator * (alpha: 't, a: 't [+]) = [for x <- a {x*alpha}]
+operator * (a: 't [+], alpha: 't): 't [+] = [for x <- a {x*alpha}]
+operator * (alpha: 't, a: 't [+]): 't [+] = [for x <- a {x*alpha}]
 
 fun diag(d: 't[])
 {

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -178,7 +178,7 @@ operator + (a: char, b: char): string
     return fx_make_str(cc, 2, fx_result);
 }
 
-operator + (l1: 't list, l2: 't list)
+operator + (l1: 't list, l2: 't list): 't list
 {
     @nothrow fun link2(l1: 't list, l2: 't list): 't list = @ccode { fx_link_lists(l1, l2, fx_result) }
     match (l1, l2) {
@@ -510,8 +510,8 @@ fun string(v: char vector, fmt: format_t) = string(string(v), fmt)
     return fx_status;
 }
 
-operator * (n: int, c: char) = c * n
-operator * (n: int, s: string) = s * n
+operator * (n: int, c: char): string = c * n
+operator * (n: int, s: string): string = s * n
 
 operator == (a: 't list, b: 't list): bool
 {
@@ -573,13 +573,13 @@ fun size(_: ('t*3)) = 3
 fun size(_: ('t*4)) = 4
 fun size(_: ('t*5)) = 5
 
-operator == (a: (...), b: (...)) =
+operator == (a: (...), b: (...)): bool =
     fold f=true for aj <- a, bj <- b {if aj == bj {f} else {false}}
-operator <=> (a: (...), b: (...)) =
+operator <=> (a: (...), b: (...)): int =
     fold d=0 for aj <- a, bj <- b {if d != 0 {d} else {aj <=> bj}}
-operator == (a: {...}, b: {...}) =
+operator == (a: {...}, b: {...}): bool =
     fold f=true for (_, aj) <- a, (_, bj) <- b {if aj == bj {f} else {false}}
-operator <=> (a: {...}, b: {...}) =
+operator <=> (a: {...}, b: {...}): int =
     fold d=0 for (_, aj) <- a, (_, bj) <- b {if d != 0 {d} else {aj <=> bj}}
 
 operator <=> (a: int, b: int): int = (a > b) - (a < b)
@@ -633,32 +633,32 @@ fun abs(a: long): long
 // (uniform-x-uniform is covered by uniform-x-anything, not conversely), so on
 // a (tuple, tuple) call the element-wise form wins by specificity, and on a
 // (tuple, scalar) call only the broadcast form is viable.
-operator .* (a: ('t...), b: 'ts) = (for aj <- a {aj * b})
-operator ./ (a: ('t...), b: 'ts) = (for aj <- a {aj / b})
-operator .* (a: 'ts, b: ('t...)) = (for bj <- b {a * bj})
-operator ./ (a: 'ts, b: ('t...)) = (for bj <- b {a / bj})
-operator + (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj + bj})
-operator - (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj - bj})
-operator .+ (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj + bj})
-operator .- (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj - bj})
-operator .* (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj * bj})
-operator ./ (a: ('t1...), b: ('t2...)) = (for aj <- a, bj <- b {aj / bj})
+operator .* (a: ('t...), b: 'ts): ('t3 ...) = (for aj <- a {aj * b})
+operator ./ (a: ('t...), b: 'ts): ('t3 ...) = (for aj <- a {aj / b})
+operator .* (a: 'ts, b: ('t...)): ('t3 ...) = (for bj <- b {a * bj})
+operator ./ (a: 'ts, b: ('t...)): ('t3 ...) = (for bj <- b {a / bj})
+operator + (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj + bj})
+operator - (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj - bj})
+operator .+ (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj + bj})
+operator .- (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj - bj})
+operator .* (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj * bj})
+operator ./ (a: ('t1...), b: ('t2...)): ('t3 ...) = (for aj <- a, bj <- b {aj / bj})
 operator | (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj | bj})
 operator & (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj & bj})
 operator ^ (a: ('t...), b: ('t...)): ('t...) = (for aj <- a, bj <- b {aj ^ bj})
 
 // complex multiplication
-operator * (a: ('t*2), b: ('t*2)) =
+operator * (a: ('t*2), b: ('t*2)): ('t*2) =
     (a.0*b.0 - a.1*b.1, a.0*b.1 + a.1*b.0)
 // and division
-operator / (a: ('t*2), b: ('t*2))
+operator / (a: ('t*2), b: ('t*2)): ('t*2)
 {
     val q = b.0*b.0 + b.1*b.1
     ((a.0*b.0 + a.1*b.1)/q, (a.1*b.0 - a.0*b.1)/q)
 }
 
 // quaternion product
-operator * (a: ('t*4), b: ('t*4)) =
+operator * (a: ('t*4), b: ('t*4)): ('t*4) =
     (a.0*b.0 - a.1*b.1 - a.2*b.2 - a.3*b.3,
     a.0*b.1 + a.1*b.0 + a.2*b.3 - a.3*b.2,
     a.0*b.2 - a.1*b.3 + a.2*b.0 + a.3*b.1,
@@ -720,13 +720,13 @@ operator .<= (a: ('t...), b: ('t...)): (bool...) = (for aj <- a, bj <- b {aj <= 
 operator .> (a: ('t...), b: ('t...)): (bool...) = (for aj <- a, bj <- b {aj > bj})
 operator .>= (a: ('t...), b: ('t...)): (bool...) = (for aj <- a, bj <- b {aj >= bj})
 
-operator == (a: 't?, b: 't?) {
+operator == (a: 't?, b: 't?): bool {
     | (Some(a), Some(b)) => a == b
     | (None, None) => true
     | _ => false
 }
 
-operator <=> (a: 't?, b: 't?) {
+operator <=> (a: 't?, b: 't?): int {
     | (Some(a), Some(b)) => a <=> b
     | (None, Some _) => -1
     | (Some _, None) => 1
@@ -775,7 +775,7 @@ operator === (a: (...), b: (...)): bool =
     fold f=true for aj<-a, bj<-b {f & (aj === bj)}
 operator === (a: {...}, b: {...}): bool =
     fold f=true for (_, aj)<-a, (_, bj)<-b {f & (aj === bj)}
-operator === (a: 't?, b: 't?) {
+operator === (a: 't?, b: 't?): bool {
     | (Some(a), Some(b)) => a === b
     | (None, None) => true
     | _ => false

--- a/lib/Date.fx
+++ b/lib/Date.fx
@@ -130,13 +130,13 @@ val weekday_short_names_eng = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", 
 val weekday_names = [for i <- 0:8 {weekday_name_(i, false)}]
 val weekday_short_names = [for i <- 0:8 {weekday_name_(i, true)}]
 
-operator + (date: t, delta: int) = date.{jdn = date.jdn + delta}
-operator + (delta: int, date: t) = date.{jdn = date.jdn + delta}
-operator - (date: t, delta: int) = date.{jdn = date.jdn - delta}
-operator - (date1: t, date2: t) = date1.jdn - date2.jdn
+operator + (date: t, delta: int): t = date.{jdn = date.jdn + delta}
+operator + (delta: int, date: t): t = date.{jdn = date.jdn + delta}
+operator - (date: t, delta: int): t = date.{jdn = date.jdn - delta}
+operator - (date1: t, date2: t): int = date1.jdn - date2.jdn
 
-operator == (date1: t, date2: t) = date1.jdn == date2.jdn
-operator <=> (date1: t, date2: t) = date1.jdn <=> date2.jdn
+operator == (date1: t, date2: t): bool = date1.jdn == date2.jdn
+operator <=> (date1: t, date2: t): int = date1.jdn <=> date2.jdn
 
 fun is_leap_year(year: int, ~calendar: calendar_t=Calendar_Auto): bool
 {

--- a/lib/Deque.fx
+++ b/lib/Deque.fx
@@ -20,7 +20,7 @@ fun length(d: 't Deque.t) = d.head.length() + d.tail.length()
 fun rev(d: 't Deque.t) = t {head=d.tail, tail=d.head}
 
 // could improve performance in many cases but the worst one
-operator == (d1: 't Deque.t, d2: 't Deque.t) = list(d1) == list(d2)
+operator == (d1: 't Deque.t, d2: 't Deque.t): bool = list(d1) == list(d2)
 
 fun first(d: 't Deque.t): 't
 {

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -5,27 +5,27 @@
 
 // operations on vectors
 
-operator .+ (a: 't1 vector, b: 't2 vector) = vector(for ai <- a, bi <- b {ai + bi})
-operator .+ (a: 't vector, b: 't) = vector(for ai <- a {ai + b})
-operator .+ (a: 't, b: 't vector) = vector(for bi <- b {a + bi})
-operator .- (a: 't1 vector, b: 't2 vector) = vector(for ai <- a, bi <- b {ai - bi})
-operator .- (a: 't vector, b: 't) = vector(for ai <- a {ai - b})
-operator .- (a: 't, b: 't vector) = vector(for bi <- b {a - bi})
-operator .* (a: 't1 vector, b: 't2 vector) = vector(for ai <- a, bi <- b {ai * bi})
-operator .* (a: 't vector, b: 't) = vector(for ai <- a {ai * b})
-operator .* (a: 't, b: 't vector) = vector(for bi <- b {a * bi})
-operator ./ (a: 't1 vector, b: 't2 vector) = vector(for ai <- a, bi <- b {ai / bi})
-operator ./ (a: 't vector, b: 't) = vector(for ai <- a {ai / b})
-operator ./ (a: 't, b: 't vector) = vector(for bi <- b {a / bi})
-operator .% (a: 'ta vector, b: 'tb vector) =
+operator .+ (a: 't1 vector, b: 't2 vector): 't3 vector = vector(for ai <- a, bi <- b {ai + bi})
+operator .+ (a: 't vector, b: 't): 't vector = vector(for ai <- a {ai + b})
+operator .+ (a: 't, b: 't vector): 't vector = vector(for bi <- b {a + bi})
+operator .- (a: 't1 vector, b: 't2 vector): 't3 vector = vector(for ai <- a, bi <- b {ai - bi})
+operator .- (a: 't vector, b: 't): 't vector = vector(for ai <- a {ai - b})
+operator .- (a: 't, b: 't vector): 't vector = vector(for bi <- b {a - bi})
+operator .* (a: 't1 vector, b: 't2 vector): 't3 vector = vector(for ai <- a, bi <- b {ai * bi})
+operator .* (a: 't vector, b: 't): 't vector = vector(for ai <- a {ai * b})
+operator .* (a: 't, b: 't vector): 't vector = vector(for bi <- b {a * bi})
+operator ./ (a: 't1 vector, b: 't2 vector): 't3 vector = vector(for ai <- a, bi <- b {ai / bi})
+operator ./ (a: 't vector, b: 't): 't vector = vector(for ai <- a {ai / b})
+operator ./ (a: 't, b: 't vector): 't vector = vector(for bi <- b {a / bi})
+operator .% (a: 'ta vector, b: 'tb vector): 't3 vector =
     vector(for x <- a, y <- b {x .% y})
-operator .** (a: 'ta vector, b: 'tb vector) =
+operator .** (a: 'ta vector, b: 'tb vector): 't3 vector =
     vector(for x <- a, y <- b {x .** y})
-operator & (a: 't vector, b: 't vector) =
+operator & (a: 't vector, b: 't vector): 't vector =
     vector(for x <- a, y <- b {x & y})
-operator | (a: 't vector, b: 't vector) =
+operator | (a: 't vector, b: 't vector): 't vector =
     vector(for x <- a, y <- b {x | y})
-operator ^ (a: 't vector, b: 't vector) =
+operator ^ (a: 't vector, b: 't vector): 't vector =
     vector(for x <- a, y <- b {x ^ y})
 
 operator .<=> (a: 't vector, b: 't vector): int vector =
@@ -34,7 +34,7 @@ operator .== (a: 't vector, b: 't vector): bool vector =
     vector(for x <- a, y <- b {x == y})
 operator .!= (a: 't vector, b: 't vector): bool vector =
     vector(for x <- a, y <- b {!(x == y)})
-operator .< (a: 't vector, b: 't vector) =
+operator .< (a: 't vector, b: 't vector): bool vector =
     vector(for x <- a, y <- b {x < y})
 operator .<= (a: 't vector, b: 't vector): bool vector =
     vector(for x <- a, y <- b {!(y < x)})

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -4,13 +4,13 @@ Candidates:
  __add__(string, char) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'string',
  __add__(char, string) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'char',
  __add__(char, char) -> string @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'char',
- __add__('t list, 't list) -> <unknown> [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
+ __add__('t list, 't list) -> 't list [generic: 't] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match ''t list',
  __add__(long, long) -> long @ Builtins.fx:L:C -- argument 1 of type 'int' does not match 'long',
- __add__(('t1 ...), ('t2 ...)) -> <unknown> [generic: 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
- __add__('t1, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t2 Complex.complex@3',
- __add__('t1 Complex.complex@3, 't2) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
- __add__('t1 Complex.complex@3, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't1, 't2, 't3] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
- __add__('ta [+], 'tb [+]) -> <unknown> [generic: 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
+ __add__(('t1 ...), ('t2 ...)) -> ('t3 ...) [generic: 't3, 't1, 't2, __var_tuple__] @ Builtins.fx:L:C -- argument 1 of type 'int' does not match '('t1 ...)',
+ __add__('t1, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't3, 't1, 't2] @ Complex.fx:L:C -- argument 2 of type 'string' does not match ''t2 Complex.complex@3',
+ __add__('t1 Complex.complex@3, 't2) -> 't3 Complex.complex@3 [generic: 't3, 't1, 't2] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
+ __add__('t1 Complex.complex@3, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't3, 't1, 't2] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
+ __add__('ta [+], 'tb [+]) -> 't3 [+] [generic: 't3, 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
 
 1 errors occured during type checking.

--- a/tools/lint_op_returns.py
+++ b/tools/lint_op_returns.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Lint: generic stdlib operators must annotate their return type.
+
+Why (see docs/found_bugs.md FB-007, the hotfix-1 near-miss): a generic
+`operator` whose return type is left to inference returns a free type var
+that unifies with ANY expected type, so the candidate stays viable at
+under-constrained call sites (free fold/recursion accumulators) and can
+steal them from the intended candidate via the env-order fallback.
+Dropping `: 't complex` from Complex.fx's operators broke the compiler's
+own build (C_gen_code.fx:1328). The return annotation is a load-bearing
+VIABILITY FILTER: annotate the exact type when the signature pins it, or a
+fresh-var form (`: 't3 complex`, `: ('t3 ...)`, `: 't3 [+]`) meaning "some
+complex / some tuple / some array".
+
+Scans .fx sources (default: lib/) for `operator` declarations and reports
+those whose signature has no `): <type>` annotation. Pure stdlib Python,
+no dependency on the compiler (same rule as tools/fxtest).
+
+Exit code: 0 if clean, 1 if violations found (CI-friendly).
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# an operator declaration, possibly prefixed by attributes (@inline etc.)
+DECL_RE = re.compile(r"^[ \t]*(?:@\w+[ \t]+)*operator\s", re.M)
+# a function declaration (for --funs mode); name captured for overload grouping
+FUN_RE = re.compile(r"^[ \t]*(?:@\w+[ \t]+)*fun[ \t]+([A-Za-z_]\w*)[ \t]*\(", re.M)
+
+
+def strip_comments_keep_positions(text: str) -> str:
+    """Blank out /* */ and // comments and string/char literals, preserving
+    offsets and newlines, so paren matching cannot be confused."""
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if text[j] == "/" and j + 1 < n and text[j + 1] == "*":
+                    depth += 1
+                    j += 2
+                elif text[j] == "*" and j + 1 < n and text[j + 1] == "/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            for k in range(i, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+        elif c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        elif c == '"' or c == "'":
+            # 'x' char literals and type vars 't both start with '.
+            # A type var has no closing quote on the same "token": treat '
+            # followed by alnum and NOT closed within 2 chars as a tyvar.
+            if c == "'" and i + 1 < n and (text[i + 1].isalpha() or text[i + 1] == "_"):
+                if not (i + 2 < n and text[i + 2] == "'"):
+                    i += 1
+                    continue
+            # the transpose operator: `operator ' (a: ...)` -- a lone ' not
+            # followed by a closing ' two chars later is not a char literal
+            if c == "'" and i + 2 < n and text[i + 2] != "'":
+                i += 1
+                continue
+            j = i + 1
+            while j < n and text[j] != c:
+                j += 2 if text[j] == "\\" else 1
+            for k in range(i + 1, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j + 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def scan_decls(text: str, regex):
+    """Yield (start, name_or_None, sig_end, annotated, params) per declaration."""
+    n = len(text)
+    pos = 0
+    while True:
+        m = regex.search(text, pos)
+        if not m:
+            break
+        name = m.group(1) if m.groups() else None
+        lp = text.find("(", m.end() - (1 if m.groups() else 0))
+        if lp < 0:
+            break
+        depth, j = 1, lp + 1
+        while j < n and depth:
+            if text[j] == "(":
+                depth += 1
+            elif text[j] == ")":
+                depth -= 1
+            j += 1
+        k = j
+        while k < n and text[k] in " \t\n":
+            k += 1
+        annotated = k < n and text[k] == ":"
+        yield m.start(), name, j, annotated, text[lp:j]
+        pos = j
+
+
+def check_file(path: Path, funs=False):
+    raw = path.read_text(encoding="utf-8")
+    text = strip_comments_keep_positions(raw)
+    violations = []   # operators: always flagged when unannotated
+    fun_decls = []    # (name, lineno, sig, annotated, generic)
+    for start, _, j, annotated, _ in scan_decls(text, DECL_RE):
+        if not annotated:
+            lineno = text.count("\n", 0, start) + 1
+            violations.append((lineno, " ".join(raw[start:j].split())))
+    if funs:
+        for start, name, j, annotated, params in scan_decls(text, FUN_RE):
+            lineno = text.count("\n", 0, start) + 1
+            generic = "'" in params
+            fun_decls.append((name, lineno, " ".join(raw[start:j].split()),
+                              annotated, generic))
+    return violations, fun_decls
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("paths", nargs="*", default=["lib"],
+                    help="files or directories to scan (default: lib)")
+    ap.add_argument("--funs", action="store_true",
+                    help="also flag GENERIC `fun`s without a return annotation "
+                         "whose name is overloaded (declared 2+ times in the "
+                         "scanned set) -- the same capture risk as operators")
+    args = ap.parse_args()
+    root = Path(__file__).resolve().parent.parent
+    files = []
+    for p in args.paths:
+        p = (root / p) if not Path(p).is_absolute() else Path(p)
+        if p.is_dir():
+            files += sorted(p.rglob("*.fx"))
+        else:
+            files.append(p)
+    total = 0
+    all_funs = []  # (file, name, lineno, sig, annotated, generic)
+    for f in files:
+        violations, fun_decls = check_file(f, funs=args.funs)
+        for lineno, sig in violations:
+            print(f"{f.relative_to(root)}:{lineno}: no return-type annotation: {sig}")
+            total += 1
+        for name, lineno, sig, annotated, generic in fun_decls:
+            all_funs.append((f, name, lineno, sig, annotated, generic))
+    if args.funs:
+        counts = {}
+        for _, name, *_ in all_funs:
+            counts[name] = counts.get(name, 0) + 1
+        for f, name, lineno, sig, annotated, generic in all_funs:
+            if counts[name] >= 2 and generic and not annotated:
+                print(f"{f.relative_to(root)}:{lineno}: overloaded generic fun "
+                      f"without return annotation: {sig}")
+                total += 1
+    if total:
+        print(f"\n{total} unannotated declaration(s). The return annotation is "
+              f"a viability filter (FB-007 near-miss); annotate the exact type "
+              f"or a fresh-var form like ': 't9 [+]' / ': ('t9 ...)'.")
+        return 1
+    print("lint_op_returns: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
…rs + CI lint

Follow-up to the hotfix-1 near-miss (FB-007): a generic operator without a return annotation returns a free var that unifies with ANY expected type, staying viable at under-constrained call sites (free fold/recursion accumulators) where the env-order fallback can hand it the call. Every generic operator in the stdlib now annotates its return type -- exact where the signature pins it (': bool' / ': int' / ': 't list' / ': t' / ': void' for compound assigns), fresh-var otherwise (': 't3 [+]', ': ('t3 ...)', ': 't3 vector' -- 'returns SOME array/tuple/vector'):
  Array.fx 58, Builtins.fx 23, Vector.fx 18, Date.fx 6, Deque.fx 1.

New tools/lint_op_returns.py (stdlib-python-only, same rule as fxtest) enforces this on CI (<1s, gcc leg): scans operator declarations, fails on an unannotated one. Its --funs mode is the worklist for the NEXT sweep: 276 overloaded generic FUNCTIONS without return annotations (string x17, elemtype, size, print, EXPECT_NEAR, norm*, min/max, ... across Builtins/UTest/Array/Math/OpenCV/Map/Set) -- not yet CI-gated.

Golden 207 re-recorded (candidate signatures now show concrete/fresh-var return types instead of <unknown>).

Verified: compiler self-typecheck OK, bootstrap at clean fixpoint (zero churn -- annotations on uninstantiated generics emit no C), test_all 136/136, fxtest all, determinism, sanitize, vision_classify, census unchanged (343 ranked + 7 fallbacks + 0 errors).