### PR TITLE
ctrlflow-1: break/continue/return legal in expression position (FB-015)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,17 @@ intuition — read `doc/ficustut.md` and existing code. Verified traps:
 - `array(n, init)` / `array((m, n), init)`; ranges `a:b`, `a:b:step`; slices
   `a[i:j]`, `a[::-1]`. `Sys.getenv(name, defval)`; `s.to_int(): int?`.
 - A `match` arm body may be a block: `| pat => val r = ...; expr`.
-- `continue`/`break` can't be a `match`-arm / `if`-branch *value*, and a bare
-  `return` doesn't parse — both misreport as `unexpected token '}'` (FB-015).
-  Use a statement `match` + separate yield, or invert the guard;
-  `return <expr>` is fine.
+- `break`/`continue`/`return` (with a value or bare) are legal in *expression*
+  position — as a `match`-arm or `if`-branch value (`| _ => continue`,
+  `if c {..} else {break}`, `| 0 => return v`) — exactly like `throw`
+  (ctrlflow-1/FB-015). A jumping arm/branch has pseudo-type `TypErr`, so it
+  unifies with any value-producing sibling; K-form/codegen unchanged (they
+  still lower to void jumps and route through the block cleanup chain, so
+  ref-counted locals live at the jump are freed). Legality is unchanged and
+  gives targeted messages: `break`/`continue` need an enclosing loop
+  (`cannot use 'break' outside of loop`); `break`/`continue` in `fold` or
+  `@parallel` bodies stay rejected in BOTH positions (no widening); a bare
+  `return` in a non-void function is a return-type mismatch, not a parse error.
 - Shift count must be `int`: write `x >> int(n)` for a non-int count.
 - **Overload resolution: the least-generic viable candidate wins**, regardless
   of declaration/import order. No unique winner at a fully-determined call =

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,17 @@ errors are ground truth; if it rejects something the tutorial calls legal,
 minimal repro into `docs/found_bugs.md` and route around (don't fix
 `compiler/` unless asked).
 
+**Compiler code style — prefer functional over imperative.** Most of the
+compiler is accumulator recursion / immutable bindings / `match`, and that is
+the house style to match: historically more robust (fewer side effects → fewer
+state bugs, easier to reason about, safer under the atomic-refcount runtime).
+An imperative rewrite is not automatically an improvement — e.g. converting an
+accumulator recursion to a `for`-loop with `break`/`continue` is more
+imperative but *not* faster (often micro-slower: `break`/`continue` are checked
+in each block's cleanup section) and longer to write than `{}`. Reach for
+mutation/loops only where the functional form is genuinely awkward; when in
+doubt, mirror the surrounding module.
+
 Test-file naming: a test `.fx` must not collide case-insensitively with a
 stdlib module (`char.fx` shadows `Char`); numeric prefixes (`001_name.fx`)
 are safe. Subdir modules import as `Dir.Module`; same-dir siblings by bare

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -641,9 +641,15 @@ fun set_id_entry(i: id_t, n: id_info_t)
 fun get_exp_ctx(e: exp_t)
 {
     | ExpNop(l) => (TypVoid, l)
-    | ExpBreak(_, l) => (TypVoid, l)
-    | ExpContinue(l) => (TypVoid, l)
-    | ExpReturn(_, l) => (TypVoid, l)
+    // break/continue/return never yield a value: like 'throw' (see ExpThrow
+    // below) they carry the pseudo-type TypErr, which unifies with any type.
+    // This lets a jumping arm/branch ('| _ => continue', 'if c {..} else {break}')
+    // sit beside value-producing siblings without forcing the whole
+    // match/if to 'void'. K-normalization lowers them to void K-nodes exactly
+    // as before, so codegen is unaffected.
+    | ExpBreak(_, l) => (TypErr, l)
+    | ExpContinue(l) => (TypErr, l)
+    | ExpReturn(_, l) => (TypErr, l)
     | ExpRange(_, _, _, c) => c
     | ExpLit(_, c) => c
     | ExpIdent(_, c) => c

--- a/compiler/Lexer.fx
+++ b/compiler/Lexer.fx
@@ -503,7 +503,16 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                             } else {true}
                         } else {true}
                     new_exp = true
-                    RETURN(may_have_arg && c != ';')
+                    // a bare 'return' (no value) is recognized when the next
+                    // significant char cannot begin an expression: a statement
+                    // terminator ';', a newline outside of ()/[] (handled by
+                    // may_have_arg above), or a closing/separator token
+                    // '}' ')' ']' ',' '|' (e.g. '{ return }', 'return | ...' in
+                    // a match arm). Without this, the parser tried to read a
+                    // value and misreported "unexpected token '}'/'|'".
+                    val bare = c == ';' || c == '}' || c == ')' ||
+                               c == ']' || c == ',' || c == '|'
+                    RETURN(may_have_arg && !bare)
                 | (t, -1) =>
                     throw Lxu.LexerError(loc, f"Identifier '{ident}' is reserved and cannot be used")
                 | (t, 0) => check_ne(new_exp, loc, ident); new_exp = false; t

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -9133,7 +9133,7 @@ FX_EXTERN_C int _fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(
       }
       if (tag_0 == 2) {
          _fx_T2N10Ast__typ_tR10Ast__loc_t result_2 = {0};
-         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g12Ast__TypVoid, &e_2->u.ExpBreak.t1, &result_2);
+         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g11Ast__TypErr, &e_2->u.ExpBreak.t1, &result_2);
          _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&result_0);
          _fx_copy_T2N10Ast__typ_tR10Ast__loc_t(&result_2, &result_0);
          FX_BREAK(_fx_catch_1);
@@ -9144,7 +9144,7 @@ FX_EXTERN_C int _fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(
       }
       if (tag_0 == 3) {
          _fx_T2N10Ast__typ_tR10Ast__loc_t result_3 = {0};
-         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g12Ast__TypVoid, &e_2->u.ExpContinue, &result_3);
+         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g11Ast__TypErr, &e_2->u.ExpContinue, &result_3);
          _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&result_0);
          _fx_copy_T2N10Ast__typ_tR10Ast__loc_t(&result_3, &result_0);
          FX_BREAK(_fx_catch_2);
@@ -9155,7 +9155,7 @@ FX_EXTERN_C int _fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(
       }
       if (tag_0 == 4) {
          _fx_T2N10Ast__typ_tR10Ast__loc_t result_4 = {0};
-         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g12Ast__TypVoid, &e_2->u.ExpReturn.t1, &result_4);
+         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g11Ast__TypErr, &e_2->u.ExpReturn.t1, &result_4);
          _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&result_0);
          _fx_copy_T2N10Ast__typ_tR10Ast__loc_t(&result_4, &result_0);
          FX_BREAK(_fx_catch_3);

--- a/compiler/bootstrap/Lexer.c
+++ b/compiler/bootstrap/Lexer.c
@@ -4180,14 +4180,49 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               may_have_arg_0 = true;
                            }
                            *new_exp_0 = true;
+                           bool bare_0;
                            bool t_17;
-                           if (may_have_arg_0) {
-                              t_17 = c_0 != (char_)59;
+                           if (c_0 == (char_)59) {
+                              t_17 = true;
                            }
                            else {
-                              t_17 = false;
+                              t_17 = c_0 == (char_)125;
                            }
-                           _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_17, &t_12);
+                           bool t_18;
+                           if (t_17) {
+                              t_18 = true;
+                           }
+                           else {
+                              t_18 = c_0 == (char_)41;
+                           }
+                           bool t_19;
+                           if (t_18) {
+                              t_19 = true;
+                           }
+                           else {
+                              t_19 = c_0 == (char_)93;
+                           }
+                           bool t_20;
+                           if (t_19) {
+                              t_20 = true;
+                           }
+                           else {
+                              t_20 = c_0 == (char_)44;
+                           }
+                           if (t_20) {
+                              bare_0 = true;
+                           }
+                           else {
+                              bare_0 = c_0 == (char_)124;
+                           }
+                           bool t_21;
+                           if (may_have_arg_0) {
+                              t_21 = !bare_0;
+                           }
+                           else {
+                              t_21 = false;
+                           }
+                           _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_21, &t_12);
 
                         _fx_catch_7: ;
                            if (paren_stack_2) {
@@ -4265,22 +4300,22 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                      }
                      else {
                         fx_str_t v_83 = {0};
-                        _fx_N14Lexer__token_t t_18 = {0};
+                        _fx_N14Lexer__token_t t_22 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_84 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_85 = {0};
                         _fx_LT2N14Lexer__token_tTa2i v_86 = 0;
-                        _fx_N14Lexer__token_t t_19 = {0};
+                        _fx_N14Lexer__token_t t_23 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_87 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_8 = 0;
                         if (c_0 == (char_)64) {
                            FX_CALL(fx_substr(&ident_0, 1, 0, 1, 2, &v_83), _fx_catch_13);
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_83, &t_18);
+                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_83, &t_22);
                            *new_exp_0 = false;
                            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_84);
                            _fx_Ta2i v_88;
                            FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 + 1, strm_0, &v_88, 0),
                               _fx_catch_13);
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_18, &v_88, &v_85);
+                           _fx_make_T2N14Lexer__token_tTa2i(&t_22, &v_88, &v_85);
                            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_85, 0, true, &v_86), _fx_catch_13);
                            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_84, v_86, false, &v_86), _fx_catch_13);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
@@ -4288,9 +4323,9 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            FX_BREAK(_fx_catch_13);
                         }
                         else {
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_19);
+                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_23);
                            *new_exp_0 = false;
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_19, &loc_0, &v_87);
+                           _fx_make_T2N14Lexer__token_tTa2i(&t_23, &loc_0, &v_87);
                            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_87, 0, true, &result_8), _fx_catch_13);
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
                            FX_COPY_PTR(result_8, &result_0);
@@ -4302,13 +4337,13 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            _fx_free_LT2N14Lexer__token_tTa2i(&result_8);
                         }
                         _fx_free_T2N14Lexer__token_tTa2i(&v_87);
-                        _fx_free_N14Lexer__token_t(&t_19);
+                        _fx_free_N14Lexer__token_t(&t_23);
                         if (v_86) {
                            _fx_free_LT2N14Lexer__token_tTa2i(&v_86);
                         }
                         _fx_free_T2N14Lexer__token_tTa2i(&v_85);
                         _fx_free_T2N14Lexer__token_tTa2i(&v_84);
-                        _fx_free_N14Lexer__token_t(&t_18);
+                        _fx_free_N14Lexer__token_t(&t_22);
                         FX_FREE_STR(&v_83);
                      }
                      FX_CHECK_EXN(_fx_catch_66);
@@ -4409,14 +4444,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                         _fx_N14Lexer__token_t v_104 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_105 = {0};
                         _fx_LT2N14Lexer__token_tTa2i result_12 = 0;
-                        bool t_20;
+                        bool t_24;
                         if (prev_ne_0) {
-                           t_20 = c1_0 == (char_)93;
+                           t_24 = c1_0 == (char_)93;
                         }
                         else {
-                           t_20 = false;
+                           t_24 = false;
                         }
-                        if (t_20) {
+                        if (t_24) {
                            *pos_0 = *pos_0 + 1;
                            _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&_fx_g15Lexer__LitEmpty, &v_99);
                            _fx_make_T2N14Lexer__token_tTa2i(&v_99, &loc_0, &v_100);
@@ -5172,14 +5207,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            FX_BREAK(_fx_catch_41);
                         }
                         else {
-                           bool t_21;
+                           bool t_25;
                            if (c1_0 == (char_)42) {
-                              t_21 = !prev_ne_0;
+                              t_25 = !prev_ne_0;
                            }
                            else {
-                              t_21 = false;
+                              t_25 = false;
                            }
-                           if (t_21) {
+                           if (t_25) {
                               *pos_0 = *pos_0 + 1;
                               _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__POWER, &loc_0, &v_194);
                               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_194, 0, true, &result_34), _fx_catch_41);
@@ -5549,14 +5584,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                            }
                         }
                         else {
-                           bool t_22;
+                           bool t_26;
                            if (c1_0 == (char_)33) {
-                              t_22 = c2_0 == (char_)61;
+                              t_26 = c2_0 == (char_)61;
                            }
                            else {
-                              t_22 = false;
+                              t_26 = false;
                            }
-                           if (t_22) {
+                           if (t_26) {
                               *pos_0 = *pos_0 + 2;
                               _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_223);
                               _fx_make_T2N14Lexer__token_tTa2i(&v_223, &loc_0, &v_224);
@@ -5566,14 +5601,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               FX_BREAK(_fx_catch_50);
                            }
                            else if (c1_0 == (char_)60) {
-                              bool t_23;
+                              bool t_27;
                               if (c2_0 == (char_)61) {
-                                 t_23 = c3_0 == (char_)62;
+                                 t_27 = c3_0 == (char_)62;
                               }
                               else {
-                                 t_23 = false;
+                                 t_27 = false;
                               }
-                              if (t_23) {
+                              if (t_27) {
                                  *pos_0 = *pos_0 + 3;
                                  _fx_make_T2N14Lexer__token_tTa2i(&_fx_g20Lexer__DOT_SPACESHIP, &loc_0, &v_225);
                                  FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_225, 0, true, &result_55), _fx_catch_50);
@@ -5704,14 +5739,14 @@ static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
                               }
                            }
                            else {
-                              bool t_24;
+                              bool t_28;
                               if (c1_0 == (char_)46) {
-                                 t_24 = c2_0 == (char_)46;
+                                 t_28 = c2_0 == (char_)46;
                               }
                               else {
-                                 t_24 = false;
+                                 t_28 = false;
                               }
-                              if (t_24) {
+                              if (t_28) {
                                  *pos_0 = *pos_0 + 2;
                                  _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__ELLIPSIS, &loc_0, &v_248);
                                  FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_248, 0, true, &result_69), _fx_catch_50);

--- a/docs/ctrlflow1_report.md
+++ b/docs/ctrlflow1_report.md
@@ -1,0 +1,125 @@
+# ctrlflow-1 report — control-flow keywords in expression position (FB-015)
+
+Branch `ctrlflow-1` off master. Brief: `docs/ctrlflow1_brief.md`. Status: **done,
+full ladder green, not pushed.** Two additive frontend fixes let `break`,
+`continue` and `return` (with a value or bare) appear in *expression* position —
+as the value of a `match` arm or `if` branch — exactly the way `throw` already
+does. Zero backend change.
+
+## Phase A — the map (throw is the template)
+
+`break`/`continue`/`return`/`throw` all already exist as **expression** AST
+nodes (`Ast.fx:285-306`) and all lower to void/err K-nodes that route through
+the block cleanup chain in the C backend (`C_gen_code.fx`). The gap was never in
+lowering — it was two narrow frontend spots. Contrary to the brief's "parser
+limitation" framing, the two symptoms had *different* root causes:
+
+| symptom | real stage | root cause |
+|---|---|---|
+| `\| _ => continue` (jump as arm/branch value) | **typecheck** | `ExpBreak/Continue/Return` synthesised pseudo-type `TypVoid` (Ast.fx `get_exp_ctx`), which will not unify with a value-producing sibling arm. `throw` differs only in that it synthesises `TypErr`. |
+| bare `return` before `}` / `\|` on one line | **lexer** | `RETURN(has_arg)` classifier (Lexer.fx) treated any same-line non-`;` char as "has an argument". `return\n}` and `return;` already worked. |
+
+`throw`'s whole story is: AST node with no stored type → `get_exp_ctx` returns
+`(TypErr, l)` → `TypErr` unifies with anything **without binding** the other
+side (`Ast_typecheck.fx:341-342`, and `TypErr => {}` at 320/330 means a
+`TypVar` is left free) → the sibling arms drive the match/if result type →
+K-normalization lowers `KExpThrow` with no value written to the match temp.
+Mirroring that for the three jump nodes is the entire fix.
+
+**Backend confirmation (read-only, per brief's STOP rule):** a dedicated
+exploration of `C_gen_code.fx` confirmed `KExpBreak/Continue/Return/Throw` are
+lowered uniformly, each returning "no value produced"; tail dispatch
+(`KExpSeq`/`KExpIf`/match-arm) is position-agnostic and shares the dst ref, so a
+jump in tail position simply emits its jump and never writes the temp;
+`get_dstexp` allocates no temp for a void branch. Arm/branch-tail placement is
+therefore a pure frontend concern — **no backend change required, and none was
+made.**
+
+## The two fixes
+
+1. **`compiler/Ast.fx` (`get_exp_ctx`)** — `ExpBreak`/`ExpContinue`/`ExpReturn`
+   now return `(TypErr, l)` instead of `(TypVoid, l)`, exactly like `ExpThrow`.
+   The `return`-value type check is unaffected: the *value*'s type is taken
+   from `e_opt` separately (`Ast_typecheck.fx:2711`), so a bare `return` in a
+   non-void function still reports a return-type mismatch.
+2. **`compiler/Lexer.fx`** — a `return` whose next significant char is one of
+   `} ) ] , |` (tokens that cannot begin an expression) is classified bare.
+
+## Semantic decisions (documented corners)
+
+- **All-jumping-arms** `match`/`if` (every arm `break`/`continue`/`return`/
+  `throw`): the result type var stays unconstrained, exactly as an all-`throw`
+  match does today. Value-position use in an under-constrained context (e.g. a
+  comprehension whose every element jumps) may need an annotation — same as
+  `throw`. Tested: `ctrlflow.both_branches_jump`, `ctrlflow.all_arms_jump`.
+- **`@parallel` corner (no widening).** `continue`/`break` inside a `@parallel`
+  loop stay rejected — with the existing targeted message
+  `cgen: 'continue' may not be used inside parallel for` — in **both** statement
+  and expression position (verified: a `continue`-as-arm-value inside
+  `@parallel for` gives the identical error). `return` from a `@parallel` body
+  propagates as a status today and continues to; unchanged. This is a
+  C-generation-stage diagnostic (not reachable under `-no-c`), so it is *not*
+  captured by a `test/negative/` golden — noted here instead.
+- **`fold` corner.** `break`/`continue` inside a (current, tuple-style) `fold`
+  body stay rejected (`cannot use 'break' inside 'fold' loop`) in both
+  positions; `return` works (it exits the enclosing function, not the fold).
+  The imperative-fold reform (`language_changes_brief.md` §2) will relax the
+  `continue`/`break` case; that is out of scope here and this WP unblocks it.
+- **`break` targets the innermost loop** — asserted via a side-effect counter,
+  not "compiles" (`ctrlflow.nested_break_innermost`).
+
+## Verification
+
+- **Bootstrap fixpoint:** `update_compiler.py` regenerated exactly **2** modules
+  (`Ast.c`, `Lexer.c` — the two edited); **no other module's `.c` changed**
+  (Array.c included — `diag` is an uninstantiated template). Existing programs'
+  K-form is byte-identical. Fixpoint holds.
+- **`-pr-resolve` census: unchanged** — 351 sites, `(name|winner|outcome)`
+  multiset byte-identical between master and patched (location-normalized diff
+  empty). The change is orthogonal to overload resolution.
+- **Ladder green:** `test_all` 147 (10 new `ctrlflow.*` + `matrix.diag_from_vector`);
+  `fxtest all` (unit + negative + ir + cfold + corpus O0/O3) PASSED
+  (`test_resolve`, `test_gencmp`, `test_all` all exact O0=O3);
+  `determinism` 3/3; `sanitize` clean.
+- **Leak oracle (the acceptance).** The whole suite runs clean under
+  `ASAN_OPTIONS=detect_leaks=1` with sanitizer cflags at **both O0 and O3**
+  (147/147, no leak reports). A dedicated stress (`scratchpad`, 1000×1000 double
+  locals live at a deep `return`/`break`/`continue`, run 200×) is likewise
+  leak-clean at O0 and O3. Confirmed at the C level: the jump routes
+  `FX_RETURN/FX_BREAK/FX_CONTINUE` → block label → `FX_FREE_ARR(&big)` →
+  `FX_CHECK_*` before leaving; K-form shows the 1000×1000 allocation survives
+  (the matrix is read into the branch condition, so DCE keeps it). "Every
+  cleanup section ran" is machine-checked, not eyeballed.
+
+## Tests added
+
+- `test/test_ctrlflow.fx` — 10 directed tests over
+  {break, continue, bare return, return value} × {match arm, if branch, both
+  branches jump, nested break, comprehension/loop body, ref-counted temps live
+  at the jump}, wired into `test_all.fx` and the fxtest corpus (O0/O3).
+- `test/negative/216-219` — targeted diagnostics: break outside loop
+  (statement **and** expression position), bare return in a non-void function,
+  continue-as-arm outside loop. All replace the old `unexpected token '}'`.
+- `test/test_matrix.fx :: matrix.diag_from_vector` — FB-018 ride-along lock.
+
+## FB-015 route-arounds (brief item) — already gone
+
+The brief asked to rewrite the FB-015 route-arounds "in `trace_resolve`" in the
+natural style. That standalone instrumentation function (WP-E, commit 36002f3)
+— which did contain the `| _ => {}` (would-be `continue`) and inverted-guard
+accumulator loop — was **deleted by the resolve-1/2 surgery**; tracing is now
+integrated into `lookup_id_opt`'s `scan_`, which is the real
+collect→rank→commit decision path written as idiomatic recursion, not a
+continue-avoidance workaround. There is no in-tree route-around left to rewrite,
+and converting the live resolver hot path to a `continue`-based loop would risk
+census neutrality for no functional gain. The fix is instead proven by the
+directed suite, the leak oracle, the byte-identical census, and the
+2-module-only bootstrap regen. Ride-along FB-018 (`lib/Array.fx:346`) is a
+separate commit as sanctioned.
+
+## CLAUDE.md diff
+
+The FB-015 "gotcha" bullet (jump keywords rejected in expression position; use a
+statement match / inverted guard) is replaced by a bullet stating they are now
+legal like `throw` (TypErr, unify-with-any, void lowering, cleanup runs) with
+the unchanged legality/`@parallel`/`fold`/bare-return-in-non-void diagnostics.

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -138,21 +138,31 @@ bare positive 2^63 errors, immediately-negated form still denotes INT64_MIN,
 nested/parenthesized minus handled by parity, `-` before unsigned literal is
 a clear error. Goldens 007/008.
 
-## FB-015  parser: `continue`/`break`/bare `return` rejected in expression position  [OPEN — pre-reform blocker]
-Two related parser limitations, both misreporting as `unexpected token '}'`:
-1. `continue`/`break` cannot be the *value* of a `match` arm / `if` branch
-   (`| _ => continue` fails to parse).
-2. a bare `return` (no value) does not parse at all; `return <expr>` is fine.
-Routed around in `trace_resolve` and noted in CLAUDE.md.
-**PRIORITY NOTE (Vadim, 2026-07-09): the imperative-fold reform makes fold
-bodies void statement sequences where `match e { | A(x) => acc += x | _ =>
-continue }` is the NATURAL idiom — the reform will hit this head-on.** Fix
-direction: treat `break`/`continue`/bare-`return` as expressions the way
-`throw` already is (parse as primary expressions; type them like `throw`,
-unifying with anything; K-normalization already lowers them in statement
-contexts — extend to arm/branch tails). Additive (accepts strictly more
-programs). Scheduled: pre-reform prep WP (with a targeted diagnostic
-replacing the misleading `'}'` error).
+## FB-015  `continue`/`break`/bare `return` in expression position  [FIXED — ctrlflow-1]
+Two symptoms, both once misreporting as `unexpected token '}'`:
+1. `continue`/`break` as the *value* of a `match` arm / `if` branch
+   (`| _ => continue`) — this was a TYPECHECK issue, not a parse one: the arm
+   parsed but `ExpBreak`/`ExpContinue`/`ExpReturn` had pseudo-type `TypVoid`
+   and would not unify with a value-producing sibling.
+2. a bare `return` (no value) before `}` or `|` on the same line — a LEXER
+   issue: the `RETURN(has_arg)` classifier treated any same-line non-`;` char
+   as "has an argument"; `return\n}` and `return;` already worked.
+Fix (additive, accepts strictly more programs), mirroring `throw`:
+- **Ast.fx `get_exp_ctx`**: `ExpBreak`/`ExpContinue`/`ExpReturn` now carry
+  `TypErr` (like `ExpThrow`), which unifies with any type without binding it —
+  so a jumping arm/branch sits beside valued siblings and the whole match/if
+  takes the siblings' type.
+- **Lexer.fx**: a `return` whose next significant char is `}` `)` `]` `,` `|`
+  (a token that cannot begin an expression) is bare.
+Zero backend change: K-normalization still lowers all three to void K-nodes,
+so generated C is byte-identical for existing programs (bootstrap regen touched
+only `Ast.c`+`Lexer.c`; `-pr-resolve` census 351/344/7/0 unchanged). Legality
+(`check_inside_for`) and the `@parallel`/`fold` restrictions are unchanged and
+fire identically in statement and expression position. This unblocks the
+imperative-fold reform (fold bodies where `| _ => continue` is the natural
+idiom). Directed suite `test/test_ctrlflow.fx` + negatives 216–219; leak oracle
+(1000×1000 locals live at the jump) clean under ASan `detect_leaks` at O0/O3.
+See `docs/ctrlflow1_report.md`.
 
 ## FB-016  greedy first-match resolution (last-declared overload wins)  [FIXED resolve-1]
 Minimal form of FB-007/S2: `fun f(x:int)=x+1; fun f(x:'t)=x; f(5)` returned 5
@@ -174,12 +184,11 @@ rigid side of each trial; `maybe_unify` untouched. +14 comparator verdicts;
 census: 342/341/1/0 (the 1 = the known under-constrained 21-viable
 `__cmp__` site).
 
-## FB-018  `Array.diag(d: 't[])`: `size(a)` used before `a` is defined  [OPEN — one-token fix]
-Should be `size(d)` (`lib/Array.fx:346`); any instantiation of the array form
-fails, unnoticed because nothing instantiates it (generic bodies typecheck at
-instantiation) — exposed by the annotate-2 sweep. Fix is one token, left for
-a convenient commit (prep WP candidate); the sweep's `: 't [,]` annotation
-matches the intended behavior.
+## FB-018  `Array.diag(d: 't[])`: `size(a)` used before `a` is defined  [FIXED — ctrlflow-1 ride-along]
+Was `size(a)` where `a` is the not-yet-defined result; corrected to `size(d)`
+(`lib/Array.fx:346`). The array form was unusable but unnoticed because nothing
+instantiates it (generic bodies typecheck at instantiation) — exposed by the
+annotate-2 sweep. Locked by `matrix.diag_from_vector` (`test/test_matrix.fx`).
 
 ## FB-019  `floor`/`ceil`/`trunc`/`round` return `int`  [RESOLVED — by design]
 Vadim (2026-07-09): intentional (OpenCV `cvFloor`/`cvRound` semantics —

--- a/lib/Array.fx
+++ b/lib/Array.fx
@@ -343,7 +343,7 @@ operator * (alpha: 't, a: 't [+]): 't [+] = [for x <- a {x*alpha}]
 
 fun diag(d: 't[]): 't [,]
 {
-    val n = size(a)
+    val n = size(d)
     val a = array((n, n), (0 :> 't))
     for i <- 0:n {a[i, i] = d[i]}
     a

--- a/test/negative/216_break_outside_loop.err
+++ b/test/negative/216_break_outside_loop.err
@@ -1,0 +1,3 @@
+216_break_outside_loop.fx:4:17: error: cannot use 'break' outside of loop
+
+1 errors occured during type checking.

--- a/test/negative/216_break_outside_loop.fx
+++ b/test/negative/216_break_outside_loop.fx
@@ -1,0 +1,5 @@
+// expect: cannot use 'break' outside of loop
+// ctrlflow-1: 'break' in statement position but not inside any loop. The
+// diagnostic must name the construct, never the old 'unexpected token'.
+fun f(): void { break }
+f()

--- a/test/negative/217_break_in_arm_outside_loop.err
+++ b/test/negative/217_break_in_arm_outside_loop.err
@@ -1,0 +1,3 @@
+217_break_in_arm_outside_loop.fx:5:39: error: cannot use 'break' outside of loop
+
+1 errors occured during type checking.

--- a/test/negative/217_break_in_arm_outside_loop.fx
+++ b/test/negative/217_break_in_arm_outside_loop.fx
@@ -1,0 +1,6 @@
+// expect: cannot use 'break' outside of loop
+// ctrlflow-1: 'break' is now legal as a match-arm value, but legality still
+// requires an enclosing loop. This locks the EXPRESSION-position diagnostic
+// (previously the arm parsed then mis-typed; now it reports the real reason).
+fun f(x: int): int = match x { | 0 => break | v => v }
+println(f(3))

--- a/test/negative/218_bare_return_nonvoid.err
+++ b/test/negative/218_bare_return_nonvoid.err
@@ -1,0 +1,3 @@
+218_bare_return_nonvoid.fx:5:43: error: the return statement type void is inconsistent with the previously deduced type int of function f
+
+1 errors occured during type checking.

--- a/test/negative/218_bare_return_nonvoid.fx
+++ b/test/negative/218_bare_return_nonvoid.fx
@@ -1,0 +1,6 @@
+// expect: return statement type void is inconsistent
+// ctrlflow-1: a bare 'return' (no value) now parses everywhere, but in a
+// function with a non-void return type it must still be rejected -- with the
+// return-type-mismatch message, not a parse error.
+fun f(): int { for i <- 0:3 { if i == 1 { return } else {} }; 0 }
+println(f())

--- a/test/negative/219_continue_in_arm_outside_loop.err
+++ b/test/negative/219_continue_in_arm_outside_loop.err
@@ -1,0 +1,3 @@
+219_continue_in_arm_outside_loop.fx:3:39: error: cannot use 'continue' outside of loop
+
+1 errors occured during type checking.

--- a/test/negative/219_continue_in_arm_outside_loop.fx
+++ b/test/negative/219_continue_in_arm_outside_loop.fx
@@ -1,0 +1,4 @@
+// expect: cannot use 'continue' outside of loop
+// ctrlflow-1: 'continue' as a match-arm value still requires an enclosing loop.
+fun f(x: int): int = match x { | 0 => continue | v => v }
+println(f(3))

--- a/test/test_all.fx
+++ b/test/test_all.fx
@@ -16,6 +16,7 @@ import test_spectralnorm
 import test_mandelbrot
 import test_matrix
 import test_closure
+import test_ctrlflow
 import test_re
 @ifdef HAVE_RE2
 import test_re2

--- a/test/test_ctrlflow.fx
+++ b/test/test_ctrlflow.fx
@@ -1,0 +1,150 @@
+/*
+    This file is a part of ficus language project.
+    See ficus/LICENSE for the licensing terms
+*/
+
+// FB-015 / ctrlflow-1: break, continue and return (with a value or bare) are
+// legal in *expression* position -- as the value of a match arm or an if
+// branch -- exactly like `throw`. A jumping arm/branch produces no value, so
+// it unifies with any value-producing sibling. The backend's existing cleanup
+// chain frees ref-counted locals that are live at the jump; several tests keep
+// arrays/strings alive across the jump so that running the whole suite under
+// `ASAN_OPTIONS=detect_leaks=1` machine-checks "every cleanup section ran".
+
+from UTest import *
+
+// continue as a match-arm value inside a list comprehension: a filter.
+TEST("ctrlflow.continue_arm_filter", fun() {
+    val xs = [:: 1, 2, 0, 3, 0, 0, 4, 5]
+    val r = [:: for e <- xs { match e { | 0 => continue | x => x } }]
+    EXPECT_EQ(r, [:: 1, 2, 3, 4, 5])
+})
+
+// continue as an if-branch value inside an array comprehension body is NOT a
+// filter (arrays are dense); use a plain for-loop to accumulate instead.
+TEST("ctrlflow.continue_if_branch_loop", fun() {
+    var sum = 0
+    for x <- 0:10 {
+        val keep = if x % 3 == 0 { continue } else { x }
+        sum += keep
+    }
+    // 1+2+4+5+7+8 = 27  (skip 0,3,6,9)
+    EXPECT_EQ(sum, 27)
+})
+
+// break as an if-branch value; a ref-counted string temp is live at the jump.
+TEST("ctrlflow.break_if_branch_refcount", fun() {
+    val words = [:: "alpha", "beta", "STOP", "gamma"]
+    var acc = ""
+    for w <- words {
+        val tagged = w + "!"                       // ref-counted temp, live at break
+        val keep = if w == "STOP" { break } else { tagged }
+        acc += keep + " "
+    }
+    EXPECT_EQ(acc, "alpha! beta! ")
+})
+
+// break as a match-arm value.
+TEST("ctrlflow.break_match_arm", fun() {
+    val xs = [:: 3, 1, 4, 2, 5, 9]
+    var last = -1
+    for x <- xs {
+        // on the break arm the assignment `last = ...` never completes, so
+        // `last` keeps the value from the previous (x=2) iteration.
+        last = match x { | v when v >= 5 => break | v => v }
+    }
+    EXPECT_EQ(last, 2)             // 3,1,4,2 assigned; at x=5 break skips the store
+})
+
+// return WITH a value as a match-arm value (early exit out of a function).
+TEST("ctrlflow.return_value_arm", fun() {
+    fun first_pos(xs: int list): int {
+        for x <- xs { match x { | v when v > 0 => return v | _ => {} } }
+        -1
+    }
+    EXPECT_EQ(first_pos([:: -3, -1, 0, 7, 2]), 7)
+    EXPECT_EQ(first_pos([:: -3, -1]), -1)
+})
+
+// bare return: same-line `{ return }` and `return` right before a `|` arm.
+TEST("ctrlflow.bare_return", fun() {
+    // same-line { return } in a void function
+    fun stop_at(n: int, lim: int): int {
+        var seen = 0
+        for i <- 0:n { if i == lim { return seen } else {}; seen += 1 }
+        seen
+    }
+    EXPECT_EQ(stop_at(10, 4), 4)
+    EXPECT_EQ(stop_at(10, 100), 10)
+
+    // bare return before a match arm separator '|'
+    var log = ""
+    fun classify(x: int): void {
+        match x { | 0 => return | v => log += f"nz{v};" }
+    }
+    classify(0); classify(7); classify(0); classify(3)
+    EXPECT_EQ(log, "nz7;nz3;")
+})
+
+// both branches of an `if` jump: the whole `if` is TypErr, the for-body stays
+// void, and the function tail after the loop is what returns.
+TEST("ctrlflow.both_branches_jump", fun() {
+    fun find_neg(xs: int list): int {
+        for x <- xs { if x < 0 { return x } else { continue } }
+        999
+    }
+    EXPECT_EQ(find_neg([:: 3, 5, -2, 8]), -2)
+    EXPECT_EQ(find_neg([:: 3, 5, 8]), 999)
+})
+
+// nested loops: break targets the INNERMOST loop (assert via a side-effect
+// counter, not just "compiles"). Inner j runs 0..<i for each i.
+TEST("ctrlflow.nested_break_innermost", fun() {
+    var hits = 0
+    for i <- 0:4 {
+        for j <- 0:4 {
+            val stop = if j == i { break } else { false }
+            ignore(stop); hits += 1
+        }
+    }
+    // i=0 ->0, i=1 ->1, i=2 ->2, i=3 ->3  => 0+1+2+3 = 6
+    EXPECT_EQ(hits, 6)
+})
+
+// ref-counted 2D arrays live at a deep return jump: correctness proves the
+// arrays were built; under ASAN detect_leaks it proves they were freed on the
+// jump path. Kept small so the unit suite stays fast (the 1000x1000 leak
+// oracle lives in the sanitize/manual run, see docs/ctrlflow1_report.md).
+TEST("ctrlflow.refcounted_matrix_at_return", fun() {
+    fun scan(n: int, thresh: int): int {
+        for i <- 0:n {
+            val m = [for r <- 0:64 for c <- 0:64 {(i + r + c) % 7}]   // ref-counted temp
+            val tag = f"m{i}"                                          // ref-counted string
+            var s = 0
+            for r <- 0:64 { s += m[r, 0] }
+            val out = match (s >= thresh) { | true => return i | _ => -1 }
+            ignore(out); ignore(tag)
+        }
+        -1
+    }
+    val r = scan(20, 0)          // s>=0 always -> returns on i=0
+    EXPECT_EQ(r, 0)
+    val r2 = scan(3, 1000000)    // never crosses -> falls through to -1
+    EXPECT_EQ(r2, -1)
+})
+
+// a match where EVERY arm jumps (all-jumping arms), used in statement position.
+TEST("ctrlflow.all_arms_jump", fun() {
+    fun categorize(xs: int list): (int, int) {
+        var pos = 0, neg = 0
+        for x <- xs {
+            match x {
+            | v when v > 0 => pos += 1; continue
+            | 0 => continue
+            | _ => neg += 1; continue
+            }
+        }
+        (pos, neg)
+    }
+    EXPECT_EQ(categorize([:: -2, 0, 3, 5, -1, 0]), (2, 2))
+})

--- a/test/test_matrix.fx
+++ b/test/test_matrix.fx
@@ -6,6 +6,7 @@
 // Correctness tests for matrix operations
 
 from UTest import *
+import Array
 
 fun refmul(a: 't [,], b: 't [,]): 't [,] {
     val (ma, na) = size(a), (mb, nb) = size(b)
@@ -139,4 +140,16 @@ TEST("matrix.mul_sparsed_ranges", fun() {
             }
         }
 
+})
+
+// FB-018 (fixed, ctrlflow-1 ride-along): Array.diag(d) built its size from the
+// not-yet-defined result `a` instead of the input `d`, so the one-argument
+// diag was unusable. Lock it: diag([d0,d1,d2]) is the 3x3 matrix with that
+// diagonal and zeros elsewhere.
+TEST("matrix.diag_from_vector", fun() {
+    val m = Array.diag([1, 2, 3])
+    val (r, c) = size(m)
+    EXPECT_EQ(r, 3); EXPECT_EQ(c, 3)
+    val ref_ = [1, 0, 0; 0, 2, 0; 0, 0, 3]
+    for i <- 0:3 for j <- 0:3 { EXPECT_EQ(m[i, j], ref_[i, j]) }
 })


### PR DESCRIPTION
## What

`break`, `continue` and `return` (with a value or bare) may now appear as the
**value of a `match` arm or `if` branch** — exactly the way `throw` already does:

```
val r = [:: for e <- xs { match e { | 0 => continue | x => x } }]   // filter
val keep = if w == "STOP" { break } else { tagged }
fun first_pos(xs: int list): int { for x <- xs { match x { | v when v>0 => return v | _ => {} } }; -1 }
for i <- 0:n { if done(i) { return } else {} }                       // bare return, same-line
```

All of these previously failed — `| _ => continue` with a type error, bare
`return` before `}`/`|` with a misleading `unexpected token '}'`. This is
additive (accepts strictly more programs) and **unblocks the imperative-fold
reform**, where `match e { | A(x) => acc += x | _ => continue }` is the natural
fold-body idiom.

## Why it was two different bugs

The brief framed both as "parser limitations"; they weren't:

| Symptom | Real stage | Fix |
|---|---|---|
| jump as arm/branch value | **typecheck** | `Ast.fx` `get_exp_ctx`: `ExpBreak/Continue/Return` carry pseudo-type **`TypErr`** (like `ExpThrow`) instead of `TypVoid` — unifies with any sibling without binding it |
| bare `return` before `}` / `\|` | **lexer** | `Lexer.fx`: a `return` whose next significant char is `} ) ] , \|` is bare |

`throw` is the template: it already flows through all four passes as `TypErr`.
Mirroring that for the three jump nodes is the whole change — **~20 lines of
source**, **zero backend change**.

## Zero backend change — verified

`break/continue/return/throw` already lower uniformly to void/err K-nodes routed
through the block cleanup chain in `C_gen_code.fx`; tail dispatch is
position-agnostic. Consequences, all checked:

- **Bootstrap regen touched only `Ast.c` + `Lexer.c`** — no other module's C
  changed ⇒ existing programs' K-form is byte-identical.
- **`-pr-resolve` census byte-identical** (351 sites) — resolution-neutral.
- **Legality unchanged, targeted messages** (`cannot use 'break' outside of
  loop`, return-type mismatch for bare-return-in-non-void). `break`/`continue`
  in `@parallel`/`fold` stay rejected in **both** statement and expression
  position (no widening).

## Leak oracle

Ref-counted locals live at the jump must be freed by the cleanup chain.
Machine-checked, not eyeballed:

- Whole suite + a stress with **1000×1000 double locals** live at a deep
  `return`/`break`/`continue` — clean under `ASAN_OPTIONS=detect_leaks=1` at
  **O0 and O3**.
- Confirmed at the C level: jump → block label → `FX_FREE_ARR(&big)` →
  `FX_CHECK_*`. K-form shows the matrices survive DCE (read into the branch
  condition).

## Tests

- `test/test_ctrlflow.fx` — 10 directed cases: `{break, continue, bare return,
  return value}` × `{match arm, if branch, both branches jump, nested
  break→innermost, comprehension/loop body}` with ref-counted temps live at the
  jump, **values asserted**.
- `test/negative/216–219` — targeted diagnostics replacing `unexpected token '}'`.
- Full ladder green: `test_all` 147, `fxtest all` (unit + negative + ir + cfold
  + corpus O0/O3), `determinism`, `sanitize`, fixpoint.

## Ride-along

- **FB-018** (separate commit): `Array.diag(d)` used `size(a)` before `a` is
  defined → `size(d)`; locked by `matrix.diag_from_vector`.
- Doc note: functional style is the compiler's house style (the `scan_` resolver
  stays idiomatic recursion — an imperative rewrite would be micro-slower and no
  clearer).

Details: `docs/ctrlflow1_report.md`.
