### PR TITLE
diag-1: type-error recovery, multiple diagnostics, caret rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,24 @@ Layers: T2 corpus differential (O0 vs O3), T3 golden diagnostics
 Harness is Python-3-stdlib-only. Compiler bugs found while on another task are
 recorded and fenced (not fixed) in `docs/found_bugs.md`.
 
+**Diagnostics (diag-1).** The type checker RECOVERS: one run reports many
+independent errors, not just the first. A failed definition/arm/branch is
+reported and its symbol is poisoned with `TypErr` (declared type when
+annotated — the annotation firewall); `typ_has_typerr` then suppresses
+cascades structurally (a `TypErr` operand makes the whole expression `TypErr`
+silently), so `val x = undef; x+1; f(x)` = ONE diagnostic. Reporting: sorted by
+`(module,line,col)`, exact-duplicate primary lines deduped (a generic-body
+error hit from N call sites → once), capped by `-fmax-errors=N` (default 100).
+A not-found name close (Levenshtein) to a visible one gets `did you mean 'x'?`.
+Frontend diagnostics (lexer/parser/typecheck **and K-normalization** — gated by
+`Ast.compiler_stage`, NOT `freeze_ids`) carry a gcc-style caret excerpt; middle/
+backend ones don't (locations drift). The excerpt is built at RAISE time in
+`compile_err`/`compile_warning`. So **every `test/negative/` golden now includes
+the source line + `^`**; the T3 harness compares excerpt lines (`N | src` /
+`  | ^`) verbatim (exact spacing) and collapses whitespace elsewhere — when
+adding a negative case, `--update-golden` captures the caret. New legality
+checks belong in typecheck (caret + `-no-c`-visible), not C-gen.
+
 ## Writing Ficus (.fx) — gotchas
 
 Ficus is underrepresented in training data; don't improvise from OCaml/Rust

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -485,6 +485,19 @@ fun default_module() =
         dm_block_idx=-1
     }
 
+/* Coarse compilation stage, tracked for diagnostic precision (diag-1). It is
+   deliberately separate from `freeze_ids` (which flips at the start of K-form
+   to lock AST id creation): the FRONTEND stage spans lexer + parser + type
+   checker AND K-normalization, because K-normalization still consumes the AST
+   and its source locations are exact -- a good share of errors surface there.
+   Locations only start to drift in the MIDDLE end (K optimizations: inlining,
+   fusion, ...) and the BACKEND (C generation). The diagnostic printer draws a
+   confident caret only while `is_compiler_frontend()` holds. Set by
+   Compiler.process_all around parse_all / k_normalize_all; reset in init_all. */
+type compiler_stage_t = CompilerInit | CompilerFrontend | CompilerMiddle | CompilerBackend
+var compiler_stage = CompilerInit
+fun is_compiler_frontend(): bool = compiler_stage == CompilerFrontend
+
 var freeze_ids = false
 var lock_all_names = 0
 var all_names = Dynvec.create(0, "")
@@ -548,12 +561,65 @@ fun string(i: id_t): string = id2str_(i, false)
 fun pp(i: id_t): string = id2str_(i, true)
 
 fun compile_err(loc: loc_t, msg: string) {
-    val whole_msg = f"{loc}: error: {msg}"
+    // Build the source excerpt HERE, at raise time, not at print time: the
+    // precision (caret vs none) depends on compiler_stage, which advances as
+    // the driver runs, so by end-of-run every error would look like a backend
+    // error. The excerpt goes right under the error line, before any
+    // "when instantiating ..." context tail.
+    val whole_msg = f"{loc}: error: {msg}{loc_excerpt(loc)}"
     val whole_msg = match all_compile_err_ctx {
         | [] => whole_msg
         | ctx => "\n\t".join(whole_msg :: ctx)
         }
     CompileError(loc, whole_msg)
+}
+
+// diag-1: source-excerpt rendering for diagnostics. Lines are read lazily (only
+// when a diagnostic is actually shown) and cached per module. loc_t carries a
+// full span {line0,col0 .. line1,col1}. Precision is stage-honest: in the
+// frontend (is_frontend_stage) locations are exact and we draw a gcc/clang
+// caret '^~~~'; past the AST they drift, so we print the source line WITHOUT a
+// caret rather than point confidently at an innocent column. One renderer
+// serves both errors and warnings.
+var src_lines_cache: (int, string list) Hashmap.t = Hashmap.empty(16, -1, ([]: string list))
+
+fun get_source_line(m_idx: int, lineno: int): string {
+    if m_idx < 0 || lineno < 1 { "" }
+    else {
+        val lines = match src_lines_cache.find_opt(m_idx) {
+            | Some(ls) => ls
+            | _ =>
+                val ls = try { File.read_utf8(all_modules[m_idx].dm_filename).split('\n', allow_empty=true) }
+                         catch { | _ => ([]: string list) }
+                src_lines_cache.add(m_idx, ls)
+                ls
+            }
+        if 1 <= lineno <= lines.length() { lines.nth(lineno-1) } else { "" }
+    }
+}
+
+fun loc_excerpt(loc: loc_t): string {
+    // Stage-honest precision: the frontend (lexer/parser/typecheck AND
+    // K-normalization) has trustworthy AST locations, so there we draw a source
+    // excerpt with a caret. In the middle end (K optimizations) and backend
+    // (C generation) locations drift -- and not all context reaches C-gen
+    // intact -- so a confident excerpt would point at an innocent line; those
+    // (rarer) diagnostics keep the plain "file:line: error: ..." form.
+    if !is_compiler_frontend() || loc.col0 < 1 { "" }
+    else {
+        val raw = get_source_line(loc.m_idx, loc.line0)
+        if raw == "" { "" }
+        else {
+            // tabs -> single space: the lexer counts one column per source char
+            // (tabs included), so a 1:1 replacement keeps the caret aligned.
+            val disp = string([for c <- raw { if c == '\t' { ' ' } else { c } }])
+            val gutter = string(loc.line0)
+            val pad = ' ' * gutter.length()
+            val span = if loc.line1 == loc.line0 && loc.col1 > loc.col0 { loc.col1 - loc.col0 } else { 1 }
+            val caret = (' ' * (loc.col0 - 1)) + "^" + ('~' * (span - 1))
+            f"\n {gutter} | {disp}\n {pad} | {caret}"
+        }
+    }
 }
 
 // non-fatal diagnostic: prints in the same format as an error but with
@@ -562,7 +628,7 @@ fun compile_err(loc: loc_t, msg: string) {
 // (Compiler.print_all_compile_warns / process_all), which can see Options.
 fun compile_warning(loc: loc_t, msg: string) {
     val whole_msg = f"{loc}: warning: {msg}"
-    println(whole_msg)
+    println(whole_msg + loc_excerpt(loc))
     all_compile_warns = all_compile_warns + 1
 }
 
@@ -1672,6 +1738,8 @@ val (std__Vector__, builtin_ids) = std_id("Vector", builtin_ids)
 fun init_all(): void
 {
     freeze_ids = false
+    compiler_stage = CompilerInit
+    src_lines_cache.clear()
     all_names.clear()
     all_strhash.clear()
     all_c_inc_dirs.clear()

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -49,7 +49,7 @@ operator == (a: id_t, b: id_t) = (a.m == b.m) & (a.i == b.i) && ((a.m == 0) | (a
 
 type scope_t =
     | ScBlock: int
-    | ScLoop: (bool, int)
+    | ScLoop: (bool, bool, int)   // (nested, parallel, block_idx)
     | ScFold: int
     | ScArrMap: int
     | ScMap: int
@@ -818,7 +818,7 @@ fun new_block_idx(m_idx: int)
 }
 
 fun new_block_scope(m_idx: int) = ScBlock(new_block_idx(m_idx))
-fun new_loop_scope(m_idx: int, nested: bool) = ScLoop(nested, new_block_idx(m_idx))
+fun new_loop_scope(m_idx: int, nested: bool, parallel: bool) = ScLoop(nested, parallel, new_block_idx(m_idx))
 fun new_map_scope(m_idx: int) = ScMap(new_block_idx(m_idx))
 fun new_arr_map_scope(m_idx: int) = ScArrMap(new_block_idx(m_idx))
 fun new_fold_scope(m_idx: int) = ScFold(new_block_idx(m_idx))
@@ -828,9 +828,10 @@ fun scope2str(sc: scope_t list): string {
     | scj :: rest =>
         val prefix = match scj {
             | ScBlock(b) => f"block({b})"
-            | ScLoop(f, b) =>
+            | ScLoop(f, par, b) =>
                 val nested = if f {"nested_"} else {""}
-                f"{nested}loop_block({b})"
+                val par_s = if par {"parallel_"} else {""}
+                f"{par_s}{nested}loop_block({b})"
             | ScArrMap(b) => f"arr_map_block({b})"
             | ScMap(b) => f"map_block({b})"
             | ScFold(b) => f"fold_block({b})"

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -1787,10 +1787,17 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
                 check_inside_(outer_sc)
             | ScFun _ :: _ | ScModule _ :: _ | ScClass _ :: _ | ScInterface _ :: _ | [] =>
                 throw compile_err(eloc, f"cannot use '{kw}' outside of loop")
-            | ScLoop(nested, _) :: _ =>
+            | ScLoop(nested, parallel, _) :: _ =>
                 if !any_for {
                     if expect_fold_loop {
                         throw compile_err(eloc, f"'{kw}' can only be used inside 'fold' loop")
+                    } else if parallel {
+                        // diag-1: lifted from C-gen (finalize_loop_body). Whether
+                        // a loop is @parallel is a pure nesting fact known at
+                        // typecheck, so reporting it here gives an exact caret and
+                        // a -no-c-visible, golden-able diagnostic instead of a
+                        // late backend error with no excerpt.
+                        throw compile_err(eloc, f"cannot use '{kw}' inside a '@parallel' loop")
                     } else if isbr && nested {
                         throw compile_err(eloc,
                             "'break' cannot be used inside nested for-loop because of ambiguity. \
@@ -2680,7 +2687,7 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
         unify(ctyp, TypBool, cloc, "while() loop condition should have 'bool' type")
         unify(btyp, TypVoid, bloc, "while() loop body should have 'void' type")
         val new_c = check_exp(c, env, sc)
-        val loop_sc = new_loop_scope(curr_m_idx, false) :: sc
+        val loop_sc = new_loop_scope(curr_m_idx, false, false) :: sc
         val new_body = check_exp(body, env, loop_sc)
         ExpWhile(new_c, new_body, eloc)
     | ExpDoWhile(body, c, _) =>
@@ -2689,7 +2696,7 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
         unify(ctyp, TypBool, cloc, "do-while() loop condition should have 'bool' type")
         unify(btyp, TypVoid, bloc, "do-while() loop body should have 'void' type")
         val new_c = check_exp(c, env, sc)
-        val loop_sc = new_loop_scope(curr_m_idx, false) :: sc
+        val loop_sc = new_loop_scope(curr_m_idx, false, false) :: sc
         val new_body = check_exp(body, env, loop_sc)
         ExpDoWhile(new_body, new_c, eloc)
     | ExpFor(for_clauses, idx_pat, body, flags, _) =>
@@ -2699,7 +2706,7 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
             throw compile_err(eloc, "@unzip for does not make sense outside of comprehensions")
         }
         val for_sc = (if is_fold {new_fold_scope(curr_m_idx)}
-                      else {new_loop_scope(curr_m_idx, is_nested)}) :: sc
+                      else {new_loop_scope(curr_m_idx, is_nested, flags.for_flag_parallel)}) :: sc
         val (trsz, pre_code, for_clauses, idx_pat, _, env, _) =
             check_for_clauses(for_clauses, idx_pat, env, empty_idset, flags, for_sc)
         if trsz > 0 {

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -587,6 +587,40 @@ fun typ_has_free_vars(t: typ_t): bool {
     has_free
 }
 
+/* Error-recovery support (diag-1). TypErr is the poison pseudo-type: it is
+   produced when a definition fails to typecheck, and it unifies with anything
+   WITHOUT binding the other side (maybe_unify ~341). typ_has_typerr detects a
+   type already contaminated by an upstream error; such a type must never drive
+   a NEW diagnostic (structural cascade suppression), it just flows silently. */
+fun typ_has_typerr(t: typ_t): bool {
+    var has_err = false
+    fun check_(t: typ_t, callb: ast_callb_t): typ_t =
+        if has_err { t }
+        else {
+            match deref_typ(t) {
+            | TypErr => has_err = true; t
+            | t1 => walk_typ(t1, callb)
+            }
+        }
+    val callb = ast_callb_t {ast_cb_typ=Some(check_), ast_cb_exp=None, ast_cb_pat=None}
+    val _ = check_(t, callb)
+    has_err
+}
+
+/* Force the RESULT of a suppressed resolution to TypErr so the poison
+   propagates upward: for a call/operator the expected type is TypFun(args, rt)
+   and rt IS the enclosing expression's result var, so pinning it to TypErr
+   makes the whole expression TypErr; for a plain value lookup the type var
+   itself is pinned. Uses direct var assignment because unify deliberately
+   does NOT bind against TypErr. Only ever runs on an already-failed path. */
+fun poison_result_typ(t: typ_t): void =
+    match deref_typ(t) {
+    | TypFun(_, rt) =>
+        (match deref_typ(rt) { | TypVar((ref None) as r) => *r = Some(TypErr) | _ => {} })
+    | TypVar((ref None) as r) => *r = Some(TypErr)
+    | _ => {}
+    }
+
 /* this is another flavor of type unification function;
    it throws an exception in the case of failure */
 fun unify(t1: typ_t, t2: typ_t, loc: loc_t, msg: string): void =
@@ -1180,7 +1214,16 @@ fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): 
             | _ => t
             }
         if df_templ_args == [] {
-            if maybe_unify(df_typ, t, loc, true) { Some((i, t)) }
+            if maybe_unify(df_typ, t, loc, true) {
+                // Recovery (diag-1): a function whose body failed keeps its
+                // declared signature, but if its return type was poisoned to
+                // TypErr (no annotation, no healthy branch), propagate that to
+                // the call result -- maybe_unify above leaves the caller's
+                // result var free because TypErr never binds. Clean compiles
+                // never reach here (no df_typ is TypErr-typed), census stands.
+                if typ_has_typerr(df_typ) { poison_result_typ(t) }
+                Some((i, t))
+            }
             else { throw compile_err(loc, f"internal error: the winning overload of \
                    '{pp(n)}' failed to re-unify at commit") }
         } else {
@@ -1307,7 +1350,13 @@ fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): 
                     | [] =>
                         unify(dv_typ, t, loc, f"incorrect type of value '{pp(n)}': \
                               expected='{typ2str(t)}', actual='{typ2str(dv_typ)}'")
-                        Some((i, t))
+                        // Recovery (diag-1): a value poisoned by a failed
+                        // definition carries TypErr; propagate that poison to
+                        // the use site (unify above leaves `t` free because
+                        // TypErr never binds), so uses stay structurally
+                        // suppressed. No effect on a clean compile (no value is
+                        // TypErr-typed there), so the -pr-resolve census stands.
+                        Some((i, if typ_has_typerr(dv_typ) {dv_typ} else {t}))
                     | _ => scan_(rest, viable)  // a viable function shadows it, as today
                     }
                 | IdModule _ =>
@@ -1368,13 +1417,23 @@ fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): 
 
 fun lookup_id(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): (id_t, typ_t)
 {
-    val (nt_opt, possible_matches) = lookup_id_opt(n, t, env, sc, loc)
-    match nt_opt {
-    | Some(nt) => nt
-    | None =>
-        match try_autogen_symbols(n, t, env, sc, loc) {
-        | Some(nt1) => nt1
-        | _ => throw report_not_found_typed(n, t, possible_matches, sc, loc)
+    // Structural cascade suppression (diag-1): if the expected type is already
+    // contaminated by an upstream error (a poisoned operand/callee), this
+    // resolution cannot succeed for an honest reason -- report nothing, pin the
+    // result to TypErr, and let the poison flow on. The genuine error was
+    // already reported at the site that produced the TypErr.
+    if typ_has_typerr(t) {
+        poison_result_typ(t)
+        (n, t)
+    } else {
+        val (nt_opt, possible_matches) = lookup_id_opt(n, t, env, sc, loc)
+        match nt_opt {
+        | Some(nt) => nt
+        | None =>
+            match try_autogen_symbols(n, t, env, sc, loc) {
+            | Some(nt1) => nt1
+            | _ => throw report_not_found_typed(n, t, possible_matches, sc, loc)
+            }
         }
     }
 }
@@ -2534,9 +2593,16 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
                 unify(typ2, etyp, loc2, "if() expression should have the same type as its branches")
             }
         }
+        // Per-branch error recovery (diag-1): a failure in one branch is
+        // reported and the other branch is still checked, so both branches'
+        // errors surface in one run. Branch types were already unified with
+        // `etyp` above, so a poisoned branch does not disturb the if's type --
+        // the healthy branch determines it, like a jumping throw/ctrlflow sibling.
         val new_c = check_exp(c, env, sc)
-        val new_e1 = check_exp(e1, env, sc)
-        val new_e2 = check_exp(e2, env, sc)
+        val new_e1 = try { check_exp(e1, env, sc) }
+                     catch { | CompileError(_, _) as err => push_compile_err(err); e1 }
+        val new_e2 = try { check_exp(e2, env, sc) }
+                     catch { | CompileError(_, _) as err => push_compile_err(err); e2 }
         ExpIf(new_c, new_e1, new_e2, ctx)
     | ExpWhile(c, body, _) =>
         val (ctyp, cloc) = get_exp_ctx(c)
@@ -3022,6 +3088,37 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
     new_e
 }
 
+/* Error recovery (diag-1): when a `val`/`var` definition fails to typecheck,
+   bind EVERY identifier its pattern introduces to a poison value of type
+   `poison_t` (TypErr when there is no usable annotation), so later statements
+   that reference those names are structurally suppressed instead of producing
+   spurious "undefined" cascades. Mirrors the single-ident recovery that was
+   here before, generalized to tuple/record/as/... patterns. */
+fun poison_pattern_vars(p: pat_t, poison_t: typ_t, flags: val_flags_t,
+                        sc: scope_t list, m_idx: int, env0: env_t): env_t
+{
+    var env = env0
+    fun bind1(n: id_t, ploc: loc_t): void {
+        val n1 = dup_id(m_idx, n)
+        val dv = defval_t {dv_name=n1, dv_typ=poison_t, dv_flags=flags, dv_scope=sc, dv_loc=ploc}
+        set_id_entry(n1, IdDVal(dv))
+        env = add_id_to_env(n, n1, env)
+    }
+    // Bind every identifier the pattern introduces; delegate the structural
+    // recursion to walk_pat so all pattern shapes (incl. future ones) are
+    // covered. PatAs' alias is an id_t (not a sub-pattern) so bind it explicitly
+    // before recursing into the aliased pattern.
+    fun cb(p: pat_t, callb: ast_callb_t): pat_t =
+        match p {
+        | PatIdent(n, ploc) => bind1(n, ploc); p
+        | PatAs(_, n, ploc) => bind1(n, ploc); walk_pat(p, callb)
+        | _ => walk_pat(p, callb)
+        }
+    val callb = ast_callb_t {ast_cb_typ=None, ast_cb_exp=None, ast_cb_pat=Some(cb)}
+    ignore(check_n_walk_pat(p, callb))
+    env
+}
+
 fun check_eseq(eseq: exp_t list, env: env_t, sc: scope_t list, create_sc: bool): (exp_t list, env_t)
 {
     /*
@@ -3098,15 +3195,19 @@ fun check_eseq(eseq: exp_t list, env: env_t, sc: scope_t list, create_sc: bool):
                 }
                 val is_mutable = flags.val_flag_mutable
                 val t = get_exp_typ(e)
-                val (p, t1) = match p {
-                | PatTyped(p1, t1, loc) =>
-                    val t1 = check_typ(t1, env, sc, loc)
-                    unify(t, t1, loc, "explicit type specification of the defined \
-                          value does not match the assigned expression type")
-                    (p1, t1)
-                | _ => (p, t)
-                }
                 try {
+                    // The annotation unify is now INSIDE the recovery try: an
+                    // explicit-type mismatch must poison the symbol like any
+                    // other failure, not escape and leave the name unbound
+                    // (which used to cascade into spurious "undefined" errors).
+                    val (p, _) = match p {
+                    | PatTyped(p1, t1, loc) =>
+                        val t1 = check_typ(t1, env, sc, loc)
+                        unify(t, t1, loc, "explicit type specification of the defined \
+                              value does not match the assigned expression type")
+                        (p1, t1)
+                    | _ => (p, t)
+                    }
                     val e1 = check_exp(e, env, sc)
                     val (p1, env1, _, _, _) = check_pat(p, t, env, empty_idset, empty_idset,
                                                         sc, false, true, is_mutable)
@@ -3114,16 +3215,19 @@ fun check_eseq(eseq: exp_t list, env: env_t, sc: scope_t list, create_sc: bool):
                 } catch {
                 | CompileError(_, _) as err =>
                     push_compile_err(err)
-                    match pat_skip_typed(p) {
-                    | PatIdent(n, ploc) =>
-                        val n1 = dup_id(curr_m_idx, n)
-                        val dv = defval_t {dv_name=n1, dv_typ=t1, dv_flags=flags, dv_scope=sc, dv_loc=loc}
-                        set_id_entry(n1, IdDVal(dv))
-                        val env1 = add_id_to_env(n, n1, env)
-                        (DefVal(PatTyped(PatIdent(n1, ploc), t1, ploc), e, flags, loc) :: eseq, env1)
-                    | _ =>
-                        (DefVal(p, e, flags, loc) :: eseq, env)
-                    }
+                    // Poison every name the pattern binds. With an explicit
+                    // annotation, poison with THAT type -- the §1.7 firewall:
+                    // callers keep checking against the declared type. Without
+                    // one, poison with TypErr so later uses are suppressed
+                    // (structural cascade suppression), not cascaded.
+                    val poison_t = match p {
+                        | PatTyped(_, t1, tloc) =>
+                            (try { check_typ(t1, env, sc, tloc) } catch { | CompileError(_, _) => TypErr })
+                        | _ => TypErr
+                        }
+                    val env1 = poison_pattern_vars(pat_skip_typed(p), poison_t, flags,
+                                                   sc, curr_m_idx, env)
+                    (DefVal(p, e, flags, loc) :: eseq, env1)
                 }
             | DefFun(df) =>
                 if idx == nexps - 1 && !is_glob_scope {
@@ -3134,7 +3238,25 @@ fun check_eseq(eseq: exp_t list, env: env_t, sc: scope_t list, create_sc: bool):
                 // return var to a concrete type for non-template functions.
                 val warn_rettype = Options.opt.W_implicit_rettype && has_implicit_rettype(df)
                 val df =
-                    if df->df_templ_args == [] { check_deffun(df, env) }
+                    if df->df_templ_args == [] {
+                        try { check_deffun(df, env) }
+                        catch {
+                        | CompileError(_, _) as err =>
+                            // Body failed. The function was registered in `env`
+                            // with its declared signature BEFORE the body check
+                            // (so recursion resolves) -- that pre-registration IS
+                            // the §1.7 firewall: callers keep checking against the
+                            // declared interface. If the return type was left to
+                            // inference and NO healthy branch pinned it, poison it
+                            // to TypErr so callers are structurally suppressed
+                            // rather than cascaded; a branch that DID typecheck
+                            // (e.g. an early `return 42`) has already resolved the
+                            // return type -- poison_result_typ leaves that intact.
+                            push_compile_err(err)
+                            poison_result_typ(df->df_typ)
+                            df
+                        }
+                    }
                     else {
                         // update environment of the template function
                         // to give it access to the above defined
@@ -4342,12 +4464,22 @@ fun check_cases( cases: (pat_t, exp_t) list, inptyp: typ_t, outtyp: typ_t,
 
     [:: for (p, e) <- cases {
         val case_sc = new_block_scope(curr_m_idx) :: sc
-        val (p1, env1, _, _, _) = check_pat(p, inptyp, env, empty_idset, empty_idset,
-                                                case_sc, false, false, false)
-        val (e1_typ, e1_loc) = get_exp_ctx(e)
-        unify(e1_typ, outtyp, e1_loc, "the case expression type does not \
-              match the whole expression type (or the type of previous case(s))")
-        (p1, check_exp(e, env1, case_sc))
+        // Per-arm error recovery (diag-1): a failure in one arm is reported and
+        // the loop moves on, so errors in sibling arms are found in the same
+        // run. A poisoned arm contributes no type to `outtyp` (the unify below
+        // ran against a fresh e1_typ that never bound it, or did not run at all),
+        // so the healthy arms determine the match result -- the same "jumping
+        // sibling" logic as throw/ctrlflow-1. The AST is discarded on error.
+        try {
+            val (p1, env1, _, _, _) = check_pat(p, inptyp, env, empty_idset, empty_idset,
+                                                    case_sc, false, false, false)
+            val (e1_typ, e1_loc) = get_exp_ctx(e)
+            unify(e1_typ, outtyp, e1_loc, "the case expression type does not \
+                  match the whole expression type (or the type of previous case(s))")
+            (p1, check_exp(e, env1, case_sc))
+        } catch {
+        | CompileError(_, _) as err => push_compile_err(err); (p, e)
+        }
     } ]
 }
 

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -993,8 +993,72 @@ fun is_real_typ(t: typ_t) {
     !have_typ_vars
 }
 
+// diag-1: Levenshtein edit distance (two-row DP). Only ever called on the
+// error path (building a not-found diagnostic), so cost is irrelevant.
+fun edit_distance(a: string, b: string): int {
+    val la = a.length(), lb = b.length()
+    if la == 0 { lb }
+    else if lb == 0 { la }
+    else {
+        val prev = array(lb+1, 0), curr = array(lb+1, 0)
+        for j <- 0:lb+1 { prev[j] = j }
+        for i <- 1:la+1 {
+            curr[0] = i
+            val ai = a[i-1]
+            for j <- 1:lb+1 {
+                val cost = if ai == b[j-1] { 0 } else { 1 }
+                curr[j] = min(min(prev[j]+1, curr[j-1]+1), prev[j-1]+cost)
+            }
+            for j <- 0:lb+1 { prev[j] = curr[j] }
+        }
+        prev[lb]
+    }
+}
+
+// diag-1: up to two visible names closest to `n` within an edit-distance
+// threshold (scaled by length), as a "; did you mean 'x'?" tail -- gcc/clang
+// style. Empty when nothing is close. Skips the name itself and compiler
+// gensym/internal names (leading '_').
+fun suggest_similar(n: id_t, env: env_t): string {
+    val target = pp(n)
+    val tlen = target.length()
+    if tlen == 0 { "" }
+    else {
+        val thresh = if tlen <= 4 { 1 } else { 2 }
+        val cand = env.foldl(fun (key: id_t, _: env_entry_t list, acc: (int, string) list) {
+            val nm = pp(key)
+            if nm == target || nm == "" || nm.startswith("_") { acc }
+            else {
+                val d = edit_distance(target, nm)
+                if d <= thresh { (d, nm) :: acc } else { acc }
+            }
+        }, [])
+        // nearest first, then alphabetical; adjacent-dedup collapses the same
+        // name reached via several ids (equal distance -> adjacent after sort).
+        val cand = cand.sort(fun ((d1, s1): (int, string), (d2, s2): (int, string)) {
+            d1 < d2 || (d1 == d2 && s1 < s2) })
+        fun take2(l: (int, string) list, last: string, acc: string list): string list =
+            if acc.length() >= 2 { acc.rev() }
+            else {
+                match l {
+                | (_, nm) :: rest => if nm == last { take2(rest, last, acc) }
+                                     else { take2(rest, nm, nm :: acc) }
+                | [] => acc.rev()
+                }
+            }
+        match take2(cand, "", []) {
+        | [] => ""
+        | a :: [] => f"; did you mean '{a}'?"
+        | a :: b :: _ => f"; did you mean '{a}' or '{b}'?"
+        }
+    }
+}
+
 fun report_not_found(n: id_t, loc: loc_t) =
     compile_err(loc, f"the appropriate match for '{pp(n)}' is not found")
+
+fun report_not_found_env(n: id_t, env: env_t, loc: loc_t) =
+    compile_err(loc, f"the appropriate match for '{pp(n)}' is not found{suggest_similar(n, env)}")
 
 /* one-line explanation of why a function candidate does not accept the call:
    arity, keyword acceptance, or the first mismatching argument (tested with
@@ -1053,7 +1117,7 @@ fun fun_mismatch_reason(df: deffun_t ref, call_argtyps: typ_t list,
 }
 
 fun report_not_found_typed(n: id_t, t: typ_t, possible_matches: env_entry_t list,
-                           sc: scope_t list, loc: loc_t) {
+                           env: env_t, sc: scope_t list, loc: loc_t) {
     val nstr = pp(n)
     val call_argtyps_opt = match deref_typ(t) {
         | TypFun(argtyps, _) => Some(argtyps)
@@ -1076,11 +1140,17 @@ fun report_not_found_typed(n: id_t, t: typ_t, possible_matches: env_entry_t list
                 f"'{nstr}: {typ2str(tj)}' defined at {locj}"
             }
         } ]
-    val candidates_msg =
-        if strs == [] { "" }
-        else { join_embrace("\nCandidates:\n\t", "\n", ",\n\t", strs) }
+    // With candidates, list them (name exists, the call does not match any).
+    // With none, the name is genuinely unknown -> offer an edit-distance
+    // "did you mean" over the visible names (diag-1).
+    val tail =
+        if strs != [] { "." + join_embrace("\nCandidates:\n\t", "\n", ",\n\t", strs) }
+        else {
+            val s = suggest_similar(n, env)
+            if s == "" { "." } else { s }
+        }
     compile_err(loc, f"the appropriate match for '{nstr}' of \
-                type '{typ2str(t)}' is not found.{candidates_msg}")
+                type '{typ2str(t)}' is not found{tail}")
 }
 
 fun find_first(n: id_t, env: env_t, env0: env_t, sc: scope_t list,
@@ -1432,7 +1502,7 @@ fun lookup_id(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): (id_
         | None =>
             match try_autogen_symbols(n, t, env, sc, loc) {
             | Some(nt1) => nt1
-            | _ => throw report_not_found_typed(n, t, possible_matches, sc, loc)
+            | _ => throw report_not_found_typed(n, t, possible_matches, env, sc, loc)
             }
         }
     }
@@ -1888,7 +1958,7 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
             | Some((f, t, _)) =>
                 ExpMem(new_e1, ExpIdent(f, (t, eloc)), ctx)
             | _ =>
-                throw report_not_found_typed(n2, etyp, candidates, sc, eloc)
+                throw report_not_found_typed(n2, etyp, candidates, env, sc, eloc)
             }
         | (TypExn, _, ExpIdent(n2, (etyp2, eloc2))) when n2 == std__tag__ =>
             unify(etyp, TypInt, eloc, "variant tag is integer, but the other type is expected")

--- a/compiler/Compiler.fx
+++ b/compiler/Compiler.fx
@@ -726,6 +726,10 @@ and there are <ficus_root>/runtime and <ficus_root>/lib.
    there are (/usr|...)/lib/ficus-{__ficus_major__}.{__ficus_minor__}/{{runtime, lib}}") }
         // classify stdlib vs user modules for -Wimplicit-rettype scoping
         Ast.ficus_std_path = Filename.normalize(ficus_root, "lib")
+        // Frontend spans parsing, type checking and K-normalization -- all
+        // consume the AST and carry exact source locations, so diagnostics
+        // there get a caret excerpt (diag-1). See Ast.compiler_stage.
+        Ast.compiler_stage = Ast.CompilerFrontend
         val ok = parse_all(fname0, ficus_path)
         if !ok { throw CumulativeParseError }
         val graph = [:: for minfo <- Ast.all_modules {
@@ -756,6 +760,10 @@ and there are <ficus_root>/runtime and <ficus_root>/lib.
             pr_verbose(clrmsg(MsgBlue, "K-normalization complete"))
             if Options.opt.print_k0 { K_pp.pp_kmods(kmods) }
         }
+        // Past K-normalization: the middle end (inlining, fusion, ...) rewrites
+        // the IR and source locations start to drift, so diagnostics from here
+        // on drop the caret (they keep the plain file:line form).
+        Ast.compiler_stage = Ast.CompilerMiddle
         val (kmods, ok) = if ok {
             pr_verbose(clrmsg(MsgBlue, "K-form optimization started"))
             k_optimize_all(kmods)
@@ -764,6 +772,7 @@ and there are <ficus_root>/runtime and <ficus_root>/lib.
             pr_verbose(clrmsg(MsgBlue, "K-form optimization complete"))
             if Options.opt.print_k { K_pp.pp_kmods(kmods) }
         }
+        Ast.compiler_stage = Ast.CompilerBackend
         val ok = if !Options.opt.gen_c { ok } else {
             val (cmods, ok) = if ok { k2c_all(kmods) } else { ([], false) }
             val ok =

--- a/compiler/Compiler.fx
+++ b/compiler/Compiler.fx
@@ -653,9 +653,46 @@ fun run_app(): bool
 
 fun print_all_compile_errs()
 {
-    val nerrs = Ast.all_compile_errs.length()
+    // Errors were accumulated most-recent-first. diag-1 makes multi-error runs
+    // readable: (1) drop exact-duplicate messages -- a generic function's body
+    // error is otherwise reported once per distinct instantiation -- and
+    // (2) sort by source position so the report reads top-to-bottom regardless
+    // of the order in which definitions happened to be checked.
+    val seen = Hashset.empty(256, "")
+    val uniq = fold acc = [] for e <- Ast.all_compile_errs.rev() {
+        // Dedup key is the PRIMARY line of the message (the "file:line:col:
+        // error: ..." line), excluding any "\n\twhen instantiating ..." context
+        // tail: the same generic-body error reached from N distinct call sites
+        // is one bug, reported once (with whichever context came first).
+        val msg = match e {
+            | Ast.CompileError(_, msg) => msg
+            | Fail(msg) => "Failure: " + msg
+            | _ => ""
+            }
+        val key = match msg.find('\n') { | (-1) => msg | nl => msg[:nl] }
+        if key != "" && seen.mem(key) { acc }
+        else { if key != "" { seen.add(key) }; e :: acc }
+    }
+    fun errkey(e: exn): (int, int, int) = match e {
+        | Ast.CompileError(loc, _) => (loc.m_idx, loc.line0, loc.col0)
+        | _ => (1000000000, 0, 0)     // non-positional (e.g. Fail) sort last
+        }
+    val sorted = uniq.rev().sort(fun (a: exn, b: exn) {
+        val (ma, la, ca) = errkey(a)
+        val (mb, lb, cb) = errkey(b)
+        ma < mb || (ma == mb && (la < lb || (la == lb && ca < cb)))
+    })
+    val nerrs = sorted.length()
     if nerrs != 0 {
-        Ast.all_compile_errs.rev().app(Ast.print_compile_err)
+        val cap = Options.opt.max_errors
+        for e@i <- sorted {
+            if i >= cap { break }
+            Ast.print_compile_err(e)
+        }
+        if nerrs > cap {
+            println(f"\n{nerrs - cap} further diagnostic(s) suppressed \
+                     (-fmax-errors={cap}).")
+        }
         println(f"\n{nerrs} errors occured during type checking.")
     }
 }

--- a/compiler/K_inline.fx
+++ b/compiler/K_inline.fx
@@ -198,8 +198,8 @@ fun subst_names(km_idx: int, e: kexp_t, subst_map0: subst_map_t, rename: bool): 
             ScModule(km_idx) :: subst_scope(rest, loc)
         | ScBlock(_) :: rest =>
             new_block_scope(km_idx) :: subst_scope(rest, loc)
-        | ScLoop(nested, _) :: rest =>
-            new_loop_scope(km_idx, nested) :: subst_scope(rest, loc)
+        | ScLoop(nested, parallel, _) :: rest =>
+            new_loop_scope(km_idx, nested, parallel) :: subst_scope(rest, loc)
         | ScMap(_) :: rest =>
             new_map_scope(km_idx) :: subst_scope(rest, loc)
         | ScArrMap(_) :: rest =>

--- a/compiler/Options.fx
+++ b/compiler/Options.fx
@@ -41,7 +41,12 @@ type options_t =
     W_unused: bool = true;
     W_implicit_rettype: bool = false;
     W_implicit_rettype_all: bool = false;
-    Werror: bool = false
+    Werror: bool = false;
+    // diag-1: cap the number of distinct diagnostics printed per run (gcc-style
+    // -fmax-errors); the report ends with a "further diagnostics suppressed"
+    // line when the cap binds. Structural cascade suppression should keep runs
+    // well under this; the cap is a backstop for pathological inputs.
+    max_errors: int = 100
 }
 
 fun default_options() = options_t {}
@@ -113,6 +118,10 @@ where options can be some of:
                     -Wimplicit-rettype)
     -Werror         Treat all emitted warnings as errors: exit with a nonzero
                     status if any warning was generated
+    -fmax-errors=N  Print at most N distinct type diagnostics per run (default
+                    100); the rest are summarized as 'further diagnostics
+                    suppressed'. The type checker recovers from an error and
+                    keeps going, so one run reports many independent problems.
     -o <output_name> Output file name (by default it matches the
                     input filename without .fx extension)
     -D symbol       Define 'symbol=true' for preprocessor
@@ -220,6 +229,13 @@ fun parse_options(): bool {
                 opt.W_implicit_rettype = true; next
             | "-Werror" :: next =>
                 opt.Werror = true; next
+            | opt_str :: next when opt_str.startswith("-fmax-errors=") =>
+                val vstr = opt_str["-fmax-errors=".length():]
+                match vstr.to_int() {
+                | Some(n) when n > 0 => opt.max_errors = n
+                | _ => println(f"invalid -fmax-errors value '{vstr}' (expected a positive integer)"); ok = false
+                }
+                next
             | "-verbose" :: next =>
                 opt.verbose = true; next
             | "-o" :: oname :: next =>

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -163,6 +163,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -1493,6 +1494,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1530,6 +1532,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1566,6 +1569,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -25,6 +25,10 @@ struct _fx_Nt6option1N10Ast__exp_t_data_t;
 
 static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_data_t**);
 
+struct _fx_Nt10Hashmap__t2iLS_data_t;
+
+static void _fx_free_Nt10Hashmap__t2iLS(struct _fx_Nt10Hashmap__t2iLS_data_t**);
+
 struct _fx_Nt10Hashmap__t2Si_data_t;
 
 static void _fx_free_Nt10Hashmap__t2Si(struct _fx_Nt10Hashmap__t2Si_data_t**);
@@ -287,6 +291,13 @@ typedef struct _fx_Nt6option1Nt10Hashset__t1R9Ast__id_t {
    } u;
 } _fx_Nt6option1Nt10Hashset__t1R9Ast__id_t;
 
+typedef struct _fx_Nt6option1LS {
+   int tag;
+   union {
+      struct _fx_LS_data_t* Some;
+   } u;
+} _fx_Nt6option1LS;
+
 typedef struct _fx_R16Ast__ast_callb_t {
    struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t* ast_cb_typ;
    struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t* ast_cb_exp;
@@ -355,6 +366,12 @@ typedef struct _fx_FPi2SS {
    fx_fcv_t* fcv;
 } _fx_FPi2SS;
 
+typedef struct _fx_Rt20Hashmap__hashentry_t2iLS {
+   uint64_t hv;
+   int_ key;
+   struct _fx_LS_data_t* data;
+} _fx_Rt20Hashmap__hashentry_t2iLS;
+
 typedef struct _fx_Rt20Hashmap__hashentry_t2Si {
    uint64_t hv;
    fx_str_t key;
@@ -366,6 +383,22 @@ typedef struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_
    struct _fx_R9Ast__id_t key;
    struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t* data;
 } _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t;
+
+typedef struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS {
+   struct _fx_Rt20Hashmap__hashentry_t2iLS t0;
+   int_ t1;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS;
+
+typedef struct _fx_Nt10Hashmap__t2iLS_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS t;
+   } u;
+} _fx_Nt10Hashmap__t2iLS_data_t, *_fx_Nt10Hashmap__t2iLS;
 
 typedef struct _fx_T6Rt20Hashmap__hashentry_t2SiiiiA1iA1Rt20Hashmap__hashentry_t2Si {
    struct _fx_Rt20Hashmap__hashentry_t2Si t0;
@@ -1295,6 +1328,10 @@ typedef struct _fx_N16Ast__defmodule_t_data_t {
    } u;
 } _fx_N16Ast__defmodule_t_data_t, *_fx_N16Ast__defmodule_t;
 
+typedef struct _fx_N21Ast__compiler_stage_t {
+   int tag;
+} _fx_N21Ast__compiler_stage_t;
+
 typedef struct _fx_T2LSi {
    struct _fx_LS_data_t* t0;
    int_ t1;
@@ -1675,6 +1712,28 @@ static void _fx_copy_Nt6option1Nt10Hashset__t1R9Ast__id_t(
    }
 }
 
+static void _fx_free_Nt6option1LS(struct _fx_Nt6option1LS* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_LS(&dst->u.Some); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_Nt6option1LS(struct _fx_Nt6option1LS* src, struct _fx_Nt6option1LS* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      FX_COPY_PTR(src->u.Some, &dst->u.Some); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
 static void _fx_free_R16Ast__ast_callb_t(struct _fx_R16Ast__ast_callb_t* dst)
 {
    _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&dst->ast_cb_typ);
@@ -1735,6 +1794,31 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
+static void _fx_free_Rt20Hashmap__hashentry_t2iLS(struct _fx_Rt20Hashmap__hashentry_t2iLS* dst)
+{
+   _fx_free_LS(&dst->data);
+}
+
+static void _fx_copy_Rt20Hashmap__hashentry_t2iLS(
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* src,
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* dst)
+{
+   dst->hv = src->hv;
+   dst->key = src->key;
+   FX_COPY_PTR(src->data, &dst->data);
+}
+
+static void _fx_make_Rt20Hashmap__hashentry_t2iLS(
+   uint64_t r_hv,
+   int_ r_key,
+   struct _fx_LS_data_t* r_data,
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* fx_result)
+{
+   fx_result->hv = r_hv;
+   fx_result->key = r_key;
+   FX_COPY_PTR(r_data, &fx_result->data);
+}
+
 static void _fx_free_Rt20Hashmap__hashentry_t2Si(struct _fx_Rt20Hashmap__hashentry_t2Si* dst)
 {
    fx_free_str(&dst->key);
@@ -1784,6 +1868,51 @@ static void _fx_make_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__i
    fx_result->hv = r_hv;
    fx_result->key = *r_key;
    FX_COPY_PTR(r_data, &fx_result->data);
+}
+
+static void _fx_free_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(
+   struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS* dst)
+{
+   _fx_free_Rt20Hashmap__hashentry_t2iLS(&dst->t0);
+   fx_free_arr(&dst->t4);
+   fx_free_arr(&dst->t5);
+}
+
+static void _fx_copy_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(
+   struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS* src,
+   struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS* dst)
+{
+   _fx_copy_Rt20Hashmap__hashentry_t2iLS(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
+   dst->t2 = src->t2;
+   dst->t3 = src->t3;
+   fx_copy_arr(&src->t4, &dst->t4);
+   fx_copy_arr(&src->t5, &dst->t5);
+}
+
+static void _fx_make_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* t0,
+   int_ t1,
+   int_ t2,
+   int_ t3,
+   fx_arr_t* t4,
+   fx_arr_t* t5,
+   struct _fx_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS* fx_result)
+{
+   _fx_copy_Rt20Hashmap__hashentry_t2iLS(t0, &fx_result->t0);
+   fx_result->t1 = t1;
+   fx_result->t2 = t2;
+   fx_result->t3 = t3;
+   fx_copy_arr(t4, &fx_result->t4);
+   fx_copy_arr(t5, &fx_result->t5);
+}
+
+static void _fx_free_Nt10Hashmap__t2iLS(struct _fx_Nt10Hashmap__t2iLS_data_t** dst)
+{
+   if (*dst && FX_DECREF((*dst)->rc) == 1) {
+      _fx_free_T6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(&(*dst)->u.t); fx_free(*dst);
+   }
+   *dst = 0;
 }
 
 static void _fx_free_T6Rt20Hashmap__hashentry_t2SiiiiA1iA1Rt20Hashmap__hashentry_t2Si(
@@ -4622,11 +4751,12 @@ static int _fx_make_rB(bool arg, struct _fx_rB_data_t** fx_result)
 }
 
 _fx_Nt6option1Nt10Hashset__t1R9Ast__id_t _fx_g9Ast__None = { 1 };
-_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g11Ast__None1_ = 0;
-_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g11Ast__None2_ = 0;
-_fx_Nt6option1N10Ast__exp_t _fx_g11Ast__None3_ = 0;
-_fx_Nt6option1N10Ast__typ_t _fx_g11Ast__None4_ = 0;
-_fx_Nt6option1i _fx_g11Ast__None5_ = { 1 };
+_fx_Nt6option1LS _fx_g11Ast__None1_ = { 1 };
+_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g11Ast__None2_ = 0;
+_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g11Ast__None3_ = 0;
+_fx_Nt6option1N10Ast__exp_t _fx_g11Ast__None4_ = 0;
+_fx_Nt6option1N10Ast__typ_t _fx_g11Ast__None5_ = 0;
+_fx_Nt6option1i _fx_g11Ast__None6_ = { 1 };
 _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t _fx_g10Ast__Empty = 0;
 _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t _fx_g12Ast__Empty1_ = 0;
 _fx_N12Set__color_t _fx_g8Ast__Red = { 1 };
@@ -4668,6 +4798,7 @@ _fx_N13Ast__binary_t _fx_g16Ast__OpSpaceship = &OpSpaceship_data_0;
 _fx_N17Ast__fun_constr_t _fx_g13Ast__CtorNone = { 1 };
 _fx_N15Ast__for_make_t _fx_g16Ast__ForMakeNone = { 1 };
 _fx_N14Ast__id_info_t _fx_g11Ast__IdNone = { 1 };
+_fx_N21Ast__compiler_stage_t _fx_g17Ast__CompilerInit = { 1 };
 _fx_T2LSi _fx_g16Ast__builtin_ids = {0};
 _fx_R9Ast__id_t _fx_g9Ast__noid;
 _fx_T2LSi _fx_g18Ast__builtin_ids1_ = {0};
@@ -4678,6 +4809,7 @@ _fx_FPi2R9Ast__id_tR9Ast__id_t _fx_g13Ast__cmp_id1_ = {0};
 _fx_Rt6Set__t1R9Ast__id_t _fx_g16Ast__empty_idset = {0};
 _fx_FPi2R9Ast__id_tR9Ast__id_t _fx_g13Ast__cmp_id2_ = {0};
 _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t _fx_g16Ast__empty_idmap = {0};
+_fx_N21Ast__compiler_stage_t _fx_g19Ast__compiler_stage;
 bool _fx_g15Ast__freeze_ids = false;
 int_ _fx_g19Ast__lock_all_names = 0;
 _fx_Nt9Dynvec__t1S _fx_g14Ast__all_names = 0;
@@ -4692,6 +4824,7 @@ _fx_LS _fx_g24Ast__all_compile_err_ctx = 0;
 _fx_LT3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t _fx_g17Ast__all_func_ctx = 0;
 fx_str_t _fx_g19Ast__ficus_std_path = {0};
 _fx_Nt10Hashset__t1S _fx_g19Ast__all_c_inc_dirs = 0;
+_fx_Nt10Hashmap__t2iLS _fx_g20Ast__src_lines_cache = 0;
 _fx_FPi2SS _fx_g8Ast__cmp = {0};
 _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t _fx_g13Ast__dup_typ_ = {0};
 _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g13Ast__dup_exp_ = {0};
@@ -4748,7 +4881,17 @@ static int _fx_M3AstFM10__lambda__v1RM4id_t(struct _fx_R9Ast__id_t*, void*);
 
 FX_EXTERN_C int _fx_F6stringS1i(int_, fx_str_t*, void*);
 
+FX_EXTERN_C int _fx_M3AstFM11loc_excerptS1RM5loc_t(struct _fx_R10Ast__loc_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int _fx_F4joinS2SLS(fx_str_t*, struct _fx_LS_data_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M4FileFM9read_utf8S1S(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M6StringFM5splitLS3SCB(fx_str_t*, char_, bool, struct _fx_LS_data_t**, void*);
+
+FX_EXTERN_C int _fx_F6stringS1A1C(fx_arr_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F7__mul__S2Ci(char_, int_, fx_str_t*, void*);
 
 FX_EXTERN_C void _fx_F12print_stringv1S(fx_str_t*, void*);
 
@@ -4781,8 +4924,6 @@ FX_EXTERN_C int _fx_F6stringS1C(char_, fx_str_t*, void*);
 FX_EXTERN_C int _fx_M3AstFM6tl2strS1LN10Ast__typ_t(struct _fx_LN10Ast__typ_t_data_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_F12join_embraceS4SSSA1S(fx_str_t*, fx_str_t*, fx_str_t*, fx_arr_t*, fx_str_t*, void*);
-
-FX_EXTERN_C int _fx_F7__mul__S2Ci(char_, int_, fx_str_t*, void*);
 
 FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
 
@@ -4970,6 +5111,12 @@ FX_EXTERN_C void _fx_M3AstFM4SomeNt6option1Nt10Hashset__t1RM4id_t1Nt10Hashset__t
    FX_COPY_PTR(arg0, &fx_result->u.Some);
 }
 
+FX_EXTERN_C void _fx_M3AstFM4SomeNt6option1LS1LS(struct _fx_LS_data_t* arg0, struct _fx_Nt6option1LS* fx_result)
+{
+   fx_result->tag = 2;
+   FX_COPY_PTR(arg0, &fx_result->u.Some);
+}
+
 FX_EXTERN_C int
    _fx_M3AstFM4SomeNt6option1FPN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t1FPN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(
    struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t* arg0,
@@ -5014,11 +5161,37 @@ FX_EXTERN_C void _fx_M3AstFM4SomeNt6option1i1i(int_ arg0, struct _fx_Nt6option1i
    fx_result->u.Some = arg0;
 }
 
+FX_EXTERN_C int_ _fx_M3AstFM6lengthi1LS(struct _fx_LS_data_t* l, void* fx_fv)
+{
+   
+return fx_list_length(l);
+
+}
+
 FX_EXTERN_C int _fx_M3AstFM3cmpi2SS(fx_str_t* s1_0, fx_str_t* s2_0, int_* fx_result, void* fx_fv)
 {
    int fx_status = 0;
    *fx_result = _fx_F7__cmp__i2SS(s1_0, s2_0, 0);
    return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM1tNt10Hashmap__t2iLS6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* arg0,
+   int_ arg1,
+   int_ arg2,
+   int_ arg3,
+   fx_arr_t* arg4,
+   fx_arr_t* arg5,
+   struct _fx_Nt10Hashmap__t2iLS_data_t** fx_result)
+{
+   FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_Nt10Hashmap__t2iLS);
+   _fx_copy_Rt20Hashmap__hashentry_t2iLS(arg0, &v->u.t.t0);
+   v->u.t.t1 = arg1;
+   v->u.t.t2 = arg2;
+   v->u.t.t3 = arg3;
+   fx_copy_arr(arg4, &v->u.t.t4);
+   fx_copy_arr(arg5, &v->u.t.t5);
+   return 0;
 }
 
 FX_EXTERN_C int _fx_M3AstFM1tNt10Hashmap__t2Si6Rt20Hashmap__hashentry_t2SiiiiA1iA1Rt20Hashmap__hashentry_t2Si(
@@ -5038,6 +5211,47 @@ FX_EXTERN_C int _fx_M3AstFM1tNt10Hashmap__t2Si6Rt20Hashmap__hashentry_t2SiiiiA1i
    fx_copy_arr(arg4, &v->u.t.t4);
    fx_copy_arr(arg5, &v->u.t.t5);
    return 0;
+}
+
+FX_EXTERN_C int _fx_M3AstFM5emptyNt10Hashmap__t2iLS3iiLS(
+   int_ size0_0,
+   int_ k0_0,
+   struct _fx_LS_data_t* d0_0,
+   struct _fx_Nt10Hashmap__t2iLS_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_Rt20Hashmap__hashentry_t2iLS entry0_0 = {0};
+   fx_arr_t v_0 = {0};
+   fx_arr_t v_1 = {0};
+   int fx_status = 0;
+   int_ size_0 = 8;
+   while (size_0 < size0_0) {
+      size_0 = size_0 * 2;
+   }
+   int_ idxsize_0 = size_0 * 2;
+   _fx_make_Rt20Hashmap__hashentry_t2iLS(0ULL, k0_0, d0_0, &entry0_0);
+   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(idxsize_0, &v_0, 0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2iLS* dstptr_0 = 0;
+   int_ n_0 = size_0;
+   {
+      const int_ shape_0[] = { n_0 };
+      FX_CALL(
+         fx_make_arr(1, shape_0, sizeof(_fx_Rt20Hashmap__hashentry_t2iLS), (fx_free_t)_fx_free_Rt20Hashmap__hashentry_t2iLS,
+            (fx_copy_t)_fx_copy_Rt20Hashmap__hashentry_t2iLS, 0, &v_1), _fx_cleanup);
+   }
+   dstptr_0 = (_fx_Rt20Hashmap__hashentry_t2iLS*)v_1.data;
+   for (int_ i_0 = 0; i_0 < n_0; i_0++, dstptr_0++) {
+      _fx_copy_Rt20Hashmap__hashentry_t2iLS(&entry0_0, dstptr_0);
+   }
+   FX_CALL(
+      _fx_M3AstFM1tNt10Hashmap__t2iLS6Rt20Hashmap__hashentry_t2iLSiiiA1iA1Rt20Hashmap__hashentry_t2iLS(&entry0_0, 0, 0, 0, &v_0,
+         &v_1, fx_result), _fx_cleanup);
+
+_fx_cleanup: ;
+   _fx_free_Rt20Hashmap__hashentry_t2iLS(&entry0_0);
+   FX_FREE_ARR(&v_0);
+   FX_FREE_ARR(&v_1);
+   return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM5emptyNt10Hashmap__t2Si3iSi(
@@ -5129,6 +5343,54 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M3AstFM9add_fast_i4iA1iA1Rt20Hashmap__hashentry_t2iLSRt20Hashmap__hashentry_t2iLS(
+   int_ tabsz_0,
+   fx_arr_t* ht_index_0,
+   fx_arr_t* ht_table_0,
+   struct _fx_Rt20Hashmap__hashentry_t2iLS* entry_0,
+   int_* fx_result,
+   void* fx_fv)
+{
+   fx_exn_t v_0 = {0};
+   int fx_status = 0;
+   int_ idxsz_0 = FX_ARR_SIZE(*ht_index_0, 0);
+   uint64_t hv_0 = entry_0->hv;
+   uint64_t perturb_0 = hv_0;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   bool found_free_slot_0 = false;
+   int_ v_1 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_1; i_0++) {
+      FX_CHKIDX(FX_CHKIDX1(*ht_index_0, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, *ht_index_0, j_0);
+      if (tidx_0 == 0) {
+         FX_CHKIDX(FX_CHKIDX1(*ht_index_0, 0, j_0), _fx_catch_0);
+         *FX_PTR_1D(int_, *ht_index_0, j_0) = tabsz_0 + 2;
+         FX_CHKIDX(FX_CHKIDX1(*ht_table_0, 0, tabsz_0), _fx_catch_0);
+         _fx_Rt20Hashmap__hashentry_t2iLS* v_2 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, *ht_table_0, tabsz_0);
+         _fx_free_Rt20Hashmap__hashentry_t2iLS(v_2);
+         _fx_copy_Rt20Hashmap__hashentry_t2iLS(entry_0, v_2);
+         found_free_slot_0 = true;
+         FX_BREAK(_fx_catch_0);
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   if (!found_free_slot_0) {
+      fx_str_t slit_0 = FX_MAKE_STR("cannot insert element (full Hashtable?!)");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_0), _fx_cleanup);
+      FX_THROW(&v_0, true, _fx_cleanup);
+   }
+   *fx_result = tabsz_0 + 1;
+
+_fx_cleanup: ;
+   fx_free_exn(&v_0);
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M3AstFM4growv2Nt10Hashmap__t2Sii(struct _fx_Nt10Hashmap__t2Si_data_t* self_0, int_ new_size_0, void* fx_fv)
 {
    fx_arr_t ht_table_0 = {0};
@@ -5181,6 +5443,66 @@ FX_EXTERN_C int _fx_M3AstFM4growv2Nt10Hashmap__t2Sii(struct _fx_Nt10Hashmap__t2S
 _fx_cleanup: ;
    FX_FREE_ARR(&ht_table_0);
    _fx_free_Rt20Hashmap__hashentry_t2Si(&v_0);
+   FX_FREE_ARR(&new_ht_table_0);
+   FX_FREE_ARR(&new_ht_index_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM4growv2Nt10Hashmap__t2iLSi(
+   struct _fx_Nt10Hashmap__t2iLS_data_t* self_0,
+   int_ new_size_0,
+   void* fx_fv)
+{
+   fx_arr_t ht_table_0 = {0};
+   _fx_Rt20Hashmap__hashentry_t2iLS v_0 = {0};
+   fx_arr_t new_ht_table_0 = {0};
+   fx_arr_t new_ht_index_0 = {0};
+   int fx_status = 0;
+   fx_copy_arr(&self_0->u.t.t5, &ht_table_0);
+   _fx_copy_Rt20Hashmap__hashentry_t2iLS(&self_0->u.t.t0, &v_0);
+   _fx_Rt20Hashmap__hashentry_t2iLS* dstptr_0 = 0;
+   {
+      const int_ shape_0[] = { new_size_0 };
+      FX_CALL(
+         fx_make_arr(1, shape_0, sizeof(_fx_Rt20Hashmap__hashentry_t2iLS), (fx_free_t)_fx_free_Rt20Hashmap__hashentry_t2iLS,
+            (fx_copy_t)_fx_copy_Rt20Hashmap__hashentry_t2iLS, 0, &new_ht_table_0), _fx_cleanup);
+   }
+   dstptr_0 = (_fx_Rt20Hashmap__hashentry_t2iLS*)new_ht_table_0.data;
+   for (int_ i_0 = 0; i_0 < new_size_0; i_0++, dstptr_0++) {
+      _fx_copy_Rt20Hashmap__hashentry_t2iLS(&v_0, dstptr_0);
+   }
+   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(new_size_0 * 2, &new_ht_index_0, 0), _fx_cleanup);
+   int_ tabsz_0 = 0;
+   int_ v_1 = self_0->u.t.t2;
+   for (int_ j_0 = 0; j_0 < v_1; j_0++) {
+      _fx_Rt20Hashmap__hashentry_t2iLS v_2 = {0};
+      FX_CHKIDX(FX_CHKIDX1(ht_table_0, 0, j_0), _fx_catch_0);
+      if (FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, ht_table_0, j_0)->hv < 9223372036854775808ULL) {
+         FX_CHKIDX(FX_CHKIDX1(ht_table_0, 0, j_0), _fx_catch_0);
+         _fx_copy_Rt20Hashmap__hashentry_t2iLS(FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, ht_table_0, j_0), &v_2);
+         int_ v_3;
+         FX_CALL(
+            _fx_M3AstFM9add_fast_i4iA1iA1Rt20Hashmap__hashentry_t2iLSRt20Hashmap__hashentry_t2iLS(tabsz_0, &new_ht_index_0,
+               &new_ht_table_0, &v_2, &v_3, 0), _fx_catch_0);
+         tabsz_0 = v_3;
+      }
+
+   _fx_catch_0: ;
+      _fx_free_Rt20Hashmap__hashentry_t2iLS(&v_2);
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   fx_arr_t* v_4 = &self_0->u.t.t4;
+   FX_FREE_ARR(v_4);
+   fx_copy_arr(&new_ht_index_0, v_4);
+   fx_arr_t* v_5 = &self_0->u.t.t5;
+   FX_FREE_ARR(v_5);
+   fx_copy_arr(&new_ht_table_0, v_5);
+   self_0->u.t.t2 = tabsz_0;
+   self_0->u.t.t3 = 0;
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&ht_table_0);
+   _fx_free_Rt20Hashmap__hashentry_t2iLS(&v_0);
    FX_FREE_ARR(&new_ht_table_0);
    FX_FREE_ARR(&new_ht_index_0);
    return fx_status;
@@ -5329,6 +5651,59 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M3AstFM9find_idx_Ta2i2Nt10Hashmap__t2iLSi(
+   struct _fx_Nt10Hashmap__t2iLS_data_t* self_0,
+   int_ k_0,
+   struct _fx_Ta2i* fx_result,
+   void* fx_fv)
+{
+   fx_arr_t v_0 = {0};
+   int fx_status = 0;
+   uint64_t hv_0 = ((uint64_t)k_0 ^ 14695981039346656037ULL) & 9223372036854775807ULL;
+   fx_copy_arr(&self_0->u.t.t4, &v_0);
+   int_ idxsz_0 = FX_ARR_SIZE(v_0, 0);
+   uint64_t perturb_0 = hv_0;
+   int_ found_0 = -1;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   int_ v_1 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_1; i_0++) {
+      _fx_Rt20Hashmap__hashentry_t2iLS entry_0 = {0};
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, self_0->u.t.t4, j_0);
+      if (tidx_0 >= 2) {
+         int_ v_2 = tidx_0 - 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, v_2), _fx_catch_0);
+         _fx_copy_Rt20Hashmap__hashentry_t2iLS(FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, self_0->u.t.t5, v_2), &entry_0);
+         bool t_0;
+         if (entry_0.hv == hv_0) {
+            t_0 = entry_0.key == k_0;
+         }
+         else {
+            t_0 = false;
+         }
+         if (t_0) {
+            found_0 = tidx_0 - 2; FX_BREAK(_fx_catch_0);
+         }
+      }
+      else if (tidx_0 == 0) {
+         FX_BREAK(_fx_catch_0);
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      _fx_free_Rt20Hashmap__hashentry_t2iLS(&entry_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   _fx_Ta2i tup_0 = { j_0, found_0 };
+   *fx_result = tup_0;
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&v_0);
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(
    struct _fx_Nt10Hashmap__t2Si_data_t* self_0,
    fx_str_t* k_0,
@@ -5451,6 +5826,133 @@ _fx_cleanup: ;
    FX_FREE_ARR(&v_1);
    _fx_free_Rt20Hashmap__hashentry_t2Si(&v_2);
    fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2iLSi(
+   struct _fx_Nt10Hashmap__t2iLS_data_t* self_0,
+   int_ k_0,
+   int_* fx_result,
+   void* fx_fv)
+{
+   fx_arr_t v_0 = {0};
+   fx_arr_t v_1 = {0};
+   _fx_LS v_2 = 0;
+   _fx_Rt20Hashmap__hashentry_t2iLS v_3 = {0};
+   fx_exn_t v_4 = {0};
+   int fx_status = 0;
+   uint64_t hv_0 = ((uint64_t)k_0 ^ 14695981039346656037ULL) & 9223372036854775807ULL;
+   fx_copy_arr(&self_0->u.t.t4, &v_0);
+   int_ idxsz_0 = FX_ARR_SIZE(v_0, 0);
+   if (self_0->u.t.t1 + 1 > idxsz_0 >> 1) {
+      while (idxsz_0 < (self_0->u.t.t1 + 1) * 2) {
+         idxsz_0 = idxsz_0 * 2;
+      }
+      FX_CALL(_fx_M3AstFM4growv2Nt10Hashmap__t2iLSi(self_0, fx_maxi(idxsz_0 / 2, self_0->u.t.t1 + 1), 0), _fx_cleanup);
+   }
+   uint64_t perturb_0 = hv_0;
+   int_ found_0 = -1;
+   int_ insert_idx_0 = -1;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   int_ v_5 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_5; i_0++) {
+      _fx_Rt20Hashmap__hashentry_t2iLS entry_0 = {0};
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, self_0->u.t.t4, j_0);
+      if (tidx_0 >= 2) {
+         int_ v_6 = tidx_0 - 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, v_6), _fx_catch_0);
+         _fx_copy_Rt20Hashmap__hashentry_t2iLS(FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, self_0->u.t.t5, v_6), &entry_0);
+         bool t_0;
+         if (entry_0.hv == hv_0) {
+            t_0 = entry_0.key == k_0;
+         }
+         else {
+            t_0 = false;
+         }
+         if (t_0) {
+            found_0 = tidx_0 - 2; FX_BREAK(_fx_catch_0);
+         }
+      }
+      else if (tidx_0 == 0) {
+         if (insert_idx_0 < 0) {
+            insert_idx_0 = j_0;
+         }
+         FX_BREAK(_fx_catch_0);
+      }
+      else {
+         bool t_1;
+         if (tidx_0 == 1) {
+            t_1 = insert_idx_0 < 0;
+         }
+         else {
+            t_1 = false;
+         }
+         if (t_1) {
+            insert_idx_0 = j_0;
+         }
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      _fx_free_Rt20Hashmap__hashentry_t2iLS(&entry_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   if (found_0 >= 0) {
+      bool t_2;
+      if (insert_idx_0 >= 0) {
+         t_2 = insert_idx_0 != j_0;
+      }
+      else {
+         t_2 = false;
+      }
+      if (t_2) {
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, insert_idx_0), _fx_cleanup);
+         *FX_PTR_1D(int_, self_0->u.t.t4, insert_idx_0) = found_0 + 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_cleanup);
+         *FX_PTR_1D(int_, self_0->u.t.t4, j_0) = 1;
+      }
+   }
+   else if (insert_idx_0 >= 0) {
+      found_0 = self_0->u.t.t3 - 1;
+      if (found_0 >= 0) {
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, found_0), _fx_cleanup);
+         self_0->u.t.t3 =
+            (int_)(FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, self_0->u.t.t5, found_0)->hv & 9223372036854775807ULL);
+      }
+      else {
+         found_0 = self_0->u.t.t2;
+         self_0->u.t.t2 = self_0->u.t.t2 + 1;
+         fx_copy_arr(&self_0->u.t.t5, &v_1);
+         FX_CALL(_fx_F6assertv1B(found_0 < FX_ARR_SIZE(v_1, 0), 0), _fx_cleanup);
+      }
+      FX_COPY_PTR(self_0->u.t.t0.data, &v_2);
+      _fx_make_Rt20Hashmap__hashentry_t2iLS(hv_0, k_0, v_2, &v_3);
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, found_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2iLS* v_7 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, self_0->u.t.t5, found_0);
+      _fx_free_Rt20Hashmap__hashentry_t2iLS(v_7);
+      _fx_copy_Rt20Hashmap__hashentry_t2iLS(&v_3, v_7);
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, insert_idx_0), _fx_cleanup);
+      *FX_PTR_1D(int_, self_0->u.t.t4, insert_idx_0) = found_0 + 2;
+      self_0->u.t.t1 = self_0->u.t.t1 + 1;
+   }
+   else {
+      fx_str_t slit_0 = FX_MAKE_STR("cannot insert element (full Hashtable?!)");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
+   }
+   *fx_result = found_0;
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&v_0);
+   FX_FREE_ARR(&v_1);
+   if (v_2) {
+      _fx_free_LS(&v_2);
+   }
+   _fx_free_Rt20Hashmap__hashentry_t2iLS(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -7747,7 +8249,7 @@ FX_EXTERN_C int _fx_M3AstFM12make_new_typN10Ast__typ_t0(struct _fx_N10Ast__typ_t
 {
    _fx_rNt6option1N10Ast__typ_t v_0 = 0;
    int fx_status = 0;
-   FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None4_, &v_0), _fx_cleanup);
+   FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None5_, &v_0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_0, fx_result), _fx_cleanup);
 
 _fx_cleanup: ;
@@ -7765,7 +8267,7 @@ FX_EXTERN_C int _fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(
    _fx_rNt6option1N10Ast__typ_t v_0 = 0;
    _fx_N10Ast__typ_t v_1 = 0;
    int fx_status = 0;
-   FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None4_, &v_0), _fx_cleanup);
+   FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None5_, &v_0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_0, &v_1), _fx_cleanup);
    _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_1, l_0, fx_result);
 
@@ -8316,42 +8818,44 @@ FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(
    fx_str_t fname_0 = {0};
    fx_str_t v_0 = {0};
    fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
    int fx_status = 0;
    if (loc_0->m_idx >= 0) {
-      int_ v_2 = loc_0->m_idx;
-      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_2), _fx_cleanup);
-      fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_2))->u.defmodule_t.t1, &fname_0);
+      int_ v_3 = loc_0->m_idx;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_3), _fx_cleanup);
+      fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_3))->u.defmodule_t.t1, &fname_0);
    }
    else {
       fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
    }
    FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_0, 0), _fx_cleanup);
    FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_1, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_2, 0), _fx_cleanup);
    fx_str_t slit_1 = FX_MAKE_STR(":");
    fx_str_t slit_2 = FX_MAKE_STR(":");
    fx_str_t slit_3 = FX_MAKE_STR(": error: ");
    {
-      const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, *msg_0 };
-      FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, *msg_0, v_2 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_0, 8, &whole_msg_0), _fx_cleanup);
    }
    FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
    if (all_compile_err_ctx_0 == 0) {
       fx_copy_str(&whole_msg_0, &whole_msg_1);
    }
    else {
-      _fx_LS v_3 = 0;
-      FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_3), _fx_catch_0);
+      _fx_LS v_4 = 0;
+      FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_4), _fx_catch_0);
       fx_str_t slit_4 =
          FX_MAKE_STR("\n"
             U"\t");
-      FX_CALL(_fx_F4joinS2SLS(&slit_4, v_3, &whole_msg_1, 0), _fx_catch_0);
+      FX_CALL(_fx_F4joinS2SLS(&slit_4, v_4, &whole_msg_1, 0), _fx_catch_0);
 
    _fx_catch_0: ;
-      if (v_3) {
-         _fx_free_LS(&v_3);
+      if (v_4) {
+         _fx_free_LS(&v_4);
       }
    }
    FX_CHECK_EXN(_fx_cleanup);
@@ -8361,11 +8865,229 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_0);
    FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15get_source_lineS2ii(int_ m_idx_0, int_ lineno_0, fx_str_t* fx_result, void* fx_fv)
+{
+   _fx_Nt6option1LS v_0 = {0};
+   _fx_LS v_1 = 0;
+   _fx_LS lines_0 = 0;
+   fx_str_t result_0 = {0};
+   _fx_LS l_0 = 0;
+   int fx_status = 0;
+   bool t_0;
+   if (m_idx_0 < 0) {
+      t_0 = true;
+   }
+   else {
+      t_0 = lineno_0 < 1;
+   }
+   if (t_0) {
+      fx_str_t slit_0 = FX_MAKE_STR(""); fx_copy_str(&slit_0, fx_result);
+   }
+   else {
+      _fx_Ta2i v_2;
+      FX_CALL(_fx_M3AstFM9find_idx_Ta2i2Nt10Hashmap__t2iLSi(_fx_g20Ast__src_lines_cache, m_idx_0, &v_2, 0), _fx_cleanup);
+      int_ j_0 = v_2.t1;
+      if (j_0 >= 0) {
+         FX_CHKIDX(FX_CHKIDX1(_fx_g20Ast__src_lines_cache->u.t.t5, 0, j_0), _fx_cleanup);
+         FX_COPY_PTR(FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, _fx_g20Ast__src_lines_cache->u.t.t5, j_0)->data, &v_1);
+         _fx_M3AstFM4SomeNt6option1LS1LS(v_1, &v_0);
+      }
+      else {
+         _fx_copy_Nt6option1LS(&_fx_g11Ast__None1_, &v_0);
+      }
+      if (v_0.tag == 2) {
+         FX_COPY_PTR(v_0.u.Some, &lines_0);
+      }
+      else {
+         _fx_LS ls_0 = 0;
+         fx_exn_t curr_exn_0 = {0};
+         fx_str_t v_3 = {0};
+         fx_str_t v_4 = {0};
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_catch_0);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0))->u.defmodule_t.t1, &v_3);
+         FX_CALL(_fx_M4FileFM9read_utf8S1S(&v_3, &v_4, 0), _fx_catch_0);
+         FX_CALL(_fx_M6StringFM5splitLS3SCB(&v_4, (char_)10, true, &ls_0, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         FX_FREE_STR(&v_3);
+         FX_FREE_STR(&v_4);
+         if (fx_status < 0) {
+            fx_exn_get_and_reset(fx_status, &curr_exn_0);
+            fx_status = 0;
+            if (ls_0) {
+               _fx_free_LS(&ls_0);
+            }
+         }
+         int_ idx_0;
+         FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2iLSi(_fx_g20Ast__src_lines_cache, m_idx_0, &idx_0, 0),
+            _fx_catch_1);
+         FX_CHKIDX(FX_CHKIDX1(_fx_g20Ast__src_lines_cache->u.t.t5, 0, idx_0), _fx_catch_1);
+         _fx_LS* v_5 = &FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, _fx_g20Ast__src_lines_cache->u.t.t5, idx_0)->data;
+         _fx_free_LS(v_5);
+         FX_COPY_PTR(ls_0, v_5);
+         FX_COPY_PTR(ls_0, &lines_0);
+
+      _fx_catch_1: ;
+         fx_free_exn(&curr_exn_0);
+         if (ls_0) {
+            _fx_free_LS(&ls_0);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      int_ v_6 = _fx_M3AstFM6lengthi1LS(lines_0, 0);
+      if ((bool)((1 <= lineno_0) & (lineno_0 <= v_6))) {
+         FX_COPY_PTR(lines_0, &l_0);
+         int_ n_0 = lineno_0 - 1;
+         for (;;) {
+            _fx_LS l_1 = 0;
+            FX_COPY_PTR(l_0, &l_1);
+            int_ n_1 = n_0;
+            if (l_1 != 0) {
+               if (n_1 == 0) {
+                  fx_str_t* a_0 = &l_1->hd; FX_FREE_STR(&result_0); fx_copy_str(a_0, &result_0); FX_BREAK(_fx_catch_2);
+               }
+               else {
+                  _fx_LS* rest_0 = &l_1->tl; _fx_free_LS(&l_0); FX_COPY_PTR(*rest_0, &l_0); n_0 = n_1 - 1;
+               }
+
+            _fx_catch_2: ;
+            }
+            else {
+               FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_3);
+            }
+            FX_CHECK_EXN(_fx_catch_3);
+
+         _fx_catch_3: ;
+            if (l_1) {
+               _fx_free_LS(&l_1);
+            }
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         fx_copy_str(&result_0, fx_result);
+      }
+      else {
+         fx_str_t slit_1 = FX_MAKE_STR(""); fx_copy_str(&slit_1, fx_result);
+      }
+   }
+
+_fx_cleanup: ;
+   _fx_free_Nt6option1LS(&v_0);
+   if (v_1) {
+      _fx_free_LS(&v_1);
+   }
+   if (lines_0) {
+      _fx_free_LS(&lines_0);
+   }
+   FX_FREE_STR(&result_0);
+   if (l_0) {
+      _fx_free_LS(&l_0);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM11loc_excerptS1RM5loc_t(struct _fx_R10Ast__loc_t* loc_0, fx_str_t* fx_result, void* fx_fv)
+{
+   fx_str_t raw_0 = {0};
+   fx_arr_t v_0 = {0};
+   fx_str_t disp_0 = {0};
+   fx_str_t gutter_0 = {0};
+   fx_str_t pad_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t caret_0 = {0};
+   int fx_status = 0;
+   bool t_0;
+   if (!(_fx_g19Ast__compiler_stage.tag == 2)) {
+      t_0 = true;
+   }
+   else {
+      t_0 = loc_0->col0 < 1;
+   }
+   if (t_0) {
+      fx_str_t slit_0 = FX_MAKE_STR(""); fx_copy_str(&slit_0, fx_result);
+   }
+   else {
+      FX_CALL(_fx_M3AstFM15get_source_lineS2ii(loc_0->m_idx, loc_0->line0, &raw_0, 0), _fx_cleanup);
+      if (FX_STR_LENGTH(raw_0) == 0) {
+         fx_str_t slit_1 = FX_MAKE_STR(""); fx_copy_str(&slit_1, fx_result);
+      }
+      else {
+         char_* dstptr_0 = 0;
+         int_ len_0 = FX_STR_LENGTH(raw_0);
+         {
+            const int_ shape_0[] = { len_0 };
+            FX_CALL(fx_make_arr(1, shape_0, sizeof(char_), 0, 0, 0, &v_0), _fx_cleanup);
+         }
+         dstptr_0 = (char_*)v_0.data;
+         for (int_ i_0 = 0; i_0 < len_0; i_0++, dstptr_0++) {
+            char_ c_0 = raw_0.data[i_0];
+            char_ t_1;
+            if (c_0 == (char_)9) {
+               t_1 = (char_)32;
+            }
+            else {
+               t_1 = c_0;
+            }
+            *dstptr_0 = t_1;
+         }
+         FX_CALL(_fx_F6stringS1A1C(&v_0, &disp_0, 0), _fx_cleanup);
+         FX_CALL(_fx_F6stringS1i(loc_0->line0, &gutter_0, 0), _fx_cleanup);
+         FX_CALL(_fx_F7__mul__S2Ci((char_)32, FX_STR_LENGTH(gutter_0), &pad_0, 0), _fx_cleanup);
+         bool t_2;
+         if (loc_0->line1 == loc_0->line0) {
+            t_2 = loc_0->col1 > loc_0->col0;
+         }
+         else {
+            t_2 = false;
+         }
+         int_ span_0;
+         if (t_2) {
+            span_0 = loc_0->col1 - loc_0->col0;
+         }
+         else {
+            span_0 = 1;
+         }
+         FX_CALL(_fx_F7__mul__S2Ci((char_)32, loc_0->col0 - 1, &v_1, 0), _fx_cleanup);
+         FX_CALL(_fx_F7__mul__S2Ci((char_)126, span_0 - 1, &v_2, 0), _fx_cleanup);
+         fx_str_t slit_2 = FX_MAKE_STR("^");
+         {
+            const fx_str_t strs_0[] = { v_1, slit_2, v_2 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &caret_0), _fx_cleanup);
+         }
+         fx_str_t slit_3 =
+            FX_MAKE_STR("\n"
+               U" ");
+         fx_str_t slit_4 = FX_MAKE_STR(" | ");
+         fx_str_t slit_5 =
+            FX_MAKE_STR("\n"
+               U" ");
+         fx_str_t slit_6 = FX_MAKE_STR(" | ");
+         {
+            const fx_str_t strs_1[] = { slit_3, gutter_0, slit_4, disp_0, slit_5, pad_0, slit_6, caret_0 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 8, fx_result), _fx_cleanup);
+         }
+      }
+   }
+
+_fx_cleanup: ;
+   FX_FREE_STR(&raw_0);
+   FX_FREE_ARR(&v_0);
+   FX_FREE_STR(&disp_0);
+   FX_FREE_STR(&gutter_0);
+   FX_FREE_STR(&pad_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&caret_0);
    return fx_status;
 }
 
@@ -8375,11 +9097,13 @@ FX_EXTERN_C int _fx_M3AstFM15compile_warningv2RM5loc_tS(struct _fx_R10Ast__loc_t
    fx_str_t v_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t whole_msg_0 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    int fx_status = 0;
    if (loc_0->m_idx >= 0) {
-      int_ v_2 = loc_0->m_idx;
-      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_2), _fx_cleanup);
-      fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_2))->u.defmodule_t.t1, &fname_0);
+      int_ v_4 = loc_0->m_idx;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_4), _fx_cleanup);
+      fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_4))->u.defmodule_t.t1, &fname_0);
    }
    else {
       fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
@@ -8393,7 +9117,12 @@ FX_EXTERN_C int _fx_M3AstFM15compile_warningv2RM5loc_tS(struct _fx_R10Ast__loc_t
       const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, *msg_0 };
       FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
    }
-   _fx_F12print_stringv1S(&whole_msg_0, 0);
+   FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_2, 0), _fx_cleanup);
+   {
+      const fx_str_t strs_1[] = { whole_msg_0, v_2 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 2, &v_3), _fx_cleanup);
+   }
+   _fx_F12print_stringv1S(&v_3, 0);
    fx_str_t slit_4 = FX_MAKE_STR("\n");
    _fx_F12print_stringv1S(&slit_4, 0);
    _fx_g22Ast__all_compile_warns = _fx_g22Ast__all_compile_warns + 1;
@@ -8403,6 +9132,8 @@ _fx_cleanup: ;
    FX_FREE_STR(&v_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&whole_msg_0);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    return fx_status;
 }
 
@@ -8514,10 +9245,11 @@ FX_EXTERN_C int _fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(
       fx_str_t fname_0 = {0};
       fx_str_t v_1 = {0};
       fx_str_t v_2 = {0};
+      fx_str_t v_3 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_3 = {0};
+      fx_exn_t v_4 = {0};
       bool t_0;
       if ((bool)((id_0->m == _fx_g9Ast__noid.m) & (id_0->i == _fx_g9Ast__noid.i))) {
          t_0 = (bool)((id_0->m == 0) | (id_0->j == _fx_g9Ast__noid.j));
@@ -8529,56 +9261,58 @@ FX_EXTERN_C int _fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(
          fx_str_t slit_0 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_0, &v_0);
       }
       else {
-         int_ v_4 = id_0->i;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_4), _fx_catch_1);
-         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_4), &v_0);
+         int_ v_5 = id_0->i;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_5), _fx_catch_1);
+         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_5), &v_0);
       }
       if (loc_0->m_idx >= 0) {
-         int_ v_5 = loc_0->m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_5), _fx_catch_1);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_5))->u.defmodule_t.t1, &fname_0);
+         int_ v_6 = loc_0->m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_6), _fx_catch_1);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_6))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_1 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_1, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_1, 0), _fx_catch_1);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_2, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_3, 0), _fx_catch_1);
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(": error: attempt to query information about unresolved \'");
       fx_str_t slit_5 = FX_MAKE_STR("\'");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_2, v_1, slit_3, v_2, slit_4, v_0, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 8, &whole_msg_0), _fx_catch_1);
+         const fx_str_t strs_0[] = { fname_0, slit_2, v_1, slit_3, v_2, slit_4, v_0, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_1);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_6 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_6), _fx_catch_0);
+         _fx_LS v_7 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_7), _fx_catch_0);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_6, &whole_msg_1, 0), _fx_catch_0);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_7, &whole_msg_1, 0), _fx_catch_0);
 
       _fx_catch_0: ;
-         if (v_6) {
-            _fx_free_LS(&v_6);
+         if (v_7) {
+            _fx_free_LS(&v_7);
          }
       }
       FX_CHECK_EXN(_fx_catch_1);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_3), _fx_catch_1);
-      FX_THROW(&v_3, true, _fx_catch_1);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_4), _fx_catch_1);
+      FX_THROW(&v_4, true, _fx_catch_1);
 
    _fx_catch_1: ;
-      fx_free_exn(&v_3);
+      fx_free_exn(&v_4);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_3);
       FX_FREE_STR(&v_2);
       FX_FREE_STR(&v_1);
       FX_FREE_STR(&fname_0);
@@ -8643,10 +9377,11 @@ FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t* s_0, int_* fx_result, vo
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
@@ -8684,57 +9419,58 @@ FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t* s_0, int_* fx_result, vo
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_4 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_4);
-         fx_copy_arr(&new_data_0, v_4);
+         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_5);
+         fx_copy_arr(&new_data_0, v_5);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_5 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
-      FX_FREE_STR(v_5);
-      fx_copy_str(s_0, v_5);
+      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      FX_FREE_STR(v_6);
+      fx_copy_str(s_0, v_6);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
       *fx_result = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_6 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_6), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_6))->u.defmodule_t.t1, &fname_0);
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_7 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_7), _fx_catch_1);
+         _fx_LS v_8 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_7, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_8, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_7) {
-            _fx_free_LS(&v_7);
+         if (v_8) {
+            _fx_free_LS(&v_8);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
 
 _fx_cleanup: ;
@@ -8745,12 +9481,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -8763,18 +9500,19 @@ FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t* s_0, struct _fx_R9Ast__id_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -8805,59 +9543,60 @@ FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t* s_0, struct _fx_R9Ast__id_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
-      FX_FREE_STR(v_6);
-      fx_copy_str(s_0, v_6);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      FX_FREE_STR(v_7);
+      fx_copy_str(s_0, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -8868,12 +9607,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -8886,18 +9626,19 @@ FX_EXTERN_C int _fx_M3AstFM6gen_idRM4id_t2iS(int_ m_idx_0, fx_str_t* s_0, struct
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -8928,61 +9669,62 @@ FX_EXTERN_C int _fx_M3AstFM6gen_idRM4id_t2iS(int_ m_idx_0, fx_str_t* s_0, struct
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
-      FX_FREE_STR(v_6);
-      fx_copy_str(s_0, v_6);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      FX_FREE_STR(v_7);
+      fx_copy_str(s_0, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   int_ v_9;
-   FX_CALL(_fx_M3AstFM10new_id_idxi1i(m_idx_0, &v_9, 0), _fx_cleanup);
-   _fx_R9Ast__id_t rec_0 = { m_idx_0, v_4, v_9 };
+   int_ v_10;
+   FX_CALL(_fx_M3AstFM10new_id_idxi1i(m_idx_0, &v_10, 0), _fx_cleanup);
+   _fx_R9Ast__id_t rec_0 = { m_idx_0, v_5, v_10 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -8993,12 +9735,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -9755,10 +10498,11 @@ FX_EXTERN_C int _fx_M3AstFM10get_moduleN16Ast__defmodule_t2RM4id_tRM5loc_t(
       fx_str_t fname_0 = {0};
       fx_str_t v_3 = {0};
       fx_str_t v_4 = {0};
+      fx_str_t v_5 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_5 = {0};
+      fx_exn_t v_6 = {0};
       bool t_0;
       if ((bool)((m_id_0->m == _fx_g9Ast__noid.m) & (m_id_0->i == _fx_g9Ast__noid.i))) {
          t_0 = (bool)((m_id_0->m == 0) | (m_id_0->j == _fx_g9Ast__noid.j));
@@ -9770,56 +10514,58 @@ FX_EXTERN_C int _fx_M3AstFM10get_moduleN16Ast__defmodule_t2RM4id_tRM5loc_t(
          fx_str_t slit_0 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_0, &v_2);
       }
       else {
-         int_ v_6 = m_id_0->i;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_6), _fx_catch_2);
-         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_6), &v_2);
+         int_ v_7 = m_id_0->i;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_7), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_7), &v_2);
       }
       if (loc_0->m_idx >= 0) {
-         int_ v_7 = loc_0->m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_catch_2);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = loc_0->m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_catch_2);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_1 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_1, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_3, 0), _fx_catch_2);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_4, 0), _fx_catch_2);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_5, 0), _fx_catch_2);
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(": error: identifier \'");
       fx_str_t slit_5 = FX_MAKE_STR("\' is not a module");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_2, v_3, slit_3, v_4, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 8, &whole_msg_0), _fx_catch_2);
+         const fx_str_t strs_0[] = { fname_0, slit_2, v_3, slit_3, v_4, slit_4, v_2, slit_5, v_5 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_2);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_catch_2);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_5), _fx_catch_2);
-      FX_THROW(&v_5, true, _fx_catch_2);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_6), _fx_catch_2);
+      FX_THROW(&v_6, true, _fx_catch_2);
 
    _fx_catch_2: ;
-      fx_free_exn(&v_5);
+      fx_free_exn(&v_6);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_5);
       FX_FREE_STR(&v_4);
       FX_FREE_STR(&v_3);
       FX_FREE_STR(&fname_0);
@@ -9872,7 +10618,7 @@ FX_EXTERN_C int _fx_M3AstFM11find_modulei2RM4id_tS(
          &v_1);
    }
    else {
-      v_1 = _fx_g11Ast__None5_;
+      v_1 = _fx_g11Ast__None6_;
    }
    if (v_1.tag == 2) {
       *fx_result = v_1.u.Some;
@@ -10282,10 +11028,11 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
    fx_str_t fname_0 = {0};
    fx_str_t v_2 = {0};
    fx_str_t v_3 = {0};
+   fx_str_t v_4 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_4 = {0};
+   fx_exn_t v_5 = {0};
    int fx_status = 0;
    bool t_0;
    if ((bool)((n_0->m == _fx_g9Ast__noid.m) & (n_0->i == _fx_g9Ast__noid.i))) {
@@ -10298,9 +11045,9 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
       fx_str_t slit_0 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_0, &n_str_0);
    }
    else {
-      int_ v_5 = n_0->i;
-      FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_5), _fx_cleanup);
-      fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_5), &n_str_0);
+      int_ v_6 = n_0->i;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_6), _fx_cleanup);
+      fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_6), &n_str_0);
    }
    int_ dot_pos_0 = _fx_M6StringFM5rfindi2SC(&n_str_0, (char_)46, 0);
    if (dot_pos_0 < 0) {
@@ -10313,9 +11060,9 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &v_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_6;
+   int_ v_7;
    if (idx_0 >= 0) {
-      v_6 = idx_0;
+      v_7 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_1);
@@ -10346,59 +11093,60 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
             FX_FREE_STR(&t_1);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_7 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_7);
-         fx_copy_arr(&new_data_0, v_7);
+         fx_arr_t* v_8 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_8);
+         fx_copy_arr(&new_data_0, v_8);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_8 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
-      FX_FREE_STR(v_8);
-      fx_copy_str(&v_0, v_8);
+      fx_str_t* v_9 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      FX_FREE_STR(v_9);
+      fx_copy_str(&v_0, v_9);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_6 = n0_0;
+      v_7 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_9 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_9), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_9))->u.defmodule_t.t1, &fname_0);
+         int_ v_10 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_10), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_10))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_1 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_1, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_2, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_3, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_4, 0), _fx_cleanup);
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_2, v_2, slit_3, v_3, slit_4 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_2, v_2, slit_3, v_3, slit_4, v_4 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_10 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_10), _fx_catch_1);
+         _fx_LS v_11 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_11), _fx_catch_1);
          fx_str_t slit_5 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_5, v_10, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_5, v_11, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_10) {
-            _fx_free_LS(&v_10);
+         if (v_11) {
+            _fx_free_LS(&v_11);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
-      FX_THROW(&v_4, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_5), _fx_cleanup);
+      FX_THROW(&v_5, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_6, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_7, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -10411,12 +11159,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_2);
    FX_FREE_STR(&v_3);
+   FX_FREE_STR(&v_4);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_4);
+   fx_free_exn(&v_5);
    return fx_status;
 }
 
@@ -10587,55 +11336,58 @@ FX_EXTERN_C int _fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc
       fx_str_t fname_0 = {0};
       fx_str_t v_5 = {0};
       fx_str_t v_6 = {0};
+      fx_str_t v_7 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_7 = {0};
+      fx_exn_t v_8 = {0};
       if (loc_0->m_idx >= 0) {
-         int_ v_8 = loc_0->m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_catch_2);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
+         int_ v_9 = loc_0->m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_9), _fx_catch_2);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_9))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_5, 0), _fx_catch_2);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_6, 0), _fx_catch_2);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_7, 0), _fx_catch_2);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: ast: attempt to request type of non-existing symbol");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_5, slit_2, v_6, slit_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_catch_2);
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_5, slit_2, v_6, slit_3, v_7 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_catch_2);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_9 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
+         _fx_LS v_10 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_10), _fx_catch_1);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_9, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_10, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_9) {
-            _fx_free_LS(&v_9);
+         if (v_10) {
+            _fx_free_LS(&v_10);
          }
       }
       FX_CHECK_EXN(_fx_catch_2);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_7), _fx_catch_2);
-      FX_THROW(&v_7, true, _fx_catch_2);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_8), _fx_catch_2);
+      FX_THROW(&v_8, true, _fx_catch_2);
 
    _fx_catch_2: ;
-      fx_free_exn(&v_7);
+      fx_free_exn(&v_8);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_7);
       FX_FREE_STR(&v_6);
       FX_FREE_STR(&v_5);
       FX_FREE_STR(&fname_0);
@@ -11716,19 +12468,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_aposRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__apos__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -11759,60 +12512,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_aposRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__apos__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -11823,12 +12577,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -11841,19 +12596,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_addRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__add__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -11884,60 +12640,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_addRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__add__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -11948,12 +12705,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -11966,19 +12724,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_subRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__sub__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12009,60 +12768,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_subRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__sub__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12073,12 +12833,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12091,19 +12852,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__mul__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12134,60 +12896,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__mul__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12198,12 +12961,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12216,19 +12980,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_divRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__div__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12259,60 +13024,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_divRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__div__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12323,12 +13089,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12341,19 +13108,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_rdivRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__rdiv__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12384,60 +13152,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_rdivRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__rdiv__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12448,12 +13217,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12466,19 +13236,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_modRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__mod__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12509,60 +13280,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_modRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__mod__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12573,12 +13345,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12591,19 +13364,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_powRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__pow__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12634,60 +13408,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_powRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__pow__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12698,12 +13473,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12716,19 +13492,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_addRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_add__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12759,60 +13536,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_addRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_add__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12823,12 +13601,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12841,19 +13620,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_subRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_sub__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -12884,60 +13664,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_subRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_sub__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -12948,12 +13729,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -12966,19 +13748,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_mulRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_mul__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13009,60 +13792,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_mulRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_mul__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13073,12 +13857,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13091,19 +13876,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_divRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_div__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13134,60 +13920,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_divRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_div__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13198,12 +13985,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13216,19 +14004,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_modRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_mod__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13259,60 +14048,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_modRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_mod__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13323,12 +14113,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13341,19 +14132,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_powRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_pow__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13384,60 +14176,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_powRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_pow__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13448,12 +14241,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13466,19 +14260,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_shlRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__shl__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13509,60 +14304,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_shlRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__shl__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13573,12 +14369,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13591,19 +14388,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_shrRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__shr__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13634,60 +14432,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_shrRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__shr__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13698,12 +14497,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13716,19 +14516,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_andRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_and__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13759,60 +14560,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_andRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__bit_and__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13823,12 +14625,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13841,19 +14644,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_bit_orRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_or__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -13884,60 +14688,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_bit_orRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__bit_or__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -13948,12 +14753,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -13966,19 +14772,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_xorRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_xor__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14009,60 +14816,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_xorRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__bit_xor__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14073,12 +14881,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14091,19 +14900,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__cmp__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14134,60 +14944,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_op_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__cmp__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14198,12 +15009,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14216,19 +15028,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__eq__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14259,60 +15072,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__eq__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14323,12 +15137,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14341,19 +15156,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_neRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__ne__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14384,60 +15200,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_neRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__ne__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14448,12 +15265,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14466,19 +15284,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__lt__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14509,60 +15328,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__lt__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14573,12 +15393,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14591,19 +15412,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__gt__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14634,60 +15456,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__gt__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14698,12 +15521,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14716,19 +15540,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_leRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__le__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14759,60 +15584,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_leRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__le__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14823,12 +15649,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14841,19 +15668,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_geRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__ge__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -14884,60 +15712,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_op_geRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__ge__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -14948,12 +15777,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -14966,19 +15796,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_cmp__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15009,60 +15840,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_cmp__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15073,12 +15905,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15091,19 +15924,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_eq__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15134,60 +15968,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_eq__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15198,12 +16033,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15216,19 +16052,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_neRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_ne__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15259,60 +16096,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_neRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_ne__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15323,12 +16161,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15341,19 +16180,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_lt__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15384,60 +16224,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_lt__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15448,12 +16289,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15466,19 +16308,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_gt__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15509,60 +16352,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_gt__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15573,12 +16417,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15591,19 +16436,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_leRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_le__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15634,60 +16480,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_leRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_le__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15698,12 +16545,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15716,19 +16564,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_geRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_ge__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15759,60 +16608,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_geRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_ge__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15823,12 +16673,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15841,19 +16692,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_sameRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__same__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -15884,60 +16736,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_sameRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__same__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -15948,12 +16801,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -15966,19 +16820,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_plusRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__plus__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16009,60 +16864,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_op_plusRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__plus__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16073,12 +16929,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16091,19 +16948,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_negateRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__negate__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16134,60 +16992,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_op_negateRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__negate__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16198,12 +17057,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16216,19 +17076,20 @@ FX_EXTERN_C int _fx_M3AstFM18fname_op_dot_minusRM4id_t0(struct _fx_R9Ast__id_t* 
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_minus__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16259,60 +17120,61 @@ FX_EXTERN_C int _fx_M3AstFM18fname_op_dot_minusRM4id_t0(struct _fx_R9Ast__id_t* 
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__dot_minus__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16323,12 +17185,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16341,19 +17204,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_notRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_not__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16384,60 +17248,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_notRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__bit_not__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16448,12 +17313,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16466,19 +17332,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_addRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_add__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16509,60 +17376,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_addRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_add__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16573,12 +17441,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16591,19 +17460,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_subRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_sub__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16634,60 +17504,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_subRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_sub__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16698,12 +17569,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16716,19 +17588,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_mulRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_mul__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16759,60 +17632,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_mulRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_mul__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16823,12 +17697,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16841,19 +17716,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_divRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_div__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -16884,60 +17760,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_divRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_div__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -16948,12 +17825,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -16966,19 +17844,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_modRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_mod__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17009,60 +17888,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_modRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_mod__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17073,12 +17953,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17091,19 +17972,20 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_andRM4id_t0(struct _fx_R9Ast__id_t
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_and__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17134,60 +18016,61 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_andRM4id_t0(struct _fx_R9Ast__id_t
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_and__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17198,12 +18081,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17216,19 +18100,20 @@ FX_EXTERN_C int _fx_M3AstFM19fname_op_aug_bit_orRM4id_t0(struct _fx_R9Ast__id_t*
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_or__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17259,60 +18144,61 @@ FX_EXTERN_C int _fx_M3AstFM19fname_op_aug_bit_orRM4id_t0(struct _fx_R9Ast__id_t*
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_or__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17323,12 +18209,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17341,19 +18228,20 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_xorRM4id_t0(struct _fx_R9Ast__id_t
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_xor__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17384,60 +18272,61 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_xorRM4id_t0(struct _fx_R9Ast__id_t
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_xor__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17448,12 +18337,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17466,19 +18356,20 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_mulRM4id_t0(struct _fx_R9Ast__id_t
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_mul__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17509,60 +18400,61 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_mulRM4id_t0(struct _fx_R9Ast__id_t
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_mul__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17573,12 +18465,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17591,19 +18484,20 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_divRM4id_t0(struct _fx_R9Ast__id_t
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_div__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17634,60 +18528,61 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_divRM4id_t0(struct _fx_R9Ast__id_t
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_div__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17698,12 +18593,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17716,19 +18612,20 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_modRM4id_t0(struct _fx_R9Ast__id_t
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_mod__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17759,60 +18656,61 @@ FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_modRM4id_t0(struct _fx_R9Ast__id_t
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_mod__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17823,12 +18721,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17841,19 +18740,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shlRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_shl__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -17884,60 +18784,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shlRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_shl__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -17948,12 +18849,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -17966,19 +18868,20 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shrRM4id_t0(struct _fx_R9Ast__id_t* fx
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_shr__");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18009,60 +18912,61 @@ FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shrRM4id_t0(struct _fx_R9Ast__id_t* fx
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("__aug_shr__");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18073,12 +18977,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18091,19 +18996,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_to_intRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("int");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18134,60 +19040,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_to_intRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("int");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18198,12 +19105,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18216,19 +19124,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_longRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("long");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18259,60 +19168,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_longRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("long");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18323,12 +19233,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18341,19 +19252,20 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_uint8RM4id_t0(struct _fx_R9Ast__id_t* fx_r
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("uint8");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18384,60 +19296,61 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_uint8RM4id_t0(struct _fx_R9Ast__id_t* fx_r
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("uint8");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18448,12 +19361,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18466,19 +19380,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_int8RM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("int8");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18509,60 +19424,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_int8RM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("int8");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18573,12 +19489,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18591,19 +19508,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint16RM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("uint16");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18634,60 +19552,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint16RM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("uint16");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18698,12 +19617,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18716,19 +19636,20 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int16RM4id_t0(struct _fx_R9Ast__id_t* fx_r
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("int16");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18759,60 +19680,61 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int16RM4id_t0(struct _fx_R9Ast__id_t* fx_r
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("int16");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18823,12 +19745,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18841,19 +19764,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint32RM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("uint32");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -18884,60 +19808,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint32RM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("uint32");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -18948,12 +19873,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -18966,19 +19892,20 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int32RM4id_t0(struct _fx_R9Ast__id_t* fx_r
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("int32");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19009,60 +19936,61 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int32RM4id_t0(struct _fx_R9Ast__id_t* fx_r
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("int32");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19073,12 +20001,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19091,19 +20020,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint64RM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("uint64");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19134,60 +20064,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_uint64RM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("uint64");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19198,12 +20129,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19216,19 +20148,20 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int64RM4id_t0(struct _fx_R9Ast__id_t* fx_r
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("int64");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19259,60 +20192,61 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_int64RM4id_t0(struct _fx_R9Ast__id_t* fx_r
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("int64");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19323,12 +20257,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19341,19 +20276,20 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_floatRM4id_t0(struct _fx_R9Ast__id_t* fx_r
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("float");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19384,60 +20320,61 @@ FX_EXTERN_C int _fx_M3AstFM14fname_to_floatRM4id_t0(struct _fx_R9Ast__id_t* fx_r
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("float");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19448,12 +20385,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19466,19 +20404,20 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_doubleRM4id_t0(struct _fx_R9Ast__id_t* fx_
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("double");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19509,60 +20448,61 @@ FX_EXTERN_C int _fx_M3AstFM15fname_to_doubleRM4id_t0(struct _fx_R9Ast__id_t* fx_
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("double");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19573,12 +20513,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19591,19 +20532,20 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_boolRM4id_t0(struct _fx_R9Ast__id_t* fx_re
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("bool");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19634,60 +20576,61 @@ FX_EXTERN_C int _fx_M3AstFM13fname_to_boolRM4id_t0(struct _fx_R9Ast__id_t* fx_re
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("bool");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19698,12 +20641,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19716,19 +20660,20 @@ FX_EXTERN_C int _fx_M3AstFM12fname_stringRM4id_t0(struct _fx_R9Ast__id_t* fx_res
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("string");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19759,60 +20704,61 @@ FX_EXTERN_C int _fx_M3AstFM12fname_stringRM4id_t0(struct _fx_R9Ast__id_t* fx_res
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("string");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19823,12 +20769,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19841,19 +20788,20 @@ FX_EXTERN_C int _fx_M3AstFM11fname_printRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("print");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -19884,60 +20832,61 @@ FX_EXTERN_C int _fx_M3AstFM11fname_printRM4id_t0(struct _fx_R9Ast__id_t* fx_resu
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("print");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -19948,12 +20897,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -19966,19 +20916,20 @@ FX_EXTERN_C int _fx_M3AstFM10fname_reprRM4id_t0(struct _fx_R9Ast__id_t* fx_resul
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("repr");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -20009,60 +20960,61 @@ FX_EXTERN_C int _fx_M3AstFM10fname_reprRM4id_t0(struct _fx_R9Ast__id_t* fx_resul
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("repr");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -20073,12 +21025,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -20091,19 +21044,20 @@ FX_EXTERN_C int _fx_M3AstFM10fname_hashRM4id_t0(struct _fx_R9Ast__id_t* fx_resul
    fx_str_t fname_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_3 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("hash");
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
    int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-   int_ v_4;
+   int_ v_5;
    if (idx_0 >= 0) {
-      v_4 = idx_0;
+      v_5 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
       fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -20134,60 +21088,61 @@ FX_EXTERN_C int _fx_M3AstFM10fname_hashRM4id_t0(struct _fx_R9Ast__id_t* fx_resul
             FX_FREE_STR(&t_0);
             FX_CHECK_EXN(_fx_cleanup);
          }
-         fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-         FX_FREE_ARR(v_5);
-         fx_copy_arr(&new_data_0, v_5);
+         fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+         FX_FREE_ARR(v_6);
+         fx_copy_arr(&new_data_0, v_6);
       }
       _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_cleanup);
-      fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+      fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
       fx_str_t slit_1 = FX_MAKE_STR("hash");
-      FX_FREE_STR(v_6);
-      fx_copy_str(&slit_1, v_6);
+      FX_FREE_STR(v_7);
+      fx_copy_str(&slit_1, v_7);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-      v_4 = n0_0;
+      v_5 = n0_0;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_7 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(":");
       fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
       _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
-      FX_THROW(&v_3, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
-   _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
@@ -20198,12 +21153,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -20652,18 +21608,19 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
       fx_str_t fname_0 = {0};
       fx_str_t v_1 = {0};
       fx_str_t v_2 = {0};
+      fx_str_t v_3 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_3 = {0};
+      fx_exn_t v_4 = {0};
       int_ h_idx_0;
       fx_str_t slit_0 = FX_MAKE_STR("__apos__");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_catch_2);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_2);
       int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-      int_ v_4;
+      int_ v_5;
       if (idx_0 >= 0) {
-         v_4 = idx_0;
+         v_5 = idx_0;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
          fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_0);
@@ -20696,69 +21653,71 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
                FX_FREE_STR(&t_0);
                FX_CHECK_EXN(_fx_catch_2);
             }
-            fx_arr_t* v_5 = &_fx_g14Ast__all_names->u.t.t1;
-            FX_FREE_ARR(v_5);
-            fx_copy_arr(&new_data_0, v_5);
+            fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
+            FX_FREE_ARR(v_6);
+            fx_copy_arr(&new_data_0, v_6);
          }
          _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
          FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_catch_2);
-         fx_str_t* v_6 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+         fx_str_t* v_7 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
          fx_str_t slit_1 = FX_MAKE_STR("__apos__");
-         FX_FREE_STR(v_6);
-         fx_copy_str(&slit_1, v_6);
+         FX_FREE_STR(v_7);
+         fx_copy_str(&slit_1, v_7);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_2);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-         v_4 = n0_0;
+         v_5 = n0_0;
       }
       else {
          if (_fx_g10Ast__noloc.m_idx >= 0) {
-            int_ v_7 = _fx_g10Ast__noloc.m_idx;
-            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_catch_2);
-            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+            int_ v_8 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_catch_2);
+            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
          }
          else {
             fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
          }
          FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_catch_2);
          FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_catch_2);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_catch_2);
          fx_str_t slit_3 = FX_MAKE_STR(":");
          fx_str_t slit_4 = FX_MAKE_STR(":");
          fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
          {
-            const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_catch_2);
+            const fx_str_t strs_0[] = { fname_0, slit_3, v_1, slit_4, v_2, slit_5, v_3 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_catch_2);
          }
          FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
          if (all_compile_err_ctx_0 == 0) {
             fx_copy_str(&whole_msg_0, &whole_msg_1);
          }
          else {
-            _fx_LS v_8 = 0;
-            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_1);
+            _fx_LS v_9 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_1);
             fx_str_t slit_6 =
                FX_MAKE_STR("\n"
                   U"\t");
-            FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_1);
+            FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_1);
 
          _fx_catch_1: ;
-            if (v_8) {
-               _fx_free_LS(&v_8);
+            if (v_9) {
+               _fx_free_LS(&v_9);
             }
          }
          FX_CHECK_EXN(_fx_catch_2);
-         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_catch_2);
-         FX_THROW(&v_3, true, _fx_catch_2);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_catch_2);
+         FX_THROW(&v_4, true, _fx_catch_2);
       }
-      _fx_R9Ast__id_t rec_0 = { 0, v_4, 0 };
+      _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
       *fx_result = rec_0;
 
    _fx_catch_2: ;
-      fx_free_exn(&v_3);
+      fx_free_exn(&v_4);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_3);
       FX_FREE_STR(&v_2);
       FX_FREE_STR(&v_1);
       FX_FREE_STR(&fname_0);
@@ -20769,29 +21728,30 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
       goto _fx_endmatch_0;
    }
    if (tag_0 == 1) {
-      fx_arr_t v_9 = {0};
+      fx_arr_t v_10 = {0};
       fx_arr_t old_data_1 = {0};
       fx_str_t val0_1 = {0};
       fx_arr_t new_data_1 = {0};
       fx_str_t fname_1 = {0};
-      fx_str_t v_10 = {0};
       fx_str_t v_11 = {0};
+      fx_str_t v_12 = {0};
+      fx_str_t v_13 = {0};
       fx_str_t whole_msg_2 = {0};
       _fx_LS all_compile_err_ctx_1 = 0;
       fx_str_t whole_msg_3 = {0};
-      fx_exn_t v_12 = {0};
+      fx_exn_t v_14 = {0};
       int_ h_idx_1;
       fx_str_t slit_7 = FX_MAKE_STR("__plus__");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_7, &h_idx_1, 0), _fx_catch_5);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_1), _fx_catch_5);
       int_ idx_1 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_1)->data;
-      int_ v_13;
+      int_ v_15;
       if (idx_1 >= 0) {
-         v_13 = idx_1;
+         v_15 = idx_1;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
-         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_9);
-         int_ sz_1 = FX_ARR_SIZE(v_9, 0);
+         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_10);
+         int_ sz_1 = FX_ARR_SIZE(v_10, 0);
          int_ n0_1 = _fx_g14Ast__all_names->u.t.t0;
          if (sz_1 <= n0_1) {
             int_ n1_1 = fx_maxi(n0_1, 128) * 2;
@@ -20820,102 +21780,105 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
                FX_FREE_STR(&t_1);
                FX_CHECK_EXN(_fx_catch_5);
             }
-            fx_arr_t* v_14 = &_fx_g14Ast__all_names->u.t.t1;
-            FX_FREE_ARR(v_14);
-            fx_copy_arr(&new_data_1, v_14);
+            fx_arr_t* v_16 = &_fx_g14Ast__all_names->u.t.t1;
+            FX_FREE_ARR(v_16);
+            fx_copy_arr(&new_data_1, v_16);
          }
          _fx_g14Ast__all_names->u.t.t0 = n0_1 + 1;
          FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_1), _fx_catch_5);
-         fx_str_t* v_15 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_1);
+         fx_str_t* v_17 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_1);
          fx_str_t slit_8 = FX_MAKE_STR("__plus__");
-         FX_FREE_STR(v_15);
-         fx_copy_str(&slit_8, v_15);
+         FX_FREE_STR(v_17);
+         fx_copy_str(&slit_8, v_17);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_1), _fx_catch_5);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_1)->data = n0_1;
-         v_13 = n0_1;
+         v_15 = n0_1;
       }
       else {
          if (_fx_g10Ast__noloc.m_idx >= 0) {
-            int_ v_16 = _fx_g10Ast__noloc.m_idx;
-            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_16), _fx_catch_5);
-            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_16))->u.defmodule_t.t1, &fname_1);
+            int_ v_18 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_18), _fx_catch_5);
+            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_18))->u.defmodule_t.t1, &fname_1);
          }
          else {
             fx_str_t slit_9 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_9, &fname_1);
          }
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_10, 0), _fx_catch_5);
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_11, 0), _fx_catch_5);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_11, 0), _fx_catch_5);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_12, 0), _fx_catch_5);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_13, 0), _fx_catch_5);
          fx_str_t slit_10 = FX_MAKE_STR(":");
          fx_str_t slit_11 = FX_MAKE_STR(":");
          fx_str_t slit_12 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
          {
-            const fx_str_t strs_1[] = { fname_1, slit_10, v_10, slit_11, v_11, slit_12 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 6, &whole_msg_2), _fx_catch_5);
+            const fx_str_t strs_1[] = { fname_1, slit_10, v_11, slit_11, v_12, slit_12, v_13 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 7, &whole_msg_2), _fx_catch_5);
          }
          FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_1);
          if (all_compile_err_ctx_1 == 0) {
             fx_copy_str(&whole_msg_2, &whole_msg_3);
          }
          else {
-            _fx_LS v_17 = 0;
-            FX_CALL(_fx_cons_LS(&whole_msg_2, all_compile_err_ctx_1, true, &v_17), _fx_catch_4);
+            _fx_LS v_19 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_2, all_compile_err_ctx_1, true, &v_19), _fx_catch_4);
             fx_str_t slit_13 =
                FX_MAKE_STR("\n"
                   U"\t");
-            FX_CALL(_fx_F4joinS2SLS(&slit_13, v_17, &whole_msg_3, 0), _fx_catch_4);
+            FX_CALL(_fx_F4joinS2SLS(&slit_13, v_19, &whole_msg_3, 0), _fx_catch_4);
 
          _fx_catch_4: ;
-            if (v_17) {
-               _fx_free_LS(&v_17);
+            if (v_19) {
+               _fx_free_LS(&v_19);
             }
          }
          FX_CHECK_EXN(_fx_catch_5);
-         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_3, &v_12), _fx_catch_5);
-         FX_THROW(&v_12, true, _fx_catch_5);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_3, &v_14), _fx_catch_5);
+         FX_THROW(&v_14, true, _fx_catch_5);
       }
-      _fx_R9Ast__id_t rec_1 = { 0, v_13, 0 };
+      _fx_R9Ast__id_t rec_1 = { 0, v_15, 0 };
       *fx_result = rec_1;
 
    _fx_catch_5: ;
-      fx_free_exn(&v_12);
+      fx_free_exn(&v_14);
       FX_FREE_STR(&whole_msg_3);
       if (all_compile_err_ctx_1) {
          _fx_free_LS(&all_compile_err_ctx_1);
       }
       FX_FREE_STR(&whole_msg_2);
+      FX_FREE_STR(&v_13);
+      FX_FREE_STR(&v_12);
       FX_FREE_STR(&v_11);
-      FX_FREE_STR(&v_10);
       FX_FREE_STR(&fname_1);
       FX_FREE_ARR(&new_data_1);
       FX_FREE_STR(&val0_1);
       FX_FREE_ARR(&old_data_1);
-      FX_FREE_ARR(&v_9);
+      FX_FREE_ARR(&v_10);
       goto _fx_endmatch_0;
    }
    if (tag_0 == 2) {
-      fx_arr_t v_18 = {0};
+      fx_arr_t v_20 = {0};
       fx_arr_t old_data_2 = {0};
       fx_str_t val0_2 = {0};
       fx_arr_t new_data_2 = {0};
       fx_str_t fname_2 = {0};
-      fx_str_t v_19 = {0};
-      fx_str_t v_20 = {0};
+      fx_str_t v_21 = {0};
+      fx_str_t v_22 = {0};
+      fx_str_t v_23 = {0};
       fx_str_t whole_msg_4 = {0};
       _fx_LS all_compile_err_ctx_2 = 0;
       fx_str_t whole_msg_5 = {0};
-      fx_exn_t v_21 = {0};
+      fx_exn_t v_24 = {0};
       int_ h_idx_2;
       fx_str_t slit_14 = FX_MAKE_STR("__negate__");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_14, &h_idx_2, 0), _fx_catch_8);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_2), _fx_catch_8);
       int_ idx_2 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_2)->data;
-      int_ v_22;
+      int_ v_25;
       if (idx_2 >= 0) {
-         v_22 = idx_2;
+         v_25 = idx_2;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
-         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_18);
-         int_ sz_2 = FX_ARR_SIZE(v_18, 0);
+         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_20);
+         int_ sz_2 = FX_ARR_SIZE(v_20, 0);
          int_ n0_2 = _fx_g14Ast__all_names->u.t.t0;
          if (sz_2 <= n0_2) {
             int_ n1_2 = fx_maxi(n0_2, 128) * 2;
@@ -20944,88 +21907,90 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
                FX_FREE_STR(&t_2);
                FX_CHECK_EXN(_fx_catch_8);
             }
-            fx_arr_t* v_23 = &_fx_g14Ast__all_names->u.t.t1;
-            FX_FREE_ARR(v_23);
-            fx_copy_arr(&new_data_2, v_23);
+            fx_arr_t* v_26 = &_fx_g14Ast__all_names->u.t.t1;
+            FX_FREE_ARR(v_26);
+            fx_copy_arr(&new_data_2, v_26);
          }
          _fx_g14Ast__all_names->u.t.t0 = n0_2 + 1;
          FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_2), _fx_catch_8);
-         fx_str_t* v_24 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_2);
+         fx_str_t* v_27 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_2);
          fx_str_t slit_15 = FX_MAKE_STR("__negate__");
-         FX_FREE_STR(v_24);
-         fx_copy_str(&slit_15, v_24);
+         FX_FREE_STR(v_27);
+         fx_copy_str(&slit_15, v_27);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_2), _fx_catch_8);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_2)->data = n0_2;
-         v_22 = n0_2;
+         v_25 = n0_2;
       }
       else {
          if (_fx_g10Ast__noloc.m_idx >= 0) {
-            int_ v_25 = _fx_g10Ast__noloc.m_idx;
-            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_25), _fx_catch_8);
-            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_25))->u.defmodule_t.t1, &fname_2);
+            int_ v_28 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_28), _fx_catch_8);
+            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_28))->u.defmodule_t.t1, &fname_2);
          }
          else {
             fx_str_t slit_16 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_16, &fname_2);
          }
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_19, 0), _fx_catch_8);
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_20, 0), _fx_catch_8);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_21, 0), _fx_catch_8);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_22, 0), _fx_catch_8);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_23, 0), _fx_catch_8);
          fx_str_t slit_17 = FX_MAKE_STR(":");
          fx_str_t slit_18 = FX_MAKE_STR(":");
          fx_str_t slit_19 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
          {
-            const fx_str_t strs_2[] = { fname_2, slit_17, v_19, slit_18, v_20, slit_19 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 6, &whole_msg_4), _fx_catch_8);
+            const fx_str_t strs_2[] = { fname_2, slit_17, v_21, slit_18, v_22, slit_19, v_23 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 7, &whole_msg_4), _fx_catch_8);
          }
          FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_2);
          if (all_compile_err_ctx_2 == 0) {
             fx_copy_str(&whole_msg_4, &whole_msg_5);
          }
          else {
-            _fx_LS v_26 = 0;
-            FX_CALL(_fx_cons_LS(&whole_msg_4, all_compile_err_ctx_2, true, &v_26), _fx_catch_7);
+            _fx_LS v_29 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_4, all_compile_err_ctx_2, true, &v_29), _fx_catch_7);
             fx_str_t slit_20 =
                FX_MAKE_STR("\n"
                   U"\t");
-            FX_CALL(_fx_F4joinS2SLS(&slit_20, v_26, &whole_msg_5, 0), _fx_catch_7);
+            FX_CALL(_fx_F4joinS2SLS(&slit_20, v_29, &whole_msg_5, 0), _fx_catch_7);
 
          _fx_catch_7: ;
-            if (v_26) {
-               _fx_free_LS(&v_26);
+            if (v_29) {
+               _fx_free_LS(&v_29);
             }
          }
          FX_CHECK_EXN(_fx_catch_8);
-         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_5, &v_21), _fx_catch_8);
-         FX_THROW(&v_21, true, _fx_catch_8);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_5, &v_24), _fx_catch_8);
+         FX_THROW(&v_24, true, _fx_catch_8);
       }
-      _fx_R9Ast__id_t rec_2 = { 0, v_22, 0 };
+      _fx_R9Ast__id_t rec_2 = { 0, v_25, 0 };
       *fx_result = rec_2;
 
    _fx_catch_8: ;
-      fx_free_exn(&v_21);
+      fx_free_exn(&v_24);
       FX_FREE_STR(&whole_msg_5);
       if (all_compile_err_ctx_2) {
          _fx_free_LS(&all_compile_err_ctx_2);
       }
       FX_FREE_STR(&whole_msg_4);
-      FX_FREE_STR(&v_20);
-      FX_FREE_STR(&v_19);
+      FX_FREE_STR(&v_23);
+      FX_FREE_STR(&v_22);
+      FX_FREE_STR(&v_21);
       FX_FREE_STR(&fname_2);
       FX_FREE_ARR(&new_data_2);
       FX_FREE_STR(&val0_2);
       FX_FREE_ARR(&old_data_2);
-      FX_FREE_ARR(&v_18);
+      FX_FREE_ARR(&v_20);
       goto _fx_endmatch_0;
    }
    if (tag_0 == 3) {
-      fx_exn_t v_27 = {0};
+      fx_exn_t v_30 = {0};
       int_ h_idx_3;
       fx_str_t slit_21 = FX_MAKE_STR("__dot_minus__");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_21, &h_idx_3, 0), _fx_catch_9);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_3), _fx_catch_9);
       int_ idx_3 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_3)->data;
-      int_ v_28;
+      int_ v_31;
       if (idx_3 >= 0) {
-         v_28 = idx_3;
+         v_31 = idx_3;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
          int_ idx_4;
@@ -21033,31 +21998,31 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
          FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_22, &idx_4, 0), _fx_catch_9);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_3), _fx_catch_9);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_3)->data = idx_4;
-         v_28 = idx_4;
+         v_31 = idx_4;
       }
       else {
          fx_str_t slit_23 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_23, &v_27, 0), _fx_catch_9);
-         FX_THROW(&v_27, false, _fx_catch_9);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_23, &v_30, 0), _fx_catch_9);
+         FX_THROW(&v_30, false, _fx_catch_9);
       }
-      _fx_R9Ast__id_t rec_3 = { 0, v_28, 0 };
+      _fx_R9Ast__id_t rec_3 = { 0, v_31, 0 };
       *fx_result = rec_3;
 
    _fx_catch_9: ;
-      fx_free_exn(&v_27);
+      fx_free_exn(&v_30);
       goto _fx_endmatch_0;
    }
    if (tag_0 == 4) {
-      fx_exn_t v_29 = {0};
+      fx_exn_t v_32 = {0};
       int_ h_idx_4;
       fx_str_t slit_24 = FX_MAKE_STR("__bit_not__");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_24, &h_idx_4, 0),
          _fx_catch_10);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_4), _fx_catch_10);
       int_ idx_5 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_4)->data;
-      int_ v_30;
+      int_ v_33;
       if (idx_5 >= 0) {
-         v_30 = idx_5;
+         v_33 = idx_5;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
          int_ idx_6;
@@ -21065,18 +22030,18 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
          FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_25, &idx_6, 0), _fx_catch_10);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_4), _fx_catch_10);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_4)->data = idx_6;
-         v_30 = idx_6;
+         v_33 = idx_6;
       }
       else {
          fx_str_t slit_26 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_26, &v_29, 0), _fx_catch_10);
-         FX_THROW(&v_29, false, _fx_catch_10);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_26, &v_32, 0), _fx_catch_10);
+         FX_THROW(&v_32, false, _fx_catch_10);
       }
-      _fx_R9Ast__id_t rec_4 = { 0, v_30, 0 };
+      _fx_R9Ast__id_t rec_4 = { 0, v_33, 0 };
       *fx_result = rec_4;
 
    _fx_catch_10: ;
-      fx_free_exn(&v_29);
+      fx_free_exn(&v_32);
       goto _fx_endmatch_0;
    }
    bool res_0;
@@ -21097,36 +22062,36 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
    }
    FX_CHECK_EXN(_fx_cleanup);
    if (res_0) {
-      fx_str_t v_31 = {0};
-      fx_str_t v_32 = {0};
-      fx_exn_t v_33 = {0};
+      fx_str_t v_34 = {0};
+      fx_str_t v_35 = {0};
+      fx_exn_t v_36 = {0};
       int tag_1 = uop_0->tag;
       if (tag_1 == 1) {
-         fx_str_t slit_27 = FX_MAKE_STR("+"); fx_copy_str(&slit_27, &v_31);
+         fx_str_t slit_27 = FX_MAKE_STR("+"); fx_copy_str(&slit_27, &v_34);
       }
       else if (tag_1 == 2) {
-         fx_str_t slit_28 = FX_MAKE_STR("-"); fx_copy_str(&slit_28, &v_31);
+         fx_str_t slit_28 = FX_MAKE_STR("-"); fx_copy_str(&slit_28, &v_34);
       }
       else if (tag_1 == 3) {
-         fx_str_t slit_29 = FX_MAKE_STR(".-"); fx_copy_str(&slit_29, &v_31);
+         fx_str_t slit_29 = FX_MAKE_STR(".-"); fx_copy_str(&slit_29, &v_34);
       }
       else if (tag_1 == 4) {
-         fx_str_t slit_30 = FX_MAKE_STR("~"); fx_copy_str(&slit_30, &v_31);
+         fx_str_t slit_30 = FX_MAKE_STR("~"); fx_copy_str(&slit_30, &v_34);
       }
       else if (tag_1 == 5) {
-         fx_str_t slit_31 = FX_MAKE_STR("!"); fx_copy_str(&slit_31, &v_31);
+         fx_str_t slit_31 = FX_MAKE_STR("!"); fx_copy_str(&slit_31, &v_34);
       }
       else if (tag_1 == 8) {
-         fx_str_t slit_32 = FX_MAKE_STR("\\"); fx_copy_str(&slit_32, &v_31);
+         fx_str_t slit_32 = FX_MAKE_STR("\\"); fx_copy_str(&slit_32, &v_34);
       }
       else if (tag_1 == 6) {
-         fx_str_t slit_33 = FX_MAKE_STR("REF"); fx_copy_str(&slit_33, &v_31);
+         fx_str_t slit_33 = FX_MAKE_STR("REF"); fx_copy_str(&slit_33, &v_34);
       }
       else if (tag_1 == 7) {
-         fx_str_t slit_34 = FX_MAKE_STR("*"); fx_copy_str(&slit_34, &v_31);
+         fx_str_t slit_34 = FX_MAKE_STR("*"); fx_copy_str(&slit_34, &v_34);
       }
       else if (tag_1 == 9) {
-         fx_str_t slit_35 = FX_MAKE_STR("\'"); fx_copy_str(&slit_35, &v_31);
+         fx_str_t slit_35 = FX_MAKE_STR("\'"); fx_copy_str(&slit_35, &v_34);
       }
       else {
          FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_11);
@@ -21135,16 +22100,16 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
       fx_str_t slit_36 = FX_MAKE_STR("for unary operation \"");
       fx_str_t slit_37 = FX_MAKE_STR("\" there is no corresponding function");
       {
-         const fx_str_t strs_3[] = { slit_36, v_31, slit_37 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_32), _fx_catch_11);
+         const fx_str_t strs_3[] = { slit_36, v_34, slit_37 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_35), _fx_catch_11);
       }
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_32, &v_33, 0), _fx_catch_11);
-      FX_THROW(&v_33, false, _fx_catch_11);
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_35, &v_36, 0), _fx_catch_11);
+      FX_THROW(&v_36, false, _fx_catch_11);
 
    _fx_catch_11: ;
-      fx_free_exn(&v_33);
-      FX_FREE_STR(&v_32);
-      FX_FREE_STR(&v_31);
+      fx_free_exn(&v_36);
+      FX_FREE_STR(&v_35);
+      FX_FREE_STR(&v_34);
       goto _fx_endmatch_0;
    }
    FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
@@ -21585,18 +22550,19 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
       fx_str_t fname_0 = {0};
       fx_str_t v_7 = {0};
       fx_str_t v_8 = {0};
+      fx_str_t v_9 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_9 = {0};
+      fx_exn_t v_10 = {0};
       int_ h_idx_0;
       fx_str_t slit_0 = FX_MAKE_STR("int");
       FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_catch_6);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_6);
       int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
-      int_ v_10;
+      int_ v_11;
       if (idx_0 >= 0) {
-         v_10 = idx_0;
+         v_11 = idx_0;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
          fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_6);
@@ -21629,69 +22595,71 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
                FX_FREE_STR(&t_3);
                FX_CHECK_EXN(_fx_catch_6);
             }
-            fx_arr_t* v_11 = &_fx_g14Ast__all_names->u.t.t1;
-            FX_FREE_ARR(v_11);
-            fx_copy_arr(&new_data_0, v_11);
+            fx_arr_t* v_12 = &_fx_g14Ast__all_names->u.t.t1;
+            FX_FREE_ARR(v_12);
+            fx_copy_arr(&new_data_0, v_12);
          }
          _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
          FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_catch_6);
-         fx_str_t* v_12 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+         fx_str_t* v_13 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
          fx_str_t slit_1 = FX_MAKE_STR("int");
-         FX_FREE_STR(v_12);
-         fx_copy_str(&slit_1, v_12);
+         FX_FREE_STR(v_13);
+         fx_copy_str(&slit_1, v_13);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_6);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
-         v_10 = n0_0;
+         v_11 = n0_0;
       }
       else {
          if (_fx_g10Ast__noloc.m_idx >= 0) {
-            int_ v_13 = _fx_g10Ast__noloc.m_idx;
-            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_13), _fx_catch_6);
-            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_13))->u.defmodule_t.t1, &fname_0);
+            int_ v_14 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_14), _fx_catch_6);
+            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_14))->u.defmodule_t.t1, &fname_0);
          }
          else {
             fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
          }
          FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_7, 0), _fx_catch_6);
          FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_8, 0), _fx_catch_6);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_9, 0), _fx_catch_6);
          fx_str_t slit_3 = FX_MAKE_STR(":");
          fx_str_t slit_4 = FX_MAKE_STR(":");
          fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
          {
-            const fx_str_t strs_0[] = { fname_0, slit_3, v_7, slit_4, v_8, slit_5 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_catch_6);
+            const fx_str_t strs_0[] = { fname_0, slit_3, v_7, slit_4, v_8, slit_5, v_9 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_catch_6);
          }
          FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
          if (all_compile_err_ctx_0 == 0) {
             fx_copy_str(&whole_msg_0, &whole_msg_1);
          }
          else {
-            _fx_LS v_14 = 0;
-            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_14), _fx_catch_5);
+            _fx_LS v_15 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_15), _fx_catch_5);
             fx_str_t slit_6 =
                FX_MAKE_STR("\n"
                   U"\t");
-            FX_CALL(_fx_F4joinS2SLS(&slit_6, v_14, &whole_msg_1, 0), _fx_catch_5);
+            FX_CALL(_fx_F4joinS2SLS(&slit_6, v_15, &whole_msg_1, 0), _fx_catch_5);
 
          _fx_catch_5: ;
-            if (v_14) {
-               _fx_free_LS(&v_14);
+            if (v_15) {
+               _fx_free_LS(&v_15);
             }
          }
          FX_CHECK_EXN(_fx_catch_6);
-         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_9), _fx_catch_6);
-         FX_THROW(&v_9, true, _fx_catch_6);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_10), _fx_catch_6);
+         FX_THROW(&v_10, true, _fx_catch_6);
       }
-      _fx_R9Ast__id_t rec_0 = { 0, v_10, 0 };
+      _fx_R9Ast__id_t rec_0 = { 0, v_11, 0 };
       *fx_result = rec_0;
 
    _fx_catch_6: ;
-      fx_free_exn(&v_9);
+      fx_free_exn(&v_10);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_9);
       FX_FREE_STR(&v_8);
       FX_FREE_STR(&v_7);
       FX_FREE_STR(&fname_0);
@@ -21703,16 +22671,16 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 8) {
-         fx_exn_t v_15 = {0};
+         fx_exn_t v_16 = {0};
          int_ h_idx_1;
          fx_str_t slit_7 = FX_MAKE_STR("int8");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_7, &h_idx_1, 0),
             _fx_catch_7);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_1), _fx_catch_7);
          int_ idx_1 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_1)->data;
-         int_ v_16;
+         int_ v_17;
          if (idx_1 >= 0) {
-            v_16 = idx_1;
+            v_17 = idx_1;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_2;
@@ -21720,33 +22688,33 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_8, &idx_2, 0), _fx_catch_7);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_1), _fx_catch_7);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_1)->data = idx_2;
-            v_16 = idx_2;
+            v_17 = idx_2;
          }
          else {
             fx_str_t slit_9 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_9, &v_15, 0), _fx_catch_7);
-            FX_THROW(&v_15, false, _fx_catch_7);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_9, &v_16, 0), _fx_catch_7);
+            FX_THROW(&v_16, false, _fx_catch_7);
          }
-         _fx_R9Ast__id_t rec_1 = { 0, v_16, 0 };
+         _fx_R9Ast__id_t rec_1 = { 0, v_17, 0 };
          *fx_result = rec_1;
 
       _fx_catch_7: ;
-         fx_free_exn(&v_15);
+         fx_free_exn(&v_16);
          goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 16) {
-         fx_exn_t v_17 = {0};
+         fx_exn_t v_18 = {0};
          int_ h_idx_2;
          fx_str_t slit_10 = FX_MAKE_STR("int16");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_10, &h_idx_2, 0),
             _fx_catch_8);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_2), _fx_catch_8);
          int_ idx_3 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_2)->data;
-         int_ v_18;
+         int_ v_19;
          if (idx_3 >= 0) {
-            v_18 = idx_3;
+            v_19 = idx_3;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_4;
@@ -21754,33 +22722,33 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_11, &idx_4, 0), _fx_catch_8);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_2), _fx_catch_8);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_2)->data = idx_4;
-            v_18 = idx_4;
+            v_19 = idx_4;
          }
          else {
             fx_str_t slit_12 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_12, &v_17, 0), _fx_catch_8);
-            FX_THROW(&v_17, false, _fx_catch_8);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_12, &v_18, 0), _fx_catch_8);
+            FX_THROW(&v_18, false, _fx_catch_8);
          }
-         _fx_R9Ast__id_t rec_2 = { 0, v_18, 0 };
+         _fx_R9Ast__id_t rec_2 = { 0, v_19, 0 };
          *fx_result = rec_2;
 
       _fx_catch_8: ;
-         fx_free_exn(&v_17);
+         fx_free_exn(&v_18);
          goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 32) {
-         fx_exn_t v_19 = {0};
+         fx_exn_t v_20 = {0};
          int_ h_idx_3;
          fx_str_t slit_13 = FX_MAKE_STR("int32");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_13, &h_idx_3, 0),
             _fx_catch_9);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_3), _fx_catch_9);
          int_ idx_5 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_3)->data;
-         int_ v_20;
+         int_ v_21;
          if (idx_5 >= 0) {
-            v_20 = idx_5;
+            v_21 = idx_5;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_6;
@@ -21788,33 +22756,33 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_14, &idx_6, 0), _fx_catch_9);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_3), _fx_catch_9);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_3)->data = idx_6;
-            v_20 = idx_6;
+            v_21 = idx_6;
          }
          else {
             fx_str_t slit_15 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_15, &v_19, 0), _fx_catch_9);
-            FX_THROW(&v_19, false, _fx_catch_9);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_15, &v_20, 0), _fx_catch_9);
+            FX_THROW(&v_20, false, _fx_catch_9);
          }
-         _fx_R9Ast__id_t rec_3 = { 0, v_20, 0 };
+         _fx_R9Ast__id_t rec_3 = { 0, v_21, 0 };
          *fx_result = rec_3;
 
       _fx_catch_9: ;
-         fx_free_exn(&v_19);
+         fx_free_exn(&v_20);
          goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 64) {
-         fx_exn_t v_21 = {0};
+         fx_exn_t v_22 = {0};
          int_ h_idx_4;
          fx_str_t slit_16 = FX_MAKE_STR("int64");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_16, &h_idx_4, 0),
             _fx_catch_10);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_4), _fx_catch_10);
          int_ idx_7 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_4)->data;
-         int_ v_22;
+         int_ v_23;
          if (idx_7 >= 0) {
-            v_22 = idx_7;
+            v_23 = idx_7;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_8;
@@ -21822,33 +22790,33 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_17, &idx_8, 0), _fx_catch_10);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_4), _fx_catch_10);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_4)->data = idx_8;
-            v_22 = idx_8;
+            v_23 = idx_8;
          }
          else {
             fx_str_t slit_18 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_18, &v_21, 0), _fx_catch_10);
-            FX_THROW(&v_21, false, _fx_catch_10);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_18, &v_22, 0), _fx_catch_10);
+            FX_THROW(&v_22, false, _fx_catch_10);
          }
-         _fx_R9Ast__id_t rec_4 = { 0, v_22, 0 };
+         _fx_R9Ast__id_t rec_4 = { 0, v_23, 0 };
          *fx_result = rec_4;
 
       _fx_catch_10: ;
-         fx_free_exn(&v_21);
+         fx_free_exn(&v_22);
          goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 8) {
-         fx_exn_t v_23 = {0};
+         fx_exn_t v_24 = {0};
          int_ h_idx_5;
          fx_str_t slit_19 = FX_MAKE_STR("uint8");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_19, &h_idx_5, 0),
             _fx_catch_11);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_5), _fx_catch_11);
          int_ idx_9 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_5)->data;
-         int_ v_24;
+         int_ v_25;
          if (idx_9 >= 0) {
-            v_24 = idx_9;
+            v_25 = idx_9;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_10;
@@ -21856,33 +22824,33 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_20, &idx_10, 0), _fx_catch_11);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_5), _fx_catch_11);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_5)->data = idx_10;
-            v_24 = idx_10;
+            v_25 = idx_10;
          }
          else {
             fx_str_t slit_21 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_21, &v_23, 0), _fx_catch_11);
-            FX_THROW(&v_23, false, _fx_catch_11);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_21, &v_24, 0), _fx_catch_11);
+            FX_THROW(&v_24, false, _fx_catch_11);
          }
-         _fx_R9Ast__id_t rec_5 = { 0, v_24, 0 };
+         _fx_R9Ast__id_t rec_5 = { 0, v_25, 0 };
          *fx_result = rec_5;
 
       _fx_catch_11: ;
-         fx_free_exn(&v_23);
+         fx_free_exn(&v_24);
          goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 16) {
-         fx_exn_t v_25 = {0};
+         fx_exn_t v_26 = {0};
          int_ h_idx_6;
          fx_str_t slit_22 = FX_MAKE_STR("uint16");
          FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_22, &h_idx_6, 0),
             _fx_catch_12);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_6), _fx_catch_12);
          int_ idx_11 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_6)->data;
-         int_ v_26;
+         int_ v_27;
          if (idx_11 >= 0) {
-            v_26 = idx_11;
+            v_27 = idx_11;
          }
          else if (_fx_g19Ast__lock_all_names == 0) {
             int_ idx_12;
@@ -21890,18 +22858,18 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
             FX_CALL(_fx_M3AstFM4pushi2Nt9Dynvec__t1SS(_fx_g14Ast__all_names, &slit_23, &idx_12, 0), _fx_catch_12);
             FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_6), _fx_catch_12);
             FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_6)->data = idx_12;
-            v_26 = idx_12;
+            v_27 = idx_12;
          }
          else {
             fx_str_t slit_24 = FX_MAKE_STR("\'all_names\' are locked. Attempt to call get_id()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_24, &v_25, 0), _fx_catch_12);
-            FX_THROW(&v_25, false, _fx_catch_12);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&_fx_g10Ast__noloc, &slit_24, &v_26, 0), _fx_catch_12);
+            FX_THROW(&v_26, false, _fx_catch_12);
          }
-         _fx_R9Ast__id_t rec_6 = { 0, v_26, 0 };
+         _fx_R9Ast__id_t rec_6 = { 0, v_27, 0 };
          *fx_result = rec_6;
 
       _fx_catch_12: ;
-         fx_free_exn(&v_25);
+         fx_free_exn(&v_26);
          goto _fx_endmatch_1;
       }
    }
@@ -21931,23 +22899,23 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
    if (tag_0 == 11) {
       FX_CALL(_fx_M3AstFM12fname_stringRM4id_t0(fx_result, 0), _fx_catch_18);  _fx_catch_18: ; goto _fx_endmatch_1;
    }
-   fx_str_t v_27 = {0};
    fx_str_t v_28 = {0};
-   fx_exn_t v_29 = {0};
-   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_27, 0), _fx_catch_19);
+   fx_str_t v_29 = {0};
+   fx_exn_t v_30 = {0};
+   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_28, 0), _fx_catch_19);
    fx_str_t slit_25 = FX_MAKE_STR("for type \'");
    fx_str_t slit_26 = FX_MAKE_STR("\' there is no corresponding cast function");
    {
-      const fx_str_t strs_1[] = { slit_25, v_27, slit_26 };
-      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_28), _fx_catch_19);
+      const fx_str_t strs_1[] = { slit_25, v_28, slit_26 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_29), _fx_catch_19);
    }
-   FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &v_28, &v_29), _fx_catch_19);
-   FX_THROW(&v_29, true, _fx_catch_19);
+   FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &v_29, &v_30), _fx_catch_19);
+   FX_THROW(&v_30, true, _fx_catch_19);
 
 _fx_catch_19: ;
-   fx_free_exn(&v_29);
+   fx_free_exn(&v_30);
+   FX_FREE_STR(&v_29);
    FX_FREE_STR(&v_28);
-   FX_FREE_STR(&v_27);
 
 _fx_endmatch_1: ;
 
@@ -22518,57 +23486,60 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
             fx_str_t fname_0 = {0};
             fx_str_t v_9 = {0};
             fx_str_t v_10 = {0};
+            fx_str_t v_11 = {0};
             fx_str_t whole_msg_0 = {0};
             _fx_LS all_compile_err_ctx_0 = 0;
             fx_str_t whole_msg_1 = {0};
-            fx_exn_t v_11 = {0};
+            fx_exn_t v_12 = {0};
             FX_CALL(_fx_F6stringS1i(n_0, &v_8, 0), _fx_catch_16);
             if (_fx_g10Ast__noloc.m_idx >= 0) {
-               int_ v_12 = _fx_g10Ast__noloc.m_idx;
-               FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_12), _fx_catch_16);
-               fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_12))->u.defmodule_t.t1, &fname_0);
+               int_ v_13 = _fx_g10Ast__noloc.m_idx;
+               FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_13), _fx_catch_16);
+               fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_13))->u.defmodule_t.t1, &fname_0);
             }
             else {
                fx_str_t slit_15 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_15, &fname_0);
             }
             FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_9, 0), _fx_catch_16);
             FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_10, 0), _fx_catch_16);
+            FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_11, 0), _fx_catch_16);
             fx_str_t slit_16 = FX_MAKE_STR(":");
             fx_str_t slit_17 = FX_MAKE_STR(":");
             fx_str_t slit_18 = FX_MAKE_STR(": error: bad floating-point type TypFloat(");
             fx_str_t slit_19 = FX_MAKE_STR(")");
             {
-               const fx_str_t strs_5[] = { fname_0, slit_16, v_9, slit_17, v_10, slit_18, v_8, slit_19 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_5, 8, &whole_msg_0), _fx_catch_16);
+               const fx_str_t strs_5[] = { fname_0, slit_16, v_9, slit_17, v_10, slit_18, v_8, slit_19, v_11 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_5, 9, &whole_msg_0), _fx_catch_16);
             }
             FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
             if (all_compile_err_ctx_0 == 0) {
                fx_copy_str(&whole_msg_0, &whole_msg_1);
             }
             else {
-               _fx_LS v_13 = 0;
-               FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_13), _fx_catch_15);
+               _fx_LS v_14 = 0;
+               FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_14), _fx_catch_15);
                fx_str_t slit_20 =
                   FX_MAKE_STR("\n"
                      U"\t");
-               FX_CALL(_fx_F4joinS2SLS(&slit_20, v_13, &whole_msg_1, 0), _fx_catch_15);
+               FX_CALL(_fx_F4joinS2SLS(&slit_20, v_14, &whole_msg_1, 0), _fx_catch_15);
 
             _fx_catch_15: ;
-               if (v_13) {
-                  _fx_free_LS(&v_13);
+               if (v_14) {
+                  _fx_free_LS(&v_14);
                }
             }
             FX_CHECK_EXN(_fx_catch_16);
-            FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_11), _fx_catch_16);
-            FX_THROW(&v_11, true, _fx_catch_16);
+            FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_12), _fx_catch_16);
+            FX_THROW(&v_12, true, _fx_catch_16);
 
          _fx_catch_16: ;
-            fx_free_exn(&v_11);
+            fx_free_exn(&v_12);
             FX_FREE_STR(&whole_msg_1);
             if (all_compile_err_ctx_0) {
                _fx_free_LS(&all_compile_err_ctx_0);
             }
             FX_FREE_STR(&whole_msg_0);
+            FX_FREE_STR(&v_11);
             FX_FREE_STR(&v_10);
             FX_FREE_STR(&v_9);
             FX_FREE_STR(&fname_0);
@@ -22625,17 +23596,17 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          goto _fx_endmatch_1;
       }
       if (tag_0 == 15) {
-         fx_str_t v_14 = {0};
          fx_str_t v_15 = {0};
+         fx_str_t v_16 = {0};
          fx_str_t result_7 = {0};
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_2 = &t_2->u.TypFun;
-         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_2->t0, &v_14, 0), _fx_catch_23);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_2->t1, &v_15, 0), _fx_catch_23);
+         FX_CALL(_fx_M3AstFM6tl2strS1LN10Ast__typ_t(vcase_2->t0, &v_15, 0), _fx_catch_23);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_2->t1, &v_16, 0), _fx_catch_23);
          fx_str_t slit_26 = FX_MAKE_STR("(");
          fx_str_t slit_27 = FX_MAKE_STR(" -> ");
          fx_str_t slit_28 = FX_MAKE_STR(")");
          {
-            const fx_str_t strs_6[] = { slit_26, v_14, slit_27, v_15, slit_28 };
+            const fx_str_t strs_6[] = { slit_26, v_15, slit_27, v_16, slit_28 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_6, 5, &result_7), _fx_catch_23);
          }
          FX_FREE_STR(&result_0);
@@ -22644,8 +23615,8 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
 
       _fx_catch_23: ;
          FX_FREE_STR(&result_7);
+         FX_FREE_STR(&v_16);
          FX_FREE_STR(&v_15);
-         FX_FREE_STR(&v_14);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 18) {
@@ -22684,29 +23655,29 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          goto _fx_endmatch_1;
       }
       if (tag_0 == 21) {
-         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = {0};
-         fx_arr_t v_17 = {0};
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_17 = {0};
+         fx_arr_t v_18 = {0};
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
          fx_str_t result_9 = {0};
-         _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t_2->u.TypRecord->data, &v_16);
+         _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&t_2->u.TypRecord->data, &v_17);
          fx_str_t* dstptr_0 = 0;
-         FX_COPY_PTR(v_16.t0, &relems_0);
+         FX_COPY_PTR(v_17.t0, &relems_0);
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_0 = relems_0;
          int_ len_0 = fx_list_length(lst_0);
          {
             const int_ shape_0[] = { len_0 };
-            FX_CALL(fx_make_arr(1, shape_0, sizeof(fx_str_t), (fx_free_t)fx_free_str, (fx_copy_t)fx_copy_str, 0, &v_17),
+            FX_CALL(fx_make_arr(1, shape_0, sizeof(fx_str_t), (fx_free_t)fx_free_str, (fx_copy_t)fx_copy_str, 0, &v_18),
                _fx_catch_28);
          }
-         dstptr_0 = (fx_str_t*)v_17.data;
+         dstptr_0 = (fx_str_t*)v_18.data;
          for (; lst_0; lst_0 = lst_0->tl, dstptr_0++) {
             _fx_R16Ast__val_flags_t flags_0 = {0};
             _fx_N10Ast__typ_t t_4 = 0;
             fx_str_t prefix_0 = {0};
-            fx_str_t v_18 = {0};
-            fx_str_t prefix_1 = {0};
             fx_str_t v_19 = {0};
+            fx_str_t prefix_1 = {0};
             fx_str_t v_20 = {0};
+            fx_str_t v_21 = {0};
             fx_str_t concat_str_0 = {0};
             _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_0->hd;
             _fx_copy_R16Ast__val_flags_t(&__pat___0->t0, &flags_0);
@@ -22726,38 +23697,38 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
                t_5 = false;
             }
             if (t_5) {
-               fx_str_t slit_33 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_33, &v_18);
+               fx_str_t slit_33 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_33, &v_19);
             }
             else {
-               int_ v_21 = i_0.i;
-               FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_21), _fx_catch_27);
-               fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_21), &prefix_1);
+               int_ v_22 = i_0.i;
+               FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_22), _fx_catch_27);
+               fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_22), &prefix_1);
                if (i_0.m == 0) {
-                  fx_copy_str(&prefix_1, &v_18);
+                  fx_copy_str(&prefix_1, &v_19);
                }
                else {
-                  FX_CALL(_fx_F6stringS1i(i_0.j, &v_19, 0), _fx_catch_27);
+                  FX_CALL(_fx_F6stringS1i(i_0.j, &v_20, 0), _fx_catch_27);
                   fx_str_t slit_34 = FX_MAKE_STR("@");
                   {
-                     const fx_str_t strs_8[] = { prefix_1, slit_34, v_19 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_8, 3, &v_18), _fx_catch_27);
+                     const fx_str_t strs_8[] = { prefix_1, slit_34, v_20 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_8, 3, &v_19), _fx_catch_27);
                   }
                }
             }
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_4, &v_20, 0), _fx_catch_27);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_4, &v_21, 0), _fx_catch_27);
             fx_str_t slit_35 = FX_MAKE_STR(": ");
             {
-               const fx_str_t strs_9[] = { prefix_0, v_18, slit_35, v_20 };
+               const fx_str_t strs_9[] = { prefix_0, v_19, slit_35, v_21 };
                FX_CALL(fx_strjoin(0, 0, 0, strs_9, 4, &concat_str_0), _fx_catch_27);
             }
             fx_copy_str(&concat_str_0, dstptr_0);
 
          _fx_catch_27: ;
             FX_FREE_STR(&concat_str_0);
+            FX_FREE_STR(&v_21);
             FX_FREE_STR(&v_20);
-            FX_FREE_STR(&v_19);
             FX_FREE_STR(&prefix_1);
-            FX_FREE_STR(&v_18);
+            FX_FREE_STR(&v_19);
             FX_FREE_STR(&prefix_0);
             if (t_4) {
                _fx_free_N10Ast__typ_t(&t_4);
@@ -22768,7 +23739,7 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          fx_str_t slit_36 = FX_MAKE_STR("{");
          fx_str_t slit_37 = FX_MAKE_STR("}");
          fx_str_t slit_38 = FX_MAKE_STR("; ");
-         FX_CALL(_fx_F12join_embraceS4SSSA1S(&slit_36, &slit_37, &slit_38, &v_17, &result_9, 0), _fx_catch_28);
+         FX_CALL(_fx_F12join_embraceS4SSSA1S(&slit_36, &slit_37, &slit_38, &v_18, &result_9, 0), _fx_catch_28);
          FX_FREE_STR(&result_0);
          fx_copy_str(&result_9, &result_0);
          FX_BREAK(_fx_catch_28);
@@ -22778,21 +23749,21 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
          if (relems_0) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
          }
-         FX_FREE_ARR(&v_17);
-         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
+         FX_FREE_ARR(&v_18);
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_17);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 20) {
-         fx_str_t v_22 = {0};
          fx_str_t v_23 = {0};
+         fx_str_t v_24 = {0};
          fx_str_t result_10 = {0};
          _fx_T2iN10Ast__typ_t* vcase_3 = &t_2->u.TypArray;
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_3->t1, &v_22, 0), _fx_catch_29);
-         FX_CALL(_fx_F7__mul__S2Ci((char_)44, vcase_3->t0 - 1, &v_23, 0), _fx_catch_29);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(vcase_3->t1, &v_23, 0), _fx_catch_29);
+         FX_CALL(_fx_F7__mul__S2Ci((char_)44, vcase_3->t0 - 1, &v_24, 0), _fx_catch_29);
          fx_str_t slit_39 = FX_MAKE_STR(" [");
          fx_str_t slit_40 = FX_MAKE_STR("]");
          {
-            const fx_str_t strs_10[] = { v_22, slit_39, v_23, slit_40 };
+            const fx_str_t strs_10[] = { v_23, slit_39, v_24, slit_40 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_10, 4, &result_10), _fx_catch_29);
          }
          FX_FREE_STR(&result_0);
@@ -22801,17 +23772,17 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
 
       _fx_catch_29: ;
          FX_FREE_STR(&result_10);
+         FX_FREE_STR(&v_24);
          FX_FREE_STR(&v_23);
-         FX_FREE_STR(&v_22);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 16) {
-         fx_str_t v_24 = {0};
+         fx_str_t v_25 = {0};
          fx_str_t result_11 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypList, &v_24, 0), _fx_catch_30);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypList, &v_25, 0), _fx_catch_30);
          fx_str_t slit_41 = FX_MAKE_STR(" list");
          {
-            const fx_str_t strs_11[] = { v_24, slit_41 };
+            const fx_str_t strs_11[] = { v_25, slit_41 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_11, 2, &result_11), _fx_catch_30);
          }
          FX_FREE_STR(&result_0);
@@ -22820,16 +23791,16 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
 
       _fx_catch_30: ;
          FX_FREE_STR(&result_11);
-         FX_FREE_STR(&v_24);
+         FX_FREE_STR(&v_25);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 17) {
-         fx_str_t v_25 = {0};
+         fx_str_t v_26 = {0};
          fx_str_t result_12 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypVector, &v_25, 0), _fx_catch_31);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypVector, &v_26, 0), _fx_catch_31);
          fx_str_t slit_42 = FX_MAKE_STR(" vector");
          {
-            const fx_str_t strs_12[] = { v_25, slit_42 };
+            const fx_str_t strs_12[] = { v_26, slit_42 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &result_12), _fx_catch_31);
          }
          FX_FREE_STR(&result_0);
@@ -22838,16 +23809,16 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
 
       _fx_catch_31: ;
          FX_FREE_STR(&result_12);
-         FX_FREE_STR(&v_25);
+         FX_FREE_STR(&v_26);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 19) {
-         fx_str_t v_26 = {0};
+         fx_str_t v_27 = {0};
          fx_str_t result_13 = {0};
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypRef, &v_26, 0), _fx_catch_32);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_2->u.TypRef, &v_27, 0), _fx_catch_32);
          fx_str_t slit_43 = FX_MAKE_STR(" ref");
          {
-            const fx_str_t strs_13[] = { v_26, slit_43 };
+            const fx_str_t strs_13[] = { v_27, slit_43 };
             FX_CALL(fx_strjoin(0, 0, 0, strs_13, 2, &result_13), _fx_catch_32);
          }
          FX_FREE_STR(&result_0);
@@ -22856,7 +23827,7 @@ FX_EXTERN_C int _fx_M3AstFM7typ2strS1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data
 
       _fx_catch_32: ;
          FX_FREE_STR(&result_13);
-         FX_FREE_STR(&v_26);
+         FX_FREE_STR(&v_27);
          goto _fx_endmatch_1;
       }
       if (tag_0 == 22) {
@@ -22997,33 +23968,35 @@ FX_EXTERN_C int _fx_M3AstFM5parseRM9pragmas_t2LT2SRM5loc_tRM9pragmas_t(
          fx_str_t fname_0 = {0};
          fx_str_t v_2 = {0};
          fx_str_t v_3 = {0};
+         fx_str_t v_4 = {0};
          fx_str_t whole_msg_0 = {0};
          _fx_LS all_compile_err_ctx_0 = 0;
          fx_str_t whole_msg_1 = {0};
-         fx_exn_t v_4 = {0};
-         _fx_T2SR10Ast__loc_t v_5 = {0};
-         _fx_LT2SR10Ast__loc_t v_6 = 0;
-         _fx_R14Ast__pragmas_t v_7 = {0};
+         fx_exn_t v_5 = {0};
+         _fx_T2SR10Ast__loc_t v_6 = {0};
+         _fx_LT2SR10Ast__loc_t v_7 = 0;
+         _fx_R14Ast__pragmas_t v_8 = {0};
          fx_str_t fname_1 = {0};
-         fx_str_t v_8 = {0};
          fx_str_t v_9 = {0};
+         fx_str_t v_10 = {0};
+         fx_str_t v_11 = {0};
          fx_str_t whole_msg_2 = {0};
          _fx_LS all_compile_err_ctx_1 = 0;
          fx_str_t whole_msg_3 = {0};
-         fx_exn_t v_10 = {0};
+         fx_exn_t v_12 = {0};
          _fx_LT2SR10Ast__loc_t rest_0 = prl_2->tl;
-         _fx_T2SR10Ast__loc_t* v_11 = &prl_2->hd;
-         _fx_R10Ast__loc_t* loc_0 = &v_11->t1;
-         fx_str_t* pr_0 = &v_11->t0;
-         bool v_12;
+         _fx_T2SR10Ast__loc_t* v_13 = &prl_2->hd;
+         _fx_R10Ast__loc_t* loc_0 = &v_13->t1;
+         fx_str_t* pr_0 = &v_13->t0;
+         bool v_14;
          fx_str_t slit_0 = FX_MAKE_STR("c++");
          if (_fx_F6__eq__B2SS(pr_0, &slit_0, 0)) {
-            v_12 = true;
+            v_14 = true;
          }
          else {
-            fx_str_t slit_1 = FX_MAKE_STR("C++"); v_12 = _fx_F6__eq__B2SS(pr_0, &slit_1, 0);
+            fx_str_t slit_1 = FX_MAKE_STR("C++"); v_14 = _fx_F6__eq__B2SS(pr_0, &slit_1, 0);
          }
-         if (v_12) {
+         if (v_14) {
             _fx_make_R14Ast__pragmas_t(true, result_3.pragma_clibs, &v_0);
             _fx_free_LT2SR10Ast__loc_t(&prl_1);
             FX_COPY_PTR(rest_0, &prl_1);
@@ -23031,10 +24004,10 @@ FX_EXTERN_C int _fx_M3AstFM5parseRM9pragmas_t2LT2SRM5loc_tRM9pragmas_t(
             _fx_copy_R14Ast__pragmas_t(&v_0, &result_2);
          }
          else {
-            bool v_13;
+            bool v_15;
             fx_str_t slit_2 = FX_MAKE_STR("clib");
-            v_13 = _fx_M6StringFM10startswithB2SS(pr_0, &slit_2, 0);
-            if (v_13) {
+            v_15 = _fx_M6StringFM10startswithB2SS(pr_0, &slit_2, 0);
+            if (v_15) {
                int_ p_0;
                fx_str_t slit_3 = FX_MAKE_STR(":");
                p_0 = _fx_M6StringFM4findi3SSi(pr_0, &slit_3, 0, 0);
@@ -23044,9 +24017,9 @@ FX_EXTERN_C int _fx_M3AstFM5parseRM9pragmas_t2LT2SRM5loc_tRM9pragmas_t(
                }
                else {
                   if (loc_0->m_idx >= 0) {
-                     int_ v_14 = loc_0->m_idx;
-                     FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_14), _fx_catch_2);
-                     fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_14))->u.defmodule_t.t1,
+                     int_ v_16 = loc_0->m_idx;
+                     FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_16), _fx_catch_2);
+                     fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_16))->u.defmodule_t.t1,
                         &fname_0);
                   }
                   else {
@@ -23054,108 +24027,112 @@ FX_EXTERN_C int _fx_M3AstFM5parseRM9pragmas_t2LT2SRM5loc_tRM9pragmas_t(
                   }
                   FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_2, 0), _fx_catch_2);
                   FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_3, 0), _fx_catch_2);
+                  FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_2);
                   fx_str_t slit_5 = FX_MAKE_STR(":");
                   fx_str_t slit_6 = FX_MAKE_STR(":");
                   fx_str_t slit_7 = FX_MAKE_STR(": error: invalid format of clib pragma \"");
                   fx_str_t slit_8 = FX_MAKE_STR("\", it should be \"clib: <libname>\"");
                   {
-                     const fx_str_t strs_0[] = { fname_0, slit_5, v_2, slit_6, v_3, slit_7, *pr_0, slit_8 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_0, 8, &whole_msg_0), _fx_catch_2);
+                     const fx_str_t strs_0[] = { fname_0, slit_5, v_2, slit_6, v_3, slit_7, *pr_0, slit_8, v_4 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_2);
                   }
                   FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
                   if (all_compile_err_ctx_0 == 0) {
                      fx_copy_str(&whole_msg_0, &whole_msg_1);
                   }
                   else {
-                     _fx_LS v_15 = 0;
-                     FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_15), _fx_catch_0);
+                     _fx_LS v_17 = 0;
+                     FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_17), _fx_catch_0);
                      fx_str_t slit_9 =
                         FX_MAKE_STR("\n"
                            U"\t");
-                     FX_CALL(_fx_F4joinS2SLS(&slit_9, v_15, &whole_msg_1, 0), _fx_catch_0);
+                     FX_CALL(_fx_F4joinS2SLS(&slit_9, v_17, &whole_msg_1, 0), _fx_catch_0);
 
                   _fx_catch_0: ;
-                     if (v_15) {
-                        _fx_free_LS(&v_15);
+                     if (v_17) {
+                        _fx_free_LS(&v_17);
                      }
                   }
                   FX_CHECK_EXN(_fx_catch_2);
-                  FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_4), _fx_catch_2);
-                  FX_THROW(&v_4, true, _fx_catch_2);
+                  FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_5), _fx_catch_2);
+                  FX_THROW(&v_5, true, _fx_catch_2);
                }
-               _fx_make_T2SR10Ast__loc_t(&libname_0, loc_0, &v_5);
-               FX_COPY_PTR(result_3.pragma_clibs, &v_6);
-               FX_CALL(_fx_cons_LT2SR10Ast__loc_t(&v_5, v_6, false, &v_6), _fx_catch_2);
-               _fx_make_R14Ast__pragmas_t(result_3.pragma_cpp, v_6, &v_7);
+               _fx_make_T2SR10Ast__loc_t(&libname_0, loc_0, &v_6);
+               FX_COPY_PTR(result_3.pragma_clibs, &v_7);
+               FX_CALL(_fx_cons_LT2SR10Ast__loc_t(&v_6, v_7, false, &v_7), _fx_catch_2);
+               _fx_make_R14Ast__pragmas_t(result_3.pragma_cpp, v_7, &v_8);
                _fx_free_LT2SR10Ast__loc_t(&prl_1);
                FX_COPY_PTR(rest_0, &prl_1);
                _fx_free_R14Ast__pragmas_t(&result_2);
-               _fx_copy_R14Ast__pragmas_t(&v_7, &result_2);
+               _fx_copy_R14Ast__pragmas_t(&v_8, &result_2);
             }
             else {
                if (loc_0->m_idx >= 0) {
-                  int_ v_16 = loc_0->m_idx;
-                  FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_16), _fx_catch_2);
-                  fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_16))->u.defmodule_t.t1,
+                  int_ v_18 = loc_0->m_idx;
+                  FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_18), _fx_catch_2);
+                  fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_18))->u.defmodule_t.t1,
                      &fname_1);
                }
                else {
                   fx_str_t slit_10 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_10, &fname_1);
                }
-               FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_8, 0), _fx_catch_2);
-               FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_9, 0), _fx_catch_2);
+               FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_9, 0), _fx_catch_2);
+               FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_10, 0), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_11, 0), _fx_catch_2);
                fx_str_t slit_11 = FX_MAKE_STR(":");
                fx_str_t slit_12 = FX_MAKE_STR(":");
                fx_str_t slit_13 = FX_MAKE_STR(": error: unrecognized pragma \"");
                fx_str_t slit_14 = FX_MAKE_STR("\"");
                {
-                  const fx_str_t strs_1[] = { fname_1, slit_11, v_8, slit_12, v_9, slit_13, *pr_0, slit_14 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 8, &whole_msg_2), _fx_catch_2);
+                  const fx_str_t strs_1[] = { fname_1, slit_11, v_9, slit_12, v_10, slit_13, *pr_0, slit_14, v_11 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 9, &whole_msg_2), _fx_catch_2);
                }
                FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_1);
                if (all_compile_err_ctx_1 == 0) {
                   fx_copy_str(&whole_msg_2, &whole_msg_3);
                }
                else {
-                  _fx_LS v_17 = 0;
-                  FX_CALL(_fx_cons_LS(&whole_msg_2, all_compile_err_ctx_1, true, &v_17), _fx_catch_1);
+                  _fx_LS v_19 = 0;
+                  FX_CALL(_fx_cons_LS(&whole_msg_2, all_compile_err_ctx_1, true, &v_19), _fx_catch_1);
                   fx_str_t slit_15 =
                      FX_MAKE_STR("\n"
                         U"\t");
-                  FX_CALL(_fx_F4joinS2SLS(&slit_15, v_17, &whole_msg_3, 0), _fx_catch_1);
+                  FX_CALL(_fx_F4joinS2SLS(&slit_15, v_19, &whole_msg_3, 0), _fx_catch_1);
 
                _fx_catch_1: ;
-                  if (v_17) {
-                     _fx_free_LS(&v_17);
+                  if (v_19) {
+                     _fx_free_LS(&v_19);
                   }
                }
                FX_CHECK_EXN(_fx_catch_2);
-               FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_3, &v_10), _fx_catch_2);
-               FX_THROW(&v_10, true, _fx_catch_2);
+               FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_3, &v_12), _fx_catch_2);
+               FX_THROW(&v_12, true, _fx_catch_2);
             }
          }
 
       _fx_catch_2: ;
-         fx_free_exn(&v_10);
+         fx_free_exn(&v_12);
          FX_FREE_STR(&whole_msg_3);
          if (all_compile_err_ctx_1) {
             _fx_free_LS(&all_compile_err_ctx_1);
          }
          FX_FREE_STR(&whole_msg_2);
+         FX_FREE_STR(&v_11);
+         FX_FREE_STR(&v_10);
          FX_FREE_STR(&v_9);
-         FX_FREE_STR(&v_8);
          FX_FREE_STR(&fname_1);
-         _fx_free_R14Ast__pragmas_t(&v_7);
-         if (v_6) {
-            _fx_free_LT2SR10Ast__loc_t(&v_6);
+         _fx_free_R14Ast__pragmas_t(&v_8);
+         if (v_7) {
+            _fx_free_LT2SR10Ast__loc_t(&v_7);
          }
-         _fx_free_T2SR10Ast__loc_t(&v_5);
-         fx_free_exn(&v_4);
+         _fx_free_T2SR10Ast__loc_t(&v_6);
+         fx_free_exn(&v_5);
          FX_FREE_STR(&whole_msg_1);
          if (all_compile_err_ctx_0) {
             _fx_free_LS(&all_compile_err_ctx_0);
          }
          FX_FREE_STR(&whole_msg_0);
+         FX_FREE_STR(&v_4);
          FX_FREE_STR(&v_3);
          FX_FREE_STR(&v_2);
          FX_FREE_STR(&fname_0);
@@ -23515,7 +24492,7 @@ FX_EXTERN_C int _fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          }
       }
       else {
-         FX_COPY_PTR(_fx_g11Ast__None4_, &v_9);
+         FX_COPY_PTR(_fx_g11Ast__None5_, &v_9);
       }
       FX_CHECK_EXN(_fx_catch_7);
       FX_CALL(_fx_M3AstFM11TypVarTupleN10Ast__typ_t1Nt6option1N10Ast__typ_t(v_9, fx_result), _fx_catch_7);
@@ -24748,7 +25725,7 @@ static int _fx_M3AstFM13walk_exp_opt_Nt6option1N10Ast__exp_t2Nt6option1N10Ast__e
       }
    }
    else {
-      FX_COPY_PTR(_fx_g11Ast__None3_, fx_result);
+      FX_COPY_PTR(_fx_g11Ast__None4_, fx_result);
    }
 
 _fx_cleanup: ;
@@ -25036,7 +26013,7 @@ FX_EXTERN_C int _fx_M3AstFM8dup_typ_N10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
    }
    if (tag_0 == 1) {
       _fx_rNt6option1N10Ast__typ_t v_4 = 0;
-      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None4_, &v_4), _fx_catch_1);
+      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g11Ast__None5_, &v_4), _fx_catch_1);
       FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_4, fx_result), _fx_catch_1);
 
    _fx_catch_1: ;
@@ -25387,7 +26364,7 @@ FX_EXTERN_C int _fx_M3AstFM13deref_typ_recN10Ast__typ_t1N10Ast__typ_t(
    FX_CALL(
       _fx_M3AstFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          &deref_typ_rec__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g11Ast__None2_, _fx_g11Ast__None1_, &deref_callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g11Ast__None3_, _fx_g11Ast__None2_, &deref_callb_0);
    if (FX_REC_VARIANT_TAG(t_0) == 1) {
       _fx_N10Ast__typ_t v_1 = 0;
       _fx_N10Ast__typ_t result_0 = 0;
@@ -25502,7 +26479,7 @@ FX_EXTERN_C int _fx_M3AstFM12is_fixed_typB1N10Ast__typ_t(struct _fx_N10Ast__typ_
    FX_CALL(
       _fx_M3AstFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(
          &is_fixed_typ__0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g11Ast__None2_, _fx_g11Ast__None1_, &callb_0);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g11Ast__None3_, _fx_g11Ast__None2_, &callb_0);
    FX_CALL(is_fixed_typ__0.fp(t_0, &callb_0, &res_0, is_fixed_typ__0.fcv), _fx_cleanup);
    *fx_result = is_fixed_ref_0->data;
 
@@ -25674,10 +26651,11 @@ FX_EXTERN_C int _fx_M3AstFM17calc_sets_closurei3iLRM4id_tNt10Hashmap__t2RM4id_tN
    fx_str_t fname_0 = {0};
    fx_str_t v_4 = {0};
    fx_str_t v_5 = {0};
+   fx_str_t v_6 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_6 = {0};
+   fx_exn_t v_7 = {0};
    int fx_status = 0;
    int_ done_i_0 = -1;
    FX_COPY_PTR(all_ids_0, &all_ids_1);
@@ -25724,9 +26702,9 @@ FX_EXTERN_C int _fx_M3AstFM17calc_sets_closurei3iLRM4id_tNt10Hashmap__t2RM4id_tN
    for (int_ iter_0 = 0; iter_0 < iters_0; iter_0++) {
       _fx_rB changed_ref_0 = 0;
       _fx_LR9Ast__id_t __fold_result___0 = 0;
-      _fx_LR9Ast__id_t v_7 = 0;
+      _fx_LR9Ast__id_t v_8 = 0;
       fx_arr_t table_0 = {0};
-      fx_arr_t v_8 = {0};
+      fx_arr_t v_9 = {0};
       FX_CALL(_fx_make_rB(false, &changed_ref_0), _fx_catch_2);
       _fx_LR9Ast__id_t lst_0 = all_ids_1;
       for (; lst_0; lst_0 = lst_0->tl) {
@@ -25758,29 +26736,29 @@ FX_EXTERN_C int _fx_M3AstFM17calc_sets_closurei3iLRM4id_tNt10Hashmap__t2RM4id_tN
          FX_FREE_LIST_SIMPLE(&r_0);
          FX_CHECK_EXN(_fx_catch_2);
       }
-      FX_COPY_PTR(__fold_result___0, &v_7);
+      FX_COPY_PTR(__fold_result___0, &v_8);
       FX_FREE_LIST_SIMPLE(&all_ids_1);
-      FX_COPY_PTR(v_7, &all_ids_1);
+      FX_COPY_PTR(v_8, &all_ids_1);
       _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t entry0_2 = visited_ids_0->u.t.t0;
       fx_copy_arr(&visited_ids_0->u.t.t5, &table_0);
-      int_ v_9 = FX_ARR_SIZE(table_0, 0);
-      FX_CHKIDX_RANGE(FX_ARR_SIZE(table_0, 0), 0, v_9, 1, 1, 0, _fx_catch_2);
+      int_ v_10 = FX_ARR_SIZE(table_0, 0);
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(table_0, 0), 0, v_10, 1, 1, 0, _fx_catch_2);
       _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t* ptr_0 = FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t, table_0, 0);
-      for (int_ i_2 = 0; i_2 < v_9; i_2++) {
+      for (int_ i_2 = 0; i_2 < v_10; i_2++) {
          ptr_0[i_2] = entry0_2;
       }
       visited_ids_0->u.t.t1 = 0;
       visited_ids_0->u.t.t2 = 0;
       visited_ids_0->u.t.t3 = 0;
-      FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(FX_ARR_SIZE(table_0, 0) * 2, &v_8, 0), _fx_catch_2);
-      fx_arr_t* v_10 = &visited_ids_0->u.t.t4;
-      FX_FREE_ARR(v_10);
-      fx_copy_arr(&v_8, v_10);
+      FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(FX_ARR_SIZE(table_0, 0) * 2, &v_9, 0), _fx_catch_2);
+      fx_arr_t* v_11 = &visited_ids_0->u.t.t4;
+      FX_FREE_ARR(v_11);
+      fx_copy_arr(&v_9, v_11);
 
    _fx_catch_2: ;
-      FX_FREE_ARR(&v_8);
+      FX_FREE_ARR(&v_9);
       FX_FREE_ARR(&table_0);
-      FX_FREE_LIST_SIMPLE(&v_7);
+      FX_FREE_LIST_SIMPLE(&v_8);
       FX_FREE_LIST_SIMPLE(&__fold_result___0);
       FX_FREE_REF_SIMPLE(&changed_ref_0);
       FX_CHECK_BREAK();
@@ -25788,42 +26766,43 @@ FX_EXTERN_C int _fx_M3AstFM17calc_sets_closurei3iLRM4id_tNt10Hashmap__t2RM4id_tN
    }
    if (done_i_0 <= 0) {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_11 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_11), _fx_cleanup);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_11))->u.defmodule_t.t1, &fname_0);
+         int_ v_12 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_12), _fx_cleanup);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_12))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_4, 0), _fx_cleanup);
       FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_5, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_6, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: calculation of sets\' closures takes too much iterations");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_4, slit_2, v_5, slit_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_cleanup);
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_4, slit_2, v_5, slit_3, v_6 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_12 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_12), _fx_catch_3);
+         _fx_LS v_13 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_13), _fx_catch_3);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_12, &whole_msg_1, 0), _fx_catch_3);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_13, &whole_msg_1, 0), _fx_catch_3);
 
       _fx_catch_3: ;
-         if (v_12) {
-            _fx_free_LS(&v_12);
+         if (v_13) {
+            _fx_free_LS(&v_13);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_6), _fx_cleanup);
-      FX_THROW(&v_6, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_7), _fx_cleanup);
+      FX_THROW(&v_7, true, _fx_cleanup);
    }
    *fx_result = done_i_0;
 
@@ -25842,12 +26821,13 @@ _fx_cleanup: ;
    FX_FREE_STR(&fname_0);
    FX_FREE_STR(&v_4);
    FX_FREE_STR(&v_5);
+   FX_FREE_STR(&v_6);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_6);
+   fx_free_exn(&v_7);
    return fx_status;
 }
 
@@ -26028,10 +27008,11 @@ FX_EXTERN_C int _fx_M3AstFM9get_ifacerRM14definterface_t2RM4id_tRM5loc_t(
       fx_str_t fname_0 = {0};
       fx_str_t v_3 = {0};
       fx_str_t v_4 = {0};
+      fx_str_t v_5 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_5 = {0};
+      fx_exn_t v_6 = {0};
       bool t_0;
       if ((bool)((iface_0->m == _fx_g9Ast__noid.m) & (iface_0->i == _fx_g9Ast__noid.i))) {
          t_0 = (bool)((iface_0->m == 0) | (iface_0->j == _fx_g9Ast__noid.j));
@@ -26043,56 +27024,58 @@ FX_EXTERN_C int _fx_M3AstFM9get_ifacerRM14definterface_t2RM4id_tRM5loc_t(
          fx_str_t slit_0 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_0, &v_2);
       }
       else {
-         int_ v_6 = iface_0->i;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_6), _fx_catch_1);
-         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_6), &v_2);
+         int_ v_7 = iface_0->i;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, v_7), _fx_catch_1);
+         fx_copy_str(FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, v_7), &v_2);
       }
       if (loc_0->m_idx >= 0) {
-         int_ v_7 = loc_0->m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_catch_1);
-         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7))->u.defmodule_t.t1, &fname_0);
+         int_ v_8 = loc_0->m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_catch_1);
+         fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8))->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_1 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_1, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_3, 0), _fx_catch_1);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_4, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_5, 0), _fx_catch_1);
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(":");
       fx_str_t slit_4 = FX_MAKE_STR(": error: \'");
       fx_str_t slit_5 = FX_MAKE_STR("\' is not an interface");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_2, v_3, slit_3, v_4, slit_4, v_2, slit_5 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 8, &whole_msg_0), _fx_catch_1);
+         const fx_str_t strs_0[] = { fname_0, slit_2, v_3, slit_3, v_4, slit_4, v_2, slit_5, v_5 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_1);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
       if (all_compile_err_ctx_0 == 0) {
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_8 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_0);
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
          fx_str_t slit_6 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_8, &whole_msg_1, 0), _fx_catch_0);
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
 
       _fx_catch_0: ;
-         if (v_8) {
-            _fx_free_LS(&v_8);
+         if (v_9) {
+            _fx_free_LS(&v_9);
          }
       }
       FX_CHECK_EXN(_fx_catch_1);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_5), _fx_catch_1);
-      FX_THROW(&v_5, true, _fx_catch_1);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &whole_msg_1, &v_6), _fx_catch_1);
+      FX_THROW(&v_6, true, _fx_catch_1);
 
    _fx_catch_1: ;
-      fx_free_exn(&v_5);
+      fx_free_exn(&v_6);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_5);
       FX_FREE_STR(&v_4);
       FX_FREE_STR(&v_3);
       FX_FREE_STR(&fname_0);
@@ -26164,65 +27147,86 @@ _fx_cleanup: ;
 
 FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
 {
-   fx_arr_t z_0 = {0};
-   _fx_Rt20Hashmap__hashentry_t2Si entry0_0 = {0};
+   _fx_Rt20Hashmap__hashentry_t2iLS entry0_0 = {0};
    fx_arr_t table_0 = {0};
    fx_arr_t v_0 = {0};
-   _fx_Rt24Hashset__hashset_entry_t1S entry0_1 = {0};
+   fx_arr_t z_0 = {0};
+   _fx_Rt20Hashmap__hashentry_t2Si entry0_1 = {0};
    fx_arr_t table_1 = {0};
    fx_arr_t v_1 = {0};
-   _fx_LS v_2 = 0;
-   _fx_LS __fold_result___0 = 0;
-   _fx_LS v_3 = 0;
-   _fx_LR9Ast__id_t res_0 = 0;
-   _fx_Rt20Hashmap__hashentry_t2Si entry0_2 = {0};
+   _fx_Rt24Hashset__hashset_entry_t1S entry0_2 = {0};
    fx_arr_t table_2 = {0};
-   fx_arr_t v_4 = {0};
+   fx_arr_t v_2 = {0};
+   _fx_LS v_3 = 0;
+   _fx_LS __fold_result___0 = 0;
+   _fx_LS v_4 = 0;
+   _fx_LR9Ast__id_t res_0 = 0;
+   _fx_Rt20Hashmap__hashentry_t2Si entry0_3 = {0};
+   fx_arr_t table_3 = {0};
+   fx_arr_t v_5 = {0};
    fx_arr_t z_1 = {0};
    _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_id_0 = {0};
-   _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t v_5 = {0};
+   _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t v_6 = {0};
    int fx_status = 0;
    _fx_g15Ast__freeze_ids = false;
-   _fx_g14Ast__all_names->u.t.t0 = 0;
-   fx_arr_t* v_6 = &_fx_g14Ast__all_names->u.t.t1;
-   FX_FREE_ARR(v_6);
-   fx_copy_arr(&z_0, v_6);
-   _fx_copy_Rt20Hashmap__hashentry_t2Si(&_fx_g16Ast__all_strhash->u.t.t0, &entry0_0);
-   fx_copy_arr(&_fx_g16Ast__all_strhash->u.t.t5, &table_0);
+   _fx_g19Ast__compiler_stage = _fx_g17Ast__CompilerInit;
+   _fx_copy_Rt20Hashmap__hashentry_t2iLS(&_fx_g20Ast__src_lines_cache->u.t.t0, &entry0_0);
+   fx_copy_arr(&_fx_g20Ast__src_lines_cache->u.t.t5, &table_0);
    int_ v_7 = FX_ARR_SIZE(table_0, 0);
    FX_CHKIDX_RANGE(FX_ARR_SIZE(table_0, 0), 0, v_7, 1, 1, 0, _fx_cleanup);
-   _fx_Rt20Hashmap__hashentry_t2Si* ptr_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, table_0, 0);
+   _fx_Rt20Hashmap__hashentry_t2iLS* ptr_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2iLS, table_0, 0);
    for (int_ i_0 = 0; i_0 < v_7; i_0++) {
-      _fx_Rt20Hashmap__hashentry_t2Si* v_8 = ptr_0 + i_0;
-      _fx_free_Rt20Hashmap__hashentry_t2Si(v_8);
-      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_0, v_8);
+      _fx_Rt20Hashmap__hashentry_t2iLS* v_8 = ptr_0 + i_0;
+      _fx_free_Rt20Hashmap__hashentry_t2iLS(v_8);
+      _fx_copy_Rt20Hashmap__hashentry_t2iLS(&entry0_0, v_8);
+   }
+   _fx_g20Ast__src_lines_cache->u.t.t1 = 0;
+   _fx_g20Ast__src_lines_cache->u.t.t2 = 0;
+   _fx_g20Ast__src_lines_cache->u.t.t3 = 0;
+   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_0, 0) * 2, &v_0, 0), _fx_cleanup);
+   fx_arr_t* v_9 = &_fx_g20Ast__src_lines_cache->u.t.t4;
+   FX_FREE_ARR(v_9);
+   fx_copy_arr(&v_0, v_9);
+   _fx_g14Ast__all_names->u.t.t0 = 0;
+   fx_arr_t* v_10 = &_fx_g14Ast__all_names->u.t.t1;
+   FX_FREE_ARR(v_10);
+   fx_copy_arr(&z_0, v_10);
+   _fx_copy_Rt20Hashmap__hashentry_t2Si(&_fx_g16Ast__all_strhash->u.t.t0, &entry0_1);
+   fx_copy_arr(&_fx_g16Ast__all_strhash->u.t.t5, &table_1);
+   int_ v_11 = FX_ARR_SIZE(table_1, 0);
+   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_1, 0), 0, v_11, 1, 1, 0, _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* ptr_1 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, table_1, 0);
+   for (int_ i_1 = 0; i_1 < v_11; i_1++) {
+      _fx_Rt20Hashmap__hashentry_t2Si* v_12 = ptr_1 + i_1;
+      _fx_free_Rt20Hashmap__hashentry_t2Si(v_12);
+      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_1, v_12);
    }
    _fx_g16Ast__all_strhash->u.t.t1 = 0;
    _fx_g16Ast__all_strhash->u.t.t2 = 0;
    _fx_g16Ast__all_strhash->u.t.t3 = 0;
-   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_0, 0) * 2, &v_0, 0), _fx_cleanup);
-   fx_arr_t* v_9 = &_fx_g16Ast__all_strhash->u.t.t4;
-   FX_FREE_ARR(v_9);
-   fx_copy_arr(&v_0, v_9);
-   _fx_copy_Rt24Hashset__hashset_entry_t1S(&_fx_g19Ast__all_c_inc_dirs->u.t.t0, &entry0_1);
-   fx_copy_arr(&_fx_g19Ast__all_c_inc_dirs->u.t.t5, &table_1);
-   int_ v_10 = FX_ARR_SIZE(table_1, 0);
-   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_1, 0), 0, v_10, 1, 1, 0, _fx_cleanup);
-   _fx_Rt24Hashset__hashset_entry_t1S* ptr_1 = FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, table_1, 0);
-   for (int_ i_1 = 0; i_1 < v_10; i_1++) {
-      _fx_Rt24Hashset__hashset_entry_t1S* v_11 = ptr_1 + i_1;
-      _fx_free_Rt24Hashset__hashset_entry_t1S(v_11);
-      _fx_copy_Rt24Hashset__hashset_entry_t1S(&entry0_1, v_11);
+   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_1, 0) * 2, &v_1, 0), _fx_cleanup);
+   fx_arr_t* v_13 = &_fx_g16Ast__all_strhash->u.t.t4;
+   FX_FREE_ARR(v_13);
+   fx_copy_arr(&v_1, v_13);
+   _fx_copy_Rt24Hashset__hashset_entry_t1S(&_fx_g19Ast__all_c_inc_dirs->u.t.t0, &entry0_2);
+   fx_copy_arr(&_fx_g19Ast__all_c_inc_dirs->u.t.t5, &table_2);
+   int_ v_14 = FX_ARR_SIZE(table_2, 0);
+   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_2, 0), 0, v_14, 1, 1, 0, _fx_cleanup);
+   _fx_Rt24Hashset__hashset_entry_t1S* ptr_2 = FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, table_2, 0);
+   for (int_ i_2 = 0; i_2 < v_14; i_2++) {
+      _fx_Rt24Hashset__hashset_entry_t1S* v_15 = ptr_2 + i_2;
+      _fx_free_Rt24Hashset__hashset_entry_t1S(v_15);
+      _fx_copy_Rt24Hashset__hashset_entry_t1S(&entry0_2, v_15);
    }
    _fx_g19Ast__all_c_inc_dirs->u.t.t1 = 0;
    _fx_g19Ast__all_c_inc_dirs->u.t.t2 = 0;
    _fx_g19Ast__all_c_inc_dirs->u.t.t3 = 0;
-   FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(FX_ARR_SIZE(table_1, 0) * 2, &v_1, 0), _fx_cleanup);
-   fx_arr_t* v_12 = &_fx_g19Ast__all_c_inc_dirs->u.t.t4;
-   FX_FREE_ARR(v_12);
-   fx_copy_arr(&v_1, v_12);
-   FX_COPY_PTR(_fx_g19Ast__builtin_ids19_.t0, &v_2);
-   _fx_LS lst_0 = v_2;
+   FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(FX_ARR_SIZE(table_2, 0) * 2, &v_2, 0), _fx_cleanup);
+   fx_arr_t* v_16 = &_fx_g19Ast__all_c_inc_dirs->u.t.t4;
+   FX_FREE_ARR(v_16);
+   fx_copy_arr(&v_2, v_16);
+   FX_COPY_PTR(_fx_g19Ast__builtin_ids19_.t0, &v_3);
+   _fx_LS lst_0 = v_3;
    for (; lst_0; lst_0 = lst_0->tl) {
       _fx_LS r_0 = 0;
       fx_str_t* a_0 = &lst_0->hd;
@@ -26237,23 +27241,24 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
       }
       FX_CHECK_EXN(_fx_cleanup);
    }
-   FX_COPY_PTR(__fold_result___0, &v_3);
-   _fx_LS lst_1 = v_3;
+   FX_COPY_PTR(__fold_result___0, &v_4);
+   _fx_LS lst_1 = v_4;
    for (; lst_1; lst_1 = lst_1->tl) {
-      fx_arr_t v_13 = {0};
+      fx_arr_t v_17 = {0};
       fx_arr_t old_data_0 = {0};
       fx_str_t val0_0 = {0};
       fx_arr_t new_data_0 = {0};
       fx_str_t fname_0 = {0};
-      fx_str_t v_14 = {0};
-      fx_str_t v_15 = {0};
+      fx_str_t v_18 = {0};
+      fx_str_t v_19 = {0};
+      fx_str_t v_20 = {0};
       fx_str_t whole_msg_0 = {0};
       _fx_LS all_compile_err_ctx_0 = 0;
       fx_str_t whole_msg_1 = {0};
-      fx_exn_t v_16 = {0};
-      fx_str_t* i_2 = &lst_1->hd;
+      fx_exn_t v_21 = {0};
+      fx_str_t* i_3 = &lst_1->hd;
       int_ h_idx_0;
-      FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, i_2, &h_idx_0, 0), _fx_catch_3);
+      FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, i_3, &h_idx_0, 0), _fx_catch_3);
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_3);
       int_ idx_0 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data;
       int_ t_0;
@@ -26261,8 +27266,8 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
          t_0 = idx_0;
       }
       else if (_fx_g19Ast__lock_all_names == 0) {
-         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_13);
-         int_ sz_0 = FX_ARR_SIZE(v_13, 0);
+         fx_copy_arr(&_fx_g14Ast__all_names->u.t.t1, &v_17);
+         int_ sz_0 = FX_ARR_SIZE(v_17, 0);
          int_ n0_0 = _fx_g14Ast__all_names->u.t.t0;
          if (sz_0 <= n0_0) {
             int_ n1_0 = fx_maxi(n0_0, 128) * 2;
@@ -26276,11 +27281,11 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
                   _fx_catch_3);
             }
             dstptr_0 = (fx_str_t*)new_data_0.data;
-            for (int_ i_3 = 0; i_3 < n1_0; i_3++, dstptr_0++) {
+            for (int_ i_4 = 0; i_4 < n1_0; i_4++, dstptr_0++) {
                fx_str_t t_1 = {0};
-               if (i_3 < n0_0) {
-                  FX_CHKIDX(FX_CHKIDX1(old_data_0, 0, i_3), _fx_catch_1);
-                  fx_copy_str(FX_PTR_1D(fx_str_t, old_data_0, i_3), &t_1);
+               if (i_4 < n0_0) {
+                  FX_CHKIDX(FX_CHKIDX1(old_data_0, 0, i_4), _fx_catch_1);
+                  fx_copy_str(FX_PTR_1D(fx_str_t, old_data_0, i_4), &t_1);
                }
                else {
                   fx_copy_str(&val0_0, &t_1);
@@ -26291,93 +27296,95 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
                FX_FREE_STR(&t_1);
                FX_CHECK_EXN(_fx_catch_3);
             }
-            fx_arr_t* v_17 = &_fx_g14Ast__all_names->u.t.t1;
-            FX_FREE_ARR(v_17);
-            fx_copy_arr(&new_data_0, v_17);
+            fx_arr_t* v_22 = &_fx_g14Ast__all_names->u.t.t1;
+            FX_FREE_ARR(v_22);
+            fx_copy_arr(&new_data_0, v_22);
          }
          _fx_g14Ast__all_names->u.t.t0 = n0_0 + 1;
          FX_CHKIDX(FX_CHKIDX1(_fx_g14Ast__all_names->u.t.t1, 0, n0_0), _fx_catch_3);
-         fx_str_t* v_18 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
-         FX_FREE_STR(v_18);
-         fx_copy_str(i_2, v_18);
+         fx_str_t* v_23 = FX_PTR_1D(fx_str_t, _fx_g14Ast__all_names->u.t.t1, n0_0);
+         FX_FREE_STR(v_23);
+         fx_copy_str(i_3, v_23);
          FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_3);
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0)->data = n0_0;
          t_0 = n0_0;
       }
       else {
          if (_fx_g10Ast__noloc.m_idx >= 0) {
-            int_ v_19 = _fx_g10Ast__noloc.m_idx;
-            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_19), _fx_catch_3);
-            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_19))->u.defmodule_t.t1, &fname_0);
+            int_ v_24 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_24), _fx_catch_3);
+            fx_copy_str(&(*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_24))->u.defmodule_t.t1, &fname_0);
          }
          else {
             fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
          }
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_14, 0), _fx_catch_3);
-         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_15, 0), _fx_catch_3);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_18, 0), _fx_catch_3);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_19, 0), _fx_catch_3);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_20, 0), _fx_catch_3);
          fx_str_t slit_1 = FX_MAKE_STR(":");
          fx_str_t slit_2 = FX_MAKE_STR(":");
          fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
          {
-            const fx_str_t strs_0[] = { fname_0, slit_1, v_14, slit_2, v_15, slit_3 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 6, &whole_msg_0), _fx_catch_3);
+            const fx_str_t strs_0[] = { fname_0, slit_1, v_18, slit_2, v_19, slit_3, v_20 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_catch_3);
          }
          FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
          if (all_compile_err_ctx_0 == 0) {
             fx_copy_str(&whole_msg_0, &whole_msg_1);
          }
          else {
-            _fx_LS v_20 = 0;
-            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_20), _fx_catch_2);
+            _fx_LS v_25 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_25), _fx_catch_2);
             fx_str_t slit_4 =
                FX_MAKE_STR("\n"
                   U"\t");
-            FX_CALL(_fx_F4joinS2SLS(&slit_4, v_20, &whole_msg_1, 0), _fx_catch_2);
+            FX_CALL(_fx_F4joinS2SLS(&slit_4, v_25, &whole_msg_1, 0), _fx_catch_2);
 
          _fx_catch_2: ;
-            if (v_20) {
-               _fx_free_LS(&v_20);
+            if (v_25) {
+               _fx_free_LS(&v_25);
             }
          }
          FX_CHECK_EXN(_fx_catch_3);
-         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_16), _fx_catch_3);
-         FX_THROW(&v_16, true, _fx_catch_3);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_21), _fx_catch_3);
+         FX_THROW(&v_21, true, _fx_catch_3);
       }
 
    _fx_catch_3: ;
-      fx_free_exn(&v_16);
+      fx_free_exn(&v_21);
       FX_FREE_STR(&whole_msg_1);
       if (all_compile_err_ctx_0) {
          _fx_free_LS(&all_compile_err_ctx_0);
       }
       FX_FREE_STR(&whole_msg_0);
-      FX_FREE_STR(&v_15);
-      FX_FREE_STR(&v_14);
+      FX_FREE_STR(&v_20);
+      FX_FREE_STR(&v_19);
+      FX_FREE_STR(&v_18);
       FX_FREE_STR(&fname_0);
       FX_FREE_ARR(&new_data_0);
       FX_FREE_STR(&val0_0);
       FX_FREE_ARR(&old_data_0);
-      FX_FREE_ARR(&v_13);
+      FX_FREE_ARR(&v_17);
       FX_CHECK_EXN(_fx_cleanup);
    }
    FX_CALL(_fx_M3AstFM19fname_always_importLRM4id_t0(&res_0, 0), _fx_cleanup);
-   _fx_copy_Rt20Hashmap__hashentry_t2Si(&_fx_g21Ast__all_modules_hash->u.t.t0, &entry0_2);
-   fx_copy_arr(&_fx_g21Ast__all_modules_hash->u.t.t5, &table_2);
-   int_ v_21 = FX_ARR_SIZE(table_2, 0);
-   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_2, 0), 0, v_21, 1, 1, 0, _fx_cleanup);
-   _fx_Rt20Hashmap__hashentry_t2Si* ptr_2 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, table_2, 0);
-   for (int_ i_4 = 0; i_4 < v_21; i_4++) {
-      _fx_Rt20Hashmap__hashentry_t2Si* v_22 = ptr_2 + i_4;
-      _fx_free_Rt20Hashmap__hashentry_t2Si(v_22);
-      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_2, v_22);
+   _fx_copy_Rt20Hashmap__hashentry_t2Si(&_fx_g21Ast__all_modules_hash->u.t.t0, &entry0_3);
+   fx_copy_arr(&_fx_g21Ast__all_modules_hash->u.t.t5, &table_3);
+   int_ v_26 = FX_ARR_SIZE(table_3, 0);
+   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_3, 0), 0, v_26, 1, 1, 0, _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* ptr_3 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, table_3, 0);
+   for (int_ i_5 = 0; i_5 < v_26; i_5++) {
+      _fx_Rt20Hashmap__hashentry_t2Si* v_27 = ptr_3 + i_5;
+      _fx_free_Rt20Hashmap__hashentry_t2Si(v_27);
+      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_3, v_27);
    }
    _fx_g21Ast__all_modules_hash->u.t.t1 = 0;
    _fx_g21Ast__all_modules_hash->u.t.t2 = 0;
    _fx_g21Ast__all_modules_hash->u.t.t3 = 0;
-   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_2, 0) * 2, &v_4, 0), _fx_cleanup);
-   fx_arr_t* v_23 = &_fx_g21Ast__all_modules_hash->u.t.t4;
-   FX_FREE_ARR(v_23);
-   fx_copy_arr(&v_4, v_23);
+   FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_3, 0) * 2, &v_5, 0), _fx_cleanup);
+   fx_arr_t* v_28 = &_fx_g21Ast__all_modules_hash->u.t.t4;
+   FX_FREE_ARR(v_28);
+   fx_copy_arr(&v_5, v_28);
    FX_FREE_ARR(&_fx_g16Ast__all_modules);
    fx_copy_arr(&z_1, &_fx_g16Ast__all_modules);
    fx_str_t slit_5 = FX_MAKE_STR("<Names>");
@@ -26394,9 +27401,9 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
    _fx_g23Ast__all_modules_sorted = 0;
    _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_id_fp_0 = { _fx_M3AstFM6cmp_idi2RM4id_tRM4id_t, 0 };
    FX_COPY_FP(&cmp_id_fp_0, &cmp_id_0);
-   _fx_make_Rt6Map__t2R9Ast__id_tR9Ast__id_t(_fx_g10Ast__Empty, &cmp_id_0, &v_5);
+   _fx_make_Rt6Map__t2R9Ast__id_tR9Ast__id_t(_fx_g10Ast__Empty, &cmp_id_0, &v_6);
    _fx_free_Rt6Map__t2R9Ast__id_tR9Ast__id_t(&_fx_g23Ast__builtin_exceptions);
-   _fx_copy_Rt6Map__t2R9Ast__id_tR9Ast__id_t(&v_5, &_fx_g23Ast__builtin_exceptions);
+   _fx_copy_Rt6Map__t2R9Ast__id_tR9Ast__id_t(&v_6, &_fx_g23Ast__builtin_exceptions);
    _fx_free_LE(&_fx_g21Ast__all_compile_errs);
    _fx_g21Ast__all_compile_errs = 0;
    _fx_g22Ast__all_compile_warns = 0;
@@ -26407,29 +27414,32 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
    fx_copy_str(&slit_7, &_fx_g19Ast__ficus_std_path);
 
 _fx_cleanup: ;
-   FX_FREE_ARR(&z_0);
-   _fx_free_Rt20Hashmap__hashentry_t2Si(&entry0_0);
+   _fx_free_Rt20Hashmap__hashentry_t2iLS(&entry0_0);
    FX_FREE_ARR(&table_0);
    FX_FREE_ARR(&v_0);
-   _fx_free_Rt24Hashset__hashset_entry_t1S(&entry0_1);
+   FX_FREE_ARR(&z_0);
+   _fx_free_Rt20Hashmap__hashentry_t2Si(&entry0_1);
    FX_FREE_ARR(&table_1);
    FX_FREE_ARR(&v_1);
-   if (v_2) {
-      _fx_free_LS(&v_2);
+   _fx_free_Rt24Hashset__hashset_entry_t1S(&entry0_2);
+   FX_FREE_ARR(&table_2);
+   FX_FREE_ARR(&v_2);
+   if (v_3) {
+      _fx_free_LS(&v_3);
    }
    if (__fold_result___0) {
       _fx_free_LS(&__fold_result___0);
    }
-   if (v_3) {
-      _fx_free_LS(&v_3);
+   if (v_4) {
+      _fx_free_LS(&v_4);
    }
    FX_FREE_LIST_SIMPLE(&res_0);
-   _fx_free_Rt20Hashmap__hashentry_t2Si(&entry0_2);
-   FX_FREE_ARR(&table_2);
-   FX_FREE_ARR(&v_4);
+   _fx_free_Rt20Hashmap__hashentry_t2Si(&entry0_3);
+   FX_FREE_ARR(&table_3);
+   FX_FREE_ARR(&v_5);
    FX_FREE_ARR(&z_1);
    FX_FREE_FP(&cmp_id_0);
-   _fx_free_Rt6Map__t2R9Ast__id_tR9Ast__id_t(&v_5);
+   _fx_free_Rt6Map__t2R9Ast__id_tR9Ast__id_t(&v_6);
    return fx_status;
 }
 
@@ -26483,6 +27493,7 @@ FX_EXTERN_C int fx_init_Ast(void)
    FX_COPY_FP(&cmp_id_fp_2, &_fx_g13Ast__cmp_id2_);
    FX_CALL(_fx_M3AstFM5emptyRt6Map__t2RM4id_tRM4id_t1FPi2RM4id_tRM4id_t(&_fx_g13Ast__cmp_id2_, &_fx_g16Ast__empty_idmap, 0),
       _fx_cleanup);
+   _fx_g19Ast__compiler_stage = _fx_g17Ast__CompilerInit;
    fx_str_t slit_1 = FX_MAKE_STR("");
    FX_CALL(_fx_M3AstFM6createNt9Dynvec__t1S2iS(0, &slit_1, &_fx_g14Ast__all_names, 0), _fx_cleanup);
    fx_str_t slit_2 = FX_MAKE_STR("");
@@ -26495,6 +27506,7 @@ FX_EXTERN_C int fx_init_Ast(void)
    fx_copy_str(&slit_4, &_fx_g19Ast__ficus_std_path);
    fx_str_t slit_5 = FX_MAKE_STR("");
    FX_CALL(_fx_M3AstFM5emptyNt10Hashset__t1S2iS(256, &slit_5, &_fx_g19Ast__all_c_inc_dirs, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM5emptyNt10Hashmap__t2iLS3iiLS(16, -1, 0, &_fx_g20Ast__src_lines_cache, 0), _fx_cleanup);
    fx_str_t slit_6 = FX_MAKE_STR("fx_fv");
    FX_CALL(_fx_cons_LS(&slit_6, 0, true, &v_0), _fx_cleanup);
    fx_str_t slit_7 = FX_MAKE_STR("fx_status");
@@ -26516,7 +27528,7 @@ FX_EXTERN_C int fx_init_Ast(void)
    FX_CALL(
       _fx_M3AstFM4SomeNt6option1FPN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t1FPN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(
          &_fx_g13Ast__dup_exp_, &v_2), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(v_1, v_2, _fx_g11Ast__None1_, &_fx_g14Ast__dup_callb);
+   _fx_make_R16Ast__ast_callb_t(v_1, v_2, _fx_g11Ast__None2_, &_fx_g14Ast__dup_callb);
    fx_str_t slit_9 = FX_MAKE_STR("_");
    FX_CALL(_fx_M3AstFM6std_idT2RM4id_tT2LSi2ST2LSi(&slit_9, &_fx_g18Ast__builtin_ids1_, &_fx_g8Ast__v1_, 0), _fx_cleanup);
    _fx_copy_T2LSi(&_fx_g8Ast__v1_.t1, &_fx_g18Ast__builtin_ids2_);
@@ -26650,6 +27662,9 @@ FX_EXTERN_C void fx_deinit_Ast(void)
    FX_FREE_STR(&_fx_g19Ast__ficus_std_path);
    if (_fx_g19Ast__all_c_inc_dirs) {
       _fx_free_Nt10Hashset__t1S(&_fx_g19Ast__all_c_inc_dirs);
+   }
+   if (_fx_g20Ast__src_lines_cache) {
+      _fx_free_Nt10Hashmap__t2iLS(&_fx_g20Ast__src_lines_cache);
    }
    FX_FREE_FP(&_fx_g8Ast__cmp);
    FX_FREE_FP(&_fx_g13Ast__dup_typ_);

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -199,16 +199,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;
@@ -6983,11 +6984,12 @@ FX_EXTERN_C void _fx_M3AstFM7ScBlockN12Ast__scope_t1i(int_ arg0, struct _fx_N12A
    fx_result->u.ScBlock = arg0;
 }
 
-FX_EXTERN_C void _fx_M3AstFM6ScLoopN12Ast__scope_t2Bi(bool arg0, int_ arg1, struct _fx_N12Ast__scope_t* fx_result)
+FX_EXTERN_C void _fx_M3AstFM6ScLoopN12Ast__scope_t3BBi(bool arg0, bool arg1, int_ arg2, struct _fx_N12Ast__scope_t* fx_result)
 {
    fx_result->tag = 2;
    fx_result->u.ScLoop.t0 = arg0;
    fx_result->u.ScLoop.t1 = arg1;
+   fx_result->u.ScLoop.t2 = arg2;
 }
 
 FX_EXTERN_C void _fx_M3AstFM6ScFoldN12Ast__scope_t1i(int_ arg0, struct _fx_N12Ast__scope_t* fx_result)
@@ -10712,9 +10714,10 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(
+FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(
    int_ m_idx_0,
    bool nested_0,
+   bool parallel_0,
    struct _fx_N12Ast__scope_t* fx_result,
    void* fx_fv)
 {
@@ -10723,7 +10726,7 @@ FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(
    int_ new_block_idx_0 = (*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0))->u.defmodule_t.t8 + 1;
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
    (*FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0))->u.defmodule_t.t8 = new_block_idx_0;
-   _fx_M3AstFM6ScLoopN12Ast__scope_t2Bi(nested_0, new_block_idx_0, fx_result);
+   _fx_M3AstFM6ScLoopN12Ast__scope_t3BBi(nested_0, parallel_0, new_block_idx_0, fx_result);
 
 _fx_cleanup: ;
    return fx_status;

--- a/compiler/bootstrap/Ast_pp.c
+++ b/compiler/bootstrap/Ast_pp.c
@@ -93,16 +93,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -1568,6 +1568,11 @@ typedef struct _fx_Ta2N10Ast__pat_t {
    struct _fx_N10Ast__pat_t_data_t* t1;
 } _fx_Ta2N10Ast__pat_t;
 
+typedef struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
+   int_ rc;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t data;
+} _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
 typedef struct _fx_T2N10Ast__pat_tN10Ast__typ_t {
    struct _fx_N10Ast__pat_t_data_t* t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
@@ -1612,11 +1617,6 @@ typedef struct _fx_T2Nt11Map__tree_t2R9Ast__id_tR9Ast__id_tB {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* t0;
    bool t1;
 } _fx_T2Nt11Map__tree_t2R9Ast__id_tR9Ast__id_tB;
-
-typedef struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
-   int_ rc;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t data;
-} _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
 typedef struct _fx_T3LN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t {
    struct _fx_LN10Ast__pat_t_data_t* t0;
@@ -5868,6 +5868,19 @@ static void _fx_make_Ta2N10Ast__pat_t(
    FX_COPY_PTR(t1, &fx_result->t1);
 }
 
+static void _fx_free_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t, _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t);
+}
+
+static int _fx_make_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* arg,
+   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t, _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t);
+}
+
 static void _fx_free_T2N10Ast__pat_tN10Ast__typ_t(struct _fx_T2N10Ast__pat_tN10Ast__typ_t* dst)
 {
    _fx_free_N10Ast__pat_t(&dst->t0);
@@ -6037,19 +6050,6 @@ static void _fx_make_T2Nt11Map__tree_t2R9Ast__id_tR9Ast__id_tB(
 {
    FX_COPY_PTR(t0, &fx_result->t0);
    fx_result->t1 = t1;
-}
-
-static void _fx_free_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t, _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t);
-}
-
-static int _fx_make_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* arg,
-   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t, _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t);
 }
 
 static void _fx_free_T3LN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
@@ -6267,9 +6267,10 @@ _fx_Nt6option1rRt6Set__t1R9Ast__id_t _fx_g21Ast_typecheck__None8_ = { 1 };
 _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t _fx_g21Ast_typecheck__None9_ = { 1 };
 _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g22Ast_typecheck__None10_ = 0;
 _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t _fx_g22Ast_typecheck__None11_ = 0;
-_fx_Nt6option1R9Ast__id_t _fx_g22Ast_typecheck__None12_ = { 1 };
-_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None13_ = 0;
-_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None14_ = 0;
+_fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t _fx_g22Ast_typecheck__None12_ = 0;
+_fx_Nt6option1R9Ast__id_t _fx_g22Ast_typecheck__None13_ = { 1 };
+_fx_Nt6option1N10Ast__exp_t _fx_g22Ast_typecheck__None14_ = 0;
+_fx_Nt6option1N10Ast__typ_t _fx_g22Ast_typecheck__None15_ = 0;
 _fx_N12Map__color_t _fx_g18Ast_typecheck__Red = { 1 };
 _fx_N12Map__color_t _fx_g20Ast_typecheck__Black = { 2 };
 _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t _fx_g20Ast_typecheck__Empty = 0;
@@ -6290,6 +6291,8 @@ static _fx_N10Ast__typ_t_data_t TypVoid_data_2 = { 1, 14 };
 _fx_N10Ast__typ_t _fx_g22Ast_typecheck__TypVoid = &TypVoid_data_2;
 static _fx_N10Ast__typ_t_data_t TypExn_data_1 = { 1, 22 };
 _fx_N10Ast__typ_t _fx_g21Ast_typecheck__TypExn = &TypExn_data_1;
+static _fx_N10Ast__typ_t_data_t TypErr_data_1 = { 1, 23 };
+_fx_N10Ast__typ_t _fx_g21Ast_typecheck__TypErr = &TypErr_data_1;
 static _fx_N10Ast__typ_t_data_t TypModule_data_1 = { 1, 27 };
 _fx_N10Ast__typ_t _fx_g24Ast_typecheck__TypModule = &TypModule_data_1;
 _fx_N12Ast__cmpop_t _fx_g20Ast_typecheck__CmpEQ = { 1 };
@@ -6471,6 +6474,16 @@ static int _fx_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_c
    struct _fx_N10Ast__typ_t_data_t**,
    void*);
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+   struct _fx_rB_data_t*,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
+
+static int _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__typ_t_data_t**,
+   void*);
+
 FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(struct _fx_R10Ast__loc_t*, fx_str_t*, fx_exn_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
@@ -6601,7 +6614,7 @@ FX_EXTERN_C int
 
 FX_EXTERN_C int _fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, void*);
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp2_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
    struct _fx_rB_data_t*,
    struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t*);
 
@@ -7000,6 +7013,8 @@ static int
 
 FX_EXTERN_C int _fx_M3AstFM20get_numeric_typ_sizei2N10Ast__typ_tB(struct _fx_N10Ast__typ_t_data_t*, bool, int_*, void*);
 
+FX_EXTERN_C int _fx_M3AstFM16push_compile_errv1E(fx_exn_t*, void*);
+
 FX_EXTERN_C int _fx_M3AstFM5ExpIfN10Ast__exp_t4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
    struct _fx_N10Ast__exp_t_data_t*,
    struct _fx_N10Ast__exp_t_data_t*,
@@ -7266,6 +7281,35 @@ FX_EXTERN_C int _fx_M3AstFM7ExpCastN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10
    struct _fx_T2N10Ast__typ_tR10Ast__loc_t*,
    struct _fx_N10Ast__exp_t_data_t**);
 
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t5rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR16Ast__val_flags_tiN10Ast__typ_tLN12Ast__scope_t(
+   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t*,
+   struct _fx_R16Ast__val_flags_t*,
+   int_,
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_LN12Ast__scope_t_data_t*,
+   struct _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t*);
+
+FX_EXTERN_C int _fx_M3AstFM16check_n_walk_patN10Ast__pat_t2N10Ast__pat_tRM11ast_callb_t(
+   struct _fx_N10Ast__pat_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__pat_t_data_t**,
+   void*);
+
+static int _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__pat_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__pat_t_data_t**,
+   void*);
+
+FX_EXTERN_C int _fx_M3AstFM6dup_idRM4id_t2iRM4id_t(int_, struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM8walk_patN10Ast__pat_t2N10Ast__pat_tRM11ast_callb_t(
+   struct _fx_N10Ast__pat_t_data_t*,
+   struct _fx_R16Ast__ast_callb_t*,
+   struct _fx_N10Ast__pat_t_data_t**,
+   void*);
+
 FX_EXTERN_C int _fx_M3AstFM15is_global_scopeB1LN12Ast__scope_t(struct _fx_LN12Ast__scope_t_data_t*, bool*, void*);
 
 FX_EXTERN_C int
@@ -7299,10 +7343,6 @@ FX_EXTERN_C int
    struct _fx_LN12Ast__scope_t_data_t*,
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    void*);
-
-FX_EXTERN_C int _fx_M3AstFM16push_compile_errv1E(fx_exn_t*, void*);
-
-FX_EXTERN_C int _fx_M3AstFM6dup_idRM4id_t2iRM4id_t(int_, struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, void*);
 
 FX_EXTERN_C int _fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(
    struct _fx_rR13Ast__deffun_t_data_t*,
@@ -7673,6 +7713,19 @@ FX_EXTERN_C void _fx_free_M13Ast_typecheckFM6check_N10Ast__typ_t2N10Ast__typ_tR1
 typedef struct {
    int_ rc;
    fx_free_t free_f;
+   struct _fx_rB_data_t* t0;
+} _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t;
+
+FX_EXTERN_C void _fx_free_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* dst)
+{
+   FX_FREE_REF_SIMPLE(&dst->t0);
+   fx_free(dst);
+}
+
+typedef struct {
+   int_ rc;
+   fx_free_t free_f;
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t t0;
 } _fx_M13Ast_typecheckFM10__lambda__Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_cldata_t;
 
@@ -7756,6 +7809,26 @@ typedef struct {
    fx_free_t free_f;
    struct _fx_R9Ast__id_t t0;
 } _fx_M13Ast_typecheckFM12__lambda__1_B1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t_cldata_t;
+
+typedef struct {
+   int_ rc;
+   fx_free_t free_f;
+   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t* t0;
+   struct _fx_R16Ast__val_flags_t t1;
+   int_ t2;
+   struct _fx_N10Ast__typ_t_data_t* t3;
+   struct _fx_LN12Ast__scope_t_data_t* t4;
+} _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_cldata_t;
+
+FX_EXTERN_C void _fx_free_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
+   _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_cldata_t* dst)
+{
+   _fx_free_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->t0);
+   _fx_free_R16Ast__val_flags_t(&dst->t1);
+   _fx_free_N10Ast__typ_t(&dst->t3);
+   FX_FREE_LIST_SIMPLE(&dst->t4);
+   fx_free(dst);
+}
 
 typedef struct {
    int_ rc;
@@ -7894,6 +7967,16 @@ FX_EXTERN_C void _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t
 {
    fx_result->tag = 2;
    _fx_copy_T2R9Ast__id_tN10Ast__typ_t(arg0, &fx_result->u.Some);
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
+   struct _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t* arg0,
+   struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t** fx_result)
+{
+   FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t);
+   FX_COPY_FP(arg0, &v->u.Some);
+   return 0;
 }
 
 FX_EXTERN_C int
@@ -9213,7 +9296,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9assoc_optNt6option1N10Ast__typ_t2LT2R9Ast
    _fx_catch_1: ;
    }
    else {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result);
    }
 
 _fx_cleanup: ;
@@ -13091,7 +13174,7 @@ static int _fx_M13Ast_typecheckFM9unskolem_N10Ast__typ_t2N10Ast__typ_tR16Ast__as
    }
    if (tag_0 == 1) {
       _fx_rNt6option1N10Ast__typ_t v_8 = 0;
-      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None14_, &v_8), _fx_catch_4);
+      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None15_, &v_8), _fx_catch_4);
       FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_8, fx_result), _fx_catch_4);
 
    _fx_catch_4: ;
@@ -14081,6 +14164,176 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPN10Ast__typ_t2N10Ast__typ_tR16As
    return 0;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM14typ_has_typerrB1N10Ast__typ_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   bool* fx_result,
+   void* fx_fv)
+{
+   _fx_rB has_err_ref_0 = 0;
+   _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t check__0 = {0};
+   _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t v_0 = 0;
+   _fx_R16Ast__ast_callb_t callb_0 = {0};
+   _fx_N10Ast__typ_t t_1 = 0;
+   _fx_N10Ast__typ_t v_1 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_make_rB(false, &has_err_ref_0), _fx_cleanup);
+   bool* has_err_0 = &has_err_ref_0->data;
+   _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(has_err_ref_0, &check__0);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+         &check__0, &v_0), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(v_0, _fx_g22Ast_typecheck__None11_, _fx_g22Ast_typecheck__None10_, &callb_0);
+   if (*has_err_0) {
+      FX_COPY_PTR(t_0, &t_1);
+   }
+   else {
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_cleanup);
+      if (FX_REC_VARIANT_TAG(v_1) == 23) {
+         *has_err_0 = true; FX_COPY_PTR(t_0, &t_1);
+      }
+      else {
+         FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(v_1, &callb_0, &t_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   *fx_result = *has_err_0;
+
+_fx_cleanup: ;
+   FX_FREE_REF_SIMPLE(&has_err_ref_0);
+   FX_FREE_FP(&check__0);
+   if (v_0) {
+      _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&v_0);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_0);
+   if (t_1) {
+      _fx_free_N10Ast__typ_t(&t_1);
+   }
+   if (v_1) {
+      _fx_free_N10Ast__typ_t(&v_1);
+   }
+   return fx_status;
+}
+
+static int _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__typ_t_data_t* t_0,
+   struct _fx_R16Ast__ast_callb_t* callb_0,
+   struct _fx_N10Ast__typ_t_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_N10Ast__typ_t v_0 = 0;
+   int fx_status = 0;
+   _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* cv_0 =
+      (_fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
+   bool* has_err_0 = &cv_0->t0->data;
+   if (*has_err_0) {
+      FX_COPY_PTR(t_0, fx_result);
+   }
+   else {
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+      if (FX_REC_VARIANT_TAG(v_0) == 23) {
+         *has_err_0 = true; FX_COPY_PTR(t_0, fx_result);
+      }
+      else {
+         FX_CALL(_fx_M3AstFM8walk_typN10Ast__typ_t2N10Ast__typ_tRM11ast_callb_t(v_0, callb_0, fx_result, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+   struct _fx_rB_data_t* arg0,
+   struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t* fx_result)
+{
+   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t,
+      _fx_free_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t,
+      _fx_M13Ast_typecheckFM8check_1_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t);
+   FX_COPY_PTR(arg0, &fcv->t0);
+   return 0;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM17poison_result_typv1N10Ast__typ_t(struct _fx_N10Ast__typ_t_data_t* t_0, void* fx_fv)
+{
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_1 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+   int tag_0 = FX_REC_VARIANT_TAG(v_0);
+   if (tag_0 == 15) {
+      _fx_N10Ast__typ_t v_2 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_3 = 0;
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_0->u.TypFun.t1, &v_2, 0), _fx_catch_1);
+      if (FX_REC_VARIANT_TAG(v_2) == 1) {
+         _fx_rNt6option1N10Ast__typ_t r_0 = v_2->u.TypVar;
+         FX_COPY_PTR(r_0->data, &v_3);
+         if ((v_3 != 0) + 1 == 1) {
+            _fx_Nt6option1N10Ast__typ_t v_4 = 0;
+            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_4),
+               _fx_catch_0);
+            _fx_Nt6option1N10Ast__typ_t* v_5 = &r_0->data;
+            _fx_free_Nt6option1N10Ast__typ_t(v_5);
+            FX_COPY_PTR(v_4, v_5);
+
+         _fx_catch_0: ;
+            if (v_4) {
+               _fx_free_Nt6option1N10Ast__typ_t(&v_4);
+            }
+            goto _fx_endmatch_0;
+         }
+      }
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_catch_1);
+
+   _fx_catch_1: ;
+      if (v_3) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_3);
+      }
+      if (v_2) {
+         _fx_free_N10Ast__typ_t(&v_2);
+      }
+      goto _fx_endmatch_1;
+   }
+   if (tag_0 == 1) {
+      _fx_rNt6option1N10Ast__typ_t r_1 = v_0->u.TypVar;
+      FX_COPY_PTR(r_1->data, &v_1);
+      if ((v_1 != 0) + 1 == 1) {
+         _fx_Nt6option1N10Ast__typ_t v_6 = 0;
+         FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_6),
+            _fx_catch_2);
+         _fx_Nt6option1N10Ast__typ_t* v_7 = &r_1->data;
+         _fx_free_Nt6option1N10Ast__typ_t(v_7);
+         FX_COPY_PTR(v_6, v_7);
+
+      _fx_catch_2: ;
+         if (v_6) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_6);
+         }
+         goto _fx_endmatch_1;
+      }
+   }
+
+_fx_endmatch_1: ;
+
+_fx_cleanup: ;
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (v_1) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_1);
+   }
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(
    struct _fx_N10Ast__typ_t_data_t* t1_0,
    struct _fx_N10Ast__typ_t_data_t* t2_0,
@@ -14148,7 +14401,7 @@ _fx_catch_0: ;
          _fx_free_Nt6option1N10Ast__typ_t(fx_result);
       }
       if (exn_0.tag == _FX_EXN_E17Ast__CompileError) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result);
       }
       else {
          FX_RETHROW(&exn_0, _fx_cleanup);
@@ -16236,7 +16489,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             _fx_free_R17Ast__defvariant_t(&v_1);
          }
          FX_CHECK_EXN(_fx_catch_3);
-         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None12_;
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None13_;
          _fx_LR9Ast__id_t lst_0 = inst_list_0;
          for (; lst_0; lst_0 = lst_0->tl) {
             _fx_N14Ast__id_info_t v_2 = {0};
@@ -16281,7 +16534,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM17find_typ_instanceNt6option1N10Ast__typ_t
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result);
          }
          FX_CHECK_EXN(_fx_catch_3);
       }
@@ -16642,7 +16895,7 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM11is_real_typB1N10Ast__typ_t(
    int fx_status = 0;
    FX_CALL(_fx_make_rB(false, &have_typ_vars_ref_0), _fx_cleanup);
    bool* have_typ_vars_0 = &have_typ_vars_ref_0->data;
-   _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(have_typ_vars_ref_0, &is_real_typ__0);
+   _fx_M13Ast_typecheckFM9make_fp2_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(have_typ_vars_ref_0, &is_real_typ__0);
    FX_CALL(
       _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
          &is_real_typ__0, &v_0), _fx_cleanup);
@@ -16733,7 +16986,7 @@ _fx_endmatch_0: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp1_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
+FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp2_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t1rB(
    struct _fx_rB_data_t* arg0,
    struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t* fx_result)
 {
@@ -17410,7 +17663,7 @@ FX_EXTERN_C int
          }
          else {
             _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, &result_0);
             FX_BREAK(_fx_catch_2);
 
          _fx_catch_2: ;
@@ -17487,7 +17740,7 @@ static int
       int_ dot_pos_2 = _fx_M6StringFM5rfindi3SCi(&n_path_2, (char_)46, dot_pos_1, 0);
       if (dot_pos_2 < 0) {
          _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, &result_0);
          FX_BREAK(_fx_catch_3);
       }
       else {
@@ -17533,7 +17786,7 @@ static int
                }
                else {
                   _fx_free_Nt6option1N10Ast__typ_t(&result_0);
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
@@ -17828,36 +18081,38 @@ static int
    _fx_LR9Ast__id_t df_templ_args_0 = 0;
    _fx_N10Ast__typ_t v_0 = 0;
    _fx_N10Ast__typ_t t_1 = 0;
-   _fx_T2R9Ast__id_tN10Ast__typ_t v_1 = {0};
-   fx_str_t v_2 = {0};
-   fx_str_t v_3 = {0};
-   fx_exn_t v_4 = {0};
-   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_5 = {0};
+   _fx_N10Ast__typ_t v_1 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_2 = 0;
+   _fx_T2R9Ast__id_tN10Ast__typ_t v_3 = {0};
+   fx_str_t v_4 = {0};
+   fx_str_t v_5 = {0};
+   fx_exn_t v_6 = {0};
+   _fx_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_7 = {0};
    _fx_N10Ast__typ_t ftyp_0 = 0;
    _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
-   fx_str_t v_6 = {0};
-   fx_str_t v_7 = {0};
-   fx_exn_t v_8 = {0};
-   _fx_T2R9Ast__id_tN10Ast__typ_t v_9 = {0};
-   _fx_LR9Ast__id_t v_10 = 0;
+   fx_str_t v_8 = {0};
+   fx_str_t v_9 = {0};
+   fx_exn_t v_10 = {0};
+   _fx_T2R9Ast__id_tN10Ast__typ_t v_11 = {0};
+   _fx_LR9Ast__id_t v_12 = 0;
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
-   _fx_R13Ast__deffun_t* v_11 = &df_0->data;
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_11->df_env, &df_env_0);
-   FX_COPY_PTR(v_11->df_templ_inst, &df_templ_inst_0);
-   _fx_R16Ast__fun_flags_t df_flags_0 = v_11->df_flags;
-   FX_COPY_PTR(v_11->df_typ, &df_typ_0);
-   FX_COPY_PTR(v_11->df_templ_args, &df_templ_args_0);
-   _fx_R9Ast__id_t df_name_0 = v_11->df_name;
+   _fx_R13Ast__deffun_t* v_13 = &df_0->data;
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_13->df_env, &df_env_0);
+   FX_COPY_PTR(v_13->df_templ_inst, &df_templ_inst_0);
+   _fx_R16Ast__fun_flags_t df_flags_0 = v_13->df_flags;
+   FX_COPY_PTR(v_13->df_typ, &df_typ_0);
+   FX_COPY_PTR(v_13->df_templ_args, &df_templ_args_0);
+   _fx_R9Ast__id_t df_name_0 = v_13->df_name;
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
    if (df_flags_0.fun_flag_have_keywords == true) {
       if (FX_REC_VARIANT_TAG(v_0) == 15) {
          _fx_LN10Ast__typ_t argtyps_0 = 0;
          _fx_N10Ast__typ_t result_0 = 0;
          _fx_LN10Ast__typ_t __pat___0 = 0;
-         _fx_N10Ast__typ_t v_12 = 0;
-         _fx_N10Ast__typ_t v_13 = 0;
-         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_14 = {0};
+         _fx_N10Ast__typ_t v_14 = 0;
+         _fx_N10Ast__typ_t v_15 = 0;
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = {0};
          _fx_T2LN10Ast__typ_tN10Ast__typ_t* vcase_0 = &v_0->u.TypFun;
          _fx_LN10Ast__typ_t argtyps_1 = vcase_0->t0;
          if (argtyps_1 != 0) {
@@ -17898,12 +18153,12 @@ static int
                FX_CHECK_BREAK();
                FX_CHECK_EXN(_fx_catch_5);
             }
-            FX_COPY_PTR(result_0, &v_12);
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_12, &v_13, 0), _fx_catch_5);
+            FX_COPY_PTR(result_0, &v_14);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_14, &v_15, 0), _fx_catch_5);
             bool res_0;
-            if (FX_REC_VARIANT_TAG(v_13) == 21) {
-               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_13->u.TypRecord->data, &v_14);
-               if (v_14.t1 == false) {
+            if (FX_REC_VARIANT_TAG(v_15) == 21) {
+               _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_15->u.TypRecord->data, &v_16);
+               if (v_16.t1 == false) {
                   res_0 = true; goto _fx_endmatch_1;
                }
             }
@@ -17915,23 +18170,23 @@ static int
                FX_COPY_PTR(argtyps_1, &argtyps_0); goto _fx_endmatch_2;
             }
          }
-         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_15 = {0};
-         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_16 = 0;
-         _fx_N10Ast__typ_t v_17 = 0;
-         _fx_LN10Ast__typ_t v_18 = 0;
-         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_15);
-         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_15, &v_16), _fx_catch_4);
-         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_16, &v_17),
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_17 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_18 = 0;
+         _fx_N10Ast__typ_t v_19 = 0;
+         _fx_LN10Ast__typ_t v_20 = 0;
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(0, false, &v_17);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_17, &v_18), _fx_catch_4);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_18, &v_19),
             _fx_catch_4);
-         FX_CALL(_fx_cons_LN10Ast__typ_t(v_17, 0, true, &v_18), _fx_catch_4);
+         FX_CALL(_fx_cons_LN10Ast__typ_t(v_19, 0, true, &v_20), _fx_catch_4);
          if (argtyps_1 == 0) {
-            FX_COPY_PTR(v_18, &argtyps_0);
+            FX_COPY_PTR(v_20, &argtyps_0);
          }
-         else if (v_18 == 0) {
+         else if (v_20 == 0) {
             FX_COPY_PTR(argtyps_1, &argtyps_0);
          }
          else {
-            _fx_LN10Ast__typ_t v_19 = 0;
+            _fx_LN10Ast__typ_t v_21 = 0;
             _fx_LN10Ast__typ_t argtyps_2 = 0;
             _fx_LN10Ast__typ_t lstend_0 = 0;
             FX_COPY_PTR(argtyps_1, &argtyps_2);
@@ -17940,46 +18195,46 @@ static int
                _fx_N10Ast__typ_t x_0 = lst_0->hd;
                _fx_LN10Ast__typ_t node_0 = 0;
                FX_CALL(_fx_cons_LN10Ast__typ_t(x_0, 0, false, &node_0), _fx_catch_2);
-               FX_LIST_APPEND(v_19, lstend_0, node_0);
+               FX_LIST_APPEND(v_21, lstend_0, node_0);
 
             _fx_catch_2: ;
                FX_CHECK_EXN(_fx_catch_3);
             }
-            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_19, v_18, &argtyps_0, 0);
+            _fx_M13Ast_typecheckFM5link2LN10Ast__typ_t2LN10Ast__typ_tLN10Ast__typ_t(v_21, v_20, &argtyps_0, 0);
 
          _fx_catch_3: ;
             if (argtyps_2) {
                _fx_free_LN10Ast__typ_t(&argtyps_2);
             }
-            if (v_19) {
-               _fx_free_LN10Ast__typ_t(&v_19);
+            if (v_21) {
+               _fx_free_LN10Ast__typ_t(&v_21);
             }
          }
          FX_CHECK_EXN(_fx_catch_4);
 
       _fx_catch_4: ;
+         if (v_20) {
+            _fx_free_LN10Ast__typ_t(&v_20);
+         }
+         if (v_19) {
+            _fx_free_N10Ast__typ_t(&v_19);
+         }
          if (v_18) {
-            _fx_free_LN10Ast__typ_t(&v_18);
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_18);
          }
-         if (v_17) {
-            _fx_free_N10Ast__typ_t(&v_17);
-         }
-         if (v_16) {
-            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
-         }
-         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_15);
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_17);
 
       _fx_endmatch_2: ;
          FX_CHECK_EXN(_fx_catch_5);
          FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(argtyps_0, vcase_0->t1, &t_1), _fx_catch_5);
 
       _fx_catch_5: ;
-         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_14);
-         if (v_13) {
-            _fx_free_N10Ast__typ_t(&v_13);
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_16);
+         if (v_15) {
+            _fx_free_N10Ast__typ_t(&v_15);
          }
-         if (v_12) {
-            _fx_free_N10Ast__typ_t(&v_12);
+         if (v_14) {
+            _fx_free_N10Ast__typ_t(&v_14);
          }
          if (__pat___0) {
             _fx_free_LN10Ast__typ_t(&__pat___0);
@@ -17998,45 +18253,108 @@ static int
 _fx_endmatch_3: ;
    FX_CHECK_EXN(_fx_cleanup);
    if (df_templ_args_0 == 0) {
-      bool v_20;
+      bool v_22;
       FX_CALL(
-         _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(df_typ_0, t_1, loc_0, true, &v_20, 0),
+         _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(df_typ_0, t_1, loc_0, true, &v_22, 0),
          _fx_cleanup);
-      if (v_20) {
-         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_1, &v_1);
-         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_1, fx_result);
+      if (v_22) {
+         bool v_23;
+         FX_CALL(_fx_M13Ast_typecheckFM14typ_has_typerrB1N10Ast__typ_t(df_typ_0, &v_23, 0), _fx_cleanup);
+         if (v_23) {
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_1, &v_1, 0), _fx_cleanup);
+            int tag_0 = FX_REC_VARIANT_TAG(v_1);
+            if (tag_0 == 15) {
+               _fx_N10Ast__typ_t v_24 = 0;
+               _fx_Nt6option1N10Ast__typ_t v_25 = 0;
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_1->u.TypFun.t1, &v_24, 0), _fx_catch_7);
+               if (FX_REC_VARIANT_TAG(v_24) == 1) {
+                  _fx_rNt6option1N10Ast__typ_t r_0 = v_24->u.TypVar;
+                  FX_COPY_PTR(r_0->data, &v_25);
+                  if ((v_25 != 0) + 1 == 1) {
+                     _fx_Nt6option1N10Ast__typ_t v_26 = 0;
+                     FX_CALL(
+                        _fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_26),
+                        _fx_catch_6);
+                     _fx_Nt6option1N10Ast__typ_t* v_27 = &r_0->data;
+                     _fx_free_Nt6option1N10Ast__typ_t(v_27);
+                     FX_COPY_PTR(v_26, v_27);
+
+                  _fx_catch_6: ;
+                     if (v_26) {
+                        _fx_free_Nt6option1N10Ast__typ_t(&v_26);
+                     }
+                     goto _fx_endmatch_4;
+                  }
+               }
+
+            _fx_endmatch_4: ;
+               FX_CHECK_EXN(_fx_catch_7);
+
+            _fx_catch_7: ;
+               if (v_25) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_25);
+               }
+               if (v_24) {
+                  _fx_free_N10Ast__typ_t(&v_24);
+               }
+               goto _fx_endmatch_5;
+            }
+            if (tag_0 == 1) {
+               _fx_rNt6option1N10Ast__typ_t r_1 = v_1->u.TypVar;
+               FX_COPY_PTR(r_1->data, &v_2);
+               if ((v_2 != 0) + 1 == 1) {
+                  _fx_Nt6option1N10Ast__typ_t v_28 = 0;
+                  FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_28),
+                     _fx_catch_8);
+                  _fx_Nt6option1N10Ast__typ_t* v_29 = &r_1->data;
+                  _fx_free_Nt6option1N10Ast__typ_t(v_29);
+                  FX_COPY_PTR(v_28, v_29);
+
+               _fx_catch_8: ;
+                  if (v_28) {
+                     _fx_free_Nt6option1N10Ast__typ_t(&v_28);
+                  }
+                  goto _fx_endmatch_5;
+               }
+            }
+
+         _fx_endmatch_5: ;
+            FX_CHECK_EXN(_fx_cleanup);
+         }
+         _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_1, &v_3);
+         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_3, fx_result);
       }
       else {
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_2, 0), _fx_cleanup);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_4, 0), _fx_cleanup);
          fx_str_t slit_0 = FX_MAKE_STR("internal error: the winning overload of \'");
          fx_str_t slit_1 = FX_MAKE_STR("\' failed to re-unify at commit");
          {
-            const fx_str_t strs_0[] = { slit_0, v_2, slit_1 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_3), _fx_cleanup);
+            const fx_str_t strs_0[] = { slit_0, v_4, slit_1 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_5), _fx_cleanup);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_3, &v_4, 0), _fx_cleanup);
-         FX_THROW(&v_4, false, _fx_cleanup);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_5, &v_6, 0), _fx_cleanup);
+         FX_THROW(&v_6, false, _fx_cleanup);
       }
    }
    else {
       FX_CALL(
          _fx_M13Ast_typecheckFM20preprocess_templ_typT2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t5LR9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-            df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_5, 0), _fx_cleanup);
-      FX_COPY_PTR(v_5.t0, &ftyp_0);
-      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5.t1, &env1_0);
-      bool v_21;
-      FX_CALL(_fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, true, &v_21, 0),
+            df_templ_args_0, df_typ_0, &df_env_0, sc_0, loc_0, &v_7, 0), _fx_cleanup);
+      FX_COPY_PTR(v_7.t0, &ftyp_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_7.t1, &env1_0);
+      bool v_30;
+      FX_CALL(_fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ftyp_0, t_1, loc_0, true, &v_30, 0),
          _fx_cleanup);
-      if (!v_21) {
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_6, 0), _fx_cleanup);
+      if (!v_30) {
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_8, 0), _fx_cleanup);
          fx_str_t slit_2 = FX_MAKE_STR("internal error: the winning overload of \'");
          fx_str_t slit_3 = FX_MAKE_STR("\' failed to re-unify at commit");
          {
-            const fx_str_t strs_1[] = { slit_2, v_6, slit_3 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_7), _fx_cleanup);
+            const fx_str_t strs_1[] = { slit_2, v_8, slit_3 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_9), _fx_cleanup);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_7, &v_8, 0), _fx_cleanup);
-         FX_THROW(&v_8, false, _fx_cleanup);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_9, &v_10, 0), _fx_cleanup);
+         FX_THROW(&v_10, false, _fx_cleanup);
       }
       bool res_1;
       FX_CALL(_fx_M3AstFM14is_constructorB1RM11fun_flags_t(&df_flags_0, &res_1, 0), _fx_cleanup);
@@ -18049,123 +18367,123 @@ _fx_endmatch_3: ;
             _fx_N10Ast__typ_t res_2 = 0;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                  ftyp_0->u.TypFun.t1, &env1_0, sc_0, loc_0, &res_2, 0), _fx_catch_6);
+                  ftyp_0->u.TypFun.t1, &env1_0, sc_0, loc_0, &res_2, 0), _fx_catch_9);
             return_orig_0 = false;
 
-         _fx_catch_6: ;
+         _fx_catch_9: ;
             if (res_2) {
                _fx_free_N10Ast__typ_t(&res_2);
             }
          }
          else {
-            bool v_22;
-            FX_CALL(_fx_M3AstFM12is_fixed_typB1N10Ast__typ_t(t_1, &v_22, 0), _fx_catch_7);
-            return_orig_0 = !v_22;
+            bool v_31;
+            FX_CALL(_fx_M3AstFM12is_fixed_typB1N10Ast__typ_t(t_1, &v_31, 0), _fx_catch_10);
+            return_orig_0 = !v_31;
 
-         _fx_catch_7: ;
+         _fx_catch_10: ;
          }
          FX_CHECK_EXN(_fx_cleanup);
       }
       if (return_orig_0) {
-         _fx_make_T2R9Ast__id_tN10Ast__typ_t(&df_name_0, t_1, &v_9);
-         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_9, fx_result);
+         _fx_make_T2R9Ast__id_tN10Ast__typ_t(&df_name_0, t_1, &v_11);
+         _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_11, fx_result);
       }
       else {
-         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None12_;
-         FX_COPY_PTR(df_templ_inst_0->data, &v_10);
-         _fx_LR9Ast__id_t lst_1 = v_10;
+         _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g22Ast_typecheck__None13_;
+         FX_COPY_PTR(df_templ_inst_0->data, &v_12);
+         _fx_LR9Ast__id_t lst_1 = v_12;
          for (; lst_1; lst_1 = lst_1->tl) {
-            _fx_N14Ast__id_info_t v_23 = {0};
+            _fx_N14Ast__id_info_t v_32 = {0};
             _fx_R9Ast__id_t* inst_0 = &lst_1->hd;
-            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(inst_0, loc_0, &v_23, 0), _fx_catch_10);
-            bool v_24;
-            if (v_23.tag == 3) {
-               _fx_R13Ast__deffun_t v_25 = {0};
-               _fx_copy_R13Ast__deffun_t(&v_23.u.IdFun->data, &v_25);
+            FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(inst_0, loc_0, &v_32, 0), _fx_catch_13);
+            bool v_33;
+            if (v_32.tag == 3) {
+               _fx_R13Ast__deffun_t v_34 = {0};
+               _fx_copy_R13Ast__deffun_t(&v_32.u.IdFun->data, &v_34);
                FX_CALL(
-                  _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(v_25.df_typ, t_1, loc_0, true,
-                     &v_24, 0), _fx_catch_8);
+                  _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(v_34.df_typ, t_1, loc_0, true,
+                     &v_33, 0), _fx_catch_11);
 
-            _fx_catch_8: ;
-               _fx_free_R13Ast__deffun_t(&v_25);
+            _fx_catch_11: ;
+               _fx_free_R13Ast__deffun_t(&v_34);
             }
             else {
-               fx_str_t v_26 = {0};
-               fx_str_t v_27 = {0};
-               fx_str_t v_28 = {0};
-               fx_exn_t v_29 = {0};
-               FX_CALL(_fx_M3AstFM6stringS1RM4id_t(inst_0, &v_26, 0), _fx_catch_9);
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&df_name_0, &v_27, 0), _fx_catch_9);
+               fx_str_t v_35 = {0};
+               fx_str_t v_36 = {0};
+               fx_str_t v_37 = {0};
+               fx_exn_t v_38 = {0};
+               FX_CALL(_fx_M3AstFM6stringS1RM4id_t(inst_0, &v_35, 0), _fx_catch_12);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&df_name_0, &v_36, 0), _fx_catch_12);
                fx_str_t slit_4 = FX_MAKE_STR("invalid (non-function) instance ");
                fx_str_t slit_5 = FX_MAKE_STR(" of template function ");
                {
-                  const fx_str_t strs_2[] = { slit_4, v_26, slit_5, v_27 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 4, &v_28), _fx_catch_9);
+                  const fx_str_t strs_2[] = { slit_4, v_35, slit_5, v_36 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 4, &v_37), _fx_catch_12);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_28, &v_29, 0), _fx_catch_9);
-               FX_THROW(&v_29, false, _fx_catch_9);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_37, &v_38, 0), _fx_catch_12);
+               FX_THROW(&v_38, false, _fx_catch_12);
 
-            _fx_catch_9: ;
-               fx_free_exn(&v_29);
-               FX_FREE_STR(&v_28);
-               FX_FREE_STR(&v_27);
-               FX_FREE_STR(&v_26);
+            _fx_catch_12: ;
+               fx_free_exn(&v_38);
+               FX_FREE_STR(&v_37);
+               FX_FREE_STR(&v_36);
+               FX_FREE_STR(&v_35);
             }
-            FX_CHECK_EXN(_fx_catch_10);
-            if (v_24) {
-               _fx_Nt6option1R9Ast__id_t v_30;
-               _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(inst_0, &v_30);
-               __fold_result___0 = v_30;
-               FX_BREAK(_fx_catch_10);
+            FX_CHECK_EXN(_fx_catch_13);
+            if (v_33) {
+               _fx_Nt6option1R9Ast__id_t v_39;
+               _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(inst_0, &v_39);
+               __fold_result___0 = v_39;
+               FX_BREAK(_fx_catch_13);
             }
 
-         _fx_catch_10: ;
-            _fx_free_N14Ast__id_info_t(&v_23);
+         _fx_catch_13: ;
+            _fx_free_N14Ast__id_info_t(&v_32);
             FX_CHECK_BREAK();
             FX_CHECK_EXN(_fx_cleanup);
          }
          _fx_Nt6option1R9Ast__id_t inst_name_opt_0 = __fold_result___0;
          if (inst_name_opt_0.tag == 2) {
-            _fx_T2R9Ast__id_tN10Ast__typ_t v_31 = {0};
-            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_opt_0.u.Some, t_1, &v_31);
-            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_31, fx_result);
-            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_31);
+            _fx_T2R9Ast__id_tN10Ast__typ_t v_40 = {0};
+            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_opt_0.u.Some, t_1, &v_40);
+            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_40, fx_result);
+            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_40);
          }
          else {
             _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t inst_env_0 = {0};
-            _fx_rR13Ast__deffun_t v_32 = 0;
+            _fx_rR13Ast__deffun_t v_41 = 0;
             _fx_N10Ast__typ_t inst_typ_0 = 0;
-            fx_exn_t v_33 = {0};
-            _fx_T2R9Ast__id_tN10Ast__typ_t v_34 = {0};
+            fx_exn_t v_42 = {0};
+            _fx_T2R9Ast__id_tN10Ast__typ_t v_43 = {0};
             FX_CALL(
                _fx_M13Ast_typecheckFM14inst_merge_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t2Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                  env_0, &env1_0, &inst_env_0, 0), _fx_catch_11);
+                  env_0, &env1_0, &inst_env_0, 0), _fx_catch_14);
             FX_CALL(
                _fx_M13Ast_typecheckFM15instantiate_funrR13Ast__deffun_t5rR13Ast__deffun_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tB(
-                  df_0, ftyp_0, &inst_env_0, loc_0, true, &v_32, 0), _fx_catch_11);
-            _fx_R13Ast__deffun_t* v_35 = &v_32->data;
-            FX_COPY_PTR(v_35->df_typ, &inst_typ_0);
-            _fx_R9Ast__id_t inst_name_0 = v_35->df_name;
-            bool v_36;
+                  df_0, ftyp_0, &inst_env_0, loc_0, true, &v_41, 0), _fx_catch_14);
+            _fx_R13Ast__deffun_t* v_44 = &v_41->data;
+            FX_COPY_PTR(v_44->df_typ, &inst_typ_0);
+            _fx_R9Ast__id_t inst_name_0 = v_44->df_name;
+            bool v_45;
             FX_CALL(
                _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(inst_typ_0, t_1, loc_0, true,
-                  &v_36, 0), _fx_catch_11);
-            if (!v_36) {
+                  &v_45, 0), _fx_catch_14);
+            if (!v_45) {
                fx_str_t slit_6 = FX_MAKE_STR("inconsistent type of the instantiated function");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_6, &v_33, 0), _fx_catch_11);
-               FX_THROW(&v_33, false, _fx_catch_11);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_6, &v_42, 0), _fx_catch_14);
+               FX_THROW(&v_42, false, _fx_catch_14);
             }
-            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_0, t_1, &v_34);
-            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_34, fx_result);
+            _fx_make_T2R9Ast__id_tN10Ast__typ_t(&inst_name_0, t_1, &v_43);
+            _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_43, fx_result);
 
-         _fx_catch_11: ;
-            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_34);
-            fx_free_exn(&v_33);
+         _fx_catch_14: ;
+            _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_43);
+            fx_free_exn(&v_42);
             if (inst_typ_0) {
                _fx_free_N10Ast__typ_t(&inst_typ_0);
             }
-            if (v_32) {
-               _fx_free_rR13Ast__deffun_t(&v_32);
+            if (v_41) {
+               _fx_free_rR13Ast__deffun_t(&v_41);
             }
             _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&inst_env_0);
          }
@@ -18188,20 +18506,26 @@ _fx_cleanup: ;
    if (t_1) {
       _fx_free_N10Ast__typ_t(&t_1);
    }
-   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_1);
-   FX_FREE_STR(&v_2);
-   FX_FREE_STR(&v_3);
-   fx_free_exn(&v_4);
-   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5);
+   if (v_1) {
+      _fx_free_N10Ast__typ_t(&v_1);
+   }
+   if (v_2) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_2);
+   }
+   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_3);
+   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_5);
+   fx_free_exn(&v_6);
+   _fx_free_T2N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_7);
    if (ftyp_0) {
       _fx_free_N10Ast__typ_t(&ftyp_0);
    }
    _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
-   FX_FREE_STR(&v_6);
-   FX_FREE_STR(&v_7);
-   fx_free_exn(&v_8);
-   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_9);
-   FX_FREE_LIST_SIMPLE(&v_10);
+   FX_FREE_STR(&v_8);
+   FX_FREE_STR(&v_9);
+   fx_free_exn(&v_10);
+   _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_11);
+   FX_FREE_LIST_SIMPLE(&v_12);
    return fx_status;
 }
 
@@ -18723,7 +19047,8 @@ static int
                   fx_str_t v_6 = {0};
                   fx_str_t v_7 = {0};
                   fx_exn_t v_8 = {0};
-                  _fx_T2R9Ast__id_tN10Ast__typ_t v_9 = {0};
+                  _fx_N10Ast__typ_t v_9 = 0;
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_10 = {0};
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_1 = {0};
                   FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_4, 0), _fx_catch_1);
                   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_5, 0), _fx_catch_1);
@@ -18736,23 +19061,34 @@ static int
                      const fx_str_t strs_0[] = { slit_0, v_4, slit_1, v_5, slit_2, v_6, slit_3 };
                      FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &v_7), _fx_catch_1);
                   }
-                  bool v_10;
+                  bool v_11;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(dv_typ_0, t_0, loc_0, true,
-                        &v_10, 0), _fx_catch_1);
-                  if (!v_10) {
+                        &v_11, 0), _fx_catch_1);
+                  if (!v_11) {
                      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_7, &v_8, 0), _fx_catch_1);
                      FX_THROW(&v_8, false, _fx_catch_1);
                   }
-                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_9);
-                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_9, &result_1);
+                  bool v_12;
+                  FX_CALL(_fx_M13Ast_typecheckFM14typ_has_typerrB1N10Ast__typ_t(dv_typ_0, &v_12, 0), _fx_catch_1);
+                  if (v_12) {
+                     FX_COPY_PTR(dv_typ_0, &v_9);
+                  }
+                  else {
+                     FX_COPY_PTR(t_0, &v_9);
+                  }
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, v_9, &v_10);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_10, &result_1);
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
                   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1, &result_0);
                   FX_BREAK(_fx_catch_1);
 
                _fx_catch_1: ;
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_1);
-                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_9);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_10);
+                  if (v_9) {
+                     _fx_free_N10Ast__typ_t(&v_9);
+                  }
                   fx_free_exn(&v_8);
                   FX_FREE_STR(&v_7);
                   FX_FREE_STR(&v_6);
@@ -18772,28 +19108,28 @@ static int
             }
             if (tag_1 == 8) {
                if (viable_2 == 0) {
-                  fx_exn_t v_11 = {0};
-                  _fx_T2R9Ast__id_tN10Ast__typ_t v_12 = {0};
+                  fx_exn_t v_13 = {0};
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_14 = {0};
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_2 = {0};
-                  bool v_13;
+                  bool v_15;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(
-                        _fx_g24Ast_typecheck__TypModule, t_0, loc_0, true, &v_13, 0), _fx_catch_3);
-                  if (!v_13) {
+                        _fx_g24Ast_typecheck__TypModule, t_0, loc_0, true, &v_15, 0), _fx_catch_3);
+                  if (!v_15) {
                      fx_str_t slit_4 = FX_MAKE_STR("unexpected module name");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_11, 0), _fx_catch_3);
-                     FX_THROW(&v_11, false, _fx_catch_3);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_13, 0), _fx_catch_3);
+                     FX_THROW(&v_13, false, _fx_catch_3);
                   }
-                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_12);
-                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_12, &result_2);
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_14);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_14, &result_2);
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
                   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_2, &result_0);
                   FX_BREAK(_fx_catch_3);
 
                _fx_catch_3: ;
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_2);
-                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_12);
-                  fx_free_exn(&v_11);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_14);
+                  fx_free_exn(&v_13);
                }
                else {
                   _fx_free_LN16Ast__env_entry_t(&elist_1);
@@ -18807,55 +19143,55 @@ static int
                goto _fx_endmatch_0;
             }
             if (tag_1 == 4) {
-               _fx_R13Ast__defexn_t v_14 = {0};
-               _fx_copy_R13Ast__defexn_t(&v_1.u.IdExn->data, &v_14);
-               _fx_N10Ast__typ_t dexn_typ_0 = v_14.dexn_typ;
+               _fx_R13Ast__defexn_t v_16 = {0};
+               _fx_copy_R13Ast__defexn_t(&v_1.u.IdExn->data, &v_16);
+               _fx_N10Ast__typ_t dexn_typ_0 = v_16.dexn_typ;
                if (viable_2 == 0) {
                   _fx_N10Ast__typ_t ctyp_0 = 0;
-                  fx_exn_t v_15 = {0};
-                  _fx_T2R9Ast__id_tN10Ast__typ_t v_16 = {0};
+                  fx_exn_t v_17 = {0};
+                  _fx_T2R9Ast__id_tN10Ast__typ_t v_18 = {0};
                   _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_3 = {0};
                   if (FX_REC_VARIANT_TAG(dexn_typ_0) == 14) {
                      FX_COPY_PTR(_fx_g21Ast_typecheck__TypExn, &ctyp_0);
                   }
                   else {
-                     _fx_LN10Ast__typ_t v_17 = 0;
+                     _fx_LN10Ast__typ_t v_19 = 0;
                      if (FX_REC_VARIANT_TAG(dexn_typ_0) == 18) {
-                        FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_17);
+                        FX_COPY_PTR(dexn_typ_0->u.TypTuple, &v_19);
                      }
                      else {
-                        FX_CALL(_fx_cons_LN10Ast__typ_t(dexn_typ_0, 0, true, &v_17), _fx_catch_5);  _fx_catch_5: ;
+                        FX_CALL(_fx_cons_LN10Ast__typ_t(dexn_typ_0, 0, true, &v_19), _fx_catch_5);  _fx_catch_5: ;
                      }
                      FX_CHECK_EXN(_fx_catch_6);
                      FX_CALL(
-                        _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_17, _fx_g21Ast_typecheck__TypExn,
+                        _fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_19, _fx_g21Ast_typecheck__TypExn,
                            &ctyp_0), _fx_catch_6);
 
                   _fx_catch_6: ;
-                     if (v_17) {
-                        _fx_free_LN10Ast__typ_t(&v_17);
+                     if (v_19) {
+                        _fx_free_LN10Ast__typ_t(&v_19);
                      }
                   }
                   FX_CHECK_EXN(_fx_catch_7);
-                  bool v_18;
+                  bool v_20;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(ctyp_0, t_0, loc_0, true,
-                        &v_18, 0), _fx_catch_7);
-                  if (!v_18) {
+                        &v_20, 0), _fx_catch_7);
+                  if (!v_20) {
                      fx_str_t slit_5 = FX_MAKE_STR("uncorrect type of exception constructor and/or its arguments");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_5, &v_15, 0), _fx_catch_7);
-                     FX_THROW(&v_15, false, _fx_catch_7);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_5, &v_17, 0), _fx_catch_7);
+                     FX_THROW(&v_17, false, _fx_catch_7);
                   }
-                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_16);
-                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_16, &result_3);
+                  _fx_make_T2R9Ast__id_tN10Ast__typ_t(i_0, t_0, &v_18);
+                  _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_tN10Ast__typ_t1T2R9Ast__id_tN10Ast__typ_t(&v_18, &result_3);
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
                   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_3, &result_0);
                   FX_BREAK(_fx_catch_7);
 
                _fx_catch_7: ;
                   _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_3);
-                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_16);
-                  fx_free_exn(&v_15);
+                  _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_18);
+                  fx_free_exn(&v_17);
                   if (ctyp_0) {
                      _fx_free_N10Ast__typ_t(&ctyp_0);
                   }
@@ -18869,7 +19205,7 @@ static int
                FX_CHECK_EXN(_fx_catch_8);
 
             _fx_catch_8: ;
-               _fx_free_R13Ast__defexn_t(&v_14);
+               _fx_free_R13Ast__defexn_t(&v_16);
                goto _fx_endmatch_0;
             }
             bool res_0;
@@ -18924,7 +19260,7 @@ static int
       }
       else {
          _fx_LT2R9Ast__id_trR13Ast__deffun_t __fold_result___0 = 0;
-         _fx_LT2R9Ast__id_trR13Ast__deffun_t v_19 = 0;
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t v_21 = 0;
          _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t result_4 = {0};
          _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_0 = viable_2;
          for (; lst_0; lst_0 = lst_0->tl) {
@@ -18941,18 +19277,18 @@ static int
             }
             FX_CHECK_EXN(_fx_catch_12);
          }
-         FX_COPY_PTR(__fold_result___0, &v_19);
+         FX_COPY_PTR(__fold_result___0, &v_21);
          FX_CALL(
             _fx_M13Ast_typecheckFM15rank_and_commitNt6option1T2R9Ast__id_tN10Ast__typ_t6LT2R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
-               v_19, env_0, loc_0, n_0, sc_0, t_0, &result_4, 0), _fx_catch_12);
+               v_21, env_0, loc_0, n_0, sc_0, t_0, &result_4, 0), _fx_catch_12);
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_0);
          _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_4, &result_0);
          FX_BREAK(_fx_catch_12);
 
       _fx_catch_12: ;
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&result_4);
-         if (v_19) {
-            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&v_19);
+         if (v_21) {
+            _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&v_21);
          }
          if (__fold_result___0) {
             _fx_free_LT2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0);
@@ -19172,49 +19508,123 @@ FX_EXTERN_C int
    struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result,
    void* fx_fv)
 {
-   _fx_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t v_0 = {0};
+   _fx_N10Ast__typ_t v_0 = 0;
+   _fx_Nt6option1N10Ast__typ_t v_1 = 0;
+   _fx_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t v_2 = {0};
    _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t nt_opt_0 = {0};
    _fx_LN16Ast__env_entry_t possible_matches_0 = 0;
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
-   FX_CALL(
-      _fx_M13Ast_typecheckFM13lookup_id_optT2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-         n_0, t_0, env_0, sc_0, loc_0, &v_0, 0), _fx_cleanup);
-   _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_0.t0, &nt_opt_0);
-   FX_COPY_PTR(v_0.t1, &possible_matches_0);
-   int tag_0 = nt_opt_0.tag;
-   if (tag_0 == 2) {
-      _fx_copy_T2R9Ast__id_tN10Ast__typ_t(&nt_opt_0.u.Some, fx_result);
-   }
-   else if (tag_0 == 1) {
-      _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t v_1 = {0};
-      FX_CALL(
-         _fx_M13Ast_typecheckFM19try_autogen_symbolsNt6option1T2R9Ast__id_tN10Ast__typ_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-            n_0, t_0, env_0, sc_0, loc_0, &v_1, 0), _fx_catch_1);
-      if (v_1.tag == 2) {
-         _fx_copy_T2R9Ast__id_tN10Ast__typ_t(&v_1.u.Some, fx_result);
-      }
-      else {
-         fx_exn_t v_2 = {0};
-         FX_CALL(
-            _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               n_0, t_0, possible_matches_0, sc_0, loc_0, &v_2, 0), _fx_catch_0);
-         FX_THROW(&v_2, false, _fx_catch_0);
+   bool v_3;
+   FX_CALL(_fx_M13Ast_typecheckFM14typ_has_typerrB1N10Ast__typ_t(t_0, &v_3, 0), _fx_cleanup);
+   if (v_3) {
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
+      int tag_0 = FX_REC_VARIANT_TAG(v_0);
+      if (tag_0 == 15) {
+         _fx_N10Ast__typ_t v_4 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_5 = 0;
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_0->u.TypFun.t1, &v_4, 0), _fx_catch_1);
+         if (FX_REC_VARIANT_TAG(v_4) == 1) {
+            _fx_rNt6option1N10Ast__typ_t r_0 = v_4->u.TypVar;
+            FX_COPY_PTR(r_0->data, &v_5);
+            if ((v_5 != 0) + 1 == 1) {
+               _fx_Nt6option1N10Ast__typ_t v_6 = 0;
+               FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_6),
+                  _fx_catch_0);
+               _fx_Nt6option1N10Ast__typ_t* v_7 = &r_0->data;
+               _fx_free_Nt6option1N10Ast__typ_t(v_7);
+               FX_COPY_PTR(v_6, v_7);
 
-      _fx_catch_0: ;
-         fx_free_exn(&v_2);
-      }
-      FX_CHECK_EXN(_fx_catch_1);
+            _fx_catch_0: ;
+               if (v_6) {
+                  _fx_free_Nt6option1N10Ast__typ_t(&v_6);
+               }
+               goto _fx_endmatch_0;
+            }
+         }
 
-   _fx_catch_1: ;
-      _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_1);
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_catch_1);
+
+      _fx_catch_1: ;
+         if (v_5) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_5);
+         }
+         if (v_4) {
+            _fx_free_N10Ast__typ_t(&v_4);
+         }
+         goto _fx_endmatch_1;
+      }
+      if (tag_0 == 1) {
+         _fx_rNt6option1N10Ast__typ_t r_1 = v_0->u.TypVar;
+         FX_COPY_PTR(r_1->data, &v_1);
+         if ((v_1 != 0) + 1 == 1) {
+            _fx_Nt6option1N10Ast__typ_t v_8 = 0;
+            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(_fx_g21Ast_typecheck__TypErr, &v_8),
+               _fx_catch_2);
+            _fx_Nt6option1N10Ast__typ_t* v_9 = &r_1->data;
+            _fx_free_Nt6option1N10Ast__typ_t(v_9);
+            FX_COPY_PTR(v_8, v_9);
+
+         _fx_catch_2: ;
+            if (v_8) {
+               _fx_free_Nt6option1N10Ast__typ_t(&v_8);
+            }
+            goto _fx_endmatch_1;
+         }
+      }
+
+   _fx_endmatch_1: ;
+      FX_CHECK_EXN(_fx_cleanup);
+      _fx_make_T2R9Ast__id_tN10Ast__typ_t(n_0, t_0, fx_result);
    }
    else {
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM13lookup_id_optT2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+            n_0, t_0, env_0, sc_0, loc_0, &v_2, 0), _fx_cleanup);
+      _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_2.t0, &nt_opt_0);
+      FX_COPY_PTR(v_2.t1, &possible_matches_0);
+      int tag_1 = nt_opt_0.tag;
+      if (tag_1 == 2) {
+         _fx_copy_T2R9Ast__id_tN10Ast__typ_t(&nt_opt_0.u.Some, fx_result);
+      }
+      else if (tag_1 == 1) {
+         _fx_Nt6option1T2R9Ast__id_tN10Ast__typ_t v_10 = {0};
+         FX_CALL(
+            _fx_M13Ast_typecheckFM19try_autogen_symbolsNt6option1T2R9Ast__id_tN10Ast__typ_t5R9Ast__id_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+               n_0, t_0, env_0, sc_0, loc_0, &v_10, 0), _fx_catch_4);
+         if (v_10.tag == 2) {
+            _fx_copy_T2R9Ast__id_tN10Ast__typ_t(&v_10.u.Some, fx_result);
+         }
+         else {
+            fx_exn_t v_11 = {0};
+            FX_CALL(
+               _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                  n_0, t_0, possible_matches_0, sc_0, loc_0, &v_11, 0), _fx_catch_3);
+            FX_THROW(&v_11, false, _fx_catch_3);
+
+         _fx_catch_3: ;
+            fx_free_exn(&v_11);
+         }
+         FX_CHECK_EXN(_fx_catch_4);
+
+      _fx_catch_4: ;
+         _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&v_10);
+      }
+      else {
+         FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
    }
 
 _fx_cleanup: ;
-   _fx_free_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t(&v_0);
+   if (v_0) {
+      _fx_free_N10Ast__typ_t(&v_0);
+   }
+   if (v_1) {
+      _fx_free_Nt6option1N10Ast__typ_t(&v_1);
+   }
+   _fx_free_T2Nt6option1T2R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_t(&v_2);
    _fx_free_Nt6option1T2R9Ast__id_tN10Ast__typ_t(&nt_opt_0);
    if (possible_matches_0) {
       _fx_free_LN16Ast__env_entry_t(&possible_matches_0);
@@ -19985,11 +20395,11 @@ FX_EXTERN_C int
       FX_COPY_PTR(e_1, &e_2);
       _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_1, &env_2);
       FX_COPY_PTR(sc_1, &sc_2);
-      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_2, &ctx_0, 0), _fx_catch_210);
+      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_2, &ctx_0, 0), _fx_catch_214);
       FX_COPY_PTR(ctx_0.t0, &etyp_0);
       _fx_R10Ast__loc_t eloc_0 = ctx_0.t1;
       int_ curr_m_idx_0;
-      FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_2, &curr_m_idx_0, 0), _fx_catch_210);
+      FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_2, &curr_m_idx_0, 0), _fx_catch_214);
       int tag_0 = FX_REC_VARIANT_TAG(e_2);
       if (tag_0 == 1) {
          _fx_free_N10Ast__exp_t(&result_0);
@@ -20473,7 +20883,7 @@ FX_EXTERN_C int
             _fx_R9Ast__id_t* n2_2 = &e2_0->u.ExpIdent.t0;
             FX_CALL(
                _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                  &_fx_g22Ast_typecheck__None12_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
+                  &_fx_g22Ast_typecheck__None13_, etyp1_1, false, &eloc1_0, &v_31, 0), _fx_catch_20);
             FX_COPY_PTR(v_31.t1, &relems_0);
             _fx_M13Ast_typecheckFM7make_fpFPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(n2_2,
                &__lambda___0);
@@ -20743,7 +21153,7 @@ FX_EXTERN_C int
                FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(new_e2_1, &v_62), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                     v_61, _fx_g22Ast_typecheck__None13_, v_62, &ctx_0, &result_11), _fx_catch_24);
+                     v_61, _fx_g22Ast_typecheck__None14_, v_62, &ctx_0, &result_11), _fx_catch_24);
                _fx_free_N10Ast__exp_t(&result_0);
                FX_COPY_PTR(result_11, &result_0);
                FX_BREAK(_fx_catch_24);
@@ -20951,7 +21361,7 @@ FX_EXTERN_C int
                         }
                         goto _fx_endmatch_2;
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_exp_opt_0);
 
                   _fx_endmatch_2: ;
                      FX_CHECK_EXN(_fx_catch_29);
@@ -21053,7 +21463,7 @@ FX_EXTERN_C int
                            }
                         }
                      }
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_exp_opt_0);
 
                   _fx_endmatch_3: ;
                      FX_CHECK_EXN(_fx_catch_32);
@@ -21095,7 +21505,7 @@ FX_EXTERN_C int
                            _fx_catch_33);
                      }
                      else {
-                        FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
+                        FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_exp_opt_0);
                      }
 
                   _fx_catch_33: ;
@@ -21118,7 +21528,7 @@ FX_EXTERN_C int
                      }
                   }
                   else {
-                     FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
+                     FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_exp_opt_0);
                   }
                   FX_CHECK_EXN(_fx_catch_34);
 
@@ -21128,7 +21538,7 @@ FX_EXTERN_C int
                   }
                   goto _fx_endmatch_4;
                }
-               FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &result_exp_opt_0);
+               FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &result_exp_opt_0);
 
             _fx_endmatch_4: ;
                FX_CHECK_EXN(_fx_catch_37);
@@ -21332,7 +21742,7 @@ FX_EXTERN_C int
                         &f_id_1, v_96, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &probably_result_0, 0), _fx_catch_41);
                }
                else {
-                  FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &probably_result_0);
+                  FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &probably_result_0);
                }
                bool v_101;
                FX_CALL(
@@ -21364,7 +21774,7 @@ FX_EXTERN_C int
                   _fx_N10Ast__exp_t v_105 = 0;
                   _fx_N10Ast__exp_t binres_0 = 0;
                   _fx_N10Ast__exp_t v_106 = 0;
-                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None14_, &v_102), _fx_catch_40);
+                  FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(_fx_g22Ast_typecheck__None15_, &v_102), _fx_catch_40);
                   FX_CALL(_fx_M3AstFM6TypVarN10Ast__typ_t1rNt6option1N10Ast__typ_t(v_102, &v_103), _fx_catch_40);
                   _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_103, &eloc_0, &v_104);
                   FX_CALL(
@@ -21647,7 +22057,7 @@ FX_EXTERN_C int
                   goto _fx_endmatch_8;
                }
             }
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &typ_opt_3);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, &typ_opt_3);
 
          _fx_endmatch_8: ;
             FX_CHECK_EXN(_fx_catch_50);
@@ -21713,10 +22123,10 @@ FX_EXTERN_C int
                _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, v_120, &v_112);
             }
             else if (FX_REC_VARIANT_TAG(etyp1_6) == 11) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None15_, &v_112);
             }
             else {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None15_, &v_112);
             }
 
          _fx_catch_52: ;
@@ -21749,18 +22159,18 @@ FX_EXTERN_C int
                v_124 = false;
             }
             if (v_124) {
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None15_, &v_112);
             }
             else {
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_6, &v_122, 0), _fx_catch_53);
                FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp2_2, &v_123, 0), _fx_catch_53);
                if (FX_REC_VARIANT_TAG(v_122) == 11) {
                   if (FX_REC_VARIANT_TAG(v_123) == 11) {
-                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None14_, &v_112);
+                     _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_wo_dot_0, _fx_g22Ast_typecheck__None15_, &v_112);
                      goto _fx_endmatch_9;
                   }
                }
-               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
+               _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None15_, &v_112);
 
             _fx_endmatch_9: ;
                FX_CHECK_EXN(_fx_catch_53);
@@ -21784,7 +22194,7 @@ FX_EXTERN_C int
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypBool,
                   &eloc_0, &slit_38, 0), _fx_catch_54);
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None15_, &v_112);
 
          _fx_catch_54: ;
             goto _fx_endmatch_10;
@@ -21823,7 +22233,7 @@ FX_EXTERN_C int
             goto _fx_endmatch_10;
          }
          if (tag_6 == 5) {
-            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None14_, &v_112);
+            _fx_make_T2N13Ast__binary_tNt6option1N10Ast__typ_t(bop_3, _fx_g22Ast_typecheck__None15_, &v_112);
             goto _fx_endmatch_10;
          }
          FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_61);
@@ -24749,32 +25159,34 @@ FX_EXTERN_C int
          _fx_N10Ast__typ_t typ2_0 = 0;
          _fx_N10Ast__exp_t new_c_0 = 0;
          _fx_N10Ast__exp_t new_e1_11 = 0;
+         fx_exn_t exn_3 = {0};
          _fx_N10Ast__exp_t new_e2_6 = 0;
+         fx_exn_t exn_4 = {0};
          _fx_N10Ast__exp_t result_38 = 0;
          _fx_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_22 = &e_2->u.ExpIf;
          _fx_N10Ast__exp_t e2_3 = vcase_22->t2;
          _fx_N10Ast__exp_t e1_4 = vcase_22->t1;
          _fx_N10Ast__exp_t c_0 = vcase_22->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_0, &v_335, 0), _fx_catch_137);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_0, &v_335, 0), _fx_catch_141);
          FX_COPY_PTR(v_335.t0, &ctyp_0);
          _fx_R10Ast__loc_t cloc_0 = v_335.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_4, &v_336, 0), _fx_catch_137);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_4, &v_336, 0), _fx_catch_141);
          FX_COPY_PTR(v_336.t0, &typ1_0);
          _fx_R10Ast__loc_t loc1_0 = v_336.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e2_3, &v_337, 0), _fx_catch_137);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e2_3, &v_337, 0), _fx_catch_141);
          FX_COPY_PTR(v_337.t0, &typ2_0);
          _fx_R10Ast__loc_t loc2_0 = v_337.t1;
          fx_str_t slit_139 = FX_MAKE_STR("if() condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_0, _fx_g22Ast_typecheck__TypBool,
-               &cloc_0, &slit_139, 0), _fx_catch_137);
+               &cloc_0, &slit_139, 0), _fx_catch_141);
          fx_str_t slit_140 = FX_MAKE_STR("if() expression should have the same type as its branches");
          FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(typ1_0, etyp_0, &loc1_0, &slit_140, 0),
-            _fx_catch_137);
+            _fx_catch_141);
          bool v_338;
          FX_CALL(
             _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(typ2_0, etyp_0, &loc2_0, true, &v_338,
-               0), _fx_catch_137);
+               0), _fx_catch_141);
          if (!v_338) {
             if (FX_REC_VARIANT_TAG(e2_3) == 1) {
                fx_exn_t v_339 = {0};
@@ -24793,31 +25205,71 @@ FX_EXTERN_C int
 
             _fx_catch_136: ;
             }
-            FX_CHECK_EXN(_fx_catch_137);
+            FX_CHECK_EXN(_fx_catch_141);
          }
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_0, &env_2, sc_2, &new_c_0, 0), _fx_catch_137);
+               c_0, &env_2, sc_2, &new_c_0, 0), _fx_catch_141);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
                e1_4, &env_2, sc_2, &new_e1_11, 0), _fx_catch_137);
-         FX_CALL(
-            _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e2_3, &env_2, sc_2, &new_e2_6, 0), _fx_catch_137);
-         FX_CALL(
-            _fx_M3AstFM5ExpIfN10Ast__exp_t4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_c_0, new_e1_11,
-               new_e2_6, &ctx_0, &result_38), _fx_catch_137);
-         _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_38, &result_0);
-         FX_BREAK(_fx_catch_137);
 
       _fx_catch_137: ;
+         if (fx_status < 0) {
+            fx_exn_get_and_reset(fx_status, &exn_3);
+            fx_status = 0;
+            if (new_e1_11) {
+               _fx_free_N10Ast__exp_t(&new_e1_11);
+            }
+            if (exn_3.tag == _FX_EXN_E17Ast__CompileError) {
+               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_138);
+               FX_COPY_PTR(e1_4, &new_e1_11);
+
+            _fx_catch_138: ;
+            }
+            else {
+               FX_RETHROW(&exn_3, _fx_catch_141);
+            }
+            FX_CHECK_EXN(_fx_catch_141);
+         }
+         FX_CALL(
+            _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+               e2_3, &env_2, sc_2, &new_e2_6, 0), _fx_catch_139);
+
+      _fx_catch_139: ;
+         if (fx_status < 0) {
+            fx_exn_get_and_reset(fx_status, &exn_4);
+            fx_status = 0;
+            if (new_e2_6) {
+               _fx_free_N10Ast__exp_t(&new_e2_6);
+            }
+            if (exn_4.tag == _FX_EXN_E17Ast__CompileError) {
+               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_4, 0), _fx_catch_140);
+               FX_COPY_PTR(e2_3, &new_e2_6);
+
+            _fx_catch_140: ;
+            }
+            else {
+               FX_RETHROW(&exn_4, _fx_catch_141);
+            }
+            FX_CHECK_EXN(_fx_catch_141);
+         }
+         FX_CALL(
+            _fx_M3AstFM5ExpIfN10Ast__exp_t4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_c_0, new_e1_11,
+               new_e2_6, &ctx_0, &result_38), _fx_catch_141);
+         _fx_free_N10Ast__exp_t(&result_0);
+         FX_COPY_PTR(result_38, &result_0);
+         FX_BREAK(_fx_catch_141);
+
+      _fx_catch_141: ;
          if (result_38) {
             _fx_free_N10Ast__exp_t(&result_38);
          }
+         fx_free_exn(&exn_4);
          if (new_e2_6) {
             _fx_free_N10Ast__exp_t(&new_e2_6);
          }
+         fx_free_exn(&exn_3);
          if (new_e1_11) {
             _fx_free_N10Ast__exp_t(&new_e1_11);
          }
@@ -24850,36 +25302,36 @@ FX_EXTERN_C int
          _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_23 = &e_2->u.ExpWhile;
          _fx_N10Ast__exp_t body_0 = vcase_23->t1;
          _fx_N10Ast__exp_t c_1 = vcase_23->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_1, &v_340, 0), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_1, &v_340, 0), _fx_catch_142);
          FX_COPY_PTR(v_340.t0, &ctyp_1);
          _fx_R10Ast__loc_t cloc_1 = v_340.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_0, &v_341, 0), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_0, &v_341, 0), _fx_catch_142);
          FX_COPY_PTR(v_341.t0, &btyp_0);
          _fx_R10Ast__loc_t bloc_0 = v_341.t1;
          fx_str_t slit_143 = FX_MAKE_STR("while() loop condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_1, _fx_g22Ast_typecheck__TypBool,
-               &cloc_1, &slit_143, 0), _fx_catch_138);
+               &cloc_1, &slit_143, 0), _fx_catch_142);
          fx_str_t slit_144 = FX_MAKE_STR("while() loop body should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_0, _fx_g22Ast_typecheck__TypVoid,
-               &bloc_0, &slit_144, 0), _fx_catch_138);
+               &bloc_0, &slit_144, 0), _fx_catch_142);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_1, &env_2, sc_2, &new_c_1, 0), _fx_catch_138);
+               c_1, &env_2, sc_2, &new_c_1, 0), _fx_catch_142);
          _fx_N12Ast__scope_t v_342;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_342, 0), _fx_catch_138);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_342, sc_2, true, &loop_sc_0), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_342, 0), _fx_catch_142);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_342, sc_2, true, &loop_sc_0), _fx_catch_142);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               body_0, &env_2, loop_sc_0, &new_body_0, 0), _fx_catch_138);
+               body_0, &env_2, loop_sc_0, &new_body_0, 0), _fx_catch_142);
          FX_CALL(_fx_M3AstFM8ExpWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_c_1, new_body_0, &eloc_0, &result_39),
-            _fx_catch_138);
+            _fx_catch_142);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_39, &result_0);
-         FX_BREAK(_fx_catch_138);
+         FX_BREAK(_fx_catch_142);
 
-      _fx_catch_138: ;
+      _fx_catch_142: ;
          if (result_39) {
             _fx_free_N10Ast__exp_t(&result_39);
          }
@@ -24912,37 +25364,37 @@ FX_EXTERN_C int
          _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_24 = &e_2->u.ExpDoWhile;
          _fx_N10Ast__exp_t c_2 = vcase_24->t1;
          _fx_N10Ast__exp_t body_1 = vcase_24->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_2, &v_343, 0), _fx_catch_139);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_2, &v_343, 0), _fx_catch_143);
          FX_COPY_PTR(v_343.t0, &ctyp_2);
          _fx_R10Ast__loc_t cloc_2 = v_343.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_1, &v_344, 0), _fx_catch_139);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_1, &v_344, 0), _fx_catch_143);
          FX_COPY_PTR(v_344.t0, &btyp_1);
          _fx_R10Ast__loc_t bloc_1 = v_344.t1;
          fx_str_t slit_145 = FX_MAKE_STR("do-while() loop condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_2, _fx_g22Ast_typecheck__TypBool,
-               &cloc_2, &slit_145, 0), _fx_catch_139);
+               &cloc_2, &slit_145, 0), _fx_catch_143);
          fx_str_t slit_146 = FX_MAKE_STR("do-while() loop body should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_1, _fx_g22Ast_typecheck__TypVoid,
-               &bloc_1, &slit_146, 0), _fx_catch_139);
+               &bloc_1, &slit_146, 0), _fx_catch_143);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_2, &env_2, sc_2, &new_c_2, 0), _fx_catch_139);
+               c_2, &env_2, sc_2, &new_c_2, 0), _fx_catch_143);
          _fx_N12Ast__scope_t v_345;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_345, 0), _fx_catch_139);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_345, sc_2, true, &loop_sc_1), _fx_catch_139);
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_345, 0), _fx_catch_143);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_345, sc_2, true, &loop_sc_1), _fx_catch_143);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               body_1, &env_2, loop_sc_1, &new_body_1, 0), _fx_catch_139);
+               body_1, &env_2, loop_sc_1, &new_body_1, 0), _fx_catch_143);
          FX_CALL(
             _fx_M3AstFM10ExpDoWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_body_1, new_c_2, &eloc_0, &result_40),
-            _fx_catch_139);
+            _fx_catch_143);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_40, &result_0);
-         FX_BREAK(_fx_catch_139);
+         FX_BREAK(_fx_catch_143);
 
-      _fx_catch_139: ;
+      _fx_catch_143: ;
          if (result_40) {
             _fx_free_N10Ast__exp_t(&result_40);
          }
@@ -24988,21 +25440,21 @@ FX_EXTERN_C int
          bool is_nested_0 = flags_0->for_flag_nested;
          if (flags_0->for_flag_unzip) {
             fx_str_t slit_147 = FX_MAKE_STR("@unzip for does not make sense outside of comprehensions");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_147, &v_346, 0), _fx_catch_141);
-            FX_THROW(&v_346, false, _fx_catch_141);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_147, &v_346, 0), _fx_catch_145);
+            FX_THROW(&v_346, false, _fx_catch_145);
          }
          _fx_N12Ast__scope_t v_351;
          if (is_fold_0) {
-            FX_CALL(_fx_M3AstFM14new_fold_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_351, 0), _fx_catch_141);
+            FX_CALL(_fx_M3AstFM14new_fold_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_351, 0), _fx_catch_145);
          }
          else {
-            FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, is_nested_0, &v_351, 0), _fx_catch_141);
+            FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, is_nested_0, &v_351, 0), _fx_catch_145);
          }
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_351, sc_2, true, &for_sc_0), _fx_catch_141);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_351, sc_2, true, &for_sc_0), _fx_catch_145);
          FX_CALL(
             _fx_M13Ast_typecheckFM17check_for_clausesT7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tR16Ast__for_flags_tLN12Ast__scope_ti(
                vcase_25->t0, vcase_25->t1, &env_2, &_fx_g16Ast__empty_idset, flags_0, for_sc_0, curr_m_idx_0, &v_347, 0),
-            _fx_catch_141);
+            _fx_catch_145);
          int_ trsz_0 = v_347.t0;
          FX_COPY_PTR(v_347.t1, &pre_code_0);
          FX_COPY_PTR(v_347.t2, &for_clauses_0);
@@ -25016,19 +25468,19 @@ FX_EXTERN_C int
                _fx_N10Ast__typ_t tj_0 = 0;
                FX_CALL(
                   _fx_M13Ast_typecheckFM20gen_for_in_tuprec_itN10Ast__exp_t8iLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tLN12Ast__scope_t(
-                     idx_2, for_clauses_0, idx_pat_0, body_2, &env_4, for_sc_0, &eloc_0, sc_2, &it_j_0, 0), _fx_catch_140);
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_0, &v_352, 0), _fx_catch_140);
+                     idx_2, for_clauses_0, idx_pat_0, body_2, &env_4, for_sc_0, &eloc_0, sc_2, &it_j_0, 0), _fx_catch_144);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_0, &v_352, 0), _fx_catch_144);
                FX_COPY_PTR(v_352.t0, &tj_0);
                _fx_R10Ast__loc_t locj_0 = v_352.t1;
                fx_str_t slit_148 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
                FX_CALL(
                   _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(tj_0, _fx_g22Ast_typecheck__TypVoid,
-                     &locj_0, &slit_148, 0), _fx_catch_140);
+                     &locj_0, &slit_148, 0), _fx_catch_144);
                _fx_LN10Ast__exp_t node_7 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_0, 0, false, &node_7), _fx_catch_140);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_0, 0, false, &node_7), _fx_catch_144);
                FX_LIST_APPEND(code_0, lstend_7, node_7);
 
-            _fx_catch_140: ;
+            _fx_catch_144: ;
                if (tj_0) {
                   _fx_free_N10Ast__typ_t(&tj_0);
                }
@@ -25036,37 +25488,37 @@ FX_EXTERN_C int
                if (it_j_0) {
                   _fx_free_N10Ast__exp_t(&it_j_0);
                }
-               FX_CHECK_EXN(_fx_catch_141);
+               FX_CHECK_EXN(_fx_catch_145);
             }
             FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_0, code_0, &v_348, 0),
-               _fx_catch_141);
+               _fx_catch_145);
             _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g22Ast_typecheck__TypVoid, &eloc_0, &v_349);
             FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_348, &v_349, &result_41),
-               _fx_catch_141);
+               _fx_catch_145);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_41, &result_0);
-            FX_BREAK(_fx_catch_141);
+            FX_BREAK(_fx_catch_145);
          }
          else {
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_2, &v_350, 0), _fx_catch_141);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_2, &v_350, 0), _fx_catch_145);
             FX_COPY_PTR(v_350.t0, &btyp_2);
             _fx_R10Ast__loc_t bloc_2 = v_350.t1;
             fx_str_t slit_149 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_2, _fx_g22Ast_typecheck__TypVoid,
-                  &bloc_2, &slit_149, 0), _fx_catch_141);
+                  &bloc_2, &slit_149, 0), _fx_catch_145);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  body_2, &env_4, for_sc_0, &new_body_2, 0), _fx_catch_141);
+                  body_2, &env_4, for_sc_0, &new_body_2, 0), _fx_catch_145);
             FX_CALL(
                _fx_M3AstFM6ExpForN10Ast__exp_t5LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRM11for_flags_tRM5loc_t(
-                  for_clauses_0, idx_pat_0, new_body_2, flags_0, &eloc_0, &result_42), _fx_catch_141);
+                  for_clauses_0, idx_pat_0, new_body_2, flags_0, &eloc_0, &result_42), _fx_catch_145);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_42, &result_0);
-            FX_BREAK(_fx_catch_141);
+            FX_BREAK(_fx_catch_145);
          }
 
-      _fx_catch_141: ;
+      _fx_catch_145: ;
          if (result_42) {
             _fx_free_N10Ast__exp_t(&result_42);
          }
@@ -25165,7 +25617,7 @@ FX_EXTERN_C int
          bool unzip_mode_0 = flags_1->for_flag_unzip;
          _fx_N12Ast__scope_t v_381;
          if (make_tuple_0) {
-            FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_153);
+            FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_157);
          }
          else {
             bool t_10;
@@ -25176,13 +25628,13 @@ FX_EXTERN_C int
                t_10 = make_vector_0;
             }
             if (t_10) {
-               FX_CALL(_fx_M3AstFM13new_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM13new_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_157);
             }
             else {
-               FX_CALL(_fx_M3AstFM17new_arr_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM17new_arr_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_381, 0), _fx_catch_157);
             }
          }
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_381, sc_2, true, &for_sc_1), _fx_catch_153);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_381, sc_2, true, &for_sc_1), _fx_catch_157);
          _fx_make_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
             0, 0, 0, 0, &env_2, &_fx_g16Ast__empty_idset, &__fold_result___3);
          FX_COPY_PTR(vcase_26->t0, &map_clauses_0);
@@ -25218,7 +25670,7 @@ FX_EXTERN_C int
             _fx_copy_Rt6Set__t1R9Ast__id_t(&v_382.t5, &idset_0);
             FX_CALL(
                _fx_M13Ast_typecheckFM17check_for_clausesT7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tR16Ast__for_flags_tLN12Ast__scope_ti(
-                  for_clauses_2, idx_pat_2, &env_6, &idset_0, flags_1, for_sc_1, curr_m_idx_0, &v_383, 0), _fx_catch_142);
+                  for_clauses_2, idx_pat_2, &env_6, &idset_0, flags_1, for_sc_1, curr_m_idx_0, &v_383, 0), _fx_catch_146);
             int_ trsz_k_0 = v_383.t0;
             FX_COPY_PTR(v_383.t1, &pre_code_k_0);
             FX_COPY_PTR(v_383.t2, &for_clauses_3);
@@ -25228,10 +25680,10 @@ FX_EXTERN_C int
             _fx_copy_Rt6Set__t1R9Ast__id_t(&v_383.t6, &idset_1);
             FX_CALL(
                _fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_k_0, pre_code_2, &v_384, 0),
-               _fx_catch_142);
+               _fx_catch_146);
             _fx_make_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(for_clauses_3, idx_pat_3, &v_385);
             FX_CALL(_fx_cons_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_385, map_clauses_2, false, &map_clauses_2),
-               _fx_catch_142);
+               _fx_catch_146);
             _fx_make_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
                v_382.t0 + trsz_k_0, v_384, map_clauses_2, v_382.t3 + dims_0, &env_7, &idset_1, &v_386);
             _fx_free_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
@@ -25239,7 +25691,7 @@ FX_EXTERN_C int
             _fx_copy_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
                &v_386, &__fold_result___3);
 
-         _fx_catch_142: ;
+         _fx_catch_146: ;
             _fx_free_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
                &v_386);
             _fx_free_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_385);
@@ -25275,7 +25727,7 @@ FX_EXTERN_C int
             if (for_clauses_2) {
                _fx_free_LT2N10Ast__pat_tN10Ast__exp_t(&for_clauses_2);
             }
-            FX_CHECK_EXN(_fx_catch_153);
+            FX_CHECK_EXN(_fx_catch_157);
          }
          _fx_copy_T6iLN10Ast__exp_tLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
             &__fold_result___3, &v_353);
@@ -25294,8 +25746,8 @@ FX_EXTERN_C int
          if (t_11) {
             fx_str_t slit_150 =
                FX_MAKE_STR("tuple comprehension with iteration over non-tuples and non-records is not supported");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_150, &v_354, 0), _fx_catch_153);
-            FX_THROW(&v_354, false, _fx_catch_153);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_150, &v_354, 0), _fx_catch_157);
+            FX_THROW(&v_354, false, _fx_catch_157);
          }
          if (make_list_0) {
             fx_str_t slit_151 = FX_MAKE_STR("list"); fx_copy_str(&slit_151, &coll_name_0);
@@ -25312,8 +25764,8 @@ FX_EXTERN_C int
          if (trsz_1 > 0) {
             if (flags_1->for_flag_unzip) {
                fx_str_t slit_155 = FX_MAKE_STR("@unzip for is not supported in tuple/record comprehensions");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_155, &v_355, 0), _fx_catch_153);
-               FX_THROW(&v_355, false, _fx_catch_153);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_155, &v_355, 0), _fx_catch_157);
+               FX_THROW(&v_355, false, _fx_catch_157);
             }
             if (map_clauses_1 != 0) {
                if (map_clauses_1->tl == 0) {
@@ -25324,17 +25776,17 @@ FX_EXTERN_C int
             }
             fx_exn_t v_388 = {0};
             fx_str_t slit_156 = FX_MAKE_STR("tuple comprehension with nested for is not supported yet");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_156, &v_388, 0), _fx_catch_143);
-            FX_THROW(&v_388, false, _fx_catch_143);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_156, &v_388, 0), _fx_catch_147);
+            FX_THROW(&v_388, false, _fx_catch_147);
 
-         _fx_catch_143: ;
+         _fx_catch_147: ;
             fx_free_exn(&v_388);
 
          _fx_endmatch_30: ;
-            FX_CHECK_EXN(_fx_catch_153);
+            FX_CHECK_EXN(_fx_catch_157);
             FX_COPY_PTR(v_356.t0, &for_clauses_1);
             FX_COPY_PTR(v_356.t1, &idx_pat_1);
-            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elem_typ_0, 0), _fx_catch_153);
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elem_typ_0, 0), _fx_catch_157);
             _fx_LN10Ast__exp_t lstend_8 = 0;
             for (int_ idx_3 = 0; idx_3 < trsz_1; idx_3++) {
                _fx_N10Ast__exp_t it_j_1 = 0;
@@ -25344,26 +25796,26 @@ FX_EXTERN_C int
                fx_str_t v_391 = {0};
                FX_CALL(
                   _fx_M13Ast_typecheckFM20gen_for_in_tuprec_itN10Ast__exp_t8iLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tLN12Ast__scope_t(
-                     idx_3, for_clauses_1, idx_pat_1, body_3, &env_5, for_sc_1, &eloc_0, sc_2, &it_j_1, 0), _fx_catch_144);
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_1, &v_389, 0), _fx_catch_144);
+                     idx_3, for_clauses_1, idx_pat_1, body_3, &env_5, for_sc_1, &eloc_0, sc_2, &it_j_1, 0), _fx_catch_148);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_1, &v_389, 0), _fx_catch_148);
                FX_COPY_PTR(v_389.t0, &tj_1);
                _fx_R10Ast__loc_t locj_1 = v_389.t1;
                if (!make_tuple_0) {
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_390, 0), _fx_catch_144);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_390, 0), _fx_catch_148);
                   fx_str_t slit_157 = FX_MAKE_STR(" comprehension should produce elements of the same type");
                   {
                      const fx_str_t strs_16[] = { v_390, slit_157 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_16, 2, &v_391), _fx_catch_144);
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_16, 2, &v_391), _fx_catch_148);
                   }
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(tj_1, elem_typ_0, &locj_1, &v_391,
-                        0), _fx_catch_144);
+                        0), _fx_catch_148);
                }
                _fx_LN10Ast__exp_t node_8 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_1, 0, false, &node_8), _fx_catch_144);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_1, 0, false, &node_8), _fx_catch_148);
                FX_LIST_APPEND(elems_0, lstend_8, node_8);
 
-            _fx_catch_144: ;
+            _fx_catch_148: ;
                FX_FREE_STR(&v_391);
                FX_FREE_STR(&v_390);
                if (tj_1) {
@@ -25373,27 +25825,27 @@ FX_EXTERN_C int
                if (it_j_1) {
                   _fx_free_N10Ast__exp_t(&it_j_1);
                }
-               FX_CHECK_EXN(_fx_catch_153);
+               FX_CHECK_EXN(_fx_catch_157);
             }
             if (make_tuple_0) {
                _fx_FPN10Ast__typ_t1N10Ast__exp_t get_exp_typ_fp_0 = { _fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t, 0 };
                FX_COPY_FP(&get_exp_typ_fp_0, &get_exp_typ_0);
                FX_CALL(
                   _fx_M13Ast_typecheckFM3mapLN10Ast__typ_t2LN10Ast__exp_tFPN10Ast__typ_t1N10Ast__exp_t(elems_0, &get_exp_typ_0,
-                     &tl_1, 0), _fx_catch_153);
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_1, &v_357), _fx_catch_153);
+                     &tl_1, 0), _fx_catch_157);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_1, &v_357), _fx_catch_157);
                _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_357, &eloc_0, &v_358);
                FX_CALL(
                   _fx_M3AstFM10ExpMkTupleN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_358, &mk_struct_exp_0),
-                  _fx_catch_153);
+                  _fx_catch_157);
             }
             else if (make_list_0) {
-               FX_CALL(_fx_M3AstFM7TypListN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &ltyp_0), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM7TypListN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &ltyp_0), _fx_catch_157);
                _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_359);
                FX_CALL(
                   _fx_M3AstFM6ExpLitN10Ast__exp_t2N10Ast__lit_tT2N10Ast__typ_tRM5loc_t(&_fx_g23Ast_typecheck__LitEmpty, &v_359,
-                     &__fold_result___4), _fx_catch_153);
-               FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_0, &v_360, 0), _fx_catch_153);
+                     &__fold_result___4), _fx_catch_157);
+               FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_0, &v_360, 0), _fx_catch_157);
                _fx_LN10Ast__exp_t lst_11 = v_360;
                for (; lst_11; lst_11 = lst_11->tl) {
                   _fx_N10Ast__exp_t l_exp_0 = 0;
@@ -25404,11 +25856,11 @@ FX_EXTERN_C int
                   _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_392);
                   FX_CALL(
                      _fx_M3AstFM9ExpBinaryN10Ast__exp_t4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                        _fx_g21Ast_typecheck__OpCons, ej_0, l_exp_0, &v_392, &v_393), _fx_catch_145);
+                        _fx_g21Ast_typecheck__OpCons, ej_0, l_exp_0, &v_392, &v_393), _fx_catch_149);
                   _fx_free_N10Ast__exp_t(&__fold_result___4);
                   FX_COPY_PTR(v_393, &__fold_result___4);
 
-               _fx_catch_145: ;
+               _fx_catch_149: ;
                   if (v_393) {
                      _fx_free_N10Ast__exp_t(&v_393);
                   }
@@ -25416,60 +25868,60 @@ FX_EXTERN_C int
                   if (l_exp_0) {
                      _fx_free_N10Ast__exp_t(&l_exp_0);
                   }
-                  FX_CHECK_EXN(_fx_catch_153);
+                  FX_CHECK_EXN(_fx_catch_157);
                }
                FX_COPY_PTR(__fold_result___4, &mk_struct_exp_0);
             }
             else if (make_vector_0) {
-               FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &v_361), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &v_361), _fx_catch_157);
                _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_361, &eloc_0, &v_362);
                FX_CALL(
                   _fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_362,
-                     &mk_struct_exp_0), _fx_catch_153);
+                     &mk_struct_exp_0), _fx_catch_157);
             }
             else {
-               FX_CALL(_fx_cons_LLN10Ast__exp_t(elems_0, 0, true, &v_363), _fx_catch_153);
-               FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, elem_typ_0, &v_364), _fx_catch_153);
+               FX_CALL(_fx_cons_LLN10Ast__exp_t(elems_0, 0, true, &v_363), _fx_catch_157);
+               FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, elem_typ_0, &v_364), _fx_catch_157);
                _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_364, &eloc_0, &v_365);
                FX_CALL(
                   _fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_363, &v_365, &mk_struct_exp_0),
-                  _fx_catch_153);
+                  _fx_catch_157);
             }
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(mk_struct_exp_0, &coll_typ_0, 0), _fx_catch_153);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_366, 0), _fx_catch_153);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(mk_struct_exp_0, &coll_typ_0, 0), _fx_catch_157);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_366, 0), _fx_catch_157);
             fx_str_t slit_158 = FX_MAKE_STR("inconsistent type of the constructed ");
             {
                const fx_str_t strs_17[] = { slit_158, v_366 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_17, 2, &v_367), _fx_catch_153);
+               FX_CALL(fx_strjoin(0, 0, 0, strs_17, 2, &v_367), _fx_catch_157);
             }
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, coll_typ_0, &eloc_0, &v_367, 0),
-               _fx_catch_153);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(mk_struct_exp_0, 0, true, &v_368), _fx_catch_153);
+               _fx_catch_157);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(mk_struct_exp_0, 0, true, &v_368), _fx_catch_157);
             FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_1, v_368, &v_369, 0),
-               _fx_catch_153);
+               _fx_catch_157);
             _fx_make_T2N10Ast__typ_tR10Ast__loc_t(coll_typ_0, &eloc_0, &v_370);
             FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_369, &v_370, &result_43),
-               _fx_catch_153);
+               _fx_catch_157);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_43, &result_0);
-            FX_BREAK(_fx_catch_153);
+            FX_BREAK(_fx_catch_157);
          }
          else {
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_3, &v_371, 0), _fx_catch_153);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_3, &v_371, 0), _fx_catch_157);
             FX_COPY_PTR(v_371.t0, &btyp_3);
             if (!unzip_mode_0) {
                FX_CALL(
                   _fx_M13Ast_typecheckFM13check_map_typv7N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBi(btyp_3, etyp_0, -1,
-                     &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_153);
+                     &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_157);
             }
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  body_3, &env_5, for_sc_1, &new_body_3, 0), _fx_catch_153);
+                  body_3, &env_5, for_sc_1, &new_body_3, 0), _fx_catch_157);
             bool new_unzip_mode_0;
             if (unzip_mode_0) {
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(btyp_3, &v_372, 0), _fx_catch_153);
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_373, 0), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(btyp_3, &v_372, 0), _fx_catch_157);
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_373, 0), _fx_catch_157);
                if (FX_REC_VARIANT_TAG(v_373) == 1) {
                   FX_COPY_PTR(v_373->u.TypVar->data, &v_374);
                   if ((v_374 != 0) + 1 == 1) {
@@ -25484,28 +25936,28 @@ FX_EXTERN_C int
                         for (; lst_12; lst_12 = lst_12->tl, i_0 += 1) {
                            _fx_N10Ast__typ_t ct_0 = 0;
                            _fx_N10Ast__typ_t bt_0 = lst_12->hd;
-                           FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&ct_0, 0), _fx_catch_146);
+                           FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&ct_0, 0), _fx_catch_150);
                            FX_CALL(
                               _fx_M13Ast_typecheckFM13check_map_typv7N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBi(bt_0, ct_0,
-                                 i_0, &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_146);
+                                 i_0, &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_150);
                            _fx_LN10Ast__typ_t node_9 = 0;
-                           FX_CALL(_fx_cons_LN10Ast__typ_t(ct_0, 0, false, &node_9), _fx_catch_146);
+                           FX_CALL(_fx_cons_LN10Ast__typ_t(ct_0, 0, false, &node_9), _fx_catch_150);
                            FX_LIST_APPEND(colls_0, lstend_9, node_9);
 
-                        _fx_catch_146: ;
+                        _fx_catch_150: ;
                            if (ct_0) {
                               _fx_free_N10Ast__typ_t(&ct_0);
                            }
-                           FX_CHECK_EXN(_fx_catch_147);
+                           FX_CHECK_EXN(_fx_catch_151);
                         }
-                        FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(colls_0, &v_394), _fx_catch_147);
+                        FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(colls_0, &v_394), _fx_catch_151);
                         fx_str_t slit_159 = FX_MAKE_STR("incorrect type of @unzip\'ped comprehension");
                         FX_CALL(
                            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_394, &eloc_0,
-                              &slit_159, 0), _fx_catch_147);
+                              &slit_159, 0), _fx_catch_151);
                         new_unzip_mode_0 = true;
 
-                     _fx_catch_147: ;
+                     _fx_catch_151: ;
                         if (v_394) {
                            _fx_free_N10Ast__typ_t(&v_394);
                         }
@@ -25530,22 +25982,22 @@ FX_EXTERN_C int
                      _fx_LN10Ast__typ_t b_elems_2 = v_372->u.TypTuple;
                      _fx_LN10Ast__typ_t colls_2 = v_373->u.TypTuple;
                      int_ nb_elems_0;
-                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(b_elems_2, &nb_elems_0, 0), _fx_catch_149);
+                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(b_elems_2, &nb_elems_0, 0), _fx_catch_153);
                      int_ ncolls_0;
-                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(colls_2, &ncolls_0, 0), _fx_catch_149);
+                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(colls_2, &ncolls_0, 0), _fx_catch_153);
                      if (nb_elems_0 != ncolls_0) {
-                        FX_CALL(_fx_F6stringS1i(nb_elems_0, &v_395, 0), _fx_catch_149);
-                        FX_CALL(_fx_F6stringS1i(ncolls_0, &v_396, 0), _fx_catch_149);
+                        FX_CALL(_fx_F6stringS1i(nb_elems_0, &v_395, 0), _fx_catch_153);
+                        FX_CALL(_fx_F6stringS1i(ncolls_0, &v_396, 0), _fx_catch_153);
                         fx_str_t slit_160 =
                            FX_MAKE_STR("the number of elements in a tuple produced by the @unzip\'pped comprehension (=");
                         fx_str_t slit_161 = FX_MAKE_STR(") and in the output tuple (=");
                         fx_str_t slit_162 = FX_MAKE_STR(") do not match");
                         {
                            const fx_str_t strs_18[] = { slit_160, v_395, slit_161, v_396, slit_162 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_18, 5, &v_397), _fx_catch_149);
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_18, 5, &v_397), _fx_catch_153);
                         }
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_397, &v_398, 0), _fx_catch_149);
-                        FX_THROW(&v_398, false, _fx_catch_149);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_397, &v_398, 0), _fx_catch_153);
+                        FX_THROW(&v_398, false, _fx_catch_153);
                      }
                      int_ i_1 = 0;
                      FX_COPY_PTR(b_elems_2, &b_elems_1);
@@ -25557,16 +26009,16 @@ FX_EXTERN_C int
                         _fx_N10Ast__typ_t bt_1 = lst_13->hd;
                         FX_CALL(
                            _fx_M13Ast_typecheckFM13check_map_typv7N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBi(bt_1, ct_1, i_1,
-                              &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_148);
+                              &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_152);
 
-                     _fx_catch_148: ;
-                        FX_CHECK_EXN(_fx_catch_149);
+                     _fx_catch_152: ;
+                        FX_CHECK_EXN(_fx_catch_153);
                      }
                      int s_0 = !lst_13 + !lst_14;
-                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_149);
+                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_153);
                      new_unzip_mode_0 = true;
 
-                  _fx_catch_149: ;
+                  _fx_catch_153: ;
                      if (colls_1) {
                         _fx_free_LN10Ast__typ_t(&colls_1);
                      }
@@ -25590,7 +26042,7 @@ FX_EXTERN_C int
                else {
                   res_36 = false;
                }
-               FX_CHECK_EXN(_fx_catch_153);
+               FX_CHECK_EXN(_fx_catch_157);
                if (res_36) {
                   fx_str_t v_399 = {0};
                   fx_str_t v_400 = {0};
@@ -25598,21 +26050,21 @@ FX_EXTERN_C int
                   fx_str_t v_402 = {0};
                   fx_str_t v_403 = {0};
                   fx_exn_t v_404 = {0};
-                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(btyp_3, &v_399, 0), _fx_catch_150);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_399, &v_400, 0), _fx_catch_150);
-                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(etyp_0, &v_401, 0), _fx_catch_150);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_401, &v_402, 0), _fx_catch_150);
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(btyp_3, &v_399, 0), _fx_catch_154);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_399, &v_400, 0), _fx_catch_154);
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(etyp_0, &v_401, 0), _fx_catch_154);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_401, &v_402, 0), _fx_catch_154);
                   fx_str_t slit_163 = FX_MAKE_STR("in the case of @unzip comprehension either both the body type \'");
                   fx_str_t slit_164 = FX_MAKE_STR("\' and the result type (\'");
                   fx_str_t slit_165 = FX_MAKE_STR("\') should be tuples or none of them");
                   {
                      const fx_str_t strs_19[] = { slit_163, v_400, slit_164, v_402, slit_165 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_19, 5, &v_403), _fx_catch_150);
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_19, 5, &v_403), _fx_catch_154);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_403, &v_404, 0), _fx_catch_150);
-                  FX_THROW(&v_404, false, _fx_catch_150);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_403, &v_404, 0), _fx_catch_154);
+                  FX_THROW(&v_404, false, _fx_catch_154);
 
-               _fx_catch_150: ;
+               _fx_catch_154: ;
                   fx_free_exn(&v_404);
                   FX_FREE_STR(&v_403);
                   FX_FREE_STR(&v_402);
@@ -25623,46 +26075,46 @@ FX_EXTERN_C int
                }
                FX_CALL(
                   _fx_M13Ast_typecheckFM13check_map_typv7N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBi(btyp_3, etyp_0, -1,
-                     &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_151);
+                     &eloc_0, make_list_0, make_vector_0, total_dims_0, 0), _fx_catch_155);
                new_unzip_mode_0 = false;
 
-            _fx_catch_151: ;
+            _fx_catch_155: ;
 
             _fx_endmatch_31: ;
-               FX_CHECK_EXN(_fx_catch_153);
+               FX_CHECK_EXN(_fx_catch_157);
             }
             else {
-               FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_body_3, &v_375, 0), _fx_catch_153);
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_375, &v_376, 0), _fx_catch_153);
+               FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_body_3, &v_375, 0), _fx_catch_157);
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_375, &v_376, 0), _fx_catch_157);
                if (FX_REC_VARIANT_TAG(v_376) == 14) {
                   fx_exn_t v_405 = {0};
                   fx_str_t slit_166 = FX_MAKE_STR("comprehension body cannot have \'void\' type");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_166, &v_405, 0), _fx_catch_152);
-                  FX_THROW(&v_405, false, _fx_catch_152);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_166, &v_405, 0), _fx_catch_156);
+                  FX_THROW(&v_405, false, _fx_catch_156);
 
-               _fx_catch_152: ;
+               _fx_catch_156: ;
                   fx_free_exn(&v_405);
                }
                else {
                   new_unzip_mode_0 = false;
                }
-               FX_CHECK_EXN(_fx_catch_153);
+               FX_CHECK_EXN(_fx_catch_157);
             }
             FX_CALL(
                _fx_M13Ast_typecheckFM3revLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t1LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(
-                  map_clauses_1, &v_377, 0), _fx_catch_153);
+                  map_clauses_1, &v_377, 0), _fx_catch_157);
             _fx_R16Ast__for_flags_t v_406 =
                { flags_1->for_flag_parallel, flags_1->for_flag_make, new_unzip_mode_0, flags_1->for_flag_fold,
                   flags_1->for_flag_nested };
             FX_CALL(
                _fx_M3AstFM6ExpMapN10Ast__exp_t4LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRM11for_flags_tT2N10Ast__typ_tRM5loc_t(
-                  v_377, new_body_3, &v_406, &vcase_26->t3, &result_44), _fx_catch_153);
+                  v_377, new_body_3, &v_406, &vcase_26->t3, &result_44), _fx_catch_157);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_44, &result_0);
-            FX_BREAK(_fx_catch_153);
+            FX_BREAK(_fx_catch_157);
          }
 
-      _fx_catch_153: ;
+      _fx_catch_157: ;
          if (result_44) {
             _fx_free_N10Ast__exp_t(&result_44);
          }
@@ -25774,23 +26226,23 @@ FX_EXTERN_C int
       if (tag_0 == 2) {
          FX_CALL(
             _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(e_2->u.ExpBreak.t0, true, false, sc_2,
-               &eloc_0, 0), _fx_catch_154);
+               &eloc_0, 0), _fx_catch_158);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(e_2, &result_0);
-         FX_BREAK(_fx_catch_154);
+         FX_BREAK(_fx_catch_158);
 
-      _fx_catch_154: ;
+      _fx_catch_158: ;
          goto _fx_endmatch_41;
       }
       if (tag_0 == 3) {
          FX_CALL(
             _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(false, false, false, sc_2, &eloc_0, 0),
-            _fx_catch_155);
+            _fx_catch_159);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(e_2, &result_0);
-         FX_BREAK(_fx_catch_155);
+         FX_BREAK(_fx_catch_159);
 
-      _fx_catch_155: ;
+      _fx_catch_159: ;
          goto _fx_endmatch_41;
       }
       if (tag_0 == 4) {
@@ -25802,16 +26254,16 @@ FX_EXTERN_C int
          fx_str_t slit_167 = FX_MAKE_STR("return statement should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypVoid,
-               &eloc_0, &slit_167, 0), _fx_catch_160);
+               &eloc_0, &slit_167, 0), _fx_catch_164);
          if ((e_opt_0 != 0) + 1 == 2) {
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_opt_0->u.Some, &t_12, 0), _fx_catch_156);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_opt_0->u.Some, &t_12, 0), _fx_catch_160);
 
-         _fx_catch_156: ;
+         _fx_catch_160: ;
          }
          else {
             FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t_12);
          }
-         FX_CHECK_EXN(_fx_catch_160);
+         FX_CHECK_EXN(_fx_catch_164);
          FX_COPY_PTR(_fx_g17Ast__all_func_ctx, &all_func_ctx_0);
          if (all_func_ctx_0 != 0) {
             fx_str_t v_408 = {0};
@@ -25823,23 +26275,23 @@ FX_EXTERN_C int
             fx_str_t v_414 = {0};
             _fx_T3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t* v_415 = &all_func_ctx_0->hd;
             _fx_N10Ast__typ_t rt_0 = v_415->t1;
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_12, &v_408, 0), _fx_catch_157);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_408, &v_409, 0), _fx_catch_157);
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(rt_0, &v_410, 0), _fx_catch_157);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_410, &v_411, 0), _fx_catch_157);
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_415->t0, &v_412, 0), _fx_catch_157);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_412, &v_413, 0), _fx_catch_157);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_12, &v_408, 0), _fx_catch_161);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_408, &v_409, 0), _fx_catch_161);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(rt_0, &v_410, 0), _fx_catch_161);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_410, &v_411, 0), _fx_catch_161);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_415->t0, &v_412, 0), _fx_catch_161);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_412, &v_413, 0), _fx_catch_161);
             fx_str_t slit_168 = FX_MAKE_STR("the return statement type ");
             fx_str_t slit_169 = FX_MAKE_STR(" is inconsistent with the previously deduced type ");
             fx_str_t slit_170 = FX_MAKE_STR(" of function ");
             {
                const fx_str_t strs_20[] = { slit_168, v_409, slit_169, v_411, slit_170, v_413 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_20, 6, &v_414), _fx_catch_157);
+               FX_CALL(fx_strjoin(0, 0, 0, strs_20, 6, &v_414), _fx_catch_161);
             }
             FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_12, rt_0, &eloc_0, &v_414, 0),
-               _fx_catch_157);
+               _fx_catch_161);
 
-         _fx_catch_157: ;
+         _fx_catch_161: ;
             FX_FREE_STR(&v_414);
             FX_FREE_STR(&v_413);
             FX_FREE_STR(&v_412);
@@ -25851,35 +26303,35 @@ FX_EXTERN_C int
          else {
             fx_exn_t v_416 = {0};
             fx_str_t slit_171 = FX_MAKE_STR("return statement occurs outside of a function body");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_171, &v_416, 0), _fx_catch_158);
-            FX_THROW(&v_416, false, _fx_catch_158);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_171, &v_416, 0), _fx_catch_162);
+            FX_THROW(&v_416, false, _fx_catch_162);
 
-         _fx_catch_158: ;
+         _fx_catch_162: ;
             fx_free_exn(&v_416);
          }
-         FX_CHECK_EXN(_fx_catch_160);
+         FX_CHECK_EXN(_fx_catch_164);
          if ((e_opt_0 != 0) + 1 == 2) {
             _fx_N10Ast__exp_t v_417 = 0;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  e_opt_0->u.Some, &env_2, sc_2, &v_417, 0), _fx_catch_159);
-            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(v_417, &v_407), _fx_catch_159);
+                  e_opt_0->u.Some, &env_2, sc_2, &v_417, 0), _fx_catch_163);
+            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(v_417, &v_407), _fx_catch_163);
 
-         _fx_catch_159: ;
+         _fx_catch_163: ;
             if (v_417) {
                _fx_free_N10Ast__exp_t(&v_417);
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, &v_407);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &v_407);
          }
-         FX_CHECK_EXN(_fx_catch_160);
-         FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_407, &eloc_0, &result_45), _fx_catch_160);
+         FX_CHECK_EXN(_fx_catch_164);
+         FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_407, &eloc_0, &result_45), _fx_catch_164);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_45, &result_0);
-         FX_BREAK(_fx_catch_160);
+         FX_BREAK(_fx_catch_164);
 
-      _fx_catch_160: ;
+      _fx_catch_164: ;
          if (result_45) {
             _fx_free_N10Ast__exp_t(&result_45);
          }
@@ -25903,7 +26355,7 @@ FX_EXTERN_C int
          _fx_N10Ast__typ_t atyp_0 = 0;
          _fx_LLN10Ast__exp_t v_419 = 0;
          _fx_N10Ast__exp_t result_46 = 0;
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_1, 0), _fx_catch_169);
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_1, 0), _fx_catch_173);
          _fx_make_T4iLLN10Ast__exp_tBi(0, 0, false, -1, &__fold_result___5);
          int_ k_0 = 0;
          FX_COPY_PTR(e_2->u.ExpMkArray.t0, &arows_0);
@@ -25966,15 +26418,15 @@ FX_EXTERN_C int
                      _fx_R10Ast__loc_t* loc_0 = &v_450->t1;
                      FX_CALL(
                         _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                           vcase_27->t1, &env_2, sc_2, &e1_5, 0), _fx_catch_162);
-                     FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_5, &v_442, 0), _fx_catch_162);
+                           vcase_27->t1, &env_2, sc_2, &e1_5, 0), _fx_catch_166);
+                     FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_5, &v_442, 0), _fx_catch_166);
                      FX_COPY_PTR(v_442.t0, &arrtyp1_0);
                      _fx_R10Ast__loc_t eloc1_8 = v_442.t1;
                      fx_str_t slit_172 = FX_MAKE_STR("incorrect type of expanded collection");
                      FX_CALL(
                         _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_450->t0, arrtyp1_0, loc_0,
-                           &slit_172, 0), _fx_catch_162);
-                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(arrtyp1_0, &v_443, 0), _fx_catch_162);
+                           &slit_172, 0), _fx_catch_166);
+                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(arrtyp1_0, &v_443, 0), _fx_catch_166);
                      int tag_12 = FX_REC_VARIANT_TAG(v_443);
                      if (tag_12 == 20) {
                         _fx_T2iN10Ast__typ_t* vcase_28 = &v_443->u.TypArray;
@@ -25993,39 +26445,39 @@ FX_EXTERN_C int
                         fx_exn_t v_451 = {0};
                         fx_str_t slit_176 =
                            FX_MAKE_STR("incorrect type of expanded collection (it should be an array, list or string)");
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_176, &v_451, 0), _fx_catch_161);
-                        FX_THROW(&v_451, false, _fx_catch_161);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_176, &v_451, 0), _fx_catch_165);
+                        FX_THROW(&v_451, false, _fx_catch_165);
 
-                     _fx_catch_161: ;
+                     _fx_catch_165: ;
                         fx_free_exn(&v_451);
                      }
-                     FX_CHECK_EXN(_fx_catch_162);
+                     FX_CHECK_EXN(_fx_catch_166);
                      fx_copy_str(&v_444.t0, &collname_0);
                      int_ d_0 = v_444.t1;
                      FX_COPY_PTR(v_444.t2, &elemtyp1_0);
                      if (d_0 > 2) {
                         fx_str_t slit_177 =
                            FX_MAKE_STR("currently expansion of more than 2-dimensional arrays is not supported");
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_177, &v_445, 0), _fx_catch_162);
-                        FX_THROW(&v_445, false, _fx_catch_162);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_177, &v_445, 0), _fx_catch_166);
+                        FX_THROW(&v_445, false, _fx_catch_166);
                      }
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_0, &v_446, 0), _fx_catch_162);
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_0, &v_446, 0), _fx_catch_166);
                      fx_str_t slit_178 = FX_MAKE_STR("the expanded ");
                      fx_str_t slit_179 = FX_MAKE_STR(" elem type does not match the previous elements");
                      {
                         const fx_str_t strs_21[] = { slit_178, v_446, slit_179 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_21, 3, &v_447), _fx_catch_162);
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_21, 3, &v_447), _fx_catch_166);
                      }
                      FX_CALL(
                         _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_1, elemtyp1_0, &eloc1_8,
-                           &v_447, 0), _fx_catch_162);
+                           &v_447, 0), _fx_catch_166);
                      _fx_make_T2N10Ast__typ_tR10Ast__loc_t(arrtyp1_0, loc_0, &v_448);
                      FX_CALL(
                         _fx_M3AstFM8ExpUnaryN10Ast__exp_t3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                           &_fx_g23Ast_typecheck__OpExpand, e1_5, &v_448, &v_449), _fx_catch_162);
+                           &_fx_g23Ast_typecheck__OpExpand, e1_5, &v_448, &v_449), _fx_catch_166);
                      _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(true, d_0, v_449, loc_0, &v_436);
 
-                  _fx_catch_162: ;
+                  _fx_catch_166: ;
                      if (v_449) {
                         _fx_free_N10Ast__exp_t(&v_449);
                      }
@@ -26054,19 +26506,19 @@ FX_EXTERN_C int
                _fx_T2N10Ast__typ_tR10Ast__loc_t v_452 = {0};
                _fx_N10Ast__typ_t elemtyp1_1 = 0;
                _fx_N10Ast__exp_t v_453 = 0;
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_0, &v_452, 0), _fx_catch_163);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_0, &v_452, 0), _fx_catch_167);
                FX_COPY_PTR(v_452.t0, &elemtyp1_1);
                _fx_R10Ast__loc_t eloc1_9 = v_452.t1;
                fx_str_t slit_180 = FX_MAKE_STR("all the scalar elements of the array should have the same type");
                FX_CALL(
                   _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_1, elemtyp1_1, &eloc1_9,
-                     &slit_180, 0), _fx_catch_163);
+                     &slit_180, 0), _fx_catch_167);
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     elem_0, &env_2, sc_2, &v_453, 0), _fx_catch_163);
+                     elem_0, &env_2, sc_2, &v_453, 0), _fx_catch_167);
                _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(false, 1, v_453, &eloc1_9, &v_436);
 
-            _fx_catch_163: ;
+            _fx_catch_167: ;
                if (v_453) {
                   _fx_free_N10Ast__exp_t(&v_453);
                }
@@ -26076,7 +26528,7 @@ FX_EXTERN_C int
                _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_452);
 
             _fx_endmatch_32: ;
-               FX_CHECK_EXN(_fx_catch_164);
+               FX_CHECK_EXN(_fx_catch_168);
                bool is_expanded_0 = v_436.t0;
                int_ elem_dims_0 = v_436.t1;
                FX_COPY_PTR(v_436.t2, &elem1_0);
@@ -26089,17 +26541,17 @@ FX_EXTERN_C int
                   row_dims_1 = elem_dims_0;
                }
                if (row_dims_1 != elem_dims_0) {
-                  FX_CALL(_fx_F6stringS1i(elem_dims_0, &v_437, 0), _fx_catch_164);
-                  FX_CALL(_fx_F6stringS1i(row_dims_1, &v_438, 0), _fx_catch_164);
+                  FX_CALL(_fx_F6stringS1i(elem_dims_0, &v_437, 0), _fx_catch_168);
+                  FX_CALL(_fx_F6stringS1i(row_dims_1, &v_438, 0), _fx_catch_168);
                   fx_str_t slit_181 = FX_MAKE_STR("dimensionality of array element (=");
                   fx_str_t slit_182 = FX_MAKE_STR(") does not match the previous elements dimensionality (=");
                   fx_str_t slit_183 = FX_MAKE_STR(") in the same row");
                   {
                      const fx_str_t strs_22[] = { slit_181, v_437, slit_182, v_438, slit_183 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_22, 5, &v_439), _fx_catch_164);
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_22, 5, &v_439), _fx_catch_168);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_0, &v_439, &v_440, 0), _fx_catch_164);
-                  FX_THROW(&v_440, false, _fx_catch_164);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_0, &v_439, &v_440, 0), _fx_catch_168);
+                  FX_THROW(&v_440, false, _fx_catch_168);
                }
                bool t_13;
                if (v_435.t0) {
@@ -26108,12 +26560,12 @@ FX_EXTERN_C int
                else {
                   t_13 = is_expanded_0;
                }
-               FX_CALL(_fx_cons_LN10Ast__exp_t(elem1_0, arow_2, false, &arow_2), _fx_catch_164);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(elem1_0, arow_2, false, &arow_2), _fx_catch_168);
                _fx_make_T3BiLN10Ast__exp_t(t_13, row_dims_1, arow_2, &v_441);
                _fx_free_T3BiLN10Ast__exp_t(&__fold_result___6);
                _fx_copy_T3BiLN10Ast__exp_t(&v_441, &__fold_result___6);
 
-            _fx_catch_164: ;
+            _fx_catch_168: ;
                _fx_free_T3BiLN10Ast__exp_t(&v_441);
                fx_free_exn(&v_440);
                FX_FREE_STR(&v_439);
@@ -26127,27 +26579,27 @@ FX_EXTERN_C int
                   _fx_free_LN10Ast__exp_t(&arow_2);
                }
                _fx_free_T3BiLN10Ast__exp_t(&v_435);
-               FX_CHECK_EXN(_fx_catch_168);
+               FX_CHECK_EXN(_fx_catch_172);
             }
             _fx_copy_T3BiLN10Ast__exp_t(&__fold_result___6, &v_421);
             bool have_expanded_i_0 = v_421.t0;
             int_ row_dims_2 = v_421.t1;
             FX_COPY_PTR(v_421.t2, &arow_0);
             int_ ncols_i_0;
-            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__exp_t(arow_0, &ncols_i_0, 0), _fx_catch_168);
+            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__exp_t(arow_0, &ncols_i_0, 0), _fx_catch_172);
             _fx_R10Ast__loc_t elem_loc_1;
             if (arow_0 != 0) {
-               FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arow_0->hd, &elem_loc_1, 0), _fx_catch_165);
+               FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arow_0->hd, &elem_loc_1, 0), _fx_catch_169);
 
-            _fx_catch_165: ;
+            _fx_catch_169: ;
             }
             else {
                if (arows_2 != 0) {
                   _fx_N10Ast__exp_t v_454 = 0;
-                  FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(arows_2->hd, &v_454, 0), _fx_catch_166);
-                  FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_454, &elem_loc_1, 0), _fx_catch_166);
+                  FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(arows_2->hd, &v_454, 0), _fx_catch_170);
+                  FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_454, &elem_loc_1, 0), _fx_catch_170);
 
-               _fx_catch_166: ;
+               _fx_catch_170: ;
                   if (v_454) {
                      _fx_free_N10Ast__exp_t(&v_454);
                   }
@@ -26155,24 +26607,24 @@ FX_EXTERN_C int
                else {
                   elem_loc_1 = eloc_0;
                }
-               FX_CHECK_EXN(_fx_catch_167);
+               FX_CHECK_EXN(_fx_catch_171);
 
-            _fx_catch_167: ;
+            _fx_catch_171: ;
             }
-            FX_CHECK_EXN(_fx_catch_168);
+            FX_CHECK_EXN(_fx_catch_172);
             if (ncols_i_0 == 0) {
-               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_422, 0), _fx_catch_168);
-               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_423, 0), _fx_catch_168);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_423, &v_424, 0), _fx_catch_168);
+               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_422, 0), _fx_catch_172);
+               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_423, 0), _fx_catch_172);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_423, &v_424, 0), _fx_catch_172);
                fx_str_t slit_184 = FX_MAKE_STR("the ");
                fx_str_t slit_185 = FX_MAKE_STR("-");
                fx_str_t slit_186 = FX_MAKE_STR(" matrix row is empty");
                {
                   const fx_str_t strs_23[] = { slit_184, v_422, slit_185, v_424, slit_186 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_23, 5, &v_425), _fx_catch_168);
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_23, 5, &v_425), _fx_catch_172);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_425, &v_426, 0), _fx_catch_168);
-               FX_THROW(&v_426, false, _fx_catch_168);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_425, &v_426, 0), _fx_catch_172);
+               FX_THROW(&v_426, false, _fx_catch_172);
             }
             bool have_expanded_0;
             if (v_420.t2) {
@@ -26196,18 +26648,18 @@ FX_EXTERN_C int
                t_15 = false;
             }
             if (t_15) {
-               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_427, 0), _fx_catch_168);
-               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_428, 0), _fx_catch_168);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_428, &v_429, 0), _fx_catch_168);
+               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_427, 0), _fx_catch_172);
+               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_428, 0), _fx_catch_172);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_428, &v_429, 0), _fx_catch_172);
                fx_str_t slit_187 = FX_MAKE_STR("the ");
                fx_str_t slit_188 = FX_MAKE_STR("-");
                fx_str_t slit_189 = FX_MAKE_STR(" matrix row contains a different number of elements");
                {
                   const fx_str_t strs_24[] = { slit_187, v_427, slit_188, v_429, slit_189 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_24, 5, &v_430), _fx_catch_168);
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_24, 5, &v_430), _fx_catch_172);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_430, &v_431, 0), _fx_catch_168);
-               FX_THROW(&v_431, false, _fx_catch_168);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_430, &v_431, 0), _fx_catch_172);
+               FX_THROW(&v_431, false, _fx_catch_172);
             }
             int_ dims_1;
             if (v_420.t3 < 0) {
@@ -26223,13 +26675,13 @@ FX_EXTERN_C int
             else {
                t_16 = ncols_0;
             }
-            FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(arow_0, &v_432, 0), _fx_catch_168);
-            FX_CALL(_fx_cons_LLN10Ast__exp_t(v_432, arows_2, true, &v_433), _fx_catch_168);
+            FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(arow_0, &v_432, 0), _fx_catch_172);
+            FX_CALL(_fx_cons_LLN10Ast__exp_t(v_432, arows_2, true, &v_433), _fx_catch_172);
             _fx_make_T4iLLN10Ast__exp_tBi(t_16, v_433, have_expanded_0, dims_1, &v_434);
             _fx_free_T4iLLN10Ast__exp_tBi(&__fold_result___5);
             _fx_copy_T4iLLN10Ast__exp_tBi(&v_434, &__fold_result___5);
 
-         _fx_catch_168: ;
+         _fx_catch_172: ;
             _fx_free_T4iLLN10Ast__exp_tBi(&v_434);
             if (v_433) {
                _fx_free_LLN10Ast__exp_t(&v_433);
@@ -26256,23 +26708,23 @@ FX_EXTERN_C int
                _fx_free_LLN10Ast__exp_t(&arows_2);
             }
             _fx_free_T4iLLN10Ast__exp_tBi(&v_420);
-            FX_CHECK_EXN(_fx_catch_169);
+            FX_CHECK_EXN(_fx_catch_173);
          }
          _fx_copy_T4iLLN10Ast__exp_tBi(&__fold_result___5, &v_418);
          FX_COPY_PTR(v_418.t1, &arows_1);
          int_ dims_2 = v_418.t3;
-         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(dims_2, elemtyp_1, &atyp_0), _fx_catch_169);
+         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(dims_2, elemtyp_1, &atyp_0), _fx_catch_173);
          fx_str_t slit_190 = FX_MAKE_STR("the array literal should produce an array");
          FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(atyp_0, etyp_0, &eloc_0, &slit_190, 0),
-            _fx_catch_169);
-         FX_CALL(_fx_M13Ast_typecheckFM3revLLN10Ast__exp_t1LLN10Ast__exp_t(arows_1, &v_419, 0), _fx_catch_169);
+            _fx_catch_173);
+         FX_CALL(_fx_M13Ast_typecheckFM3revLLN10Ast__exp_t1LLN10Ast__exp_t(arows_1, &v_419, 0), _fx_catch_173);
          FX_CALL(_fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_419, &ctx_0, &result_46),
-            _fx_catch_169);
+            _fx_catch_173);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_46, &result_0);
-         FX_BREAK(_fx_catch_169);
+         FX_BREAK(_fx_catch_173);
 
-      _fx_catch_169: ;
+      _fx_catch_173: ;
          if (result_46) {
             _fx_free_N10Ast__exp_t(&result_46);
          }
@@ -26303,7 +26755,7 @@ FX_EXTERN_C int
          _fx_N10Ast__typ_t vectyp_0 = 0;
          _fx_LN10Ast__exp_t v_455 = 0;
          _fx_N10Ast__exp_t result_47 = 0;
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_2, 0), _fx_catch_174);
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_2, 0), _fx_catch_178);
          FX_COPY_PTR(e_2->u.ExpMkVector.t0, &elems_1);
          _fx_LN10Ast__exp_t lst_17 = elems_1;
          for (; lst_17; lst_17 = lst_17->tl) {
@@ -26329,15 +26781,15 @@ FX_EXTERN_C int
                   _fx_N10Ast__typ_t t_17 = v_464->t0;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                        vcase_29->t1, &env_2, sc_2, &e1_6, 0), _fx_catch_171);
-                  FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_6, &v_457, 0), _fx_catch_171);
+                        vcase_29->t1, &env_2, sc_2, &e1_6, 0), _fx_catch_175);
+                  FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_6, &v_457, 0), _fx_catch_175);
                   FX_COPY_PTR(v_457.t0, &etyp1_11);
                   _fx_R10Ast__loc_t eloc1_10 = v_457.t1;
                   fx_str_t slit_191 = FX_MAKE_STR("incorrect type of expanded collection");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_17, etyp1_11, &eloc1_10,
-                        &slit_191, 0), _fx_catch_171);
-                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_11, &v_458, 0), _fx_catch_171);
+                        &slit_191, 0), _fx_catch_175);
+                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_11, &v_458, 0), _fx_catch_175);
                   int tag_13 = FX_REC_VARIANT_TAG(v_458);
                   if (tag_13 == 20) {
                      _fx_T2iN10Ast__typ_t* vcase_30 = &v_458->u.TypArray;
@@ -26366,33 +26818,33 @@ FX_EXTERN_C int
                   fx_str_t slit_196 =
                      FX_MAKE_STR(
                         "incorrect type \'{typ2str(etyp1)} of the expanded collection (it should be an 1D array, list or string)");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc1_10, &slit_196, &v_465, 0), _fx_catch_170);
-                  FX_THROW(&v_465, false, _fx_catch_170);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc1_10, &slit_196, &v_465, 0), _fx_catch_174);
+                  FX_THROW(&v_465, false, _fx_catch_174);
 
-               _fx_catch_170: ;
+               _fx_catch_174: ;
                   fx_free_exn(&v_465);
 
                _fx_endmatch_33: ;
-                  FX_CHECK_EXN(_fx_catch_171);
+                  FX_CHECK_EXN(_fx_catch_175);
                   fx_copy_str(&v_459.t0, &collname_1);
                   FX_COPY_PTR(v_459.t1, &elemtyp1_2);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_1, &v_460, 0), _fx_catch_171);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_1, &v_460, 0), _fx_catch_175);
                   fx_str_t slit_197 = FX_MAKE_STR("the expanded \'");
                   fx_str_t slit_198 = FX_MAKE_STR("\' elem type does not match the previous elements");
                   {
                      const fx_str_t strs_25[] = { slit_197, v_460, slit_198 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_25, 3, &v_461), _fx_catch_171);
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_25, 3, &v_461), _fx_catch_175);
                   }
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_2, elemtyp1_2, &eloc1_10,
-                        &v_461, 0), _fx_catch_171);
+                        &v_461, 0), _fx_catch_175);
                   _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t_17, &v_464->t1, &v_462);
                   FX_CALL(
                      _fx_M3AstFM8ExpUnaryN10Ast__exp_t3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                        &_fx_g23Ast_typecheck__OpExpand, e1_6, &v_462, &v_463), _fx_catch_171);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_463, elems_3, true, &v_456), _fx_catch_171);
+                        &_fx_g23Ast_typecheck__OpExpand, e1_6, &v_462, &v_463), _fx_catch_175);
+                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_463, elems_3, true, &v_456), _fx_catch_175);
 
-               _fx_catch_171: ;
+               _fx_catch_175: ;
                   if (v_463) {
                      _fx_free_N10Ast__exp_t(&v_463);
                   }
@@ -26420,19 +26872,19 @@ FX_EXTERN_C int
             _fx_T2N10Ast__typ_tR10Ast__loc_t v_466 = {0};
             _fx_N10Ast__typ_t elemtyp1_3 = 0;
             _fx_N10Ast__exp_t v_467 = 0;
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_1, &v_466, 0), _fx_catch_172);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_1, &v_466, 0), _fx_catch_176);
             FX_COPY_PTR(v_466.t0, &elemtyp1_3);
             _fx_R10Ast__loc_t eloc1_11 = v_466.t1;
             fx_str_t slit_199 = FX_MAKE_STR("all the scalar elements of the vector should have the same type");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_2, elemtyp1_3, &eloc1_11,
-                  &slit_199, 0), _fx_catch_172);
+                  &slit_199, 0), _fx_catch_176);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  elem_1, &env_2, sc_2, &v_467, 0), _fx_catch_172);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(v_467, elems_3, true, &v_456), _fx_catch_172);
+                  elem_1, &env_2, sc_2, &v_467, 0), _fx_catch_176);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_467, elems_3, true, &v_456), _fx_catch_176);
 
-         _fx_catch_172: ;
+         _fx_catch_176: ;
             if (v_467) {
                _fx_free_N10Ast__exp_t(&v_467);
             }
@@ -26442,35 +26894,35 @@ FX_EXTERN_C int
             _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_466);
 
          _fx_endmatch_34: ;
-            FX_CHECK_EXN(_fx_catch_173);
+            FX_CHECK_EXN(_fx_catch_177);
             _fx_free_LN10Ast__exp_t(&__fold_result___7);
             FX_COPY_PTR(v_456, &__fold_result___7);
 
-         _fx_catch_173: ;
+         _fx_catch_177: ;
             if (v_456) {
                _fx_free_LN10Ast__exp_t(&v_456);
             }
             if (elems_3) {
                _fx_free_LN10Ast__exp_t(&elems_3);
             }
-            FX_CHECK_EXN(_fx_catch_174);
+            FX_CHECK_EXN(_fx_catch_178);
          }
          FX_COPY_PTR(__fold_result___7, &elems_2);
-         FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(elemtyp_2, &vectyp_0), _fx_catch_174);
+         FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(elemtyp_2, &vectyp_0), _fx_catch_178);
          fx_str_t slit_200 =
             FX_MAKE_STR(
                "the constructed vector has type \'{typ2str(vectype)}\', but is expected to have type \'{typ2str(etyp)}\'");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(vectyp_0, etyp_0, &eloc_0, &slit_200, 0),
-            _fx_catch_174);
-         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_2, &v_455, 0), _fx_catch_174);
+            _fx_catch_178);
+         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_2, &v_455, 0), _fx_catch_178);
          FX_CALL(_fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_455, &ctx_0, &result_47),
-            _fx_catch_174);
+            _fx_catch_178);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_47, &result_0);
-         FX_BREAK(_fx_catch_174);
+         FX_BREAK(_fx_catch_178);
 
-      _fx_catch_174: ;
+      _fx_catch_178: ;
          if (result_47) {
             _fx_free_N10Ast__exp_t(&result_47);
          }
@@ -26515,14 +26967,14 @@ FX_EXTERN_C int
          for (; lst_20; lst_20 = lst_20->tl) {
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___3 = &lst_20->hd;
             _fx_LR9Ast__id_t node_10 = 0;
-            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___3->t0, 0, false, &node_10), _fx_catch_175);
+            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___3->t0, 0, false, &node_10), _fx_catch_179);
             FX_LIST_APPEND(v_468, lstend_10, node_10);
 
-         _fx_catch_175: ;
-            FX_CHECK_EXN(_fx_catch_179);
+         _fx_catch_179: ;
+            FX_CHECK_EXN(_fx_catch_183);
          }
          FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_468, &eloc_0, 0),
-            _fx_catch_179);
+            _fx_catch_183);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_11 = 0;
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lstend_12 = 0;
          FX_COPY_PTR(r_initializers_2, &r_initializers_1);
@@ -26542,25 +26994,25 @@ FX_EXTERN_C int
             FX_COPY_PTR(__pat___4->t1, &e_7);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  e_7, &env_2, sc_2, &e_8, 0), _fx_catch_176);
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_8, &v_472, 0), _fx_catch_176);
+                  e_7, &env_2, sc_2, &e_8, 0), _fx_catch_180);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_8, &v_472, 0), _fx_catch_180);
             FX_COPY_PTR(v_472.t0, &etypi_0);
             _fx_R10Ast__loc_t eloci_0 = v_472.t1;
             _fx_make_T2R9Ast__id_tN10Ast__exp_t(&n_1, e_8, &v_473);
-            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_474, 0), _fx_catch_176);
-            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloci_0, &v_475), _fx_catch_176);
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_474, 0), _fx_catch_180);
+            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloci_0, &v_475), _fx_catch_180);
             _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_474, &n_1, etypi_0, v_475, &v_476);
             _fx_make_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_473, &v_476,
                &tup_0);
             _fx_LT2R9Ast__id_tN10Ast__exp_t node_11 = 0;
-            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&tup_0.t0, 0, false, &node_11), _fx_catch_176);
+            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&tup_0.t0, 0, false, &node_11), _fx_catch_180);
             FX_LIST_APPEND(lst_18, lstend_11, node_11);
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t node_12 = 0;
             FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0.t1, 0, false, &node_12),
-               _fx_catch_176);
+               _fx_catch_180);
             FX_LIST_APPEND(lst_19, lstend_12, node_12);
 
-         _fx_catch_176: ;
+         _fx_catch_180: ;
             _fx_free_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0);
             _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_476);
             if (v_475) {
@@ -26578,30 +27030,30 @@ FX_EXTERN_C int
             if (e_7) {
                _fx_free_N10Ast__exp_t(&e_7);
             }
-            FX_CHECK_EXN(_fx_catch_179);
+            FX_CHECK_EXN(_fx_catch_183);
          }
          _fx_make_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(lst_18, lst_19,
             &v_469);
          FX_COPY_PTR(v_469.t0, &r_new_initializers_0);
          FX_COPY_PTR(v_469.t1, &relems_1);
          _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(relems_1, false, &v_470);
-         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_470, &v_471), _fx_catch_179);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_470, &v_471), _fx_catch_183);
          FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_471, &rtyp_0),
-            _fx_catch_179);
+            _fx_catch_183);
          if (FX_REC_VARIANT_TAG(r_e_0) == 1) {
             _fx_N10Ast__exp_t result_48 = 0;
             fx_str_t slit_201 = FX_MAKE_STR("unexpected record type");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, rtyp_0, &eloc_0, &slit_201, 0),
-               _fx_catch_177);
+               _fx_catch_181);
             FX_CALL(
                _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(r_e_0,
-                  r_new_initializers_0, &ctx_0, &result_48), _fx_catch_177);
+                  r_new_initializers_0, &ctx_0, &result_48), _fx_catch_181);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_48, &result_0);
-            FX_BREAK(_fx_catch_177);
+            FX_BREAK(_fx_catch_181);
 
-         _fx_catch_177: ;
+         _fx_catch_181: ;
             if (result_48) {
                _fx_free_N10Ast__exp_t(&result_48);
             }
@@ -26613,27 +27065,27 @@ FX_EXTERN_C int
             _fx_N10Ast__typ_t r_expected_typ_0 = 0;
             _fx_N10Ast__exp_t new_r_e_0 = 0;
             _fx_N10Ast__exp_t result_49 = 0;
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_0, &v_477, 0), _fx_catch_178);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_0, &v_477, 0), _fx_catch_182);
             FX_COPY_PTR(v_477.t0, &r_etyp_0);
             _fx_R10Ast__loc_t r_eloc_0 = v_477.t1;
-            FX_CALL(_fx_cons_LN10Ast__typ_t(rtyp_0, 0, true, &v_478), _fx_catch_178);
+            FX_CALL(_fx_cons_LN10Ast__typ_t(rtyp_0, 0, true, &v_478), _fx_catch_182);
             FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_478, etyp_0, &r_expected_typ_0),
-               _fx_catch_178);
+               _fx_catch_182);
             fx_str_t slit_202 = FX_MAKE_STR("there is no proper record constructor/function with record argument");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(r_etyp_0, r_expected_typ_0, &r_eloc_0,
-                  &slit_202, 0), _fx_catch_178);
+                  &slit_202, 0), _fx_catch_182);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  r_e_0, &env_2, sc_2, &new_r_e_0, 0), _fx_catch_178);
+                  r_e_0, &env_2, sc_2, &new_r_e_0, 0), _fx_catch_182);
             FX_CALL(
                _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_r_e_0,
-                  r_new_initializers_0, &ctx_0, &result_49), _fx_catch_178);
+                  r_new_initializers_0, &ctx_0, &result_49), _fx_catch_182);
             _fx_free_N10Ast__exp_t(&result_0);
             FX_COPY_PTR(result_49, &result_0);
-            FX_BREAK(_fx_catch_178);
+            FX_BREAK(_fx_catch_182);
 
-         _fx_catch_178: ;
+         _fx_catch_182: ;
             if (result_49) {
                _fx_free_N10Ast__exp_t(&result_49);
             }
@@ -26651,9 +27103,9 @@ FX_EXTERN_C int
             }
             _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_477);
          }
-         FX_CHECK_EXN(_fx_catch_179);
+         FX_CHECK_EXN(_fx_catch_183);
 
-      _fx_catch_179: ;
+      _fx_catch_183: ;
          if (rtyp_0) {
             _fx_free_N10Ast__typ_t(&rtyp_0);
          }
@@ -26703,26 +27155,26 @@ FX_EXTERN_C int
          for (; lst_22; lst_22 = lst_22->tl) {
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___5 = &lst_22->hd;
             _fx_LR9Ast__id_t node_13 = 0;
-            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___5->t0, 0, false, &node_13), _fx_catch_180);
+            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___5->t0, 0, false, &node_13), _fx_catch_184);
             FX_LIST_APPEND(v_479, lstend_13, node_13);
 
-         _fx_catch_180: ;
-            FX_CHECK_EXN(_fx_catch_184);
+         _fx_catch_184: ;
+            FX_CHECK_EXN(_fx_catch_188);
          }
          FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_479, &eloc_0, 0),
-            _fx_catch_184);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_1, &v_480, 0), _fx_catch_184);
+            _fx_catch_188);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_1, &v_480, 0), _fx_catch_188);
          FX_COPY_PTR(v_480.t0, &rtyp_1);
          _fx_R10Ast__loc_t rloc_0 = v_480.t1;
          fx_str_t slit_203 = FX_MAKE_STR("the types of the update-record argument and the result do not match");
          FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(rtyp_1, etyp_0, &eloc_0, &slit_203, 0),
-            _fx_catch_184);
+            _fx_catch_188);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_184);
+               r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_188);
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g22Ast_typecheck__None12_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_184);
+               &_fx_g22Ast_typecheck__None13_, rtyp_1, false, &rloc_0, &v_481, 0), _fx_catch_188);
          FX_COPY_PTR(v_481.t1, &relems_2);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_14 = 0;
          FX_COPY_PTR(r_initializers_5, &r_initializers_4);
@@ -26737,36 +27189,36 @@ FX_EXTERN_C int
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___6 = &lst_23->hd;
             _fx_R9Ast__id_t ni_0 = __pat___6->t0;
             FX_COPY_PTR(__pat___6->t1, &ei_0);
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(ei_0, &v_482, 0), _fx_catch_183);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(ei_0, &v_482, 0), _fx_catch_187);
             FX_COPY_PTR(v_482.t0, &ei_typ_0);
             _fx_R10Ast__loc_t ei_loc_0 = v_482.t1;
             _fx_M13Ast_typecheckFM9make_fp1_FPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(&ni_0,
                &__lambda___1);
             FX_CALL(
                _fx_M13Ast_typecheckFM8find_optNt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tFPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
-                  relems_2, &__lambda___1, &v_483, 0), _fx_catch_183);
+                  relems_2, &__lambda___1, &v_483, 0), _fx_catch_187);
             if (v_483.tag == 2) {
                fx_str_t v_484 = {0};
                fx_str_t v_485 = {0};
                fx_str_t v_486 = {0};
                _fx_N10Ast__exp_t new_ei_0 = 0;
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_484, 0), _fx_catch_181);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_484, &v_485, 0), _fx_catch_181);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_484, 0), _fx_catch_185);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_484, &v_485, 0), _fx_catch_185);
                fx_str_t slit_204 = FX_MAKE_STR("invalid type of the initializer of record field \'");
                fx_str_t slit_205 = FX_MAKE_STR("\'");
                {
                   const fx_str_t strs_26[] = { slit_204, v_485, slit_205 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_486), _fx_catch_181);
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_486), _fx_catch_185);
                }
                FX_CALL(
                   _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_483.u.Some.t2, ei_typ_0, &ei_loc_0,
-                     &v_486, 0), _fx_catch_181);
+                     &v_486, 0), _fx_catch_185);
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     ei_0, &env_2, sc_2, &new_ei_0, 0), _fx_catch_181);
+                     ei_0, &env_2, sc_2, &new_ei_0, 0), _fx_catch_185);
                _fx_make_T2R9Ast__id_tN10Ast__exp_t(&ni_0, new_ei_0, &res_37);
 
-            _fx_catch_181: ;
+            _fx_catch_185: ;
                if (new_ei_0) {
                   _fx_free_N10Ast__exp_t(&new_ei_0);
                }
@@ -26779,29 +27231,29 @@ FX_EXTERN_C int
                fx_str_t v_488 = {0};
                fx_str_t v_489 = {0};
                fx_exn_t v_490 = {0};
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_487, 0), _fx_catch_182);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_487, &v_488, 0), _fx_catch_182);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_487, 0), _fx_catch_186);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_487, &v_488, 0), _fx_catch_186);
                fx_str_t slit_206 = FX_MAKE_STR("there is no record field \'");
                fx_str_t slit_207 = FX_MAKE_STR("\' in the updated record");
                {
                   const fx_str_t strs_27[] = { slit_206, v_488, slit_207 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_489), _fx_catch_182);
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_489), _fx_catch_186);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&ei_loc_0, &v_489, &v_490, 0), _fx_catch_182);
-               FX_THROW(&v_490, false, _fx_catch_182);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&ei_loc_0, &v_489, &v_490, 0), _fx_catch_186);
+               FX_THROW(&v_490, false, _fx_catch_186);
 
-            _fx_catch_182: ;
+            _fx_catch_186: ;
                fx_free_exn(&v_490);
                FX_FREE_STR(&v_489);
                FX_FREE_STR(&v_488);
                FX_FREE_STR(&v_487);
             }
-            FX_CHECK_EXN(_fx_catch_183);
+            FX_CHECK_EXN(_fx_catch_187);
             _fx_LT2R9Ast__id_tN10Ast__exp_t node_14 = 0;
-            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&res_37, 0, false, &node_14), _fx_catch_183);
+            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&res_37, 0, false, &node_14), _fx_catch_187);
             FX_LIST_APPEND(new_r_initializers_0, lstend_14, node_14);
 
-         _fx_catch_183: ;
+         _fx_catch_187: ;
             _fx_free_T2R9Ast__id_tN10Ast__exp_t(&res_37);
             _fx_free_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_483);
             FX_FREE_FP(&__lambda___1);
@@ -26812,16 +27264,16 @@ FX_EXTERN_C int
             if (ei_0) {
                _fx_free_N10Ast__exp_t(&ei_0);
             }
-            FX_CHECK_EXN(_fx_catch_184);
+            FX_CHECK_EXN(_fx_catch_188);
          }
          FX_CALL(
             _fx_M3AstFM15ExpUpdateRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_r_e_1,
-               new_r_initializers_0, &ctx_0, &result_50), _fx_catch_184);
+               new_r_initializers_0, &ctx_0, &result_50), _fx_catch_188);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_50, &result_0);
-         FX_BREAK(_fx_catch_184);
+         FX_BREAK(_fx_catch_188);
 
-      _fx_catch_184: ;
+      _fx_catch_188: ;
          if (result_50) {
             _fx_free_N10Ast__exp_t(&result_50);
          }
@@ -26858,29 +27310,29 @@ FX_EXTERN_C int
          _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_33 = &e_2->u.ExpTryCatch;
          _fx_N10Ast__exp_t e1_7 = vcase_33->t0;
          _fx_N12Ast__scope_t v_492;
-         FX_CALL(_fx_M3AstFM13new_try_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_492, 0), _fx_catch_185);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_492, sc_2, true, &sc_3), _fx_catch_185);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_7, &v_491, 0), _fx_catch_185);
+         FX_CALL(_fx_M3AstFM13new_try_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_492, 0), _fx_catch_189);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_492, sc_2, true, &sc_3), _fx_catch_189);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_7, &v_491, 0), _fx_catch_189);
          FX_COPY_PTR(v_491.t0, &e1typ_0);
          _fx_R10Ast__loc_t e1loc_0 = v_491.t1;
          fx_str_t slit_208 = FX_MAKE_STR("try body type does match the whole try-catch type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, e1typ_0, &e1loc_0, &slit_208, 0),
-            _fx_catch_185);
+            _fx_catch_189);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e1_7, &env_2, sc_3, &new_e1_12, 0), _fx_catch_185);
+               e1_7, &env_2, sc_3, &new_e1_12, 0), _fx_catch_189);
          FX_CALL(
             _fx_M13Ast_typecheckFM11check_casesLT2N10Ast__pat_tN10Ast__exp_t6LT2N10Ast__pat_tN10Ast__exp_tN10Ast__typ_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_33->t1, _fx_g21Ast_typecheck__TypExn, etyp_0, &env_2, sc_3, &eloc_0, &new_cases_0, 0), _fx_catch_185);
+               vcase_33->t1, _fx_g21Ast_typecheck__TypExn, etyp_0, &env_2, sc_3, &eloc_0, &new_cases_0, 0), _fx_catch_189);
          FX_CALL(
             _fx_M3AstFM11ExpTryCatchN10Ast__exp_t3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_e1_12,
-               new_cases_0, &ctx_0, &result_51), _fx_catch_185);
+               new_cases_0, &ctx_0, &result_51), _fx_catch_189);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_51, &result_0);
-         FX_BREAK(_fx_catch_185);
+         FX_BREAK(_fx_catch_189);
 
-      _fx_catch_185: ;
+      _fx_catch_189: ;
          if (result_51) {
             _fx_free_N10Ast__exp_t(&result_51);
          }
@@ -26905,19 +27357,19 @@ FX_EXTERN_C int
          _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_34 = &e_2->u.ExpMatch;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               vcase_34->t0, &env_2, sc_2, &new_e1_13, 0), _fx_catch_186);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_e1_13, &new_e1typ_0, 0), _fx_catch_186);
+               vcase_34->t0, &env_2, sc_2, &new_e1_13, 0), _fx_catch_190);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_e1_13, &new_e1typ_0, 0), _fx_catch_190);
          FX_CALL(
             _fx_M13Ast_typecheckFM11check_casesLT2N10Ast__pat_tN10Ast__exp_t6LT2N10Ast__pat_tN10Ast__exp_tN10Ast__typ_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_34->t1, new_e1typ_0, etyp_0, &env_2, sc_2, &eloc_0, &new_cases_1, 0), _fx_catch_186);
+               vcase_34->t1, new_e1typ_0, etyp_0, &env_2, sc_2, &eloc_0, &new_cases_1, 0), _fx_catch_190);
          FX_CALL(
             _fx_M3AstFM8ExpMatchN10Ast__exp_t3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_e1_13,
-               new_cases_1, &ctx_0, &result_52), _fx_catch_186);
+               new_cases_1, &ctx_0, &result_52), _fx_catch_190);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_52, &result_0);
-         FX_BREAK(_fx_catch_186);
+         FX_BREAK(_fx_catch_190);
 
-      _fx_catch_186: ;
+      _fx_catch_190: ;
          if (result_52) {
             _fx_free_N10Ast__exp_t(&result_52);
          }
@@ -26946,13 +27398,13 @@ FX_EXTERN_C int
          _fx_T3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tR10Ast__loc_t* vcase_35 = &e_2->u.ExpCast;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_35->t1, &env_2, sc_2, &eloc_0, &t2_0, 0), _fx_catch_201);
+               vcase_35->t1, &env_2, sc_2, &eloc_0, &t2_0, 0), _fx_catch_205);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               vcase_35->t0, &env_2, sc_2, &e1_8, 0), _fx_catch_201);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_8, &t1_0, 0), _fx_catch_201);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_493, 0), _fx_catch_201);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_494, 0), _fx_catch_201);
+               vcase_35->t0, &env_2, sc_2, &e1_8, 0), _fx_catch_205);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_8, &t1_0, 0), _fx_catch_205);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_493, 0), _fx_catch_205);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_494, 0), _fx_catch_205);
          bool res_38;
          if (FX_REC_VARIANT_TAG(e1_8) == 7) {
             res_38 = true;
@@ -26963,7 +27415,7 @@ FX_EXTERN_C int
          else {
             res_38 = false;
          }
-         FX_CHECK_EXN(_fx_catch_201);
+         FX_CHECK_EXN(_fx_catch_205);
          if (res_38) {
             _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_495); goto _fx_endmatch_35;
          }
@@ -26977,7 +27429,7 @@ FX_EXTERN_C int
          else {
             res_39 = false;
          }
-         FX_CHECK_EXN(_fx_catch_201);
+         FX_CHECK_EXN(_fx_catch_205);
          if (res_39) {
             _fx_R16Ast__val_flags_t flags_2 = {0};
             _fx_R13Ast__defval_t dv_0 = {0};
@@ -26989,22 +27441,22 @@ FX_EXTERN_C int
             _fx_LN10Ast__exp_t v_503 = 0;
             _fx_R9Ast__id_t temp_id_0;
             fx_str_t slit_209 = FX_MAKE_STR("v");
-            FX_CALL(_fx_M3AstFM6gen_idRM4id_t2iS(curr_m_idx_0, &slit_209, &temp_id_0, 0), _fx_catch_187);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&flags_2, 0), _fx_catch_187);
+            FX_CALL(_fx_M3AstFM6gen_idRM4id_t2iS(curr_m_idx_0, &slit_209, &temp_id_0, 0), _fx_catch_191);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&flags_2, 0), _fx_catch_191);
             _fx_make_R13Ast__defval_t(&temp_id_0, t1_0, &flags_2, sc_2, &eloc_0, &dv_0);
             _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_0, &v_498);
-            FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&temp_id_0, &v_498, 0), _fx_catch_187);
+            FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&temp_id_0, &v_498, 0), _fx_catch_191);
             _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t1_0, &eloc_0, &v_499);
             FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&temp_id_0, &v_499, &v_500),
-               _fx_catch_187);
-            FX_CALL(_fx_M3AstFM8PatIdentN10Ast__pat_t2RM4id_tRM5loc_t(&temp_id_0, &eloc_0, &v_501), _fx_catch_187);
+               _fx_catch_191);
+            FX_CALL(_fx_M3AstFM8PatIdentN10Ast__pat_t2RM4id_tRM5loc_t(&temp_id_0, &eloc_0, &v_501), _fx_catch_191);
             FX_CALL(
                _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(v_501, e1_8, &flags_2, &eloc_0,
-                  &v_502), _fx_catch_187);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(v_502, 0, true, &v_503), _fx_catch_187);
+                  &v_502), _fx_catch_191);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_502, 0, true, &v_503), _fx_catch_191);
             _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(v_500, v_503, &v_495);
 
-         _fx_catch_187: ;
+         _fx_catch_191: ;
             if (v_503) {
                _fx_free_LN10Ast__exp_t(&v_503);
             }
@@ -27026,11 +27478,11 @@ FX_EXTERN_C int
          _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_495);
 
       _fx_endmatch_35: ;
-         FX_CHECK_EXN(_fx_catch_201);
+         FX_CHECK_EXN(_fx_catch_205);
          FX_COPY_PTR(v_495.t0, &e1_9);
          FX_COPY_PTR(v_495.t1, &code_1);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_496, 0), _fx_catch_201);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_497, 0), _fx_catch_201);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_496, 0), _fx_catch_205);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_497, 0), _fx_catch_205);
          if (FX_REC_VARIANT_TAG(v_497) == 25) {
             _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_36 = &v_497->u.TypApp;
             if (vcase_36->t0 == 0) {
@@ -27043,13 +27495,13 @@ FX_EXTERN_C int
                      _fx_R9Ast__id_t* tn1_0 = &vcase_37->t1;
                      _fx_R9Ast__id_t* tn2_0 = &vcase_36->t1;
                      bool res_40;
-                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(tn1_0, tn2_0, &res_40, 0), _fx_catch_194);
+                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(tn1_0, tn2_0, &res_40, 0), _fx_catch_198);
                      if (res_40) {
                         FX_COPY_PTR(e1_9, &new_e1_14);
                      }
                      else {
-                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn1_0, &eloc_0, &v_504, 0), _fx_catch_194);
-                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn2_0, &eloc_0, &v_505, 0), _fx_catch_194);
+                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn1_0, &eloc_0, &v_504, 0), _fx_catch_198);
+                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn2_0, &eloc_0, &v_505, 0), _fx_catch_198);
                         if (v_504.tag == 6) {
                            if (v_505.tag == 6) {
                               fx_str_t v_506 = {0};
@@ -27058,21 +27510,21 @@ FX_EXTERN_C int
                               fx_str_t v_509 = {0};
                               fx_str_t v_510 = {0};
                               fx_exn_t v_511 = {0};
-                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_506, 0), _fx_catch_188);
-                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_506, &v_507, 0), _fx_catch_188);
-                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn2_0, &v_508, 0), _fx_catch_188);
-                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_508, &v_509, 0), _fx_catch_188);
+                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_506, 0), _fx_catch_192);
+                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_506, &v_507, 0), _fx_catch_192);
+                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn2_0, &v_508, 0), _fx_catch_192);
+                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_508, &v_509, 0), _fx_catch_192);
                               fx_str_t slit_210 = FX_MAKE_STR("variant/record type \'");
                               fx_str_t slit_211 = FX_MAKE_STR("\' cannot be casted to another variant/record type \'");
                               fx_str_t slit_212 = FX_MAKE_STR("\'; define a custom function to do the conversion and call it");
                               {
                                  const fx_str_t strs_28[] = { slit_210, v_507, slit_211, v_509, slit_212 };
-                                 FX_CALL(fx_strjoin(0, 0, 0, strs_28, 5, &v_510), _fx_catch_188);
+                                 FX_CALL(fx_strjoin(0, 0, 0, strs_28, 5, &v_510), _fx_catch_192);
                               }
-                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_510, &v_511, 0), _fx_catch_188);
-                              FX_THROW(&v_511, false, _fx_catch_188);
+                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_510, &v_511, 0), _fx_catch_192);
+                              FX_THROW(&v_511, false, _fx_catch_192);
 
-                           _fx_catch_188: ;
+                           _fx_catch_192: ;
                               fx_free_exn(&v_511);
                               FX_FREE_STR(&v_510);
                               FX_FREE_STR(&v_509);
@@ -27107,20 +27559,20 @@ FX_EXTERN_C int
                                  bool v_522;
                                  FX_CALL(
                                     _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_2, di_name_0, &eloc_0, &v_522, 0),
-                                    _fx_catch_189);
+                                    _fx_catch_193);
                                  if (v_522) {
-                                    __fold_result___8 = true; FX_BREAK(_fx_catch_189);
+                                    __fold_result___8 = true; FX_BREAK(_fx_catch_193);
                                  }
 
-                              _fx_catch_189: ;
+                              _fx_catch_193: ;
                                  FX_CHECK_BREAK();
-                                 FX_CHECK_EXN(_fx_catch_190);
+                                 FX_CHECK_EXN(_fx_catch_194);
                               }
                               if (!__fold_result___8) {
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_514, 0), _fx_catch_190);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_514, &v_515, 0), _fx_catch_190);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_0, &v_516, 0), _fx_catch_190);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_516, &v_517, 0), _fx_catch_190);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_514, 0), _fx_catch_194);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_514, &v_515, 0), _fx_catch_194);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_0, &v_516, 0), _fx_catch_194);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_516, &v_517, 0), _fx_catch_194);
                                  fx_str_t slit_213 = FX_MAKE_STR("variant/record type \'");
                                  fx_str_t slit_214 = FX_MAKE_STR("\' is casted to interface \'");
                                  fx_str_t slit_215 =
@@ -27128,18 +27580,18 @@ FX_EXTERN_C int
                                        "\', but the type does not implement any of the interfaces that can be casted to the interface");
                                  {
                                     const fx_str_t strs_29[] = { slit_213, v_515, slit_214, v_517, slit_215 };
-                                    FX_CALL(fx_strjoin(0, 0, 0, strs_29, 5, &v_518), _fx_catch_190);
+                                    FX_CALL(fx_strjoin(0, 0, 0, strs_29, 5, &v_518), _fx_catch_194);
                                  }
-                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_518, &v_519, 0), _fx_catch_190);
-                                 FX_THROW(&v_519, false, _fx_catch_190);
+                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_518, &v_519, 0), _fx_catch_194);
+                                 FX_THROW(&v_519, false, _fx_catch_194);
                               }
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_520), _fx_catch_190);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_520), _fx_catch_194);
                               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_521);
                               FX_CALL(
                                  _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_520, &v_521, &new_e1_14), _fx_catch_190);
+                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_520, &v_521, &new_e1_14), _fx_catch_194);
 
-                           _fx_catch_190: ;
+                           _fx_catch_194: ;
                               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_521);
                               if (v_520) {
                                  _fx_free_LN10Ast__exp_t(&v_520);
@@ -27185,40 +27637,40 @@ FX_EXTERN_C int
                                  bool v_535;
                                  FX_CALL(
                                     _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_3, di_name_1, &eloc_0, &v_535, 0),
-                                    _fx_catch_191);
+                                    _fx_catch_195);
                                  if (v_535) {
-                                    __fold_result___9 = true; FX_BREAK(_fx_catch_191);
+                                    __fold_result___9 = true; FX_BREAK(_fx_catch_195);
                                  }
 
-                              _fx_catch_191: ;
+                              _fx_catch_195: ;
                                  FX_CHECK_BREAK();
-                                 FX_CHECK_EXN(_fx_catch_192);
+                                 FX_CHECK_EXN(_fx_catch_196);
                               }
                               if (!__fold_result___9) {
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_525, 0), _fx_catch_192);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_525, &v_526, 0), _fx_catch_192);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_527, 0), _fx_catch_192);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_527, &v_528, 0), _fx_catch_192);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_529, 0), _fx_catch_192);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_529, &v_530, 0), _fx_catch_192);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_525, 0), _fx_catch_196);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_525, &v_526, 0), _fx_catch_196);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_527, 0), _fx_catch_196);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_527, &v_528, 0), _fx_catch_196);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_529, 0), _fx_catch_196);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_529, &v_530, 0), _fx_catch_196);
                                  fx_str_t slit_216 = FX_MAKE_STR("interface \'");
                                  fx_str_t slit_217 = FX_MAKE_STR("\' is casted to variant/record type \'");
                                  fx_str_t slit_218 = FX_MAKE_STR("\', but the type does not implement neither \'");
                                  fx_str_t slit_219 = FX_MAKE_STR("\' nor anything derived from it");
                                  {
                                     const fx_str_t strs_30[] = { slit_216, v_526, slit_217, v_528, slit_218, v_530, slit_219 };
-                                    FX_CALL(fx_strjoin(0, 0, 0, strs_30, 7, &v_531), _fx_catch_192);
+                                    FX_CALL(fx_strjoin(0, 0, 0, strs_30, 7, &v_531), _fx_catch_196);
                                  }
-                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_531, &v_532, 0), _fx_catch_192);
-                                 FX_THROW(&v_532, false, _fx_catch_192);
+                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_531, &v_532, 0), _fx_catch_196);
+                                 FX_THROW(&v_532, false, _fx_catch_196);
                               }
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_533), _fx_catch_192);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_533), _fx_catch_196);
                               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_534);
                               FX_CALL(
                                  _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g30Ast_typecheck__IntrinGetObject, v_533, &v_534, &new_e1_14), _fx_catch_192);
+                                    &_fx_g30Ast_typecheck__IntrinGetObject, v_533, &v_534, &new_e1_14), _fx_catch_196);
 
-                           _fx_catch_192: ;
+                           _fx_catch_196: ;
                               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_534);
                               if (v_533) {
                                  _fx_free_LN10Ast__exp_t(&v_533);
@@ -27243,13 +27695,13 @@ FX_EXTERN_C int
                            if (v_505.tag == 7) {
                               _fx_LN10Ast__exp_t v_536 = 0;
                               _fx_T2N10Ast__typ_tR10Ast__loc_t v_537 = {0};
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_536), _fx_catch_193);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_536), _fx_catch_197);
                               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_537);
                               FX_CALL(
                                  _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_536, &v_537, &new_e1_14), _fx_catch_193);
+                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_536, &v_537, &new_e1_14), _fx_catch_197);
 
-                           _fx_catch_193: ;
+                           _fx_catch_197: ;
                               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_537);
                               if (v_536) {
                                  _fx_free_LN10Ast__exp_t(&v_536);
@@ -27257,21 +27709,21 @@ FX_EXTERN_C int
                               goto _fx_endmatch_36;
                            }
                         }
-                        FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_194);
+                        FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_198);
 
                      _fx_endmatch_36: ;
-                        FX_CHECK_EXN(_fx_catch_194);
+                        FX_CHECK_EXN(_fx_catch_198);
                      }
                      fx_str_t slit_220 =
                         FX_MAKE_STR("the output type of cast operation \'{t2}\' does not match the expected type \'{etyp}\'");
                      FX_CALL(
                         _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t2_0, etyp_0, &eloc_0, &slit_220,
-                           0), _fx_catch_194);
+                           0), _fx_catch_198);
                      _fx_free_N10Ast__exp_t(&result_0);
                      FX_COPY_PTR(new_e1_14, &result_0);
-                     FX_BREAK(_fx_catch_194);
+                     FX_BREAK(_fx_catch_198);
 
-                  _fx_catch_194: ;
+                  _fx_catch_198: ;
                      _fx_free_N14Ast__id_info_t(&v_505);
                      _fx_free_N14Ast__id_info_t(&v_504);
                      if (new_e1_14) {
@@ -27291,20 +27743,20 @@ FX_EXTERN_C int
          fx_str_t v_544 = {0};
          fx_exn_t v_545 = {0};
          _fx_N10Ast__exp_t result_53 = 0;
-         fx_exn_t exn_3 = {0};
+         fx_exn_t exn_5 = {0};
          bool v_546;
-         FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t1_0, &v_546, 0), _fx_catch_200);
+         FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t1_0, &v_546, 0), _fx_catch_204);
          bool v_547;
          bool t_18;
          if (!v_546) {
-            bool v_548; FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t2_0, &v_548, 0), _fx_catch_200); t_18 = !v_548;
+            bool v_548; FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t2_0, &v_548, 0), _fx_catch_204); t_18 = !v_548;
          }
          else {
             t_18 = false;
          }
          if (t_18) {
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_538, 0), _fx_catch_200);
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_539, 0), _fx_catch_200);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_538, 0), _fx_catch_204);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_539, 0), _fx_catch_204);
             if (FX_REC_VARIANT_TAG(v_538) == 18) {
                if (FX_REC_VARIANT_TAG(v_539) == 18) {
                   v_547 = false; goto _fx_endmatch_37;
@@ -27313,47 +27765,47 @@ FX_EXTERN_C int
             v_547 = true;
 
          _fx_endmatch_37: ;
-            FX_CHECK_EXN(_fx_catch_200);
+            FX_CHECK_EXN(_fx_catch_204);
          }
          else {
             v_547 = false;
          }
          if (v_547) {
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_540, 0), _fx_catch_200);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_540, &v_541, 0), _fx_catch_200);
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_542, 0), _fx_catch_200);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_542, &v_543, 0), _fx_catch_200);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_540, 0), _fx_catch_204);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_540, &v_541, 0), _fx_catch_204);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_542, 0), _fx_catch_204);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_542, &v_543, 0), _fx_catch_204);
             fx_str_t slit_221 = FX_MAKE_STR("invalid cast operation: \'");
             fx_str_t slit_222 = FX_MAKE_STR("\' to \'");
             fx_str_t slit_223 = FX_MAKE_STR("\'");
             {
                const fx_str_t strs_31[] = { slit_221, v_541, slit_222, v_543, slit_223 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_31, 5, &v_544), _fx_catch_200);
+               FX_CALL(fx_strjoin(0, 0, 0, strs_31, 5, &v_544), _fx_catch_204);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_544, &v_545, 0), _fx_catch_200);
-            FX_THROW(&v_545, false, _fx_catch_200);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_544, &v_545, 0), _fx_catch_204);
+            FX_THROW(&v_545, false, _fx_catch_204);
          }
          _fx_N10Ast__exp_t e2_4 = 0;
          _fx_N10Ast__typ_t t2_1 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(e1_9, t1_0, t2_0,
-               &eloc_0, &e2_4, 0), _fx_catch_196);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e2_4, &t2_1, 0), _fx_catch_196);
+               &eloc_0, &e2_4, 0), _fx_catch_200);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e2_4, &t2_1, 0), _fx_catch_200);
          fx_str_t slit_224 = FX_MAKE_STR("unexpected type of cast operation");
          FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t2_1, &eloc_0, &slit_224, 0),
-            _fx_catch_196);
+            _fx_catch_200);
          if (code_1 != 0) {
             _fx_LN10Ast__exp_t v_549 = 0;
             _fx_LN10Ast__exp_t v_550 = 0;
             _fx_T2N10Ast__typ_tR10Ast__loc_t v_551 = {0};
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e2_4, 0, true, &v_549), _fx_catch_195);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e2_4, 0, true, &v_549), _fx_catch_199);
             FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(code_1, v_549, &v_550, 0),
-               _fx_catch_195);
+               _fx_catch_199);
             _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_1, &eloc_0, &v_551);
             FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_550, &v_551, &result_53),
-               _fx_catch_195);
+               _fx_catch_199);
 
-         _fx_catch_195: ;
+         _fx_catch_199: ;
             _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_551);
             if (v_550) {
                _fx_free_LN10Ast__exp_t(&v_550);
@@ -27365,9 +27817,9 @@ FX_EXTERN_C int
          else {
             FX_COPY_PTR(e2_4, &result_53);
          }
-         FX_CHECK_EXN(_fx_catch_196);
+         FX_CHECK_EXN(_fx_catch_200);
 
-      _fx_catch_196: ;
+      _fx_catch_200: ;
          if (e2_4) {
             _fx_free_N10Ast__exp_t(&e2_4);
          }
@@ -27375,53 +27827,53 @@ FX_EXTERN_C int
             _fx_free_N10Ast__typ_t(&t2_1);
          }
          if (fx_status < 0) {
-            fx_exn_get_and_reset(fx_status, &exn_3);
+            fx_exn_get_and_reset(fx_status, &exn_5);
             fx_status = 0;
             if (result_53) {
                _fx_free_N10Ast__exp_t(&result_53);
             }
-            if (exn_3.tag == _FX_EXN_E17Ast__CompileError) {
-               fx_exn_t exn_4 = {0};
+            if (exn_5.tag == _FX_EXN_E17Ast__CompileError) {
+               fx_exn_t exn_6 = {0};
                _fx_LN10Ast__exp_t v_552 = 0;
                _fx_R9Ast__id_t fname_0;
-               FX_CALL(_fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(t2_0, &eloc_0, &fname_0, 0), _fx_catch_197);
-               FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_552), _fx_catch_197);
+               FX_CALL(_fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(t2_0, &eloc_0, &fname_0, 0), _fx_catch_201);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_552), _fx_catch_201);
                FX_CALL(
                   _fx_M13Ast_typecheckFM19check_and_make_callN10Ast__exp_t7R9Ast__id_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_tR10Ast__loc_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tN10Ast__typ_tLN12Ast__scope_t(
-                     &fname_0, v_552, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &result_53, 0), _fx_catch_197);
+                     &fname_0, v_552, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &result_53, 0), _fx_catch_201);
 
-            _fx_catch_197: ;
+            _fx_catch_201: ;
                if (v_552) {
                   _fx_free_LN10Ast__exp_t(&v_552);
                }
                if (fx_status < 0) {
-                  fx_exn_get_and_reset(fx_status, &exn_4);
+                  fx_exn_get_and_reset(fx_status, &exn_6);
                   fx_status = 0;
                   if (result_53) {
                      _fx_free_N10Ast__exp_t(&result_53);
                   }
-                  if (exn_4.tag == _FX_EXN_E17Ast__CompileError) {
+                  if (exn_6.tag == _FX_EXN_E17Ast__CompileError) {
                      fx_str_t v_553 = {0};
                      fx_str_t v_554 = {0};
                      fx_str_t v_555 = {0};
                      fx_str_t v_556 = {0};
                      fx_str_t v_557 = {0};
                      fx_exn_t v_558 = {0};
-                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_553, 0), _fx_catch_198);
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_553, &v_554, 0), _fx_catch_198);
-                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_555, 0), _fx_catch_198);
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_555, &v_556, 0), _fx_catch_198);
+                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_553, 0), _fx_catch_202);
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_553, &v_554, 0), _fx_catch_202);
+                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_555, 0), _fx_catch_202);
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_555, &v_556, 0), _fx_catch_202);
                      fx_str_t slit_225 = FX_MAKE_STR("invalid cast operation: \'");
                      fx_str_t slit_226 = FX_MAKE_STR("\' to \'");
                      fx_str_t slit_227 = FX_MAKE_STR("\'");
                      {
                         const fx_str_t strs_32[] = { slit_225, v_554, slit_226, v_556, slit_227 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_557), _fx_catch_198);
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_557), _fx_catch_202);
                      }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_557, &v_558, 0), _fx_catch_198);
-                     FX_THROW(&v_558, false, _fx_catch_198);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_557, &v_558, 0), _fx_catch_202);
+                     FX_THROW(&v_558, false, _fx_catch_202);
 
-                  _fx_catch_198: ;
+                  _fx_catch_202: ;
                      fx_free_exn(&v_558);
                      FX_FREE_STR(&v_557);
                      FX_FREE_STR(&v_556);
@@ -27430,25 +27882,25 @@ FX_EXTERN_C int
                      FX_FREE_STR(&v_553);
                   }
                   else {
-                     FX_RETHROW(&exn_4, _fx_catch_199);
+                     FX_RETHROW(&exn_6, _fx_catch_203);
                   }
-                  FX_CHECK_EXN(_fx_catch_199);
+                  FX_CHECK_EXN(_fx_catch_203);
                }
 
-            _fx_catch_199: ;
-               fx_free_exn(&exn_4);
+            _fx_catch_203: ;
+               fx_free_exn(&exn_6);
             }
             else {
-               FX_RETHROW(&exn_3, _fx_catch_200);
+               FX_RETHROW(&exn_5, _fx_catch_204);
             }
-            FX_CHECK_EXN(_fx_catch_200);
+            FX_CHECK_EXN(_fx_catch_204);
          }
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_53, &result_0);
-         FX_BREAK(_fx_catch_200);
+         FX_BREAK(_fx_catch_204);
 
-      _fx_catch_200: ;
-         fx_free_exn(&exn_3);
+      _fx_catch_204: ;
+         fx_free_exn(&exn_5);
          if (result_53) {
             _fx_free_N10Ast__exp_t(&result_53);
          }
@@ -27466,9 +27918,9 @@ FX_EXTERN_C int
          }
 
       _fx_endmatch_38: ;
-         FX_CHECK_EXN(_fx_catch_201);
+         FX_CHECK_EXN(_fx_catch_205);
 
-      _fx_catch_201: ;
+      _fx_catch_205: ;
          if (v_497) {
             _fx_free_N10Ast__typ_t(&v_497);
          }
@@ -27509,29 +27961,29 @@ FX_EXTERN_C int
          _fx_N10Ast__exp_t e1_10 = vcase_38->t0;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_38->t1, &env_2, sc_2, &eloc_0, &new_t1_0, 0), _fx_catch_202);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_10, &v_559, 0), _fx_catch_202);
+               vcase_38->t1, &env_2, sc_2, &eloc_0, &new_t1_0, 0), _fx_catch_206);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_10, &v_559, 0), _fx_catch_206);
          FX_COPY_PTR(v_559.t0, &e1typ_1);
          _fx_R10Ast__loc_t e1loc_1 = v_559.t1;
          fx_str_t slit_228 = FX_MAKE_STR("improper explicit type of the expression");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, new_t1_0, &eloc_0, &slit_228, 0),
-            _fx_catch_202);
+            _fx_catch_206);
          fx_str_t slit_229 = FX_MAKE_STR("improper explicit type of the expression");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(e1typ_1, new_t1_0, &e1loc_1, &slit_229, 0),
-            _fx_catch_202);
+            _fx_catch_206);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e1_10, &env_2, sc_2, &new_e1_15, 0), _fx_catch_202);
+               e1_10, &env_2, sc_2, &new_e1_15, 0), _fx_catch_206);
          FX_CALL(
             _fx_M3AstFM8ExpTypedN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(new_e1_15, new_t1_0, &ctx_0,
-               &result_54), _fx_catch_202);
+               &result_54), _fx_catch_206);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_54, &result_0);
-         FX_BREAK(_fx_catch_202);
+         FX_BREAK(_fx_catch_206);
 
-      _fx_catch_202: ;
+      _fx_catch_206: ;
          if (result_54) {
             _fx_free_N10Ast__exp_t(&result_54);
          }
@@ -27552,16 +28004,16 @@ FX_EXTERN_C int
             if (sc_2->hd.tag == 10) {
                _fx_free_N10Ast__exp_t(&result_0);
                FX_COPY_PTR(e_2, &result_0);
-               FX_BREAK(_fx_catch_203);
+               FX_BREAK(_fx_catch_207);
 
-            _fx_catch_203: ;
+            _fx_catch_207: ;
                goto _fx_endmatch_39;
             }
          }
          fx_str_t str_0 = {0};
          fx_str_t str_1 = {0};
          _fx_N10Ast__exp_t result_55 = 0;
-         FX_CALL(_fx_M6StringFM5stripS1S(&e_2->u.ExpCCode.t0, &str_0, 0), _fx_catch_204);
+         FX_CALL(_fx_M6StringFM5stripS1S(&e_2->u.ExpCCode.t0, &str_0, 0), _fx_catch_208);
          bool v_560;
          if (_fx_M6StringFM8endswithB2SC(&str_0, (char_)125, 0)) {
             v_560 = true;
@@ -27574,14 +28026,14 @@ FX_EXTERN_C int
          }
          else {
             const fx_str_t strs_33[] = { str_0, FX_MAKE_STR1(";") };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &str_1), _fx_catch_204);
+            FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &str_1), _fx_catch_208);
          }
-         FX_CALL(_fx_M3AstFM8ExpCCodeN10Ast__exp_t2ST2N10Ast__typ_tRM5loc_t(&str_1, &ctx_0, &result_55), _fx_catch_204);
+         FX_CALL(_fx_M3AstFM8ExpCCodeN10Ast__exp_t2ST2N10Ast__typ_tRM5loc_t(&str_1, &ctx_0, &result_55), _fx_catch_208);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_55, &result_0);
-         FX_BREAK(_fx_catch_204);
+         FX_BREAK(_fx_catch_208);
 
-      _fx_catch_204: ;
+      _fx_catch_208: ;
          if (result_55) {
             _fx_free_N10Ast__exp_t(&result_55);
          }
@@ -27589,9 +28041,9 @@ FX_EXTERN_C int
          FX_FREE_STR(&str_0);
 
       _fx_endmatch_39: ;
-         FX_CHECK_EXN(_fx_catch_205);
+         FX_CHECK_EXN(_fx_catch_209);
 
-      _fx_catch_205: ;
+      _fx_catch_209: ;
          goto _fx_endmatch_41;
       }
       if (tag_0 == 33) {
@@ -27608,15 +28060,15 @@ FX_EXTERN_C int
             FX_COPY_PTR(_fx_g24Ast_typecheck__TypString, &t_19);
          }
          else {
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_561, 0), _fx_catch_208);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_561, 0), _fx_catch_212);
             if (FX_REC_VARIANT_TAG(v_561) == 1) {
                FX_COPY_PTR(v_561->u.TypVar->data, &v_562);
                if ((v_562 != 0) + 1 == 1) {
                   _fx_N10Ast__typ_t v_564 = 0;
-                  FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_564), _fx_catch_206);
-                  FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_564, &t_19), _fx_catch_206);
+                  FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_564), _fx_catch_210);
+                  FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_564, &t_19), _fx_catch_210);
 
-               _fx_catch_206: ;
+               _fx_catch_210: ;
                   if (v_564) {
                      _fx_free_N10Ast__typ_t(&v_564);
                   }
@@ -27624,28 +28076,28 @@ FX_EXTERN_C int
                }
             }
             _fx_N10Ast__typ_t v_565 = 0;
-            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_565, 0), _fx_catch_207);
-            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_565, &t_19), _fx_catch_207);
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_565, 0), _fx_catch_211);
+            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_565, &t_19), _fx_catch_211);
 
-         _fx_catch_207: ;
+         _fx_catch_211: ;
             if (v_565) {
                _fx_free_N10Ast__typ_t(&v_565);
             }
 
          _fx_endmatch_40: ;
-            FX_CHECK_EXN(_fx_catch_208);
+            FX_CHECK_EXN(_fx_catch_212);
          }
          fx_str_t slit_231 =
             FX_MAKE_STR("the output type of @data/@text \'{typ2str(t)}\' does not match the expected one \'{typ2str(etyp)}\'");
          FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t_19, &eloc_0, &slit_231, 0),
-            _fx_catch_208);
+            _fx_catch_212);
          FX_CALL(_fx_M3AstFM7ExpDataN10Ast__exp_t3SST2N10Ast__typ_tRM5loc_t(kind_0, &vcase_39->t1, &ctx_0, &result_56),
-            _fx_catch_208);
+            _fx_catch_212);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_56, &result_0);
-         FX_BREAK(_fx_catch_208);
+         FX_BREAK(_fx_catch_212);
 
-      _fx_catch_208: ;
+      _fx_catch_212: ;
          if (result_56) {
             _fx_free_N10Ast__exp_t(&result_56);
          }
@@ -27691,24 +28143,24 @@ FX_EXTERN_C int
       else {
          res_41 = false;
       }
-      FX_CHECK_EXN(_fx_catch_210);
+      FX_CHECK_EXN(_fx_catch_214);
       if (res_41) {
          fx_exn_t v_566 = {0};
          fx_str_t slit_232 =
             FX_MAKE_STR("internal err: should not get here; all the declarations and directives must be handled in check_eseq");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_232, &v_566, 0), _fx_catch_209);
-         FX_THROW(&v_566, false, _fx_catch_209);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_232, &v_566, 0), _fx_catch_213);
+         FX_THROW(&v_566, false, _fx_catch_213);
 
-      _fx_catch_209: ;
+      _fx_catch_213: ;
          fx_free_exn(&v_566);
          goto _fx_endmatch_41;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_210);
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_214);
 
    _fx_endmatch_41: ;
-      FX_CHECK_EXN(_fx_catch_210);
+      FX_CHECK_EXN(_fx_catch_214);
 
-   _fx_catch_210: ;
+   _fx_catch_214: ;
       if (etyp_0) {
          _fx_free_N10Ast__typ_t(&etyp_0);
       }
@@ -27775,7 +28227,7 @@ static int
       fx_exn_t exn_0 = {0};
       FX_CALL(
          _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-            &_fx_g22Ast_typecheck__None12_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
+            &_fx_g22Ast_typecheck__None13_, etyp_1, false, &eloc_0, &v_1, 0), _fx_catch_0);
 
    _fx_catch_0: ;
       if (fx_status < 0) {
@@ -28610,7 +29062,7 @@ static int
          _fx_LN10Ast__exp_t v_33 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g22Ast_typecheck__None12_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
+               &_fx_g22Ast_typecheck__None13_, ttrj_0, false, &locj_0, &v_18, 0), _fx_catch_6);
          FX_COPY_PTR(v_18.t1, &relems_0);
          FX_COPY_PTR(relems_0, &l_2);
          int_ n_2 = idx_0;
@@ -29375,7 +29827,7 @@ static int
       _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_1);
    }
    else if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
    }
    else {
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
@@ -29488,7 +29940,7 @@ static int _fx_M13Ast_typecheckFM9is_lvalueB4BN10Ast__exp_tT2N10Ast__typ_tR10Ast
                FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(rec_0, &rtyp_0, 0), _fx_catch_6);
                FX_CALL(
                   _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-                     &_fx_g22Ast_typecheck__None12_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
+                     &_fx_g22Ast_typecheck__None13_, rtyp_0, false, &exploc_0, &v_2, 0), _fx_catch_6);
                FX_COPY_PTR(v_2.t1, &relems_0);
                _fx_copy_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g21Ast_typecheck__None1_,
                   &__fold_result___0);
@@ -29641,7 +30093,7 @@ static int
    FX_CALL(fx_check_stack(), _fx_cleanup);
    int tag_0 = (e_opt_0 != 0) + 1;
    if (tag_0 == 1) {
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None13_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
    }
    else if (tag_0 == 2) {
       _fx_T2N10Ast__typ_tR10Ast__loc_t v_0 = {0};
@@ -30579,6 +31031,137 @@ _fx_cleanup: ;
 }
 
 FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM19poison_pattern_varsRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__pat_tN10Ast__typ_tR16Ast__val_flags_tLN12Ast__scope_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_N10Ast__pat_t_data_t* p_0,
+   struct _fx_N10Ast__typ_t_data_t* poison_t_0,
+   struct _fx_R16Ast__val_flags_t* flags_0,
+   struct _fx_LN12Ast__scope_t_data_t* sc_0,
+   int_ m_idx_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env0_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result,
+   void* fx_fv)
+{
+   _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_ref_0 = 0;
+   _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t cb_0 = {0};
+   _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t v_0 = 0;
+   _fx_R16Ast__ast_callb_t callb_0 = {0};
+   _fx_N10Ast__pat_t res_0 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_make_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env0_0, &env_ref_0), _fx_cleanup);
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t5rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR16Ast__val_flags_tiN10Ast__typ_tLN12Ast__scope_t(
+      env_ref_0, flags_0, m_idx_0, poison_t_0, sc_0, &cb_0);
+   FX_CALL(
+      _fx_M13Ast_typecheckFM4SomeNt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
+         &cb_0, &v_0), _fx_cleanup);
+   _fx_make_R16Ast__ast_callb_t(_fx_g22Ast_typecheck__None12_, _fx_g22Ast_typecheck__None11_, v_0, &callb_0);
+   FX_CALL(_fx_M3AstFM16check_n_walk_patN10Ast__pat_t2N10Ast__pat_tRM11ast_callb_t(p_0, &callb_0, &res_0, 0), _fx_cleanup);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_ref_0->data, fx_result);
+
+_fx_cleanup: ;
+   if (env_ref_0) {
+      _fx_free_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_ref_0);
+   }
+   FX_FREE_FP(&cb_0);
+   if (v_0) {
+      _fx_free_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(&v_0);
+   }
+   _fx_free_R16Ast__ast_callb_t(&callb_0);
+   if (res_0) {
+      _fx_free_N10Ast__pat_t(&res_0);
+   }
+   return fx_status;
+}
+
+static int _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
+   struct _fx_N10Ast__pat_t_data_t* p_0,
+   struct _fx_R16Ast__ast_callb_t* callb_0,
+   struct _fx_N10Ast__pat_t_data_t** fx_result,
+   void* fx_fv)
+{
+   int fx_status = 0;
+   _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_cldata_t* cv_0 =
+      (_fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
+   _fx_R16Ast__val_flags_t* flags_0 = &cv_0->t1;
+   int_* m_idx_0 = &cv_0->t2;
+   _fx_N10Ast__typ_t poison_t_0 = cv_0->t3;
+   _fx_LN12Ast__scope_t sc_0 = cv_0->t4;
+   _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0 = &cv_0->t0->data;
+   int tag_0 = FX_REC_VARIANT_TAG(p_0);
+   if (tag_0 == 3) {
+      _fx_R13Ast__defval_t dv_0 = {0};
+      _fx_N14Ast__id_info_t v_0 = {0};
+      _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_1 = {0};
+      _fx_T2R9Ast__id_tR10Ast__loc_t* vcase_0 = &p_0->u.PatIdent;
+      _fx_R9Ast__id_t* n_0 = &vcase_0->t0;
+      _fx_R9Ast__id_t n1_0;
+      FX_CALL(_fx_M3AstFM6dup_idRM4id_t2iRM4id_t(*m_idx_0, n_0, &n1_0, 0), _fx_catch_0);
+      _fx_make_R13Ast__defval_t(&n1_0, poison_t_0, flags_0, sc_0, &vcase_0->t1, &dv_0);
+      _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_0, &v_0);
+      FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&n1_0, &v_0, 0), _fx_catch_0);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM13add_id_to_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tR9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+            n_0, &n1_0, env_0, &v_1, 0), _fx_catch_0);
+      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1, env_0);
+      FX_COPY_PTR(p_0, fx_result);
+
+   _fx_catch_0: ;
+      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1);
+      _fx_free_N14Ast__id_info_t(&v_0);
+      _fx_free_R13Ast__defval_t(&dv_0);
+   }
+   else if (tag_0 == 8) {
+      _fx_R13Ast__defval_t dv_1 = {0};
+      _fx_N14Ast__id_info_t v_2 = {0};
+      _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_3 = {0};
+      _fx_T3N10Ast__pat_tR9Ast__id_tR10Ast__loc_t* vcase_1 = &p_0->u.PatAs;
+      _fx_R9Ast__id_t* n_1 = &vcase_1->t1;
+      _fx_R9Ast__id_t n1_1;
+      FX_CALL(_fx_M3AstFM6dup_idRM4id_t2iRM4id_t(*m_idx_0, n_1, &n1_1, 0), _fx_catch_1);
+      _fx_make_R13Ast__defval_t(&n1_1, poison_t_0, flags_0, sc_0, &vcase_1->t2, &dv_1);
+      _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_1, &v_2);
+      FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&n1_1, &v_2, 0), _fx_catch_1);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM13add_id_to_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tR9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+            n_1, &n1_1, env_0, &v_3, 0), _fx_catch_1);
+      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(env_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3, env_0);
+      FX_CALL(_fx_M3AstFM8walk_patN10Ast__pat_t2N10Ast__pat_tRM11ast_callb_t(p_0, callb_0, fx_result, 0), _fx_catch_1);
+
+   _fx_catch_1: ;
+      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3);
+      _fx_free_N14Ast__id_info_t(&v_2);
+      _fx_free_R13Ast__defval_t(&dv_1);
+   }
+   else {
+      FX_CALL(_fx_M3AstFM8walk_patN10Ast__pat_t2N10Ast__pat_tRM11ast_callb_t(p_0, callb_0, fx_result, 0), _fx_catch_2);
+
+   _fx_catch_2: ;
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM7make_fpFPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t5rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR16Ast__val_flags_tiN10Ast__typ_tLN12Ast__scope_t(
+   struct _fx_rRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t_data_t* arg0,
+   struct _fx_R16Ast__val_flags_t* arg1,
+   int_ arg2,
+   struct _fx_N10Ast__typ_t_data_t* arg3,
+   struct _fx_LN12Ast__scope_t_data_t* arg4,
+   struct _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t* fx_result)
+{
+   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_cldata_t,
+      _fx_free_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t,
+      _fx_M13Ast_typecheckFM2cbN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t);
+   FX_COPY_PTR(arg0, &fcv->t0);
+   _fx_copy_R16Ast__val_flags_t(arg1, &fcv->t1);
+   fcv->t2 = arg2;
+   FX_COPY_PTR(arg3, &fcv->t3);
+   FX_COPY_PTR(arg4, &fcv->t4);
+   return 0;
+}
+
+FX_EXTERN_C int
    _fx_M13Ast_typecheckFM10check_eseqT2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t4LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tB(
    struct _fx_LN10Ast__exp_t_data_t* eseq_0,
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
@@ -30709,7 +31292,7 @@ _fx_endmatch_0: ;
       else {
          res_0 = false;
       }
-      FX_CHECK_EXN(_fx_catch_16);
+      FX_CHECK_EXN(_fx_catch_18);
       if (res_0) {
          fx_exn_t v_7 = {0};
          _fx_LN10Ast__exp_t v_8 = 0;
@@ -30740,15 +31323,12 @@ _fx_endmatch_0: ;
       if (tag_1 == 34) {
          fx_exn_t v_10 = {0};
          _fx_N10Ast__typ_t t_1 = 0;
-         _fx_T2N10Ast__pat_tN10Ast__typ_t v_11 = {0};
-         _fx_N10Ast__pat_t p_0 = 0;
-         _fx_N10Ast__typ_t t1_0 = 0;
          fx_exn_t exn_1 = {0};
          _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t* vcase_0 = &e_1->u.DefVal;
          _fx_R10Ast__loc_t* loc_0 = &vcase_0->t3;
          _fx_R16Ast__val_flags_t* flags_0 = &vcase_0->t2;
          _fx_N10Ast__exp_t e_2 = vcase_0->t1;
-         _fx_N10Ast__pat_t p_1 = vcase_0->t0;
+         _fx_N10Ast__pat_t p_0 = vcase_0->t0;
          bool t_2;
          if (idx_0 == nexps_0 - 1) {
             t_2 = !is_glob_scope_0;
@@ -30763,149 +31343,135 @@ _fx_endmatch_0: ;
          }
          bool is_mutable_0 = flags_0->val_flag_mutable;
          FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_2, &t_1, 0), _fx_catch_9);
-         if (FX_REC_VARIANT_TAG(p_1) == 9) {
-            _fx_N10Ast__typ_t t1_1 = 0;
-            fx_exn_t v_12 = {0};
-            _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_1 = &p_1->u.PatTyped;
+         _fx_T2N10Ast__pat_tN10Ast__typ_t v_11 = {0};
+         _fx_N10Ast__pat_t p_1 = 0;
+         _fx_N10Ast__exp_t e1_0 = 0;
+         _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_12 = {0};
+         _fx_N10Ast__pat_t p1_0 = 0;
+         _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_1 = {0};
+         _fx_N10Ast__exp_t v_13 = 0;
+         _fx_LN10Ast__exp_t v_14 = 0;
+         if (FX_REC_VARIANT_TAG(p_0) == 9) {
+            _fx_N10Ast__typ_t t1_0 = 0;
+            _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_1 = &p_0->u.PatTyped;
             _fx_R10Ast__loc_t* loc_1 = &vcase_1->t2;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                  vcase_1->t1, &env_7, sc_1, loc_1, &t1_1, 0), _fx_catch_4);
-            bool v_13;
-            FX_CALL(
-               _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(t_1, t1_1, loc_1, true, &v_13, 0),
+                  vcase_1->t1, &env_7, sc_1, loc_1, &t1_0, 0), _fx_catch_4);
+            fx_str_t slit_2 =
+               FX_MAKE_STR("explicit type specification of the defined value does not match the assigned expression type");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_1, t1_0, loc_1, &slit_2, 0),
                _fx_catch_4);
-            if (!v_13) {
-               fx_str_t slit_2 =
-                  FX_MAKE_STR("explicit type specification of the defined value does not match the assigned expression type");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_1, &slit_2, &v_12, 0), _fx_catch_4);
-               FX_THROW(&v_12, false, _fx_catch_4);
-            }
-            _fx_make_T2N10Ast__pat_tN10Ast__typ_t(vcase_1->t0, t1_1, &v_11);
+            _fx_make_T2N10Ast__pat_tN10Ast__typ_t(vcase_1->t0, t1_0, &v_11);
 
          _fx_catch_4: ;
-            fx_free_exn(&v_12);
-            if (t1_1) {
-               _fx_free_N10Ast__typ_t(&t1_1);
+            if (t1_0) {
+               _fx_free_N10Ast__typ_t(&t1_0);
             }
          }
          else {
-            _fx_make_T2N10Ast__pat_tN10Ast__typ_t(p_1, t_1, &v_11);
+            _fx_make_T2N10Ast__pat_tN10Ast__typ_t(p_0, t_1, &v_11);
          }
-         FX_CHECK_EXN(_fx_catch_9);
-         FX_COPY_PTR(v_11.t0, &p_0);
-         FX_COPY_PTR(v_11.t1, &t1_0);
-         _fx_N10Ast__exp_t e1_0 = 0;
-         _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_14 = {0};
-         _fx_N10Ast__pat_t p1_0 = 0;
-         _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_1 = {0};
-         _fx_N10Ast__exp_t v_15 = 0;
-         _fx_LN10Ast__exp_t v_16 = 0;
+         FX_CHECK_EXN(_fx_catch_5);
+         FX_COPY_PTR(v_11.t0, &p_1);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
                e_2, &env_7, sc_1, &e1_0, 0), _fx_catch_5);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_patT5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB9N10Ast__pat_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tLN12Ast__scope_tBBB(
-               p_0, t_1, &env_7, &_fx_g16Ast__empty_idset, &_fx_g16Ast__empty_idset, sc_1, false, true, is_mutable_0, &v_14, 0),
+               p_1, t_1, &env_7, &_fx_g16Ast__empty_idset, &_fx_g16Ast__empty_idset, sc_1, false, true, is_mutable_0, &v_12, 0),
             _fx_catch_5);
-         FX_COPY_PTR(v_14.t0, &p1_0);
-         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_14.t1, &env1_1);
+         FX_COPY_PTR(v_12.t0, &p1_0);
+         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_12.t1, &env1_1);
          FX_CALL(
             _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p1_0, e1_0, flags_0, loc_0,
-               &v_15), _fx_catch_5);
-         FX_CALL(_fx_cons_LN10Ast__exp_t(v_15, eseq_2, true, &v_16), _fx_catch_5);
-         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_16, &env1_1, &v_5);
+               &v_13), _fx_catch_5);
+         FX_CALL(_fx_cons_LN10Ast__exp_t(v_13, eseq_2, true, &v_14), _fx_catch_5);
+         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_14, &env1_1, &v_5);
 
       _fx_catch_5: ;
+         _fx_free_T2N10Ast__pat_tN10Ast__typ_t(&v_11);
+         if (p_1) {
+            _fx_free_N10Ast__pat_t(&p_1);
+         }
          if (e1_0) {
             _fx_free_N10Ast__exp_t(&e1_0);
          }
-         _fx_free_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB(&v_14);
+         _fx_free_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB(&v_12);
          if (p1_0) {
             _fx_free_N10Ast__pat_t(&p1_0);
          }
          _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_1);
-         if (v_15) {
-            _fx_free_N10Ast__exp_t(&v_15);
+         if (v_13) {
+            _fx_free_N10Ast__exp_t(&v_13);
          }
-         if (v_16) {
-            _fx_free_LN10Ast__exp_t(&v_16);
+         if (v_14) {
+            _fx_free_LN10Ast__exp_t(&v_14);
          }
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_1);
             fx_status = 0;
             _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5);
             if (exn_1.tag == _FX_EXN_E17Ast__CompileError) {
-               _fx_N10Ast__pat_t v_17 = 0;
+               _fx_N10Ast__typ_t poison_t_0 = 0;
+               _fx_N10Ast__pat_t v_15 = 0;
+               _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_2 = {0};
+               _fx_N10Ast__exp_t v_16 = 0;
+               _fx_LN10Ast__exp_t v_17 = 0;
                FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_1, 0), _fx_catch_8);
-               FX_CALL(_fx_M3AstFM14pat_skip_typedN10Ast__pat_t1N10Ast__pat_t(p_0, &v_17, 0), _fx_catch_8);
-               if (FX_REC_VARIANT_TAG(v_17) == 3) {
-                  _fx_R13Ast__defval_t dv_0 = {0};
-                  _fx_N14Ast__id_info_t v_18 = {0};
-                  _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_2 = {0};
-                  _fx_N10Ast__pat_t v_19 = 0;
-                  _fx_N10Ast__pat_t v_20 = 0;
-                  _fx_N10Ast__exp_t v_21 = 0;
-                  _fx_LN10Ast__exp_t v_22 = 0;
-                  _fx_T2R9Ast__id_tR10Ast__loc_t* vcase_2 = &v_17->u.PatIdent;
-                  _fx_R10Ast__loc_t* ploc_0 = &vcase_2->t1;
-                  _fx_R9Ast__id_t* n_0 = &vcase_2->t0;
-                  _fx_R9Ast__id_t n1_0;
-                  FX_CALL(_fx_M3AstFM6dup_idRM4id_t2iRM4id_t(curr_m_idx_0, n_0, &n1_0, 0), _fx_catch_6);
-                  _fx_make_R13Ast__defval_t(&n1_0, t1_0, flags_0, sc_1, loc_0, &dv_0);
-                  _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_0, &v_18);
-                  FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&n1_0, &v_18, 0), _fx_catch_6);
+               if (FX_REC_VARIANT_TAG(p_0) == 9) {
+                  fx_exn_t exn_2 = {0};
+                  _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_2 = &p_0->u.PatTyped;
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM13add_id_to_envRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tR9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                        n_0, &n1_0, &env_7, &env1_2, 0), _fx_catch_6);
-                  FX_CALL(_fx_M3AstFM8PatIdentN10Ast__pat_t2RM4id_tRM5loc_t(&n1_0, ploc_0, &v_19), _fx_catch_6);
-                  FX_CALL(_fx_M3AstFM8PatTypedN10Ast__pat_t3N10Ast__pat_tN10Ast__typ_tRM5loc_t(v_19, t1_0, ploc_0, &v_20),
-                     _fx_catch_6);
-                  FX_CALL(
-                     _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(v_20, e_2, flags_0,
-                        loc_0, &v_21), _fx_catch_6);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_21, eseq_2, true, &v_22), _fx_catch_6);
-                  _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_22, &env1_2, &v_5);
+                     _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                        vcase_2->t1, &env_7, sc_1, &vcase_2->t2, &poison_t_0, 0), _fx_catch_6);
 
                _fx_catch_6: ;
-                  if (v_22) {
-                     _fx_free_LN10Ast__exp_t(&v_22);
+                  if (fx_status < 0) {
+                     fx_exn_get_and_reset(fx_status, &exn_2);
+                     fx_status = 0;
+                     if (poison_t_0) {
+                        _fx_free_N10Ast__typ_t(&poison_t_0);
+                     }
+                     if (exn_2.tag == _FX_EXN_E17Ast__CompileError) {
+                        FX_COPY_PTR(_fx_g21Ast_typecheck__TypErr, &poison_t_0);
+                     }
+                     else {
+                        FX_RETHROW(&exn_2, _fx_catch_7);
+                     }
+                     FX_CHECK_EXN(_fx_catch_7);
                   }
-                  if (v_21) {
-                     _fx_free_N10Ast__exp_t(&v_21);
-                  }
-                  if (v_20) {
-                     _fx_free_N10Ast__pat_t(&v_20);
-                  }
-                  if (v_19) {
-                     _fx_free_N10Ast__pat_t(&v_19);
-                  }
-                  _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_2);
-                  _fx_free_N14Ast__id_info_t(&v_18);
-                  _fx_free_R13Ast__defval_t(&dv_0);
-               }
-               else {
-                  _fx_N10Ast__exp_t v_23 = 0;
-                  _fx_LN10Ast__exp_t v_24 = 0;
-                  FX_CALL(
-                     _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p_0, e_2, flags_0, loc_0,
-                        &v_23), _fx_catch_7);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_23, eseq_2, true, &v_24), _fx_catch_7);
-                  _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_24, &env_7, &v_5);
 
                _fx_catch_7: ;
-                  if (v_24) {
-                     _fx_free_LN10Ast__exp_t(&v_24);
-                  }
-                  if (v_23) {
-                     _fx_free_N10Ast__exp_t(&v_23);
-                  }
+                  fx_free_exn(&exn_2);
+               }
+               else {
+                  FX_COPY_PTR(_fx_g21Ast_typecheck__TypErr, &poison_t_0);
                }
                FX_CHECK_EXN(_fx_catch_8);
+               FX_CALL(_fx_M3AstFM14pat_skip_typedN10Ast__pat_t1N10Ast__pat_t(p_0, &v_15, 0), _fx_catch_8);
+               FX_CALL(
+                  _fx_M13Ast_typecheckFM19poison_pattern_varsRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__pat_tN10Ast__typ_tR16Ast__val_flags_tLN12Ast__scope_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+                     v_15, poison_t_0, flags_0, sc_1, curr_m_idx_0, &env_7, &env1_2, 0), _fx_catch_8);
+               FX_CALL(
+                  _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p_0, e_2, flags_0, loc_0,
+                     &v_16), _fx_catch_8);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(v_16, eseq_2, true, &v_17), _fx_catch_8);
+               _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_17, &env1_2, &v_5);
 
             _fx_catch_8: ;
                if (v_17) {
-                  _fx_free_N10Ast__pat_t(&v_17);
+                  _fx_free_LN10Ast__exp_t(&v_17);
+               }
+               if (v_16) {
+                  _fx_free_N10Ast__exp_t(&v_16);
+               }
+               _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_2);
+               if (v_15) {
+                  _fx_free_N10Ast__pat_t(&v_15);
+               }
+               if (poison_t_0) {
+                  _fx_free_N10Ast__typ_t(&poison_t_0);
                }
             }
             else {
@@ -30916,13 +31482,6 @@ _fx_endmatch_0: ;
 
       _fx_catch_9: ;
          fx_free_exn(&exn_1);
-         if (t1_0) {
-            _fx_free_N10Ast__typ_t(&t1_0);
-         }
-         if (p_0) {
-            _fx_free_N10Ast__pat_t(&p_0);
-         }
-         _fx_free_T2N10Ast__pat_tN10Ast__typ_t(&v_11);
          if (t_1) {
             _fx_free_N10Ast__typ_t(&t_1);
          }
@@ -30930,12 +31489,13 @@ _fx_endmatch_0: ;
          goto _fx_endmatch_4;
       }
       if (tag_1 == 35) {
-         fx_exn_t v_25 = {0};
-         _fx_LR9Ast__id_t v_26 = 0;
+         fx_exn_t v_18 = {0};
+         _fx_LR9Ast__id_t v_19 = 0;
          _fx_rR13Ast__deffun_t df_0 = 0;
-         _fx_R13Ast__deffun_t v_27 = {0};
-         _fx_N10Ast__exp_t v_28 = 0;
-         _fx_LN10Ast__exp_t v_29 = 0;
+         fx_exn_t exn_3 = {0};
+         _fx_R13Ast__deffun_t v_20 = {0};
+         _fx_N10Ast__exp_t v_21 = 0;
+         _fx_LN10Ast__exp_t v_22 = 0;
          _fx_rR13Ast__deffun_t df_1 = e_1->u.DefFun;
          bool t_3;
          if (idx_0 == nexps_0 - 1) {
@@ -30945,63 +31505,89 @@ _fx_endmatch_0: ;
             t_3 = false;
          }
          if (t_3) {
-            _fx_R10Ast__loc_t v_30 = df_1->data.df_loc;
+            _fx_R10Ast__loc_t v_23 = df_1->data.df_loc;
             fx_str_t slit_3 = FX_MAKE_STR("function definition occurs in the end of block; put some expression after it");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_30, &slit_3, &v_25, 0), _fx_catch_10);
-            FX_THROW(&v_25, false, _fx_catch_10);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_23, &slit_3, &v_18, 0), _fx_catch_12);
+            FX_THROW(&v_18, false, _fx_catch_12);
          }
          bool warn_rettype_0;
          if (_fx_g12Options__opt.W_implicit_rettype) {
-            FX_CALL(_fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(df_1, &warn_rettype_0, 0), _fx_catch_10);
+            FX_CALL(_fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(df_1, &warn_rettype_0, 0), _fx_catch_12);
          }
          else {
             warn_rettype_0 = false;
          }
-         FX_COPY_PTR(df_1->data.df_templ_args, &v_26);
-         if (v_26 == 0) {
+         FX_COPY_PTR(df_1->data.df_templ_args, &v_19);
+         if (v_19 == 0) {
             FX_CALL(
                _fx_M13Ast_typecheckFM12check_deffunrR13Ast__deffun_t2rR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
                   df_1, &env_7, &df_0, 0), _fx_catch_10);
+
+         _fx_catch_10: ;
+            if (fx_status < 0) {
+               fx_exn_get_and_reset(fx_status, &exn_3);
+               fx_status = 0;
+               if (df_0) {
+                  _fx_free_rR13Ast__deffun_t(&df_0);
+               }
+               if (exn_3.tag == _FX_EXN_E17Ast__CompileError) {
+                  _fx_N10Ast__typ_t v_24 = 0;
+                  FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_11);
+                  FX_COPY_PTR(df_1->data.df_typ, &v_24);
+                  FX_CALL(_fx_M13Ast_typecheckFM17poison_result_typv1N10Ast__typ_t(v_24, 0), _fx_catch_11);
+                  FX_COPY_PTR(df_1, &df_0);
+
+               _fx_catch_11: ;
+                  if (v_24) {
+                     _fx_free_N10Ast__typ_t(&v_24);
+                  }
+               }
+               else {
+                  FX_RETHROW(&exn_3, _fx_catch_12);
+               }
+               FX_CHECK_EXN(_fx_catch_12);
+            }
          }
          else {
-            _fx_R13Ast__deffun_t* v_31 = &df_1->data;
-            _fx_make_R13Ast__deffun_t(&v_31->df_name, v_31->df_templ_args, v_31->df_args, v_31->df_typ, v_31->df_body,
-               &v_31->df_flags, v_31->df_scope, &v_31->df_loc, v_31->df_templ_inst, &env_7, &v_27);
-            _fx_R13Ast__deffun_t* v_32 = &df_1->data;
-            _fx_free_R13Ast__deffun_t(v_32);
-            _fx_copy_R13Ast__deffun_t(&v_27, v_32);
+            _fx_R13Ast__deffun_t* v_25 = &df_1->data;
+            _fx_make_R13Ast__deffun_t(&v_25->df_name, v_25->df_templ_args, v_25->df_args, v_25->df_typ, v_25->df_body,
+               &v_25->df_flags, v_25->df_scope, &v_25->df_loc, v_25->df_templ_inst, &env_7, &v_20);
+            _fx_R13Ast__deffun_t* v_26 = &df_1->data;
+            _fx_free_R13Ast__deffun_t(v_26);
+            _fx_copy_R13Ast__deffun_t(&v_20, v_26);
             FX_COPY_PTR(df_1, &df_0);
          }
          if (warn_rettype_0) {
-            FX_CALL(_fx_M13Ast_typecheckFM21warn_implicit_rettypev1rR13Ast__deffun_t(df_0, 0), _fx_catch_10);
+            FX_CALL(_fx_M13Ast_typecheckFM21warn_implicit_rettypev1rR13Ast__deffun_t(df_0, 0), _fx_catch_12);
          }
-         FX_CALL(_fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(df_0, &v_28), _fx_catch_10);
-         FX_CALL(_fx_cons_LN10Ast__exp_t(v_28, eseq_2, true, &v_29), _fx_catch_10);
-         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_29, &env_7, &v_5);
+         FX_CALL(_fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(df_0, &v_21), _fx_catch_12);
+         FX_CALL(_fx_cons_LN10Ast__exp_t(v_21, eseq_2, true, &v_22), _fx_catch_12);
+         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_22, &env_7, &v_5);
 
-      _fx_catch_10: ;
-         if (v_29) {
-            _fx_free_LN10Ast__exp_t(&v_29);
+      _fx_catch_12: ;
+         if (v_22) {
+            _fx_free_LN10Ast__exp_t(&v_22);
          }
-         if (v_28) {
-            _fx_free_N10Ast__exp_t(&v_28);
+         if (v_21) {
+            _fx_free_N10Ast__exp_t(&v_21);
          }
-         _fx_free_R13Ast__deffun_t(&v_27);
+         _fx_free_R13Ast__deffun_t(&v_20);
+         fx_free_exn(&exn_3);
          if (df_0) {
             _fx_free_rR13Ast__deffun_t(&df_0);
          }
-         FX_FREE_LIST_SIMPLE(&v_26);
-         fx_free_exn(&v_25);
+         FX_FREE_LIST_SIMPLE(&v_19);
+         fx_free_exn(&v_18);
          goto _fx_endmatch_4;
       }
       _fx_N10Ast__exp_t e_3 = 0;
       _fx_N10Ast__exp_t e_4 = 0;
-      _fx_T2N10Ast__typ_tR10Ast__loc_t v_33 = {0};
+      _fx_T2N10Ast__typ_tR10Ast__loc_t v_27 = {0};
       _fx_N10Ast__typ_t etyp_0 = 0;
-      _fx_LN10Ast__exp_t v_34 = 0;
+      _fx_LN10Ast__exp_t v_28 = 0;
       if (FX_REC_VARIANT_TAG(e_1) == 4) {
-         _fx_Nt6option1N10Ast__exp_t v_35 = e_1->u.ExpReturn.t0;
-         if ((v_35 != 0) + 1 == 2) {
+         _fx_Nt6option1N10Ast__exp_t v_29 = e_1->u.ExpReturn.t0;
+         if ((v_29 != 0) + 1 == 2) {
             bool t_4;
             if (idx_0 == nexps_0 - 1) {
                t_4 = is_func_scope_0;
@@ -31010,7 +31596,7 @@ _fx_endmatch_0: ;
                t_4 = false;
             }
             if (t_4) {
-               FX_COPY_PTR(v_35->u.Some, &e_3);
+               FX_COPY_PTR(v_29->u.Some, &e_3);
             }
             else {
                FX_COPY_PTR(e_1, &e_3);
@@ -31021,24 +31607,24 @@ _fx_endmatch_0: ;
       FX_COPY_PTR(e_1, &e_3);
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_15);
+      FX_CHECK_EXN(_fx_catch_17);
       FX_CALL(
          _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-            e_3, &env_7, sc_1, &e_4, 0), _fx_catch_15);
-      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_4, &v_33, 0), _fx_catch_15);
-      FX_COPY_PTR(v_33.t0, &etyp_0);
-      _fx_R10Ast__loc_t eloc_0 = v_33.t1;
+            e_3, &env_7, sc_1, &e_4, 0), _fx_catch_17);
+      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_4, &v_27, 0), _fx_catch_17);
+      FX_COPY_PTR(v_27.t0, &etyp_0);
+      _fx_R10Ast__loc_t eloc_0 = v_27.t1;
       int tag_2 = FX_REC_VARIANT_TAG(e_4);
       if (tag_2 == 1) {
-         fx_exn_t v_36 = {0};
+         fx_exn_t v_30 = {0};
          if (nexps_0 != 1) {
             fx_str_t slit_4 = FX_MAKE_STR("there cannot be {} operators inside code blocks");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_36, 0), _fx_catch_11);
-            FX_THROW(&v_36, false, _fx_catch_11);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_30, 0), _fx_catch_13);
+            FX_THROW(&v_30, false, _fx_catch_13);
          }
 
-      _fx_catch_11: ;
-         fx_free_exn(&v_36);
+      _fx_catch_13: ;
+         fx_free_exn(&v_30);
          goto _fx_endmatch_3;
       }
       bool res_1;
@@ -31054,28 +31640,28 @@ _fx_endmatch_0: ;
       else {
          res_1 = false;
       }
-      FX_CHECK_EXN(_fx_catch_15);
+      FX_CHECK_EXN(_fx_catch_17);
       if (res_1) {
-         fx_exn_t v_37 = {0};
+         fx_exn_t v_31 = {0};
          if (idx_0 != nexps_0 - 1) {
             fx_str_t slit_5 =
                FX_MAKE_STR(
                   "break/continue/return operator should not be followed by any other operators in the same linear code sequence");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_37, 0), _fx_catch_12);
-            FX_THROW(&v_37, false, _fx_catch_12);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_31, 0), _fx_catch_14);
+            FX_THROW(&v_31, false, _fx_catch_14);
          }
 
-      _fx_catch_12: ;
-         fx_free_exn(&v_37);
+      _fx_catch_14: ;
+         fx_free_exn(&v_31);
          goto _fx_endmatch_3;
       }
       if (tag_2 == 32) {
          goto _fx_endmatch_3;
       }
-      _fx_N10Ast__typ_t v_38 = 0;
-      _fx_Nt6option1N10Ast__typ_t v_39 = 0;
-      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_38, 0), _fx_catch_14);
-      int tag_3 = FX_REC_VARIANT_TAG(v_38);
+      _fx_N10Ast__typ_t v_32 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_33 = 0;
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_32, 0), _fx_catch_16);
+      int tag_3 = FX_REC_VARIANT_TAG(v_32);
       bool res_2;
       if (tag_3 == 14) {
          res_2 = true;
@@ -31086,52 +31672,52 @@ _fx_endmatch_0: ;
       else {
          res_2 = false;
       }
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
       if (res_2) {
          goto _fx_endmatch_2;
       }
       if (tag_3 == 1) {
-         FX_COPY_PTR(v_38->u.TypVar->data, &v_39);
-         if ((v_39 != 0) + 1 == 1) {
+         FX_COPY_PTR(v_32->u.TypVar->data, &v_33);
+         if ((v_33 != 0) + 1 == 1) {
             goto _fx_endmatch_2;
          }
       }
-      fx_exn_t v_40 = {0};
+      fx_exn_t v_34 = {0};
       if (idx_0 != nexps_0 - 1) {
          fx_str_t slit_6 =
             FX_MAKE_STR(
                "non-void expression occurs before the end of code block. Check the line breaks; if it\'s valid, use ignore() function to dismiss the error");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_6, &v_40, 0), _fx_catch_13);
-         FX_THROW(&v_40, false, _fx_catch_13);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_6, &v_34, 0), _fx_catch_15);
+         FX_THROW(&v_34, false, _fx_catch_15);
       }
 
-   _fx_catch_13: ;
-      fx_free_exn(&v_40);
+   _fx_catch_15: ;
+      fx_free_exn(&v_34);
 
    _fx_endmatch_2: ;
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
 
-   _fx_catch_14: ;
-      if (v_39) {
-         _fx_free_Nt6option1N10Ast__typ_t(&v_39);
+   _fx_catch_16: ;
+      if (v_33) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_33);
       }
-      if (v_38) {
-         _fx_free_N10Ast__typ_t(&v_38);
+      if (v_32) {
+         _fx_free_N10Ast__typ_t(&v_32);
       }
 
    _fx_endmatch_3: ;
-      FX_CHECK_EXN(_fx_catch_15);
-      FX_CALL(_fx_cons_LN10Ast__exp_t(e_4, eseq_2, true, &v_34), _fx_catch_15);
-      _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_34, &env_7, &v_5);
+      FX_CHECK_EXN(_fx_catch_17);
+      FX_CALL(_fx_cons_LN10Ast__exp_t(e_4, eseq_2, true, &v_28), _fx_catch_17);
+      _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_28, &env_7, &v_5);
 
-   _fx_catch_15: ;
-      if (v_34) {
-         _fx_free_LN10Ast__exp_t(&v_34);
+   _fx_catch_17: ;
+      if (v_28) {
+         _fx_free_LN10Ast__exp_t(&v_28);
       }
       if (etyp_0) {
          _fx_free_N10Ast__typ_t(&etyp_0);
       }
-      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_33);
+      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_27);
       if (e_4) {
          _fx_free_N10Ast__exp_t(&e_4);
       }
@@ -31140,39 +31726,39 @@ _fx_endmatch_0: ;
       }
 
    _fx_endmatch_4: ;
-      FX_CHECK_EXN(_fx_catch_16);
+      FX_CHECK_EXN(_fx_catch_18);
 
-   _fx_catch_16: ;
+   _fx_catch_18: ;
       if (fx_status < 0) {
          fx_exn_get_and_reset(fx_status, &exn_0);
          fx_status = 0;
          _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5);
          int tag_4 = exn_0.tag;
          if (tag_4 == _FX_EXN_E17Ast__CompileError) {
-            _fx_LN10Ast__exp_t v_41 = 0;
-            FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_0, 0), _fx_catch_17);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_2, true, &v_41), _fx_catch_17);
-            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_41, &env_7, &v_5);
+            _fx_LN10Ast__exp_t v_35 = 0;
+            FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_0, 0), _fx_catch_19);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_2, true, &v_35), _fx_catch_19);
+            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_35, &env_7, &v_5);
 
-         _fx_catch_17: ;
-            if (v_41) {
-               _fx_free_LN10Ast__exp_t(&v_41);
+         _fx_catch_19: ;
+            if (v_35) {
+               _fx_free_LN10Ast__exp_t(&v_35);
             }
          }
          else if (tag_4 == _FX_EXN_E26Ast__PropagateCompileError) {
-            _fx_LN10Ast__exp_t v_42 = 0;
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_2, true, &v_42), _fx_catch_18);
-            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_42, &env_7, &v_5);
+            _fx_LN10Ast__exp_t v_36 = 0;
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_2, true, &v_36), _fx_catch_20);
+            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_36, &env_7, &v_5);
 
-         _fx_catch_18: ;
-            if (v_42) {
-               _fx_free_LN10Ast__exp_t(&v_42);
+         _fx_catch_20: ;
+            if (v_36) {
+               _fx_free_LN10Ast__exp_t(&v_36);
             }
          }
          else {
-            FX_THROW(&exn_0, false, _fx_catch_19);
+            FX_THROW(&exn_0, false, _fx_catch_21);
          }
-         FX_CHECK_EXN(_fx_catch_19);
+         FX_CHECK_EXN(_fx_catch_21);
       }
       FX_COPY_PTR(v_5.t0, &eseq1_0);
       _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_5.t1, &env1_0);
@@ -31180,7 +31766,7 @@ _fx_endmatch_0: ;
       _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&__fold_result___1);
       _fx_copy_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_6, &__fold_result___1);
 
-   _fx_catch_19: ;
+   _fx_catch_21: ;
       _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_6);
       _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
       if (eseq1_0) {
@@ -33302,7 +33888,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 1) {
       if (e_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result); goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 1) {
@@ -33388,7 +33974,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__Nt6option1N10Ast__typ_t1N16Ast__env
          FX_FREE_STR(&v_4);
          goto _fx_endmatch_0;
       }
-      FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result);
+      FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result);
 
    _fx_endmatch_0: ;
       FX_CHECK_EXN(_fx_catch_3);
@@ -34297,7 +34883,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
    }
    if (tag_0 == 1) {
       if (entry_0->u.EnvId.m == 0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_2;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result); goto _fx_endmatch_2;
       }
    }
    if (tag_0 == 1) {
@@ -34326,7 +34912,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
       }
       FX_CHECK_EXN(_fx_catch_10);
       if (res_0) {
-         FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, fx_result); goto _fx_endmatch_1;
+         FX_COPY_PTR(_fx_g22Ast_typecheck__None15_, fx_result); goto _fx_endmatch_1;
       }
       if (tag_1 == 7) {
          _fx_R19Ast__definterface_t v_4 = {0};
@@ -34538,7 +35124,7 @@ static int _fx_M13Ast_typecheckFM12__lambda__1_Nt6option1N10Ast__typ_t1N16Ast__e
          else if (cv_0->t6) {
             FX_CALL(_fx_M3AstFM6TypAppN10Ast__typ_t2LN10Ast__typ_tRM4id_t(ty_args_0, &dvar_name_0, &t1_0), _fx_catch_9);
             FX_COPY_PTR(dvar_templ_inst_0->data, &v_25);
-            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g22Ast_typecheck__None12_;
+            _fx_Nt6option1R9Ast__id_t __fold_result___1 = _fx_g22Ast_typecheck__None13_;
             _fx_LR9Ast__id_t lst_2 = v_25;
             for (; lst_2; lst_2 = lst_2->tl) {
                _fx_N14Ast__id_info_t v_27 = {0};
@@ -38006,7 +38592,7 @@ static int
          _fx_M13Ast_typecheckFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(&ctor_0, &v_53);
       }
       else {
-         v_53 = _fx_g22Ast_typecheck__None12_;
+         v_53 = _fx_g22Ast_typecheck__None13_;
       }
       FX_CALL(
          _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&v_53, new_relems_0, loc_4, &v_42),
@@ -38044,7 +38630,7 @@ static int
                      0), _fx_catch_24);
                FX_CALL(
                   _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(
-                     &_fx_g22Ast_typecheck__None12_, relems_0, loc_4, &v_54), _fx_catch_24);
+                     &_fx_g22Ast_typecheck__None13_, relems_0, loc_4, &v_54), _fx_catch_24);
                FX_CALL(_fx_cons_LN10Ast__pat_t(v_54, 0, true, &v_55), _fx_catch_24);
                FX_CALL(_fx_M3AstFM10PatVariantN10Ast__pat_t3RM4id_tLN10Ast__pat_tRM5loc_t(&v_57, v_55, loc_4, &v_56),
                   _fx_catch_24);
@@ -38361,29 +38947,30 @@ FX_EXTERN_C int
       _fx_N10Ast__pat_t p_0 = 0;
       _fx_N10Ast__exp_t e_0 = 0;
       _fx_LN12Ast__scope_t case_sc_0 = 0;
-      _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_0 = {0};
-      _fx_N10Ast__pat_t p1_0 = 0;
-      _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
-      _fx_T2N10Ast__typ_tR10Ast__loc_t v_1 = {0};
-      _fx_N10Ast__typ_t e1_typ_0 = 0;
-      fx_exn_t v_2 = {0};
-      _fx_N10Ast__exp_t v_3 = 0;
-      _fx_T2N10Ast__pat_tN10Ast__exp_t tup_0 = {0};
+      _fx_T2N10Ast__pat_tN10Ast__exp_t res_0 = {0};
+      fx_exn_t exn_0 = {0};
       _fx_T2N10Ast__pat_tN10Ast__exp_t* __pat___0 = &lst_0->hd;
       FX_COPY_PTR(__pat___0->t0, &p_0);
       FX_COPY_PTR(__pat___0->t1, &e_0);
-      _fx_N12Ast__scope_t v_4;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_4, 0), _fx_catch_0);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_4, sc_0, true, &case_sc_0), _fx_catch_0);
+      _fx_N12Ast__scope_t v_0;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_0, 0), _fx_catch_2);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_0, sc_0, true, &case_sc_0), _fx_catch_2);
+      _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_1 = {0};
+      _fx_N10Ast__pat_t p1_0 = 0;
+      _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_0 = {0};
+      _fx_T2N10Ast__typ_tR10Ast__loc_t v_2 = {0};
+      _fx_N10Ast__typ_t e1_typ_0 = 0;
+      fx_exn_t v_3 = {0};
+      _fx_N10Ast__exp_t v_4 = 0;
       FX_CALL(
          _fx_M13Ast_typecheckFM9check_patT5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB9N10Ast__pat_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tLN12Ast__scope_tBBB(
-            p_0, inptyp_0, env_0, &_fx_g16Ast__empty_idset, &_fx_g16Ast__empty_idset, case_sc_0, false, false, false, &v_0, 0),
+            p_0, inptyp_0, env_0, &_fx_g16Ast__empty_idset, &_fx_g16Ast__empty_idset, case_sc_0, false, false, false, &v_1, 0),
          _fx_catch_0);
-      FX_COPY_PTR(v_0.t0, &p1_0);
-      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_0.t1, &env1_0);
-      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_0, &v_1, 0), _fx_catch_0);
-      FX_COPY_PTR(v_1.t0, &e1_typ_0);
-      _fx_R10Ast__loc_t e1_loc_0 = v_1.t1;
+      FX_COPY_PTR(v_1.t0, &p1_0);
+      _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_1.t1, &env1_0);
+      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_0, &v_2, 0), _fx_catch_0);
+      FX_COPY_PTR(v_2.t0, &e1_typ_0);
+      _fx_R10Ast__loc_t e1_loc_0 = v_2.t1;
       bool v_5;
       FX_CALL(
          _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(e1_typ_0, outtyp_0, &e1_loc_0, true,
@@ -38391,32 +38978,50 @@ FX_EXTERN_C int
       if (!v_5) {
          fx_str_t slit_0 =
             FX_MAKE_STR("the case expression type does not match the whole expression type (or the type of previous case(s))");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1_loc_0, &slit_0, &v_2, 0), _fx_catch_0);
-         FX_THROW(&v_2, false, _fx_catch_0);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1_loc_0, &slit_0, &v_3, 0), _fx_catch_0);
+         FX_THROW(&v_3, false, _fx_catch_0);
       }
       FX_CALL(
          _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-            e_0, &env1_0, case_sc_0, &v_3, 0), _fx_catch_0);
-      _fx_make_T2N10Ast__pat_tN10Ast__exp_t(p1_0, v_3, &tup_0);
-      _fx_LT2N10Ast__pat_tN10Ast__exp_t node_0 = 0;
-      FX_CALL(_fx_cons_LT2N10Ast__pat_tN10Ast__exp_t(&tup_0, 0, false, &node_0), _fx_catch_0);
-      FX_LIST_APPEND(*fx_result, lstend_0, node_0);
+            e_0, &env1_0, case_sc_0, &v_4, 0), _fx_catch_0);
+      _fx_make_T2N10Ast__pat_tN10Ast__exp_t(p1_0, v_4, &res_0);
 
    _fx_catch_0: ;
-      _fx_free_T2N10Ast__pat_tN10Ast__exp_t(&tup_0);
-      if (v_3) {
-         _fx_free_N10Ast__exp_t(&v_3);
-      }
-      fx_free_exn(&v_2);
-      if (e1_typ_0) {
-         _fx_free_N10Ast__typ_t(&e1_typ_0);
-      }
-      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_1);
-      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
+      _fx_free_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB(&v_1);
       if (p1_0) {
          _fx_free_N10Ast__pat_t(&p1_0);
       }
-      _fx_free_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB(&v_0);
+      _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
+      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_2);
+      if (e1_typ_0) {
+         _fx_free_N10Ast__typ_t(&e1_typ_0);
+      }
+      fx_free_exn(&v_3);
+      if (v_4) {
+         _fx_free_N10Ast__exp_t(&v_4);
+      }
+      if (fx_status < 0) {
+         fx_exn_get_and_reset(fx_status, &exn_0);
+         fx_status = 0;
+         _fx_free_T2N10Ast__pat_tN10Ast__exp_t(&res_0);
+         if (exn_0.tag == _FX_EXN_E17Ast__CompileError) {
+            FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_0, 0), _fx_catch_1);
+            _fx_make_T2N10Ast__pat_tN10Ast__exp_t(p_0, e_0, &res_0);
+
+         _fx_catch_1: ;
+         }
+         else {
+            FX_RETHROW(&exn_0, _fx_catch_2);
+         }
+         FX_CHECK_EXN(_fx_catch_2);
+      }
+      _fx_LT2N10Ast__pat_tN10Ast__exp_t node_0 = 0;
+      FX_CALL(_fx_cons_LT2N10Ast__pat_tN10Ast__exp_t(&res_0, 0, false, &node_0), _fx_catch_2);
+      FX_LIST_APPEND(*fx_result, lstend_0, node_0);
+
+   _fx_catch_2: ;
+      fx_free_exn(&exn_0);
+      _fx_free_T2N10Ast__pat_tN10Ast__exp_t(&res_0);
       FX_FREE_LIST_SIMPLE(&case_sc_0);
       if (e_0) {
          _fx_free_N10Ast__exp_t(&e_0);

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -1256,6 +1256,16 @@ typedef struct _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t {
    struct _fx_T2R9Ast__id_trR13Ast__deffun_t hd;
 } _fx_LT2R9Ast__id_trR13Ast__deffun_t_data_t, *_fx_LT2R9Ast__id_trR13Ast__deffun_t;
 
+typedef struct _fx_T2iS {
+   int_ t0;
+   fx_str_t t1;
+} _fx_T2iS;
+
+typedef struct _fx_FPB2T2iST2iS {
+   int (*fp)(struct _fx_T2iS*, struct _fx_T2iS*, bool*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPB2T2iST2iS;
+
 typedef struct _fx_FPN10Ast__typ_t1N10Ast__exp_t {
    int (*fp)(struct _fx_N10Ast__exp_t_data_t*, struct _fx_N10Ast__typ_t_data_t**, void*);
    fx_fcv_t* fcv;
@@ -1282,6 +1292,19 @@ typedef struct _fx_FPLR9Ast__id_t3R9Ast__id_tLN16Ast__env_entry_tLR9Ast__id_t {
          struct _fx_LR9Ast__id_t_data_t**, void*);
    fx_fcv_t* fcv;
 } _fx_FPLR9Ast__id_t3R9Ast__id_tLN16Ast__env_entry_tLR9Ast__id_t;
+
+typedef struct _fx_LT2iS_data_t {
+   int_ rc;
+   struct _fx_LT2iS_data_t* tl;
+   struct _fx_T2iS hd;
+} _fx_LT2iS_data_t, *_fx_LT2iS;
+
+typedef struct _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS {
+   int (*fp)(
+      struct _fx_R9Ast__id_t*, struct _fx_LN16Ast__env_entry_t_data_t*, struct _fx_LT2iS_data_t*, struct _fx_LT2iS_data_t**,
+         void*);
+   fx_fcv_t* fcv;
+} _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS;
 
 typedef struct _fx_FPRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3R9Ast__id_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
    int (*fp)(
@@ -4836,6 +4859,33 @@ static int _fx_cons_LT2R9Ast__id_trR13Ast__deffun_t(
    FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_trR13Ast__deffun_t, _fx_copy_T2R9Ast__id_trR13Ast__deffun_t);
 }
 
+static void _fx_free_T2iS(struct _fx_T2iS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2iS(struct _fx_T2iS* src, struct _fx_T2iS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2iS(int_ t0, fx_str_t* t1, struct _fx_T2iS* fx_result)
+{
+   fx_result->t0 = t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2iS(struct _fx_LT2iS_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2iS, _fx_free_T2iS);
+}
+
+static int _fx_cons_LT2iS(struct _fx_T2iS* hd, struct _fx_LT2iS_data_t* tl, bool addref_tl, struct _fx_LT2iS_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2iS, _fx_copy_T2iS);
+}
+
 static void _fx_free_T2Nt11Set__tree_t1R9Ast__id_ti(struct _fx_T2Nt11Set__tree_t1R9Ast__id_ti* dst)
 {
    _fx_free_Nt11Set__tree_t1R9Ast__id_t(&dst->t0);
@@ -6345,6 +6395,8 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N10Ast__typ_tN10Ast__ty
 
 FX_EXTERN_C void _fx_F12print_stringv1S(fx_str_t*, void*);
 
+static int _fx_M13Ast_typecheckFM6qsort_v5iiA1T2iSFPB2T2iST2iSi(int_, int_, fx_arr_t*, struct _fx_FPB2T2iST2iS*, int_, void*);
+
 FX_EXTERN_C int _fx_F9make_FailE1S(fx_str_t*, fx_exn_t*);
 
 FX_EXTERN_C int _fx_M7HashsetFM9makeindexA1i1i(int_, fx_arr_t*, void*);
@@ -6627,6 +6679,24 @@ static int _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast
    struct _fx_R16Ast__ast_callb_t*,
    struct _fx_N10Ast__typ_t_data_t**,
    void*);
+
+FX_EXTERN_C int_ _fx_F7__cmp__i2SS(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C bool _fx_F6__eq__B2SS(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS2Si(
+   fx_str_t*,
+   int_,
+   struct _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS*);
+
+static int _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS(
+   struct _fx_R9Ast__id_t*,
+   struct _fx_LN16Ast__env_entry_t_data_t*,
+   struct _fx_LT2iS_data_t*,
+   struct _fx_LT2iS_data_t**,
+   void*);
+
+FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
 
@@ -6913,8 +6983,6 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
 
 FX_EXTERN_C_VAL(int FX_EXN_BadArgError)
 FX_EXTERN_C int _fx_M3AstFM6stringS1N12Ast__unary_t(struct _fx_N12Ast__unary_t*, fx_str_t*, void*);
-
-FX_EXTERN_C bool _fx_F6__eq__B2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C void _fx_M3AstFM10IntrinMathN13Ast__intrin_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_N13Ast__intrin_t*);
 
@@ -7467,8 +7535,6 @@ FX_EXTERN_C void _fx_M3AstFM5IdExnN14Ast__id_info_t1rRM8defexn_t(
 
 FX_EXTERN_C_VAL(struct _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t _fx_g23Ast__builtin_exceptions)
 FX_EXTERN_C_VAL(fx_str_t _fx_g19Ast__ficus_std_path)
-FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
-
 FX_EXTERN_C int _fx_M2ReFM7compileRM1t1S(fx_str_t*, struct _fx_R5Re__t*, void*);
 
 FX_EXTERN_C int _fx_M2ReFM7replaceS5RM1tSSBB(struct _fx_R5Re__t*, fx_str_t*, fx_str_t*, bool, bool, fx_str_t*, void*);
@@ -7767,6 +7833,20 @@ FX_EXTERN_C void _fx_free_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__
    _fx_M13Ast_typecheckFM12is_real_typ_N10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_cldata_t* dst)
 {
    FX_FREE_REF_SIMPLE(&dst->t0);
+   fx_free(dst);
+}
+
+typedef struct {
+   int_ rc;
+   fx_free_t free_f;
+   fx_str_t t0;
+   int_ t1;
+} _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS_cldata_t;
+
+FX_EXTERN_C void _fx_free_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS(
+   _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS_cldata_t* dst)
+{
+   FX_FREE_STR(&dst->t0);
    fx_free(dst);
 }
 
@@ -8133,6 +8213,13 @@ return fx_list_length(l);
 }
 
 FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LN10Ast__typ_t(struct _fx_LN10Ast__typ_t_data_t* l, void* fx_fv)
+{
+   
+return fx_list_length(l);
+
+}
+
+FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LS(struct _fx_LS_data_t* l, void* fx_fv)
 {
    
 return fx_list_length(l);
@@ -8790,6 +8877,239 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM5printv1S(fx_str_t* a_0, void* fx_fv)
 {
    int fx_status = 0;
    _fx_F12print_stringv1S(a_0, 0);
+   return fx_status;
+}
+
+FX_EXTERN_C void _fx_M13Ast_typecheckFM6_swap_v3A1T2iSii(fx_arr_t* arr, int_ i, int_ j, void* fx_fv)
+{
+   
+size_t esz = arr->dim[0].step;
+    if(esz % sizeof(int) == 0) {
+        int* ptr0 = (int*)(arr->data + i*esz);
+        int* ptr1 = (int*)(arr->data + j*esz);
+        esz /= sizeof(int);
+        for( size_t k = 0; k < esz; k++ ) {
+            int t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    } else {
+        char* ptr0 = arr->data + i*esz;
+        char* ptr1 = arr->data + j*esz;
+        for( size_t k = 0; k < esz; k++ ) {
+            char t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    }
+
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM4sortv3A1T2iSFPB2T2iST2iSi(
+   fx_arr_t* arr_0,
+   struct _fx_FPB2T2iST2iS* lt_0,
+   int_ prefix_0,
+   void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(_fx_M13Ast_typecheckFM6qsort_v5iiA1T2iSFPB2T2iST2iSi(0, FX_ARR_SIZE(*arr_0, 0) - 1, arr_0, lt_0, prefix_0, 0),
+      _fx_cleanup);
+
+_fx_cleanup: ;
+   return fx_status;
+}
+
+static int _fx_M13Ast_typecheckFM6qsort_v5iiA1T2iSFPB2T2iST2iSi(
+   int_ lo_0,
+   int_ hi_0,
+   fx_arr_t* arr_0,
+   struct _fx_FPB2T2iST2iS* lt_0,
+   int_ prefix_0,
+   void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   int_ lo_1 = lo_0;
+   int_ hi_1 = hi_0;
+   for (;;) {
+      _fx_T2iS a_0 = {0};
+      _fx_T2iS b_0 = {0};
+      _fx_T2iS p_0 = {0};
+      _fx_T2iS p_1 = {0};
+      _fx_T2iS a_1 = {0};
+      _fx_T2iS a_2 = {0};
+      _fx_T2iS b_1 = {0};
+      int_ lo_2 = lo_1;
+      int_ hi_2 = hi_1;
+      if (lo_2 + 1 < hi_2) {
+         int_ m_0 = (lo_2 + hi_2) / 2;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, lo_2), &a_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, m_0), &b_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, hi_2), &p_0);
+         bool v_0;
+         FX_CALL(lt_0->fp(&a_0, &b_0, &v_0, lt_0->fcv), _fx_catch_2);
+         if (v_0) {
+            bool v_1;
+            FX_CALL(lt_0->fp(&b_0, &p_0, &v_1, lt_0->fcv), _fx_catch_2);
+            if (v_1) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+               _fx_T2iS* v_2 = FX_PTR_1D(_fx_T2iS, *arr_0, m_0);
+               _fx_free_T2iS(v_2);
+               _fx_copy_T2iS(&p_0, v_2);
+               _fx_copy_T2iS(&b_0, &p_1);
+            }
+            else {
+               bool v_3;
+               FX_CALL(lt_0->fp(&a_0, &p_0, &v_3, lt_0->fcv), _fx_catch_2);
+               if (v_3) {
+                  _fx_copy_T2iS(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+                  _fx_T2iS* v_4 = FX_PTR_1D(_fx_T2iS, *arr_0, lo_2);
+                  _fx_free_T2iS(v_4);
+                  _fx_copy_T2iS(&p_0, v_4);
+                  _fx_copy_T2iS(&a_0, &p_1);
+               }
+            }
+         }
+         else {
+            bool v_5;
+            FX_CALL(lt_0->fp(&a_0, &p_0, &v_5, lt_0->fcv), _fx_catch_2);
+            if (v_5) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+               _fx_T2iS* v_6 = FX_PTR_1D(_fx_T2iS, *arr_0, lo_2);
+               _fx_free_T2iS(v_6);
+               _fx_copy_T2iS(&p_0, v_6);
+               _fx_copy_T2iS(&a_0, &p_1);
+            }
+            else {
+               bool v_7;
+               FX_CALL(lt_0->fp(&b_0, &p_0, &v_7, lt_0->fcv), _fx_catch_2);
+               if (v_7) {
+                  _fx_copy_T2iS(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+                  _fx_T2iS* v_8 = FX_PTR_1D(_fx_T2iS, *arr_0, m_0);
+                  _fx_free_T2iS(v_8);
+                  _fx_copy_T2iS(&p_0, v_8);
+                  _fx_copy_T2iS(&b_0, &p_1);
+               }
+            }
+         }
+         int_ __fold_result___0 = lo_2;
+         int_ n_0 = FX_LOOP_COUNT(lo_2, hi_2, 1);
+         for (int_ j_0 = 0; j_0 < n_0; j_0++) {
+            _fx_T2iS v_9 = {0};
+            int_ j_1 = lo_2 + j_0 * 1;
+            int_ i0_0 = __fold_result___0;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, j_1), _fx_catch_0);
+            _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, j_1), &v_9);
+            bool v_10;
+            FX_CALL(lt_0->fp(&v_9, &p_1, &v_10, lt_0->fcv), _fx_catch_0);
+            int_ v_11;
+            if (v_10) {
+               _fx_M13Ast_typecheckFM6_swap_v3A1T2iSii(arr_0, i0_0, j_1, 0); v_11 = i0_0 + 1;
+            }
+            else {
+               v_11 = i0_0;
+            }
+            __fold_result___0 = v_11;
+
+         _fx_catch_0: ;
+            _fx_free_T2iS(&v_9);
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         int_ i0_1 = __fold_result___0;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, i0_1), &a_1);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         _fx_T2iS* v_12 = FX_PTR_1D(_fx_T2iS, *arr_0, hi_2);
+         _fx_free_T2iS(v_12);
+         _fx_copy_T2iS(&a_1, v_12);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         _fx_T2iS* v_13 = FX_PTR_1D(_fx_T2iS, *arr_0, i0_1);
+         _fx_free_T2iS(v_13);
+         _fx_copy_T2iS(&p_1, v_13);
+         int_ i1_0 = hi_2;
+         int_ n_1 = FX_LOOP_COUNT(i0_1, hi_2, 1);
+         for (int_ j_2 = 0; j_2 < n_1; j_2++) {
+            _fx_T2iS v_14 = {0};
+            int_ j_3 = i0_1 + j_2 * 1;
+            int_ v_15 = j_3 + 1;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, v_15), _fx_catch_1);
+            _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, v_15), &v_14);
+            bool v_16;
+            FX_CALL(lt_0->fp(&p_1, &v_14, &v_16, lt_0->fcv), _fx_catch_1);
+            if (v_16) {
+               i1_0 = j_3; FX_BREAK(_fx_catch_1);
+            }
+
+         _fx_catch_1: ;
+            _fx_free_T2iS(&v_14);
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         if (i0_1 - lo_2 < hi_2 - i1_0) {
+            if (i1_0 < prefix_0) {
+               FX_CALL(_fx_M13Ast_typecheckFM6qsort_v5iiA1T2iSFPB2T2iST2iSi(i1_0 + 1, hi_2, arr_0, lt_0, prefix_0, 0),
+                  _fx_catch_2);
+            }
+            lo_1 = lo_2;
+            hi_1 = i0_1 - 1;
+         }
+         else {
+            FX_CALL(_fx_M13Ast_typecheckFM6qsort_v5iiA1T2iSFPB2T2iST2iSi(lo_2, i0_1 - 1, arr_0, lt_0, prefix_0, 0),
+               _fx_catch_2);
+            if (i1_0 < prefix_0) {
+               lo_1 = i1_0 + 1; hi_1 = hi_2;
+            }
+            else {
+               FX_BREAK(_fx_catch_2);
+            }
+         }
+      }
+      else if (lo_2 < hi_2) {
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, lo_2), &a_2);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         _fx_copy_T2iS(FX_PTR_1D(_fx_T2iS, *arr_0, hi_2), &b_1);
+         bool v_17;
+         FX_CALL(lt_0->fp(&b_1, &a_2, &v_17, lt_0->fcv), _fx_catch_2);
+         if (v_17) {
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+            _fx_T2iS* v_18 = FX_PTR_1D(_fx_T2iS, *arr_0, hi_2);
+            _fx_free_T2iS(v_18);
+            _fx_copy_T2iS(&a_2, v_18);
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+            _fx_T2iS* v_19 = FX_PTR_1D(_fx_T2iS, *arr_0, lo_2);
+            _fx_free_T2iS(v_19);
+            _fx_copy_T2iS(&b_1, v_19);
+            FX_BREAK(_fx_catch_2);
+         }
+         else {
+            FX_BREAK(_fx_catch_2);
+         }
+      }
+      else {
+         FX_BREAK(_fx_catch_2);
+      }
+
+   _fx_catch_2: ;
+      _fx_free_T2iS(&b_1);
+      _fx_free_T2iS(&a_2);
+      _fx_free_T2iS(&a_1);
+      _fx_free_T2iS(&p_1);
+      _fx_free_T2iS(&p_0);
+      _fx_free_T2iS(&b_0);
+      _fx_free_T2iS(&a_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
    return fx_status;
 }
 
@@ -10370,6 +10690,87 @@ _fx_cleanup: ;
    }
    FX_FREE_FP(&f_1);
    FX_FREE_LIST_SIMPLE(&res_1);
+   return fx_status;
+}
+
+FX_EXTERN_C int
+   _fx_M13Ast_typecheckFM7update_LT2iS3Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iSLT2iS(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* t_0,
+   struct _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS* f_0,
+   struct _fx_LT2iS_data_t* res_0,
+   struct _fx_LT2iS_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_LT2iS result_0 = 0;
+   _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t t_1 = 0;
+   _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS f_1 = {0};
+   _fx_LT2iS res_1 = 0;
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   FX_COPY_PTR(t_0, &t_1);
+   FX_COPY_FP(f_0, &f_1);
+   FX_COPY_PTR(res_0, &res_1);
+   for (;;) {
+      _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t t_2 = 0;
+      _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS f_2 = {0};
+      _fx_LT2iS res_2 = 0;
+      FX_COPY_PTR(t_1, &t_2);
+      FX_COPY_FP(&f_1, &f_2);
+      FX_COPY_PTR(res_1, &res_2);
+      if ((t_2 != 0) + 1 == 2) {
+         _fx_LT2iS v_0 = 0;
+         _fx_LT2iS v_1 = 0;
+         _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tR9Ast__id_tLN16Ast__env_entry_tNt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t*
+            vcase_0 = &t_2->u.Node;
+         FX_CALL(
+            _fx_M13Ast_typecheckFM7update_LT2iS3Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iSLT2iS(
+               vcase_0->t1, &f_2, res_2, &v_0, 0), _fx_catch_0);
+         FX_CALL(f_2.fp(&vcase_0->t2, vcase_0->t3, v_0, &v_1, f_2.fcv), _fx_catch_0);
+         _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t* r_0 = &vcase_0->t4;
+         _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_1);
+         FX_COPY_PTR(*r_0, &t_1);
+         FX_FREE_FP(&f_1);
+         FX_COPY_FP(&f_2, &f_1);
+         _fx_free_LT2iS(&res_1);
+         FX_COPY_PTR(v_1, &res_1);
+
+      _fx_catch_0: ;
+         if (v_1) {
+            _fx_free_LT2iS(&v_1);
+         }
+         if (v_0) {
+            _fx_free_LT2iS(&v_0);
+         }
+      }
+      else {
+         _fx_free_LT2iS(&result_0); FX_COPY_PTR(res_2, &result_0); FX_BREAK(_fx_catch_1);  _fx_catch_1: ;
+      }
+      FX_CHECK_EXN(_fx_catch_2);
+
+   _fx_catch_2: ;
+      if (res_2) {
+         _fx_free_LT2iS(&res_2);
+      }
+      FX_FREE_FP(&f_2);
+      if (t_2) {
+         _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_2);
+      }
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   FX_COPY_PTR(result_0, fx_result);
+
+_fx_cleanup: ;
+   if (result_0) {
+      _fx_free_LT2iS(&result_0);
+   }
+   if (t_1) {
+      _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&t_1);
+   }
+   FX_FREE_FP(&f_1);
+   if (res_1) {
+      _fx_free_LT2iS(&res_1);
+   }
    return fx_status;
 }
 
@@ -17001,6 +17402,510 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp2_FPN10Ast__typ_t2N10Ast__typ_tR16
    return 0;
 }
 
+FX_EXTERN_C int _fx_M13Ast_typecheckFM13edit_distancei2SS(fx_str_t* a_0, fx_str_t* b_0, int_* fx_result, void* fx_fv)
+{
+   fx_arr_t prev_0 = {0};
+   fx_arr_t curr_0 = {0};
+   int fx_status = 0;
+   int_ la_0 = FX_STR_LENGTH(*a_0);
+   int_ lb_0 = FX_STR_LENGTH(*b_0);
+   if (la_0 == 0) {
+      *fx_result = lb_0;
+   }
+   else if (lb_0 == 0) {
+      *fx_result = la_0;
+   }
+   else {
+      int_* dstptr_0 = 0;
+      int_ v_0 = lb_0 + 1;
+      {
+         const int_ shape_0[] = { v_0 };
+         FX_CALL(fx_make_arr(1, shape_0, sizeof(int_), 0, 0, 0, &prev_0), _fx_cleanup);
+      }
+      dstptr_0 = (int_*)prev_0.data;
+      for (int_ i_0 = 0; i_0 < v_0; i_0++, dstptr_0++) {
+         *dstptr_0 = 0;
+      }
+      int_* dstptr_1 = 0;
+      int_ v_1 = lb_0 + 1;
+      {
+         const int_ shape_1[] = { v_1 };
+         FX_CALL(fx_make_arr(1, shape_1, sizeof(int_), 0, 0, 0, &curr_0), _fx_cleanup);
+      }
+      dstptr_1 = (int_*)curr_0.data;
+      for (int_ i_1 = 0; i_1 < v_1; i_1++, dstptr_1++) {
+         *dstptr_1 = 0;
+      }
+      int_ v_2 = lb_0 + 1;
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_2, 1, 1, 0, _fx_cleanup);
+      int_* ptr_0 = FX_PTR_1D(int_, prev_0, 0);
+      for (int_ j_0 = 0; j_0 < v_2; j_0++) {
+         ptr_0[j_0] = j_0;
+      }
+      int_ v_3 = la_0 + 1;
+      int_ v_4 = lb_0 + 1;
+      int_ v_5 = lb_0 + 1;
+      FX_CHKIDX_RANGE(FX_STR_LENGTH(*a_0), 1, v_3, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_SCALAR(FX_ARR_SIZE(curr_0, 0), 0, _fx_cleanup);
+      int_ size_0 = FX_ARR_SIZE(curr_0, 0);
+      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, 0, _fx_cleanup);
+      int_ size_1 = FX_ARR_SIZE(prev_0, 0);
+      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, 0, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_STR_LENGTH(*b_0), 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(curr_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
+      int_* ptr_1 = FX_PTR_1D(int_, curr_0, 0);
+      int_* ptr_2 = FX_PTR_1D(int_, prev_0, 0);
+      int_ n_0 = FX_LOOP_COUNT(1, v_3, 1);
+      for (int_ i_2 = 0; i_2 < n_0; i_2++) {
+         int_ i_3 = 1 + i_2 * 1;
+         ptr_1[0] = i_3;
+         char_ ai_0 = FX_STR_ELEM(*a_0, i_3 + -1);
+         int_ n_1 = FX_LOOP_COUNT(1, v_4, 1);
+         for (int_ j_1 = 0; j_1 < n_1; j_1++) {
+            int_ j_2 = 1 + j_1 * 1;
+            int_ cost_0;
+            if (ai_0 == FX_STR_ELEM(*b_0, j_2 + -1)) {
+               cost_0 = 0;
+            }
+            else {
+               cost_0 = 1;
+            }
+            ptr_1[j_2] = fx_mini(fx_mini(ptr_2[j_2] + 1, ptr_1[j_2 + -1] + 1), ptr_2[j_2 + -1] + cost_0);
+
+         _fx_catch_0: ;
+            FX_CHECK_EXN(_fx_catch_1);
+         }
+         for (int_ j_3 = 0; j_3 < v_5; j_3++) {
+            ptr_2[j_3] = ptr_1[j_3];
+         }
+
+      _fx_catch_1: ;
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      FX_CHKIDX(FX_CHKIDX1(prev_0, 0, lb_0), _fx_cleanup);
+      *fx_result = *FX_PTR_1D(int_, prev_0, lb_0);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&prev_0);
+   FX_FREE_ARR(&curr_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM10__lambda__B2T2iST2iS(
+   struct _fx_T2iS* arg0_0,
+   struct _fx_T2iS* arg1_0,
+   bool* fx_result,
+   void* fx_fv)
+{
+   fx_str_t s1_0 = {0};
+   fx_str_t s2_0 = {0};
+   int fx_status = 0;
+   int_ d1_0 = arg0_0->t0;
+   fx_copy_str(&arg0_0->t1, &s1_0);
+   int_ d2_0 = arg1_0->t0;
+   fx_copy_str(&arg1_0->t1, &s2_0);
+   if (d1_0 < d2_0) {
+      *fx_result = true;
+   }
+   else if (d1_0 == d2_0) {
+      int_ v_0 = _fx_F7__cmp__i2SS(&s1_0, &s2_0, 0); *fx_result = v_0 < 0;
+   }
+   else {
+      *fx_result = false;
+   }
+   FX_FREE_STR(&s1_0);
+   FX_FREE_STR(&s2_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM5take2LS3LT2iSSLS(
+   struct _fx_LT2iS_data_t* l_0,
+   fx_str_t* last_0,
+   struct _fx_LS_data_t* acc_0,
+   struct _fx_LS_data_t** fx_result,
+   void* fx_fv)
+{
+   _fx_LS result_0 = 0;
+   _fx_LT2iS l_1 = 0;
+   fx_str_t last_1 = {0};
+   _fx_LS acc_1 = 0;
+   int fx_status = 0;
+   FX_COPY_PTR(l_0, &l_1);
+   fx_copy_str(last_0, &last_1);
+   FX_COPY_PTR(acc_0, &acc_1);
+   for (;;) {
+      _fx_LT2iS l_2 = 0;
+      fx_str_t last_2 = {0};
+      _fx_LS acc_2 = 0;
+      _fx_LS __fold_result___0 = 0;
+      _fx_LS result_1 = 0;
+      FX_COPY_PTR(l_1, &l_2);
+      fx_copy_str(&last_1, &last_2);
+      FX_COPY_PTR(acc_1, &acc_2);
+      int_ v_0 = _fx_M13Ast_typecheckFM6lengthi1LS(acc_2, 0);
+      if (v_0 >= 2) {
+         _fx_LS lst_0 = acc_2;
+         for (; lst_0; lst_0 = lst_0->tl) {
+            _fx_LS r_0 = 0;
+            fx_str_t* a_0 = &lst_0->hd;
+            FX_COPY_PTR(__fold_result___0, &r_0);
+            FX_CALL(_fx_cons_LS(a_0, r_0, false, &r_0), _fx_catch_0);
+            _fx_free_LS(&__fold_result___0);
+            FX_COPY_PTR(r_0, &__fold_result___0);
+
+         _fx_catch_0: ;
+            if (r_0) {
+               _fx_free_LS(&r_0);
+            }
+            FX_CHECK_EXN(_fx_catch_4);
+         }
+         FX_COPY_PTR(__fold_result___0, &result_1);
+         _fx_free_LS(&result_0);
+         FX_COPY_PTR(result_1, &result_0);
+         FX_BREAK(_fx_catch_4);
+      }
+      else {
+         if (l_2 != 0) {
+            _fx_LS v_1 = 0;
+            _fx_LT2iS rest_0 = l_2->tl;
+            fx_str_t* nm_0 = &l_2->hd.t1;
+            bool v_2 = _fx_F6__eq__B2SS(nm_0, &last_2, 0);
+            if (v_2) {
+               _fx_free_LT2iS(&l_1);
+               FX_COPY_PTR(rest_0, &l_1);
+               FX_FREE_STR(&last_1);
+               fx_copy_str(&last_2, &last_1);
+               _fx_free_LS(&acc_1);
+               FX_COPY_PTR(acc_2, &acc_1);
+            }
+            else {
+               FX_CALL(_fx_cons_LS(nm_0, acc_2, true, &v_1), _fx_catch_1);
+               _fx_free_LT2iS(&l_1);
+               FX_COPY_PTR(rest_0, &l_1);
+               FX_FREE_STR(&last_1);
+               fx_copy_str(nm_0, &last_1);
+               _fx_free_LS(&acc_1);
+               FX_COPY_PTR(v_1, &acc_1);
+            }
+
+         _fx_catch_1: ;
+            if (v_1) {
+               _fx_free_LS(&v_1);
+            }
+         }
+         else if (l_2 == 0) {
+            _fx_LS __fold_result___1 = 0;
+            _fx_LS result_2 = 0;
+            _fx_LS lst_1 = acc_2;
+            for (; lst_1; lst_1 = lst_1->tl) {
+               _fx_LS r_1 = 0;
+               fx_str_t* a_1 = &lst_1->hd;
+               FX_COPY_PTR(__fold_result___1, &r_1);
+               FX_CALL(_fx_cons_LS(a_1, r_1, false, &r_1), _fx_catch_2);
+               _fx_free_LS(&__fold_result___1);
+               FX_COPY_PTR(r_1, &__fold_result___1);
+
+            _fx_catch_2: ;
+               if (r_1) {
+                  _fx_free_LS(&r_1);
+               }
+               FX_CHECK_EXN(_fx_catch_3);
+            }
+            FX_COPY_PTR(__fold_result___1, &result_2);
+            _fx_free_LS(&result_0);
+            FX_COPY_PTR(result_2, &result_0);
+            FX_BREAK(_fx_catch_3);
+
+         _fx_catch_3: ;
+            if (result_2) {
+               _fx_free_LS(&result_2);
+            }
+            if (__fold_result___1) {
+               _fx_free_LS(&__fold_result___1);
+            }
+         }
+         else {
+            FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_4);
+         }
+         FX_CHECK_EXN(_fx_catch_4);
+      }
+
+   _fx_catch_4: ;
+      if (result_1) {
+         _fx_free_LS(&result_1);
+      }
+      if (__fold_result___0) {
+         _fx_free_LS(&__fold_result___0);
+      }
+      if (acc_2) {
+         _fx_free_LS(&acc_2);
+      }
+      FX_FREE_STR(&last_2);
+      if (l_2) {
+         _fx_free_LT2iS(&l_2);
+      }
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   FX_COPY_PTR(result_0, fx_result);
+
+_fx_cleanup: ;
+   if (result_0) {
+      _fx_free_LS(&result_0);
+   }
+   if (l_1) {
+      _fx_free_LT2iS(&l_1);
+   }
+   FX_FREE_STR(&last_1);
+   if (acc_1) {
+      _fx_free_LS(&acc_1);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM15suggest_similarS2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_R9Ast__id_t* n_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
+   fx_str_t* fx_result,
+   void* fx_fv)
+{
+   fx_str_t target_0 = {0};
+   _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS __lambda___0 = {0};
+   _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t v_0 = 0;
+   _fx_LT2iS cand_0 = 0;
+   _fx_LT2iS cand_1 = 0;
+   _fx_LS v_1 = 0;
+   int fx_status = 0;
+   FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &target_0, 0), _fx_cleanup);
+   int_ tlen_0 = FX_STR_LENGTH(target_0);
+   if (tlen_0 == 0) {
+      fx_str_t slit_0 = FX_MAKE_STR(""); fx_copy_str(&slit_0, fx_result);
+   }
+   else {
+      int_ thresh_0;
+      if (tlen_0 <= 4) {
+         thresh_0 = 1;
+      }
+      else {
+         thresh_0 = 2;
+      }
+      _fx_M13Ast_typecheckFM7make_fpFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS2Si(&target_0, thresh_0, &__lambda___0);
+      FX_COPY_PTR(env_0->root, &v_0);
+      FX_CALL(
+         _fx_M13Ast_typecheckFM7update_LT2iS3Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_tFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iSLT2iS(
+            v_0, &__lambda___0, 0, &cand_0, 0), _fx_cleanup);
+      if (cand_0 == 0) {
+         FX_COPY_PTR(cand_0, &cand_1); goto _fx_endmatch_0;
+      }
+      if (cand_0 != 0) {
+         if (cand_0->tl == 0) {
+            FX_COPY_PTR(cand_0, &cand_1); goto _fx_endmatch_0;
+         }
+      }
+      if (cand_0 != 0) {
+         _fx_LT2iS v_2 = cand_0->tl;
+         if (v_2 != 0) {
+            if (v_2->tl == 0) {
+               fx_str_t s1_0 = {0};
+               fx_str_t s2_0 = {0};
+               _fx_LT2iS v_3 = 0;
+               _fx_T2iS* b_0 = &v_2->hd;
+               _fx_T2iS* a_0 = &cand_0->hd;
+               int_ d1_0 = b_0->t0;
+               fx_copy_str(&b_0->t1, &s1_0);
+               int_ d2_0 = a_0->t0;
+               fx_copy_str(&a_0->t1, &s2_0);
+               bool v_4;
+               if (d1_0 < d2_0) {
+                  v_4 = true;
+               }
+               else if (d1_0 == d2_0) {
+                  int_ v_5 = _fx_F7__cmp__i2SS(&s1_0, &s2_0, 0); v_4 = v_5 < 0;
+               }
+               else {
+                  v_4 = false;
+               }
+               if (v_4) {
+                  FX_CALL(_fx_cons_LT2iS(a_0, 0, true, &v_3), _fx_catch_0);
+                  FX_CALL(_fx_cons_LT2iS(b_0, v_3, true, &cand_1), _fx_catch_0);
+               }
+               else {
+                  FX_COPY_PTR(cand_0, &cand_1);
+               }
+
+            _fx_catch_0: ;
+               if (v_3) {
+                  _fx_free_LT2iS(&v_3);
+               }
+               FX_FREE_STR(&s2_0);
+               FX_FREE_STR(&s1_0);
+               goto _fx_endmatch_0;
+            }
+         }
+      }
+      fx_arr_t arr_0 = {0};
+      _fx_FPB2T2iST2iS __lambda___1 = {0};
+      _fx_T2iS* dstptr_0 = 0;
+      _fx_LT2iS lst_0 = cand_0;
+      int_ len_0 = fx_list_length(lst_0);
+      {
+         const int_ shape_0[] = { len_0 };
+         FX_CALL(fx_make_arr(1, shape_0, sizeof(_fx_T2iS), (fx_free_t)_fx_free_T2iS, (fx_copy_t)_fx_copy_T2iS, 0, &arr_0),
+            _fx_catch_2);
+      }
+      dstptr_0 = (_fx_T2iS*)arr_0.data;
+      for (; lst_0; lst_0 = lst_0->tl, dstptr_0++) {
+         _fx_T2iS* x_0 = &lst_0->hd; _fx_copy_T2iS(x_0, dstptr_0);
+      }
+      _fx_FPB2T2iST2iS __lambda___fp_0 = { _fx_M13Ast_typecheckFM10__lambda__B2T2iST2iS, 0 };
+      FX_COPY_FP(&__lambda___fp_0, &__lambda___1);
+      FX_CALL(_fx_M13Ast_typecheckFM4sortv3A1T2iSFPB2T2iST2iSi(&arr_0, &__lambda___1, FX_ARR_SIZE(arr_0, 0), 0), _fx_catch_2);
+      _fx_LT2iS lstend_0 = 0;
+      int_ ni_0 = FX_ARR_SIZE(arr_0, 0);
+      _fx_T2iS* ptr_arr_0 = FX_PTR_1D(_fx_T2iS, arr_0, 0);
+      for (int_ i_0 = 0; i_0 < ni_0; i_0++) {
+         _fx_T2iS x_1 = {0};
+         _fx_copy_T2iS(ptr_arr_0 + i_0, &x_1);
+         _fx_LT2iS node_0 = 0;
+         FX_CALL(_fx_cons_LT2iS(&x_1, 0, false, &node_0), _fx_catch_1);
+         FX_LIST_APPEND(cand_1, lstend_0, node_0);
+
+      _fx_catch_1: ;
+         _fx_free_T2iS(&x_1);
+         FX_CHECK_EXN(_fx_catch_2);
+      }
+
+   _fx_catch_2: ;
+      FX_FREE_FP(&__lambda___1);
+      FX_FREE_ARR(&arr_0);
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_cleanup);
+      fx_str_t slit_1 = FX_MAKE_STR("");
+      FX_CALL(_fx_M13Ast_typecheckFM5take2LS3LT2iSSLS(cand_1, &slit_1, 0, &v_1, 0), _fx_cleanup);
+      if (v_1 == 0) {
+         fx_str_t slit_2 = FX_MAKE_STR(""); fx_copy_str(&slit_2, fx_result); goto _fx_endmatch_1;
+      }
+      if (v_1 != 0) {
+         if (v_1->tl == 0) {
+            fx_str_t slit_3 = FX_MAKE_STR("; did you mean \'");
+            fx_str_t* a_1 = &v_1->hd;
+            fx_str_t slit_4 = FX_MAKE_STR("\'?");
+            {
+               const fx_str_t strs_0[] = { slit_3, *a_1, slit_4 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, fx_result), _fx_catch_3);
+            }
+
+         _fx_catch_3: ;
+            goto _fx_endmatch_1;
+         }
+      }
+      if (v_1 != 0) {
+         _fx_LS v_6 = v_1->tl;
+         if (v_6 != 0) {
+            fx_str_t slit_5 = FX_MAKE_STR("; did you mean \'");
+            fx_str_t* a_2 = &v_1->hd;
+            fx_str_t slit_6 = FX_MAKE_STR("\' or \'");
+            fx_str_t* b_1 = &v_6->hd;
+            fx_str_t slit_7 = FX_MAKE_STR("\'?");
+            {
+               const fx_str_t strs_1[] = { slit_5, *a_2, slit_6, *b_1, slit_7 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 5, fx_result), _fx_catch_4);
+            }
+
+         _fx_catch_4: ;
+            goto _fx_endmatch_1;
+         }
+      }
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
+
+   _fx_endmatch_1: ;
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_STR(&target_0);
+   FX_FREE_FP(&__lambda___0);
+   if (v_0) {
+      _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&v_0);
+   }
+   if (cand_0) {
+      _fx_free_LT2iS(&cand_0);
+   }
+   if (cand_1) {
+      _fx_free_LT2iS(&cand_1);
+   }
+   if (v_1) {
+      _fx_free_LS(&v_1);
+   }
+   return fx_status;
+}
+
+static int _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS(
+   struct _fx_R9Ast__id_t* key_0,
+   struct _fx_LN16Ast__env_entry_t_data_t* __0,
+   struct _fx_LT2iS_data_t* acc_0,
+   struct _fx_LT2iS_data_t** fx_result,
+   void* fx_fv)
+{
+   fx_str_t nm_0 = {0};
+   _fx_T2iS v_0 = {0};
+   int fx_status = 0;
+   _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS_cldata_t* cv_0 =
+      (_fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS_cldata_t*)fx_fv;
+   fx_str_t* target_0 = &cv_0->t0;
+   FX_CALL(_fx_M3AstFM2ppS1RM4id_t(key_0, &nm_0, 0), _fx_cleanup);
+   bool v_1;
+   bool t_0;
+   if (_fx_F6__eq__B2SS(&nm_0, target_0, 0)) {
+      t_0 = true;
+   }
+   else {
+      t_0 = FX_STR_LENGTH(nm_0) == 0;
+   }
+   if (t_0) {
+      v_1 = true;
+   }
+   else {
+      fx_str_t slit_0 = FX_MAKE_STR("_"); v_1 = _fx_M6StringFM10startswithB2SS(&nm_0, &slit_0, 0);
+   }
+   if (v_1) {
+      FX_COPY_PTR(acc_0, fx_result);
+   }
+   else {
+      int_ d_0;
+      FX_CALL(_fx_M13Ast_typecheckFM13edit_distancei2SS(target_0, &nm_0, &d_0, 0), _fx_cleanup);
+      if (d_0 <= cv_0->t1) {
+         _fx_make_T2iS(d_0, &nm_0, &v_0); FX_CALL(_fx_cons_LT2iS(&v_0, acc_0, true, fx_result), _fx_cleanup);
+      }
+      else {
+         FX_COPY_PTR(acc_0, fx_result);
+      }
+   }
+
+_fx_cleanup: ;
+   FX_FREE_STR(&nm_0);
+   _fx_free_T2iS(&v_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M13Ast_typecheckFM7make_fpFPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS2Si(
+   fx_str_t* arg0,
+   int_ arg1,
+   struct _fx_FPLT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS* fx_result)
+{
+   FX_MAKE_FP_IMPL_START(_fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS_cldata_t,
+      _fx_free_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS,
+      _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry_tLT2iS);
+   fx_copy_str(arg0, &fcv->t0);
+   fcv->t1 = arg1;
+   return 0;
+}
+
 FX_EXTERN_C int _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_rR13Ast__deffun_t_data_t* df_0,
    struct _fx_LN10Ast__typ_t_data_t* call_argtyps_0,
@@ -17448,10 +18353,11 @@ _fx_cleanup: ;
 }
 
 FX_EXTERN_C int
-   _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+   _fx_M13Ast_typecheckFM22report_not_found_typedE6R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* n_0,
    struct _fx_N10Ast__typ_t_data_t* t_0,
    struct _fx_LN16Ast__env_entry_t_data_t* possible_matches_0,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* env_0,
    struct _fx_LN12Ast__scope_t_data_t* sc_0,
    struct _fx_R10Ast__loc_t* loc_0,
    fx_exn_t* fx_result,
@@ -17461,9 +18367,11 @@ FX_EXTERN_C int
    _fx_N10Ast__typ_t v_0 = 0;
    _fx_Nt6option1LN10Ast__typ_t call_argtyps_opt_0 = {0};
    _fx_LS strs_0 = 0;
-   fx_str_t candidates_msg_0 = {0};
+   fx_str_t tail_0 = {0};
    fx_str_t v_1 = {0};
+   fx_str_t s_0 = {0};
    fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
    int fx_status = 0;
    FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &nstr_0, 0), _fx_cleanup);
    FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_0, 0), _fx_cleanup);
@@ -17511,44 +18419,44 @@ FX_EXTERN_C int
       }
       if (call_argtyps_opt_0.tag == 2) {
          if (info_0.tag == 3) {
-            fx_str_t v_3 = {0};
             fx_str_t v_4 = {0};
+            fx_str_t v_5 = {0};
             _fx_rR13Ast__deffun_t df_0 = info_0.u.IdFun;
-            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(df_0, &v_3, 0), _fx_catch_0);
+            FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(df_0, &v_4, 0), _fx_catch_0);
             FX_CALL(
                _fx_M13Ast_typecheckFM19fun_mismatch_reasonS4rR13Ast__deffun_tLN10Ast__typ_tLN12Ast__scope_tR10Ast__loc_t(df_0,
-                  call_argtyps_opt_0.u.Some, sc_0, loc_0, &v_4, 0), _fx_catch_0);
+                  call_argtyps_opt_0.u.Some, sc_0, loc_0, &v_5, 0), _fx_catch_0);
             fx_str_t slit_0 = FX_MAKE_STR(" -- ");
             {
-               const fx_str_t strs_1[] = { v_3, slit_0, v_4 };
+               const fx_str_t strs_1[] = { v_4, slit_0, v_5 };
                FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &res_0), _fx_catch_0);
             }
 
          _fx_catch_0: ;
+            FX_FREE_STR(&v_5);
             FX_FREE_STR(&v_4);
-            FX_FREE_STR(&v_3);
             goto _fx_endmatch_0;
          }
       }
       _fx_N10Ast__typ_t tj_0 = 0;
-      fx_str_t v_5 = {0};
       fx_str_t v_6 = {0};
+      fx_str_t v_7 = {0};
       FX_CALL(_fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc_t(&info_0, loc_0, &tj_0, 0), _fx_catch_1);
       _fx_R10Ast__loc_t locj_0;
       FX_CALL(_fx_M3AstFM14get_idinfo_locRM5loc_t1N14Ast__id_info_t(&info_0, &locj_0, 0), _fx_catch_1);
-      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(tj_0, &v_5, 0), _fx_catch_1);
-      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&locj_0, &v_6, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(tj_0, &v_6, 0), _fx_catch_1);
+      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&locj_0, &v_7, 0), _fx_catch_1);
       fx_str_t slit_1 = FX_MAKE_STR("\'");
       fx_str_t slit_2 = FX_MAKE_STR(": ");
       fx_str_t slit_3 = FX_MAKE_STR("\' defined at ");
       {
-         const fx_str_t strs_2[] = { slit_1, nstr_0, slit_2, v_5, slit_3, v_6 };
+         const fx_str_t strs_2[] = { slit_1, nstr_0, slit_2, v_6, slit_3, v_7 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_2, 6, &res_0), _fx_catch_1);
       }
 
    _fx_catch_1: ;
+      FX_FREE_STR(&v_7);
       FX_FREE_STR(&v_6);
-      FX_FREE_STR(&v_5);
       if (tj_0) {
          _fx_free_N10Ast__typ_t(&tj_0);
       }
@@ -17565,29 +18473,42 @@ FX_EXTERN_C int
       FX_CHECK_CONTINUE();
       FX_CHECK_EXN(_fx_cleanup);
    }
-   if (strs_0 == 0) {
-      fx_str_t slit_4 = FX_MAKE_STR(""); fx_copy_str(&slit_4, &candidates_msg_0);
-   }
-   else {
-      fx_str_t slit_5 =
+   if (strs_0 != 0) {
+      fx_str_t slit_4 =
          FX_MAKE_STR("\n"
             U"Candidates:\n"
             U"\t");
-      fx_str_t slit_6 = FX_MAKE_STR("\n");
-      fx_str_t slit_7 =
+      fx_str_t slit_5 = FX_MAKE_STR("\n");
+      fx_str_t slit_6 =
          FX_MAKE_STR(",\n"
             U"\t");
-      FX_CALL(_fx_F12join_embraceS4SSSLS(&slit_5, &slit_6, &slit_7, strs_0, &candidates_msg_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F12join_embraceS4SSSLS(&slit_4, &slit_5, &slit_6, strs_0, &v_1, 0), _fx_cleanup);
+      fx_str_t slit_7 = FX_MAKE_STR(".");
+      {
+         const fx_str_t strs_3[] = { slit_7, v_1 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_3, 2, &tail_0), _fx_cleanup);
+      }
    }
-   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_1, 0), _fx_cleanup);
-   fx_str_t slit_8 = FX_MAKE_STR("the appropriate match for \'");
-   fx_str_t slit_9 = FX_MAKE_STR("\' of type \'");
-   fx_str_t slit_10 = FX_MAKE_STR("\' is not found.");
+   else {
+      FX_CALL(
+         _fx_M13Ast_typecheckFM15suggest_similarS2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(n_0, env_0, &s_0, 0),
+         _fx_cleanup);
+      if (FX_STR_LENGTH(s_0) == 0) {
+         fx_str_t slit_8 = FX_MAKE_STR("."); fx_copy_str(&slit_8, &tail_0);
+      }
+      else {
+         fx_copy_str(&s_0, &tail_0);
+      }
+   }
+   FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_2, 0), _fx_cleanup);
+   fx_str_t slit_9 = FX_MAKE_STR("the appropriate match for \'");
+   fx_str_t slit_10 = FX_MAKE_STR("\' of type \'");
+   fx_str_t slit_11 = FX_MAKE_STR("\' is not found");
    {
-      const fx_str_t strs_3[] = { slit_8, nstr_0, slit_9, v_1, slit_10, candidates_msg_0 };
-      FX_CALL(fx_strjoin(0, 0, 0, strs_3, 6, &v_2), _fx_cleanup);
+      const fx_str_t strs_4[] = { slit_9, nstr_0, slit_10, v_2, slit_11, tail_0 };
+      FX_CALL(fx_strjoin(0, 0, 0, strs_4, 6, &v_3), _fx_cleanup);
    }
-   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_2, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_3, fx_result, 0), _fx_cleanup);
 
 _fx_cleanup: ;
    FX_FREE_STR(&nstr_0);
@@ -17598,9 +18519,11 @@ _fx_cleanup: ;
    if (strs_0) {
       _fx_free_LS(&strs_0);
    }
-   FX_FREE_STR(&candidates_msg_0);
+   FX_FREE_STR(&tail_0);
    FX_FREE_STR(&v_1);
+   FX_FREE_STR(&s_0);
    FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
    return fx_status;
 }
 
@@ -19603,8 +20526,8 @@ FX_EXTERN_C int
          else {
             fx_exn_t v_11 = {0};
             FX_CALL(
-               _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                  n_0, t_0, possible_matches_0, sc_0, loc_0, &v_11, 0), _fx_catch_3);
+               _fx_M13Ast_typecheckFM22report_not_found_typedE6R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                  n_0, t_0, possible_matches_0, env_0, sc_0, loc_0, &v_11, 0), _fx_catch_3);
             FX_THROW(&v_11, false, _fx_catch_3);
 
          _fx_catch_3: ;
@@ -20828,8 +21751,8 @@ FX_EXTERN_C int
                   else {
                      fx_exn_t v_30 = {0};
                      FX_CALL(
-                        _fx_M13Ast_typecheckFM22report_not_found_typedE5R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                           n2_1, etyp_0, candidates_0, sc_2, &eloc_0, &v_30, 0), _fx_catch_15);
+                        _fx_M13Ast_typecheckFM22report_not_found_typedE6R9Ast__id_tN10Ast__typ_tLN16Ast__env_entry_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
+                           n2_1, etyp_0, candidates_0, &env_2, sc_2, &eloc_0, &v_30, 0), _fx_catch_15);
                      FX_THROW(&v_30, false, _fx_catch_15);
 
                   _fx_catch_15: ;

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -138,6 +138,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -1814,6 +1815,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1851,6 +1853,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1887,6 +1890,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -170,16 +170,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;
@@ -1478,6 +1479,11 @@ typedef struct _fx_T4LN10Ast__exp_tiii {
    int_ t2;
    int_ t3;
 } _fx_T4LN10Ast__exp_tiii;
+
+typedef struct _fx_T2Bi {
+   bool t0;
+   int_ t1;
+} _fx_T2Bi;
 
 typedef struct _fx_T7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t {
    int_ t0;
@@ -7094,7 +7100,7 @@ FX_EXTERN_C int _fx_M3AstFM5ExpIfN10Ast__exp_t4N10Ast__exp_tN10Ast__exp_tN10Ast_
    struct _fx_T2N10Ast__typ_tR10Ast__loc_t*,
    struct _fx_N10Ast__exp_t_data_t**);
 
-FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(int_, bool, struct _fx_N12Ast__scope_t*, void*);
+FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(int_, bool, bool, struct _fx_N12Ast__scope_t*, void*);
 
 FX_EXTERN_C int _fx_M3AstFM8ExpWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(
    struct _fx_N10Ast__exp_t_data_t*,
@@ -8511,10 +8517,11 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM15__eq_variants__B2N12Ast__scope_tN12Ast__
       }
    }
    if (b_0->tag == 2) {
-      _fx_T2Bi* vcase_0 = &b_0->u.ScLoop;
+      _fx_T3BBi* vcase_0 = &b_0->u.ScLoop;
       if (a_0->tag == 2) {
-         _fx_T2Bi* vcase_1 = &a_0->u.ScLoop;
-         *fx_result = (bool)((vcase_1->t0 == vcase_0->t0) & (vcase_1->t1 == vcase_0->t1));
+         _fx_T3BBi* vcase_1 = &a_0->u.ScLoop;
+         *fx_result =
+            (bool)((bool)((vcase_1->t0 == vcase_0->t0) & (vcase_1->t1 == vcase_0->t1)) & (vcase_1->t2 == vcase_0->t2));
          goto _fx_endmatch_0;
       }
    }
@@ -26247,7 +26254,7 @@ FX_EXTERN_C int
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
                c_1, &env_2, sc_2, &new_c_1, 0), _fx_catch_142);
          _fx_N12Ast__scope_t v_342;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_342, 0), _fx_catch_142);
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_342, 0), _fx_catch_142);
          FX_CALL(_fx_cons_LN12Ast__scope_t(&v_342, sc_2, true, &loop_sc_0), _fx_catch_142);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
@@ -26309,7 +26316,7 @@ FX_EXTERN_C int
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
                c_2, &env_2, sc_2, &new_c_2, 0), _fx_catch_143);
          _fx_N12Ast__scope_t v_345;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, false, &v_345, 0), _fx_catch_143);
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_345, 0), _fx_catch_143);
          FX_CALL(_fx_cons_LN12Ast__scope_t(&v_345, sc_2, true, &loop_sc_1), _fx_catch_143);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
@@ -26375,7 +26382,9 @@ FX_EXTERN_C int
             FX_CALL(_fx_M3AstFM14new_fold_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_351, 0), _fx_catch_145);
          }
          else {
-            FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(curr_m_idx_0, is_nested_0, &v_351, 0), _fx_catch_145);
+            FX_CALL(
+               _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, is_nested_0, flags_0->for_flag_parallel, &v_351, 0),
+               _fx_catch_145);
          }
          FX_CALL(_fx_cons_LN12Ast__scope_t(&v_351, sc_2, true, &for_sc_0), _fx_catch_145);
          FX_CALL(
@@ -30454,7 +30463,10 @@ static int _fx_M13Ast_typecheckFM13check_inside_v6LN12Ast__scope_tBR10Ast__loc_t
          if (v_4->tag == 2) {
             fx_str_t v_5 = {0};
             fx_exn_t v_6 = {0};
-            fx_exn_t v_7 = {0};
+            fx_str_t v_7 = {0};
+            fx_exn_t v_8 = {0};
+            fx_exn_t v_9 = {0};
+            _fx_T3BBi* vcase_0 = &v_4->u.ScLoop;
             if (!any_for_0) {
                if (expect_fold_loop_0) {
                   fx_str_t slit_4 = FX_MAKE_STR("\'");
@@ -30466,20 +30478,30 @@ static int _fx_M13Ast_typecheckFM13check_inside_v6LN12Ast__scope_tBR10Ast__loc_t
                   FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_5, &v_6, 0), _fx_catch_2);
                   FX_THROW(&v_6, false, _fx_catch_2);
                }
+               else if (vcase_0->t1) {
+                  fx_str_t slit_6 = FX_MAKE_STR("cannot use \'");
+                  fx_str_t slit_7 = FX_MAKE_STR("\' inside a \'@parallel\' loop");
+                  {
+                     const fx_str_t strs_3[] = { slit_6, *kw_0, slit_7 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_7), _fx_catch_2);
+                  }
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_7, &v_8, 0), _fx_catch_2);
+                  FX_THROW(&v_8, false, _fx_catch_2);
+               }
                else {
                   bool t_2;
                   if (isbr_0) {
-                     t_2 = v_4->u.ScLoop.t0;
+                     t_2 = vcase_0->t0;
                   }
                   else {
                      t_2 = false;
                   }
                   if (t_2) {
-                     fx_str_t slit_6 =
+                     fx_str_t slit_8 =
                         FX_MAKE_STR(
                            "\'break\' cannot be used inside nested for-loop because of ambiguity. Use explicit curly braces, e.g. \'for ... { for ... { for ... { break }}}\' to exit a single for-loop, or use exceptions, e.g. the standard \'Break\' exception to exit nested loops.");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &slit_6, &v_7, 0), _fx_catch_2);
-                     FX_THROW(&v_7, false, _fx_catch_2);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &slit_8, &v_9, 0), _fx_catch_2);
+                     FX_THROW(&v_9, false, _fx_catch_2);
                   }
                   else {
                      FX_BREAK(_fx_catch_2);
@@ -30491,7 +30513,9 @@ static int _fx_M13Ast_typecheckFM13check_inside_v6LN12Ast__scope_tBR10Ast__loc_t
             }
 
          _fx_catch_2: ;
-            fx_free_exn(&v_7);
+            fx_free_exn(&v_9);
+            fx_free_exn(&v_8);
+            FX_FREE_STR(&v_7);
             fx_free_exn(&v_6);
             FX_FREE_STR(&v_5);
             goto _fx_endmatch_1;
@@ -30499,73 +30523,73 @@ static int _fx_M13Ast_typecheckFM13check_inside_v6LN12Ast__scope_tBR10Ast__loc_t
       }
       if (sc_2 != 0) {
          if (sc_2->hd.tag == 3) {
-            fx_str_t v_8 = {0};
-            fx_exn_t v_9 = {0};
+            fx_str_t v_10 = {0};
+            fx_exn_t v_11 = {0};
             if (t_0) {
-               fx_str_t slit_7 = FX_MAKE_STR("cannot use \'");
-               fx_str_t slit_8 = FX_MAKE_STR("\' inside \'fold\' loop");
+               fx_str_t slit_9 = FX_MAKE_STR("cannot use \'");
+               fx_str_t slit_10 = FX_MAKE_STR("\' inside \'fold\' loop");
                {
-                  const fx_str_t strs_3[] = { slit_7, *kw_0, slit_8 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_8), _fx_catch_3);
+                  const fx_str_t strs_4[] = { slit_9, *kw_0, slit_10 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_10), _fx_catch_3);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_8, &v_9, 0), _fx_catch_3);
-               FX_THROW(&v_9, false, _fx_catch_3);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_10, &v_11, 0), _fx_catch_3);
+               FX_THROW(&v_11, false, _fx_catch_3);
             }
             else {
                FX_BREAK(_fx_catch_3);
             }
 
          _fx_catch_3: ;
-            fx_free_exn(&v_9);
-            FX_FREE_STR(&v_8);
-            goto _fx_endmatch_1;
-         }
-      }
-      if (sc_2 != 0) {
-         if (sc_2->hd.tag == 4) {
-            fx_str_t v_10 = {0};
-            fx_exn_t v_11 = {0};
-            if (!any_for_0) {
-               fx_str_t slit_9 = FX_MAKE_STR("cannot use \'");
-               fx_str_t slit_10 = FX_MAKE_STR("\' inside array comprehension");
-               {
-                  const fx_str_t strs_4[] = { slit_9, *kw_0, slit_10 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_10), _fx_catch_4);
-               }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_10, &v_11, 0), _fx_catch_4);
-               FX_THROW(&v_11, false, _fx_catch_4);
-            }
-            else {
-               FX_BREAK(_fx_catch_4);
-            }
-
-         _fx_catch_4: ;
             fx_free_exn(&v_11);
             FX_FREE_STR(&v_10);
             goto _fx_endmatch_1;
          }
       }
       if (sc_2 != 0) {
-         if (sc_2->hd.tag == 5) {
+         if (sc_2->hd.tag == 4) {
             fx_str_t v_12 = {0};
             fx_exn_t v_13 = {0};
-            if (t_1) {
-               fx_str_t slit_11 = FX_MAKE_STR("\'");
-               fx_str_t slit_12 = FX_MAKE_STR("\' can only be used inside \'fold\' loop");
+            if (!any_for_0) {
+               fx_str_t slit_11 = FX_MAKE_STR("cannot use \'");
+               fx_str_t slit_12 = FX_MAKE_STR("\' inside array comprehension");
                {
                   const fx_str_t strs_5[] = { slit_11, *kw_0, slit_12 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_5);
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_4);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_12, &v_13, 0), _fx_catch_5);
-               FX_THROW(&v_13, false, _fx_catch_5);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_12, &v_13, 0), _fx_catch_4);
+               FX_THROW(&v_13, false, _fx_catch_4);
+            }
+            else {
+               FX_BREAK(_fx_catch_4);
+            }
+
+         _fx_catch_4: ;
+            fx_free_exn(&v_13);
+            FX_FREE_STR(&v_12);
+            goto _fx_endmatch_1;
+         }
+      }
+      if (sc_2 != 0) {
+         if (sc_2->hd.tag == 5) {
+            fx_str_t v_14 = {0};
+            fx_exn_t v_15 = {0};
+            if (t_1) {
+               fx_str_t slit_13 = FX_MAKE_STR("\'");
+               fx_str_t slit_14 = FX_MAKE_STR("\' can only be used inside \'fold\' loop");
+               {
+                  const fx_str_t strs_6[] = { slit_13, *kw_0, slit_14 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &v_14), _fx_catch_5);
+               }
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(eloc_0, &v_14, &v_15, 0), _fx_catch_5);
+               FX_THROW(&v_15, false, _fx_catch_5);
             }
             else {
                FX_BREAK(_fx_catch_5);
             }
 
          _fx_catch_5: ;
-            fx_free_exn(&v_13);
-            FX_FREE_STR(&v_12);
+            fx_free_exn(&v_15);
+            FX_FREE_STR(&v_14);
             goto _fx_endmatch_1;
          }
       }

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -8219,16 +8219,16 @@ return fx_list_length(l);
 
 }
 
-FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LS(struct _fx_LS_data_t* l, void* fx_fv)
+FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* l,
+   void* fx_fv)
 {
    
 return fx_list_length(l);
 
 }
 
-FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* l,
-   void* fx_fv)
+FX_EXTERN_C int_ _fx_M13Ast_typecheckFM6lengthi1LS(struct _fx_LS_data_t* l, void* fx_fv)
 {
    
 return fx_list_length(l);

--- a/compiler/bootstrap/C_form.c
+++ b/compiler/bootstrap/C_form.c
@@ -157,16 +157,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_gen_code.c
+++ b/compiler/bootstrap/C_gen_code.c
@@ -10458,49 +10458,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M10C_gen_codeFM3nthS2LSi(struct _fx_LS_data_t* l_0, int_ n_0, fx_str_t* fx_result, void* fx_fv)
-{
-   fx_str_t result_0 = {0};
-   _fx_LS l_1 = 0;
-   int fx_status = 0;
-   FX_COPY_PTR(l_0, &l_1);
-   int_ n_1 = n_0;
-   for (;;) {
-      _fx_LS l_2 = 0;
-      FX_COPY_PTR(l_1, &l_2);
-      int_ n_2 = n_1;
-      if (l_2 != 0) {
-         if (n_2 == 0) {
-            fx_str_t* a_0 = &l_2->hd; FX_FREE_STR(&result_0); fx_copy_str(a_0, &result_0); FX_BREAK(_fx_catch_0);
-         }
-         else {
-            _fx_LS* rest_0 = &l_2->tl; _fx_free_LS(&l_1); FX_COPY_PTR(*rest_0, &l_1); n_1 = n_2 - 1;
-         }
-
-      _fx_catch_0: ;
-      }
-      else {
-         FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_1);
-      }
-      FX_CHECK_EXN(_fx_catch_1);
-
-   _fx_catch_1: ;
-      if (l_2) {
-         _fx_free_LS(&l_2);
-      }
-      FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   fx_copy_str(&result_0, fx_result);
-
-_fx_cleanup: ;
-   FX_FREE_STR(&result_0);
-   if (l_1) {
-      _fx_free_LS(&l_1);
-   }
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M10C_gen_codeFM3nthR9Ast__id_t2LR9Ast__id_ti(
    struct _fx_LR9Ast__id_t_data_t* l_0,
    int_ n_0,
@@ -10592,6 +10549,49 @@ _fx_cleanup: ;
    _fx_free_T2R9Ast__id_tN14K_form__ktyp_t(&result_0);
    if (l_1) {
       _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&l_1);
+   }
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M10C_gen_codeFM3nthS2LSi(struct _fx_LS_data_t* l_0, int_ n_0, fx_str_t* fx_result, void* fx_fv)
+{
+   fx_str_t result_0 = {0};
+   _fx_LS l_1 = 0;
+   int fx_status = 0;
+   FX_COPY_PTR(l_0, &l_1);
+   int_ n_1 = n_0;
+   for (;;) {
+      _fx_LS l_2 = 0;
+      FX_COPY_PTR(l_1, &l_2);
+      int_ n_2 = n_1;
+      if (l_2 != 0) {
+         if (n_2 == 0) {
+            fx_str_t* a_0 = &l_2->hd; FX_FREE_STR(&result_0); fx_copy_str(a_0, &result_0); FX_BREAK(_fx_catch_0);
+         }
+         else {
+            _fx_LS* rest_0 = &l_2->tl; _fx_free_LS(&l_1); FX_COPY_PTR(*rest_0, &l_1); n_1 = n_2 - 1;
+         }
+
+      _fx_catch_0: ;
+      }
+      else {
+         FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_1);
+      }
+      FX_CHECK_EXN(_fx_catch_1);
+
+   _fx_catch_1: ;
+      if (l_2) {
+         _fx_free_LS(&l_2);
+      }
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   fx_copy_str(&result_0, fx_result);
+
+_fx_cleanup: ;
+   FX_FREE_STR(&result_0);
+   if (l_1) {
+      _fx_free_LS(&l_1);
    }
    return fx_status;
 }

--- a/compiler/bootstrap/C_gen_code.c
+++ b/compiler/bootstrap/C_gen_code.c
@@ -93,16 +93,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_gen_fdecls.c
+++ b/compiler/bootstrap/C_gen_fdecls.c
@@ -59,16 +59,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_gen_std.c
+++ b/compiler/bootstrap/C_gen_std.c
@@ -47,16 +47,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_gen_types.c
+++ b/compiler/bootstrap/C_gen_types.c
@@ -107,16 +107,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_post_adjust_decls.c
+++ b/compiler/bootstrap/C_post_adjust_decls.c
@@ -62,16 +62,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_post_rename_locals.c
+++ b/compiler/bootstrap/C_post_rename_locals.c
@@ -75,16 +75,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/C_pp.c
+++ b/compiler/bootstrap/C_pp.c
@@ -79,6 +79,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -975,6 +976,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1012,6 +1014,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1048,6 +1051,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/C_pp.c
+++ b/compiler/bootstrap/C_pp.c
@@ -111,16 +111,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -1359,6 +1359,10 @@ typedef struct _fx_N16Ast__defmodule_t_data_t {
    } u;
 } _fx_N16Ast__defmodule_t_data_t, *_fx_N16Ast__defmodule_t;
 
+typedef struct _fx_N21Ast__compiler_stage_t {
+   int tag;
+} _fx_N21Ast__compiler_stage_t;
+
 typedef struct _fx_LE_data_t {
    int_ rc;
    struct _fx_LE_data_t* tl;
@@ -8349,6 +8353,9 @@ static void _fx_make_T2LR17C_form__cmodule_tB(
    fx_result->t1 = t1;
 }
 
+_fx_N21Ast__compiler_stage_t _fx_g26Compiler__CompilerFrontend = { 2 };
+_fx_N21Ast__compiler_stage_t _fx_g24Compiler__CompilerMiddle = { 3 };
+_fx_N21Ast__compiler_stage_t _fx_g25Compiler__CompilerBackend = { 4 };
 _fx_N14Lexer__token_t _fx_g14Compiler__FROM = { 20 };
 _fx_N14Lexer__token_t _fx_g19Compiler__SEMICOLON = { 53 };
 _fx_N14Lexer__token_t _fx_g19Compiler__PP_DEFINE = { 101 };
@@ -8608,6 +8615,7 @@ FX_EXTERN_C int _fx_M3AstFM17print_compile_errv1E(fx_exn_t*, void*);
 FX_EXTERN_C int _fx_M3AstFM8init_allv0(void*);
 
 FX_EXTERN_C_VAL(fx_str_t _fx_g19Ast__ficus_std_path)
+FX_EXTERN_C_VAL(struct _fx_N21Ast__compiler_stage_t _fx_g19Ast__compiler_stage)
 FX_EXTERN_C_VAL(fx_exn_t _fx_E30Compiler__CumulativeParseErrorv)
 FX_EXTERN_C_VAL(struct _fx_Li_data_t* _fx_g23Ast__all_modules_sorted)
 FX_EXTERN_C int _fx_M6Ast_ppFM10pprint_modv1N16Ast__defmodule_t(struct _fx_N16Ast__defmodule_t_data_t*, void*);
@@ -12714,6 +12722,7 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
    FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&ficus_root_0, &slit_3, &v_5, 0), _fx_catch_6);
    FX_FREE_STR(&_fx_g19Ast__ficus_std_path);
    fx_copy_str(&v_5, &_fx_g19Ast__ficus_std_path);
+   _fx_g19Ast__compiler_stage = _fx_g26Compiler__CompilerFrontend;
    bool ok_0;
    FX_CALL(_fx_M8CompilerFM9parse_allB2SLS(fname0_0, ficus_path_0, &ok_0, 0), _fx_catch_6);
    if (!ok_0) {
@@ -12863,6 +12872,7 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
          FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_1, 0), _fx_catch_6);
       }
    }
+   _fx_g19Ast__compiler_stage = _fx_g24Compiler__CompilerMiddle;
    if (ok_2) {
       if (_fx_g21Compiler__iscolorterm) {
          fx_str_t slit_12 = FX_MAKE_STR("[34;1mK-form optimization started[0m"); fx_copy_str(&slit_12, &v_15);
@@ -12890,6 +12900,7 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
          FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_2, 0), _fx_catch_6);
       }
    }
+   _fx_g19Ast__compiler_stage = _fx_g25Compiler__CompilerBackend;
    bool ok_4;
    if (!_fx_g12Options__opt.gen_c) {
       ok_4 = ok_3;

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -158,6 +158,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -2070,6 +2071,11 @@ typedef struct _fx_LR17C_form__cmodule_t_data_t {
    struct _fx_R17C_form__cmodule_t hd;
 } _fx_LR17C_form__cmodule_t_data_t, *_fx_LR17C_form__cmodule_t;
 
+typedef struct _fx_FPB2EE {
+   int (*fp)(fx_exn_t*, fx_exn_t*, bool*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPB2EE;
+
 typedef struct _fx_N20Compiler__msgcolor_t {
    int tag;
 } _fx_N20Compiler__msgcolor_t;
@@ -2172,6 +2178,12 @@ typedef struct _fx_T5BBLSBLS {
    bool t3;
    struct _fx_LS_data_t* t4;
 } _fx_T5BBLSBLS;
+
+typedef struct _fx_Ta3i {
+   int_ t0;
+   int_ t1;
+   int_ t2;
+} _fx_Ta3i;
 
 typedef struct _fx_T2LR17C_form__cmodule_tB {
    struct _fx_LR17C_form__cmodule_t_data_t* t0;
@@ -2343,6 +2355,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -2380,6 +2393,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -2416,6 +2430,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)
@@ -8345,9 +8360,19 @@ bool _fx_g21Compiler__iscolorterm;
 fx_str_t _fx_g15Compiler__error = {0};
 FX_EXTERN_C void _fx_F12print_stringv1S(fx_str_t*, void*);
 
+static int _fx_M8CompilerFM6qsort_v5iiA1EFPB2EEi(int_, int_, fx_arr_t*, struct _fx_FPB2EE*, int_, void*);
+
 FX_EXTERN_C int _fx_F4joinS2SLS(fx_str_t*, struct _fx_LS_data_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int_ _fx_M6StringFM4findi3SSi(fx_str_t*, fx_str_t*, int_, void*);
+
+FX_EXTERN_C int _fx_F9make_FailE1S(fx_str_t*, fx_exn_t*);
+
+FX_EXTERN_C int _fx_M7HashsetFM9makeindexA1i1i(int_, fx_arr_t*, void*);
+
+FX_EXTERN_C bool _fx_F6__eq__B2SS(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_F6assertv1B(bool, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
 FX_EXTERN_C int _fx_F6stringS1B(bool, fx_str_t*, void*);
@@ -8361,8 +8386,6 @@ FX_EXTERN_C int _fx_M3SysFM9colortermB0(bool*, void*);
 FX_EXTERN_C int _fx_M8FilenameFM8basenameS1S(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M8FilenameFM16remove_extensionS1S(fx_str_t*, fx_str_t*, void*);
-
-FX_EXTERN_C bool _fx_F6__eq__B2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C void _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(bool, fx_str_t*, struct _fx_N14Lexer__token_t*);
 
@@ -8422,8 +8445,6 @@ static int _fx_M8CompilerFM3dfsv5iLiA1LiA1BrLi(
 FX_EXTERN_C int _fx_M3AstFM15get_module_nameRM4id_t1i(int_, struct _fx_R9Ast__id_t*, void*);
 
 FX_EXTERN_C int _fx_M3AstFM2ppS1RM4id_t(struct _fx_R9Ast__id_t*, fx_str_t*, void*);
-
-FX_EXTERN_C int _fx_F9make_FailE1S(fx_str_t*, fx_exn_t*);
 
 FX_EXTERN_C int _fx_M3SysFM5mkdirB2Si(fx_str_t*, int_, bool*, void*);
 
@@ -8576,6 +8597,14 @@ FX_EXTERN_C int _fx_M4FileFM18pclose_exit_statusi1RM1t(struct _fx_R7File__t*, in
 
 FX_EXTERN_C int _fx_M3SysFM7commandi1S(fx_str_t*, int_*, void*);
 
+FX_EXTERN_C_VAL(int _FX_EXN_E17Ast__CompileError)
+FX_EXTERN_C_VAL(int _FX_EXN_E4Fail)
+FX_EXTERN_C int_ _fx_M6StringFM4findi2SC(fx_str_t*, char_, void*);
+
+FX_EXTERN_C uint64_t _fx_F4hashq1S(fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM17print_compile_errv1E(fx_exn_t*, void*);
+
 FX_EXTERN_C int _fx_M3AstFM8init_allv0(void*);
 
 FX_EXTERN_C_VAL(fx_str_t _fx_g19Ast__ficus_std_path)
@@ -8613,11 +8642,7 @@ FX_EXTERN_C int _fx_M19C_post_adjust_declsFM12adjust_declsR17C_form__cmodule_t1R
    struct _fx_R17C_form__cmodule_t*,
    void*);
 
-FX_EXTERN_C int _fx_M3AstFM17print_compile_errv1E(fx_exn_t*, void*);
-
 FX_EXTERN_C_VAL(int_ _fx_g22Ast__all_compile_warns)
-FX_EXTERN_C_VAL(int _FX_EXN_E4Fail)
-FX_EXTERN_C_VAL(int _FX_EXN_E17Ast__CompileError)
 fx_exn_info_t _fx_E30Compiler__CumulativeParseError_info = {0};
 fx_exn_t _fx_E30Compiler__CumulativeParseErrorv = {0};
 FX_EXTERN_C int_ _fx_M8CompilerFM6lengthi1LE(struct _fx_LE_data_t* l, void* fx_fv)
@@ -8730,6 +8755,232 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C void _fx_M8CompilerFM6_swap_v3A1Eii(fx_arr_t* arr, int_ i, int_ j, void* fx_fv)
+{
+   
+size_t esz = arr->dim[0].step;
+    if(esz % sizeof(int) == 0) {
+        int* ptr0 = (int*)(arr->data + i*esz);
+        int* ptr1 = (int*)(arr->data + j*esz);
+        esz /= sizeof(int);
+        for( size_t k = 0; k < esz; k++ ) {
+            int t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    } else {
+        char* ptr0 = arr->data + i*esz;
+        char* ptr1 = arr->data + j*esz;
+        for( size_t k = 0; k < esz; k++ ) {
+            char t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    }
+
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM4sortv3A1EFPB2EEi(fx_arr_t* arr_0, struct _fx_FPB2EE* lt_0, int_ prefix_0, void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(_fx_M8CompilerFM6qsort_v5iiA1EFPB2EEi(0, FX_ARR_SIZE(*arr_0, 0) - 1, arr_0, lt_0, prefix_0, 0), _fx_cleanup);
+
+_fx_cleanup: ;
+   return fx_status;
+}
+
+static int _fx_M8CompilerFM6qsort_v5iiA1EFPB2EEi(
+   int_ lo_0,
+   int_ hi_0,
+   fx_arr_t* arr_0,
+   struct _fx_FPB2EE* lt_0,
+   int_ prefix_0,
+   void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   int_ lo_1 = lo_0;
+   int_ hi_1 = hi_0;
+   for (;;) {
+      fx_exn_t a_0 = {0};
+      fx_exn_t b_0 = {0};
+      fx_exn_t p_0 = {0};
+      fx_exn_t p_1 = {0};
+      fx_exn_t a_1 = {0};
+      fx_exn_t a_2 = {0};
+      fx_exn_t b_1 = {0};
+      int_ lo_2 = lo_1;
+      int_ hi_2 = hi_1;
+      if (lo_2 + 1 < hi_2) {
+         int_ m_0 = (lo_2 + hi_2) / 2;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, lo_2), &a_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, m_0), &b_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, hi_2), &p_0);
+         bool v_0;
+         FX_CALL(lt_0->fp(&a_0, &b_0, &v_0, lt_0->fcv), _fx_catch_2);
+         if (v_0) {
+            bool v_1;
+            FX_CALL(lt_0->fp(&b_0, &p_0, &v_1, lt_0->fcv), _fx_catch_2);
+            if (v_1) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+               fx_exn_t* v_2 = FX_PTR_1D(fx_exn_t, *arr_0, m_0);
+               fx_free_exn(v_2);
+               fx_copy_exn(&p_0, v_2);
+               fx_copy_exn(&b_0, &p_1);
+            }
+            else {
+               bool v_3;
+               FX_CALL(lt_0->fp(&a_0, &p_0, &v_3, lt_0->fcv), _fx_catch_2);
+               if (v_3) {
+                  fx_copy_exn(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+                  fx_exn_t* v_4 = FX_PTR_1D(fx_exn_t, *arr_0, lo_2);
+                  fx_free_exn(v_4);
+                  fx_copy_exn(&p_0, v_4);
+                  fx_copy_exn(&a_0, &p_1);
+               }
+            }
+         }
+         else {
+            bool v_5;
+            FX_CALL(lt_0->fp(&a_0, &p_0, &v_5, lt_0->fcv), _fx_catch_2);
+            if (v_5) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+               fx_exn_t* v_6 = FX_PTR_1D(fx_exn_t, *arr_0, lo_2);
+               fx_free_exn(v_6);
+               fx_copy_exn(&p_0, v_6);
+               fx_copy_exn(&a_0, &p_1);
+            }
+            else {
+               bool v_7;
+               FX_CALL(lt_0->fp(&b_0, &p_0, &v_7, lt_0->fcv), _fx_catch_2);
+               if (v_7) {
+                  fx_copy_exn(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+                  fx_exn_t* v_8 = FX_PTR_1D(fx_exn_t, *arr_0, m_0);
+                  fx_free_exn(v_8);
+                  fx_copy_exn(&p_0, v_8);
+                  fx_copy_exn(&b_0, &p_1);
+               }
+            }
+         }
+         int_ __fold_result___0 = lo_2;
+         int_ n_0 = FX_LOOP_COUNT(lo_2, hi_2, 1);
+         for (int_ j_0 = 0; j_0 < n_0; j_0++) {
+            fx_exn_t v_9 = {0};
+            int_ j_1 = lo_2 + j_0 * 1;
+            int_ i0_0 = __fold_result___0;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, j_1), _fx_catch_0);
+            fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, j_1), &v_9);
+            bool v_10;
+            FX_CALL(lt_0->fp(&v_9, &p_1, &v_10, lt_0->fcv), _fx_catch_0);
+            int_ v_11;
+            if (v_10) {
+               _fx_M8CompilerFM6_swap_v3A1Eii(arr_0, i0_0, j_1, 0); v_11 = i0_0 + 1;
+            }
+            else {
+               v_11 = i0_0;
+            }
+            __fold_result___0 = v_11;
+
+         _fx_catch_0: ;
+            fx_free_exn(&v_9);
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         int_ i0_1 = __fold_result___0;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, i0_1), &a_1);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_exn_t* v_12 = FX_PTR_1D(fx_exn_t, *arr_0, hi_2);
+         fx_free_exn(v_12);
+         fx_copy_exn(&a_1, v_12);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         fx_exn_t* v_13 = FX_PTR_1D(fx_exn_t, *arr_0, i0_1);
+         fx_free_exn(v_13);
+         fx_copy_exn(&p_1, v_13);
+         int_ i1_0 = hi_2;
+         int_ n_1 = FX_LOOP_COUNT(i0_1, hi_2, 1);
+         for (int_ j_2 = 0; j_2 < n_1; j_2++) {
+            fx_exn_t v_14 = {0};
+            int_ j_3 = i0_1 + j_2 * 1;
+            int_ v_15 = j_3 + 1;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, v_15), _fx_catch_1);
+            fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, v_15), &v_14);
+            bool v_16;
+            FX_CALL(lt_0->fp(&p_1, &v_14, &v_16, lt_0->fcv), _fx_catch_1);
+            if (v_16) {
+               i1_0 = j_3; FX_BREAK(_fx_catch_1);
+            }
+
+         _fx_catch_1: ;
+            fx_free_exn(&v_14);
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         if (i0_1 - lo_2 < hi_2 - i1_0) {
+            if (i1_0 < prefix_0) {
+               FX_CALL(_fx_M8CompilerFM6qsort_v5iiA1EFPB2EEi(i1_0 + 1, hi_2, arr_0, lt_0, prefix_0, 0), _fx_catch_2);
+            }
+            lo_1 = lo_2;
+            hi_1 = i0_1 - 1;
+         }
+         else {
+            FX_CALL(_fx_M8CompilerFM6qsort_v5iiA1EFPB2EEi(lo_2, i0_1 - 1, arr_0, lt_0, prefix_0, 0), _fx_catch_2);
+            if (i1_0 < prefix_0) {
+               lo_1 = i1_0 + 1; hi_1 = hi_2;
+            }
+            else {
+               FX_BREAK(_fx_catch_2);
+            }
+         }
+      }
+      else if (lo_2 < hi_2) {
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, lo_2), &a_2);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_copy_exn(FX_PTR_1D(fx_exn_t, *arr_0, hi_2), &b_1);
+         bool v_17;
+         FX_CALL(lt_0->fp(&b_1, &a_2, &v_17, lt_0->fcv), _fx_catch_2);
+         if (v_17) {
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+            fx_exn_t* v_18 = FX_PTR_1D(fx_exn_t, *arr_0, hi_2);
+            fx_free_exn(v_18);
+            fx_copy_exn(&a_2, v_18);
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+            fx_exn_t* v_19 = FX_PTR_1D(fx_exn_t, *arr_0, lo_2);
+            fx_free_exn(v_19);
+            fx_copy_exn(&b_1, v_19);
+            FX_BREAK(_fx_catch_2);
+         }
+         else {
+            FX_BREAK(_fx_catch_2);
+         }
+      }
+      else {
+         FX_BREAK(_fx_catch_2);
+      }
+
+   _fx_catch_2: ;
+      fx_free_exn(&b_1);
+      fx_free_exn(&a_2);
+      fx_free_exn(&a_1);
+      fx_free_exn(&p_1);
+      fx_free_exn(&p_0);
+      fx_free_exn(&b_0);
+      fx_free_exn(&a_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M8CompilerFM3revLS1LS(struct _fx_LS_data_t* l_0, struct _fx_LS_data_t** fx_result, void* fx_fv)
 {
    _fx_LS __fold_result___0 = 0;
@@ -8772,6 +9023,310 @@ FX_EXTERN_C int _fx_M8CompilerFM8containsB2SS(fx_str_t* s_0, fx_str_t* substr_0,
    int fx_status = 0;
    int_ v_0 = _fx_M6StringFM4findi3SSi(s_0, substr_0, 0, 0);
    *fx_result = v_0 >= 0;
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM1tNt10Hashset__t1S6Rt24Hashset__hashset_entry_t1SiiiA1iA1Rt24Hashset__hashset_entry_t1S(
+   struct _fx_Rt24Hashset__hashset_entry_t1S* arg0,
+   int_ arg1,
+   int_ arg2,
+   int_ arg3,
+   fx_arr_t* arg4,
+   fx_arr_t* arg5,
+   struct _fx_Nt10Hashset__t1S_data_t** fx_result)
+{
+   FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_Nt10Hashset__t1S);
+   _fx_copy_Rt24Hashset__hashset_entry_t1S(arg0, &v->u.t.t0);
+   v->u.t.t1 = arg1;
+   v->u.t.t2 = arg2;
+   v->u.t.t3 = arg3;
+   fx_copy_arr(arg4, &v->u.t.t4);
+   fx_copy_arr(arg5, &v->u.t.t5);
+   return 0;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM9add_fast_i4iA1iA1Rt24Hashset__hashset_entry_t1SRt24Hashset__hashset_entry_t1S(
+   int_ tabsz_0,
+   fx_arr_t* ht_index_0,
+   fx_arr_t* ht_table_0,
+   struct _fx_Rt24Hashset__hashset_entry_t1S* entry_0,
+   int_* fx_result,
+   void* fx_fv)
+{
+   fx_exn_t v_0 = {0};
+   int fx_status = 0;
+   int_ idxsz_0 = FX_ARR_SIZE(*ht_index_0, 0);
+   uint64_t hv_0 = entry_0->hv;
+   uint64_t perturb_0 = hv_0;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   bool found_free_slot_0 = false;
+   int_ v_1 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_1; i_0++) {
+      FX_CHKIDX(FX_CHKIDX1(*ht_index_0, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, *ht_index_0, j_0);
+      if (tidx_0 == 0) {
+         FX_CHKIDX(FX_CHKIDX1(*ht_index_0, 0, j_0), _fx_catch_0);
+         *FX_PTR_1D(int_, *ht_index_0, j_0) = tabsz_0 + 2;
+         FX_CHKIDX(FX_CHKIDX1(*ht_table_0, 0, tabsz_0), _fx_catch_0);
+         _fx_Rt24Hashset__hashset_entry_t1S* v_2 = FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, *ht_table_0, tabsz_0);
+         _fx_free_Rt24Hashset__hashset_entry_t1S(v_2);
+         _fx_copy_Rt24Hashset__hashset_entry_t1S(entry_0, v_2);
+         found_free_slot_0 = true;
+         FX_BREAK(_fx_catch_0);
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   if (!found_free_slot_0) {
+      fx_str_t slit_0 = FX_MAKE_STR("cannot insert element (full Hashtable?!)");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_0), _fx_cleanup);
+      FX_THROW(&v_0, true, _fx_cleanup);
+   }
+   *fx_result = tabsz_0 + 1;
+
+_fx_cleanup: ;
+   fx_free_exn(&v_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM4growv2Nt10Hashset__t1Si(
+   struct _fx_Nt10Hashset__t1S_data_t* self_0,
+   int_ new_size_0,
+   void* fx_fv)
+{
+   fx_arr_t ht_table_0 = {0};
+   _fx_Rt24Hashset__hashset_entry_t1S v_0 = {0};
+   fx_arr_t new_ht_table_0 = {0};
+   fx_arr_t new_ht_index_0 = {0};
+   int fx_status = 0;
+   fx_copy_arr(&self_0->u.t.t5, &ht_table_0);
+   _fx_copy_Rt24Hashset__hashset_entry_t1S(&self_0->u.t.t0, &v_0);
+   _fx_Rt24Hashset__hashset_entry_t1S* dstptr_0 = 0;
+   {
+      const int_ shape_0[] = { new_size_0 };
+      FX_CALL(
+         fx_make_arr(1, shape_0, sizeof(_fx_Rt24Hashset__hashset_entry_t1S), (fx_free_t)_fx_free_Rt24Hashset__hashset_entry_t1S,
+            (fx_copy_t)_fx_copy_Rt24Hashset__hashset_entry_t1S, 0, &new_ht_table_0), _fx_cleanup);
+   }
+   dstptr_0 = (_fx_Rt24Hashset__hashset_entry_t1S*)new_ht_table_0.data;
+   for (int_ i_0 = 0; i_0 < new_size_0; i_0++, dstptr_0++) {
+      _fx_copy_Rt24Hashset__hashset_entry_t1S(&v_0, dstptr_0);
+   }
+   FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(new_size_0 * 2, &new_ht_index_0, 0), _fx_cleanup);
+   int_ tabsz_0 = 0;
+   int_ v_1 = self_0->u.t.t2;
+   for (int_ j_0 = 0; j_0 < v_1; j_0++) {
+      _fx_Rt24Hashset__hashset_entry_t1S v_2 = {0};
+      FX_CHKIDX(FX_CHKIDX1(ht_table_0, 0, j_0), _fx_catch_0);
+      if (FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, ht_table_0, j_0)->hv < 9223372036854775808ULL) {
+         FX_CHKIDX(FX_CHKIDX1(ht_table_0, 0, j_0), _fx_catch_0);
+         _fx_copy_Rt24Hashset__hashset_entry_t1S(FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, ht_table_0, j_0), &v_2);
+         int_ v_3;
+         FX_CALL(
+            _fx_M8CompilerFM9add_fast_i4iA1iA1Rt24Hashset__hashset_entry_t1SRt24Hashset__hashset_entry_t1S(tabsz_0,
+               &new_ht_index_0, &new_ht_table_0, &v_2, &v_3, 0), _fx_catch_0);
+         tabsz_0 = v_3;
+      }
+
+   _fx_catch_0: ;
+      _fx_free_Rt24Hashset__hashset_entry_t1S(&v_2);
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   fx_arr_t* v_4 = &self_0->u.t.t4;
+   FX_FREE_ARR(v_4);
+   fx_copy_arr(&new_ht_index_0, v_4);
+   fx_arr_t* v_5 = &self_0->u.t.t5;
+   FX_FREE_ARR(v_5);
+   fx_copy_arr(&new_ht_table_0, v_5);
+   self_0->u.t.t2 = tabsz_0;
+   self_0->u.t.t3 = 0;
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&ht_table_0);
+   _fx_free_Rt24Hashset__hashset_entry_t1S(&v_0);
+   FX_FREE_ARR(&new_ht_table_0);
+   FX_FREE_ARR(&new_ht_index_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM9find_idx_Ta2i3Nt10Hashset__t1SSq(
+   struct _fx_Nt10Hashset__t1S_data_t* self_0,
+   fx_str_t* k_0,
+   uint64_t hv_0,
+   struct _fx_Ta2i* fx_result,
+   void* fx_fv)
+{
+   fx_arr_t v_0 = {0};
+   int fx_status = 0;
+   fx_copy_arr(&self_0->u.t.t4, &v_0);
+   int_ idxsz_0 = FX_ARR_SIZE(v_0, 0);
+   uint64_t perturb_0 = hv_0;
+   int_ found_0 = -1;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   int_ v_1 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_1; i_0++) {
+      _fx_Rt24Hashset__hashset_entry_t1S entry_0 = {0};
+      fx_str_t v_2 = {0};
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, self_0->u.t.t4, j_0);
+      if (tidx_0 >= 2) {
+         int_ v_3 = tidx_0 - 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, v_3), _fx_catch_0);
+         _fx_copy_Rt24Hashset__hashset_entry_t1S(FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, self_0->u.t.t5, v_3), &entry_0);
+         bool v_4;
+         if (entry_0.hv == hv_0) {
+            fx_copy_str(&entry_0.key, &v_2); v_4 = _fx_F6__eq__B2SS(&v_2, k_0, 0);
+         }
+         else {
+            v_4 = false;
+         }
+         if (v_4) {
+            found_0 = tidx_0 - 2; FX_BREAK(_fx_catch_0);
+         }
+      }
+      else if (tidx_0 == 0) {
+         FX_BREAK(_fx_catch_0);
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      FX_FREE_STR(&v_2);
+      _fx_free_Rt24Hashset__hashset_entry_t1S(&entry_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   _fx_Ta2i tup_0 = { j_0, found_0 };
+   *fx_result = tup_0;
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&v_0);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM4add_v3Nt10Hashset__t1SSq(
+   struct _fx_Nt10Hashset__t1S_data_t* self_0,
+   fx_str_t* k_0,
+   uint64_t hv_0,
+   void* fx_fv)
+{
+   fx_arr_t v_0 = {0};
+   fx_arr_t v_1 = {0};
+   _fx_Rt24Hashset__hashset_entry_t1S v_2 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   fx_copy_arr(&self_0->u.t.t4, &v_0);
+   int_ idxsz_0 = FX_ARR_SIZE(v_0, 0);
+   if (self_0->u.t.t1 + 1 > idxsz_0 >> 1) {
+      while (idxsz_0 < (self_0->u.t.t1 + 1) * 2) {
+         idxsz_0 = idxsz_0 * 2;
+      }
+      FX_CALL(_fx_M8CompilerFM4growv2Nt10Hashset__t1Si(self_0, fx_maxi(idxsz_0 / 2, self_0->u.t.t1 + 1), 0), _fx_cleanup);
+   }
+   uint64_t perturb_0 = hv_0;
+   int_ found_0 = -1;
+   int_ insert_idx_0 = -1;
+   int_ j_0 = (int_)hv_0 & (idxsz_0 - 1);
+   int_ v_4 = idxsz_0 + 14;
+   for (int_ i_0 = 0; i_0 < v_4; i_0++) {
+      _fx_Rt24Hashset__hashset_entry_t1S entry_0 = {0};
+      fx_str_t v_5 = {0};
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_catch_0);
+      int_ tidx_0 = *FX_PTR_1D(int_, self_0->u.t.t4, j_0);
+      if (tidx_0 >= 2) {
+         int_ v_6 = tidx_0 - 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, v_6), _fx_catch_0);
+         _fx_copy_Rt24Hashset__hashset_entry_t1S(FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, self_0->u.t.t5, v_6), &entry_0);
+         bool v_7;
+         if (entry_0.hv == hv_0) {
+            fx_copy_str(&entry_0.key, &v_5); v_7 = _fx_F6__eq__B2SS(&v_5, k_0, 0);
+         }
+         else {
+            v_7 = false;
+         }
+         if (v_7) {
+            found_0 = tidx_0 - 2; FX_BREAK(_fx_catch_0);
+         }
+      }
+      else if (tidx_0 == 0) {
+         if (insert_idx_0 < 0) {
+            insert_idx_0 = j_0;
+         }
+         FX_BREAK(_fx_catch_0);
+      }
+      else {
+         bool t_0;
+         if (tidx_0 == 1) {
+            t_0 = insert_idx_0 < 0;
+         }
+         else {
+            t_0 = false;
+         }
+         if (t_0) {
+            insert_idx_0 = j_0;
+         }
+      }
+      perturb_0 = perturb_0 >> 5;
+      j_0 = (int_)((uint64_t)(j_0 * 5 + 1) + perturb_0) & (idxsz_0 - 1);
+
+   _fx_catch_0: ;
+      FX_FREE_STR(&v_5);
+      _fx_free_Rt24Hashset__hashset_entry_t1S(&entry_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   if (found_0 >= 0) {
+      bool t_1;
+      if (insert_idx_0 >= 0) {
+         t_1 = insert_idx_0 != j_0;
+      }
+      else {
+         t_1 = false;
+      }
+      if (t_1) {
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, insert_idx_0), _fx_cleanup);
+         *FX_PTR_1D(int_, self_0->u.t.t4, insert_idx_0) = found_0 + 2;
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, j_0), _fx_cleanup);
+         *FX_PTR_1D(int_, self_0->u.t.t4, j_0) = 1;
+      }
+   }
+   else if (insert_idx_0 >= 0) {
+      found_0 = self_0->u.t.t3 - 1;
+      if (found_0 >= 0) {
+         FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, found_0), _fx_cleanup);
+         self_0->u.t.t3 =
+            (int_)(FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, self_0->u.t.t5, found_0)->hv & 9223372036854775807ULL);
+      }
+      else {
+         found_0 = self_0->u.t.t2;
+         self_0->u.t.t2 = self_0->u.t.t2 + 1;
+         fx_copy_arr(&self_0->u.t.t5, &v_1);
+         FX_CALL(_fx_F6assertv1B(found_0 < FX_ARR_SIZE(v_1, 0), 0), _fx_cleanup);
+      }
+      _fx_make_Rt24Hashset__hashset_entry_t1S(hv_0, k_0, &v_2);
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t5, 0, found_0), _fx_cleanup);
+      _fx_Rt24Hashset__hashset_entry_t1S* v_8 = FX_PTR_1D(_fx_Rt24Hashset__hashset_entry_t1S, self_0->u.t.t5, found_0);
+      _fx_free_Rt24Hashset__hashset_entry_t1S(v_8);
+      _fx_copy_Rt24Hashset__hashset_entry_t1S(&v_2, v_8);
+      FX_CHKIDX(FX_CHKIDX1(self_0->u.t.t4, 0, insert_idx_0), _fx_cleanup);
+      *FX_PTR_1D(int_, self_0->u.t.t4, insert_idx_0) = found_0 + 2;
+      self_0->u.t.t1 = self_0->u.t.t1 + 1;
+   }
+   else {
+      fx_str_t slit_0 = FX_MAKE_STR("cannot insert element (full Hashtable?!)");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&v_0);
+   FX_FREE_ARR(&v_1);
+   _fx_free_Rt24Hashset__hashset_entry_t1S(&v_2);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
@@ -11699,67 +12254,445 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_result, void* fx_fv)
+FX_EXTERN_C int _fx_M8CompilerFM10__lambda__B2EE(fx_exn_t* a_0, fx_exn_t* b_0, bool* fx_result, void* fx_fv)
 {
-   fx_exn_t exn_0 = {0};
-   _fx_LE __fold_result___0 = 0;
-   _fx_LE v_0 = 0;
-   fx_str_t v_1 = {0};
-   fx_str_t v_2 = {0};
    int fx_status = 0;
-   FX_CALL(_fx_M3AstFM8init_allv0(0), _fx_cleanup);
-   _fx_T2SLS v_3 = {0};
-   fx_str_t ficus_root_0 = {0};
-   _fx_LS ficus_path_0 = 0;
+   _fx_Ta3i v_0;
+   if (a_0->tag == _FX_EXN_E17Ast__CompileError) {
+      _fx_R10Ast__loc_t* loc_0 = &FX_EXN_DATA(_fx_E17Ast__CompileError_data_t, a_0->data).t0;
+      _fx_Ta3i tup_0 = { loc_0->m_idx, loc_0->line0, loc_0->col0 };
+      v_0 = tup_0;
+   }
+   else {
+      _fx_Ta3i tup_1 = { 1000000000, 0, 0 }; v_0 = tup_1;
+   }
+   FX_CHECK_EXN(_fx_cleanup);
+   int_ ma_0 = v_0.t0;
+   int_ la_0 = v_0.t1;
+   int_ ca_0 = v_0.t2;
+   _fx_Ta3i v_1;
+   if (b_0->tag == _FX_EXN_E17Ast__CompileError) {
+      _fx_R10Ast__loc_t* loc_1 = &FX_EXN_DATA(_fx_E17Ast__CompileError_data_t, b_0->data).t0;
+      _fx_Ta3i tup_2 = { loc_1->m_idx, loc_1->line0, loc_1->col0 };
+      v_1 = tup_2;
+   }
+   else {
+      _fx_Ta3i tup_3 = { 1000000000, 0, 0 }; v_1 = tup_3;
+   }
+   FX_CHECK_EXN(_fx_cleanup);
+   int_ mb_0 = v_1.t0;
+   int_ lb_0 = v_1.t1;
+   int_ cb_0 = v_1.t2;
+   if (ma_0 < mb_0) {
+      *fx_result = true;
+   }
+   else if (ma_0 == mb_0) {
+      if (la_0 < lb_0) {
+         *fx_result = true;
+      }
+      else if (la_0 == lb_0) {
+         *fx_result = ca_0 < cb_0;
+      }
+      else {
+         *fx_result = false;
+      }
+   }
+   else {
+      *fx_result = false;
+   }
+
+_fx_cleanup: ;
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM22print_all_compile_errsv0(void* fx_fv)
+{
+   _fx_Rt24Hashset__hashset_entry_t1S entry0_0 = {0};
+   fx_arr_t v_0 = {0};
+   fx_arr_t v_1 = {0};
+   _fx_Nt10Hashset__t1S seen_0 = 0;
+   _fx_LE __fold_result___0 = 0;
+   _fx_LE __fold_result___1 = 0;
+   _fx_LE v_2 = 0;
+   _fx_LE uniq_0 = 0;
+   _fx_LE __fold_result___2 = 0;
+   _fx_LE v_3 = 0;
+   _fx_LE sorted_0 = 0;
    fx_str_t v_4 = {0};
    fx_str_t v_5 = {0};
    fx_str_t v_6 = {0};
-   fx_exn_t v_7 = {0};
+   fx_str_t v_7 = {0};
    fx_str_t v_8 = {0};
+   int fx_status = 0;
+   int_ size_0 = 8;
+   while (size_0 < 256) {
+      size_0 = size_0 * 2;
+   }
+   int_ idxsize_0 = size_0 * 2;
+   fx_str_t slit_0 = FX_MAKE_STR("");
+   _fx_make_Rt24Hashset__hashset_entry_t1S(0ULL, &slit_0, &entry0_0);
+   FX_CALL(_fx_M7HashsetFM9makeindexA1i1i(idxsize_0, &v_0, 0), _fx_cleanup);
+   _fx_Rt24Hashset__hashset_entry_t1S* dstptr_0 = 0;
+   int_ n_0 = size_0;
+   {
+      const int_ shape_0[] = { n_0 };
+      FX_CALL(
+         fx_make_arr(1, shape_0, sizeof(_fx_Rt24Hashset__hashset_entry_t1S), (fx_free_t)_fx_free_Rt24Hashset__hashset_entry_t1S,
+            (fx_copy_t)_fx_copy_Rt24Hashset__hashset_entry_t1S, 0, &v_1), _fx_cleanup);
+   }
+   dstptr_0 = (_fx_Rt24Hashset__hashset_entry_t1S*)v_1.data;
+   for (int_ i_0 = 0; i_0 < n_0; i_0++, dstptr_0++) {
+      _fx_copy_Rt24Hashset__hashset_entry_t1S(&entry0_0, dstptr_0);
+   }
+   FX_CALL(
+      _fx_M8CompilerFM1tNt10Hashset__t1S6Rt24Hashset__hashset_entry_t1SiiiA1iA1Rt24Hashset__hashset_entry_t1S(&entry0_0, 0, 0,
+         0, &v_0, &v_1, &seen_0), _fx_cleanup);
+   _fx_LE lst_0 = _fx_g21Ast__all_compile_errs;
+   for (; lst_0; lst_0 = lst_0->tl) {
+      _fx_LE r_0 = 0;
+      fx_exn_t* a_0 = &lst_0->hd;
+      FX_COPY_PTR(__fold_result___1, &r_0);
+      FX_CALL(_fx_cons_LE(a_0, r_0, false, &r_0), _fx_catch_0);
+      _fx_free_LE(&__fold_result___1);
+      FX_COPY_PTR(r_0, &__fold_result___1);
+
+   _fx_catch_0: ;
+      if (r_0) {
+         _fx_free_LE(&r_0);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   FX_COPY_PTR(__fold_result___1, &v_2);
+   _fx_LE lst_1 = v_2;
+   for (; lst_1; lst_1 = lst_1->tl) {
+      _fx_LE acc_0 = 0;
+      fx_str_t msg_0 = {0};
+      fx_str_t key_0 = {0};
+      _fx_LE v_9 = 0;
+      fx_exn_t* e_0 = &lst_1->hd;
+      FX_COPY_PTR(__fold_result___0, &acc_0);
+      int tag_0 = e_0->tag;
+      if (tag_0 == _FX_EXN_E17Ast__CompileError) {
+         fx_copy_str(&FX_EXN_DATA(_fx_E17Ast__CompileError_data_t, e_0->data).t1, &msg_0);
+      }
+      else if (tag_0 == _FX_EXN_E4Fail) {
+         fx_str_t slit_1 = FX_MAKE_STR("Failure: ");
+         fx_str_t* msg_1 = &FX_EXN_DATA(_fx_E4Fail_data_t, e_0->data);
+         {
+            const fx_str_t strs_0[] = { slit_1, *msg_1 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 2, &msg_0), _fx_catch_1);
+         }
+
+      _fx_catch_1: ;
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR(""); fx_copy_str(&slit_2, &msg_0);
+      }
+      FX_CHECK_EXN(_fx_catch_3);
+      int_ v_10 = _fx_M6StringFM4findi2SC(&msg_0, (char_)10, 0);
+      if (v_10 == -1) {
+         fx_copy_str(&msg_0, &key_0);
+      }
+      else {
+         FX_CALL(fx_substr(&msg_0, 0, v_10, 1, 1, &key_0), _fx_catch_2);  _fx_catch_2: ;
+      }
+      FX_CHECK_EXN(_fx_catch_3);
+      bool v_11;
+      if (FX_STR_LENGTH(key_0) != 0) {
+         uint64_t v_12 = _fx_F4hashq1S(&key_0, 0);
+         _fx_Ta2i v_13;
+         FX_CALL(_fx_M8CompilerFM9find_idx_Ta2i3Nt10Hashset__t1SSq(seen_0, &key_0, v_12 & 9223372036854775807ULL, &v_13, 0),
+            _fx_catch_3);
+         v_11 = v_13.t1 >= 0;
+      }
+      else {
+         v_11 = false;
+      }
+      if (v_11) {
+         FX_COPY_PTR(acc_0, &v_9);
+      }
+      else {
+         if (FX_STR_LENGTH(key_0) != 0) {
+            uint64_t v_14 = _fx_F4hashq1S(&key_0, 0);
+            FX_CALL(_fx_M8CompilerFM4add_v3Nt10Hashset__t1SSq(seen_0, &key_0, v_14 & 9223372036854775807ULL, 0), _fx_catch_3);
+         }
+         FX_CALL(_fx_cons_LE(e_0, acc_0, true, &v_9), _fx_catch_3);
+      }
+      _fx_free_LE(&__fold_result___0);
+      FX_COPY_PTR(v_9, &__fold_result___0);
+
+   _fx_catch_3: ;
+      if (v_9) {
+         _fx_free_LE(&v_9);
+      }
+      FX_FREE_STR(&key_0);
+      FX_FREE_STR(&msg_0);
+      if (acc_0) {
+         _fx_free_LE(&acc_0);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   FX_COPY_PTR(__fold_result___0, &uniq_0);
+   _fx_LE lst_2 = uniq_0;
+   for (; lst_2; lst_2 = lst_2->tl) {
+      _fx_LE r_1 = 0;
+      fx_exn_t* a_1 = &lst_2->hd;
+      FX_COPY_PTR(__fold_result___2, &r_1);
+      FX_CALL(_fx_cons_LE(a_1, r_1, false, &r_1), _fx_catch_4);
+      _fx_free_LE(&__fold_result___2);
+      FX_COPY_PTR(r_1, &__fold_result___2);
+
+   _fx_catch_4: ;
+      if (r_1) {
+         _fx_free_LE(&r_1);
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   FX_COPY_PTR(__fold_result___2, &v_3);
+   if (v_3 == 0) {
+      FX_COPY_PTR(v_3, &sorted_0); goto _fx_endmatch_0;
+   }
+   if (v_3 != 0) {
+      if (v_3->tl == 0) {
+         FX_COPY_PTR(v_3, &sorted_0); goto _fx_endmatch_0;
+      }
+   }
+   if (v_3 != 0) {
+      _fx_LE v_15 = v_3->tl;
+      if (v_15 != 0) {
+         if (v_15->tl == 0) {
+            _fx_LE v_16 = 0;
+            fx_exn_t* b_0 = &v_15->hd;
+            fx_exn_t* a_2 = &v_3->hd;
+            _fx_Ta3i v_17;
+            if (b_0->tag == _FX_EXN_E17Ast__CompileError) {
+               _fx_R10Ast__loc_t* loc_0 = &FX_EXN_DATA(_fx_E17Ast__CompileError_data_t, b_0->data).t0;
+               _fx_Ta3i tup_0 = { loc_0->m_idx, loc_0->line0, loc_0->col0 };
+               v_17 = tup_0;
+            }
+            else {
+               _fx_Ta3i tup_1 = { 1000000000, 0, 0 }; v_17 = tup_1;
+            }
+            FX_CHECK_EXN(_fx_catch_5);
+            int_ ma_0 = v_17.t0;
+            int_ la_0 = v_17.t1;
+            int_ ca_0 = v_17.t2;
+            _fx_Ta3i v_18;
+            if (a_2->tag == _FX_EXN_E17Ast__CompileError) {
+               _fx_R10Ast__loc_t* loc_1 = &FX_EXN_DATA(_fx_E17Ast__CompileError_data_t, a_2->data).t0;
+               _fx_Ta3i tup_2 = { loc_1->m_idx, loc_1->line0, loc_1->col0 };
+               v_18 = tup_2;
+            }
+            else {
+               _fx_Ta3i tup_3 = { 1000000000, 0, 0 }; v_18 = tup_3;
+            }
+            FX_CHECK_EXN(_fx_catch_5);
+            int_ mb_0 = v_18.t0;
+            int_ lb_0 = v_18.t1;
+            int_ cb_0 = v_18.t2;
+            bool t_0;
+            if (ma_0 < mb_0) {
+               t_0 = true;
+            }
+            else if (ma_0 == mb_0) {
+               if (la_0 < lb_0) {
+                  t_0 = true;
+               }
+               else if (la_0 == lb_0) {
+                  t_0 = ca_0 < cb_0;
+               }
+               else {
+                  t_0 = false;
+               }
+            }
+            else {
+               t_0 = false;
+            }
+            if (t_0) {
+               FX_CALL(_fx_cons_LE(a_2, 0, true, &v_16), _fx_catch_5);
+               FX_CALL(_fx_cons_LE(b_0, v_16, true, &sorted_0), _fx_catch_5);
+            }
+            else {
+               FX_COPY_PTR(v_3, &sorted_0);
+            }
+
+         _fx_catch_5: ;
+            if (v_16) {
+               _fx_free_LE(&v_16);
+            }
+            goto _fx_endmatch_0;
+         }
+      }
+   }
+   fx_arr_t arr_0 = {0};
+   _fx_FPB2EE __lambda___0 = {0};
+   fx_exn_t* dstptr_1 = 0;
+   _fx_LE lst_3 = v_3;
+   int_ len_0 = fx_list_length(lst_3);
+   {
+      const int_ shape_1[] = { len_0 };
+      FX_CALL(fx_make_arr(1, shape_1, sizeof(fx_exn_t), (fx_free_t)fx_free_exn, (fx_copy_t)fx_copy_exn, 0, &arr_0),
+         _fx_catch_7);
+   }
+   dstptr_1 = (fx_exn_t*)arr_0.data;
+   for (; lst_3; lst_3 = lst_3->tl, dstptr_1++) {
+      fx_exn_t* x_0 = &lst_3->hd; fx_copy_exn(x_0, dstptr_1);
+   }
+   _fx_FPB2EE __lambda___fp_0 = { _fx_M8CompilerFM10__lambda__B2EE, 0 };
+   FX_COPY_FP(&__lambda___fp_0, &__lambda___0);
+   FX_CALL(_fx_M8CompilerFM4sortv3A1EFPB2EEi(&arr_0, &__lambda___0, FX_ARR_SIZE(arr_0, 0), 0), _fx_catch_7);
+   _fx_LE lstend_0 = 0;
+   int_ ni_0 = FX_ARR_SIZE(arr_0, 0);
+   fx_exn_t* ptr_arr_0 = FX_PTR_1D(fx_exn_t, arr_0, 0);
+   for (int_ i_1 = 0; i_1 < ni_0; i_1++) {
+      fx_exn_t x_1 = {0};
+      fx_copy_exn(ptr_arr_0 + i_1, &x_1);
+      _fx_LE node_0 = 0;
+      FX_CALL(_fx_cons_LE(&x_1, 0, false, &node_0), _fx_catch_6);
+      FX_LIST_APPEND(sorted_0, lstend_0, node_0);
+
+   _fx_catch_6: ;
+      fx_free_exn(&x_1);
+      FX_CHECK_EXN(_fx_catch_7);
+   }
+
+_fx_catch_7: ;
+   FX_FREE_FP(&__lambda___0);
+   FX_FREE_ARR(&arr_0);
+
+_fx_endmatch_0: ;
+   FX_CHECK_EXN(_fx_cleanup);
+   int_ nerrs_0 = _fx_M8CompilerFM6lengthi1LE(sorted_0, 0);
+   if (nerrs_0 != 0) {
+      int_ cap_0 = _fx_g12Options__opt.max_errors;
+      int_ i_2 = 0;
+      _fx_LE lst_4 = sorted_0;
+      for (; lst_4; lst_4 = lst_4->tl, i_2 += 1) {
+         fx_exn_t* e_1 = &lst_4->hd;
+         if (i_2 >= cap_0) {
+            FX_BREAK(_fx_catch_8);
+         }
+         FX_CALL(_fx_M3AstFM17print_compile_errv1E(e_1, 0), _fx_catch_8);
+
+      _fx_catch_8: ;
+         FX_CHECK_BREAK();
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      if (nerrs_0 > cap_0) {
+         FX_CALL(_fx_F6stringS1i(nerrs_0 - cap_0, &v_4, 0), _fx_cleanup);
+         FX_CALL(_fx_F6stringS1i(cap_0, &v_5, 0), _fx_cleanup);
+         fx_str_t slit_3 = FX_MAKE_STR("\n");
+         fx_str_t slit_4 = FX_MAKE_STR(" further diagnostic(s) suppressed (-fmax-errors=");
+         fx_str_t slit_5 = FX_MAKE_STR(").");
+         {
+            const fx_str_t strs_1[] = { slit_3, v_4, slit_4, v_5, slit_5 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_1, 5, &v_6), _fx_cleanup);
+         }
+         _fx_F12print_stringv1S(&v_6, 0);
+         fx_str_t slit_6 = FX_MAKE_STR("\n");
+         _fx_F12print_stringv1S(&slit_6, 0);
+      }
+      FX_CALL(_fx_F6stringS1i(nerrs_0, &v_7, 0), _fx_cleanup);
+      fx_str_t slit_7 = FX_MAKE_STR("\n");
+      fx_str_t slit_8 = FX_MAKE_STR(" errors occured during type checking.");
+      {
+         const fx_str_t strs_2[] = { slit_7, v_7, slit_8 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_8), _fx_cleanup);
+      }
+      _fx_F12print_stringv1S(&v_8, 0);
+      fx_str_t slit_9 = FX_MAKE_STR("\n");
+      _fx_F12print_stringv1S(&slit_9, 0);
+   }
+
+_fx_cleanup: ;
+   _fx_free_Rt24Hashset__hashset_entry_t1S(&entry0_0);
+   FX_FREE_ARR(&v_0);
+   FX_FREE_ARR(&v_1);
+   if (seen_0) {
+      _fx_free_Nt10Hashset__t1S(&seen_0);
+   }
+   if (__fold_result___0) {
+      _fx_free_LE(&__fold_result___0);
+   }
+   if (__fold_result___1) {
+      _fx_free_LE(&__fold_result___1);
+   }
+   if (v_2) {
+      _fx_free_LE(&v_2);
+   }
+   if (uniq_0) {
+      _fx_free_LE(&uniq_0);
+   }
+   if (__fold_result___2) {
+      _fx_free_LE(&__fold_result___2);
+   }
+   if (v_3) {
+      _fx_free_LE(&v_3);
+   }
+   if (sorted_0) {
+      _fx_free_LE(&sorted_0);
+   }
+   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_5);
+   FX_FREE_STR(&v_6);
+   FX_FREE_STR(&v_7);
+   FX_FREE_STR(&v_8);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_result, void* fx_fv)
+{
+   fx_exn_t exn_0 = {0};
+   int fx_status = 0;
+   FX_CALL(_fx_M3AstFM8init_allv0(0), _fx_cleanup);
+   _fx_T2SLS v_0 = {0};
+   fx_str_t ficus_root_0 = {0};
+   _fx_LS ficus_path_0 = 0;
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
+   fx_exn_t v_4 = {0};
+   fx_str_t v_5 = {0};
    _fx_LT2iLi graph_0 = 0;
-   _fx_Li v_9 = 0;
-   _fx_Li v_10 = 0;
-   _fx_Li v_11 = 0;
-   _fx_LS v_12 = 0;
+   _fx_Li v_6 = 0;
+   _fx_Li v_7 = 0;
+   _fx_Li v_8 = 0;
+   _fx_LS v_9 = 0;
    fx_str_t modules_used_0 = {0};
    fx_str_t parsing_complete_0 = {0};
-   fx_str_t v_13 = {0};
-   fx_str_t v_14 = {0};
-   _fx_T2LR17K_form__kmodule_tB v_15 = {0};
+   fx_str_t v_10 = {0};
+   fx_str_t v_11 = {0};
+   _fx_T2LR17K_form__kmodule_tB v_12 = {0};
    _fx_LR17K_form__kmodule_t kmods_0 = 0;
    _fx_LR17K_form__kmodule_t kmods_1 = 0;
-   fx_str_t v_16 = {0};
-   _fx_T2LR17K_form__kmodule_tB v_17 = {0};
-   fx_str_t v_18 = {0};
+   fx_str_t v_13 = {0};
+   _fx_T2LR17K_form__kmodule_tB v_14 = {0};
+   fx_str_t v_15 = {0};
    _fx_LR17K_form__kmodule_t kmods_2 = 0;
-   fx_str_t v_19 = {0};
-   _fx_T2LR17C_form__cmodule_tB v_20 = {0};
-   fx_str_t v_21 = {0};
+   fx_str_t v_16 = {0};
+   _fx_T2LR17C_form__cmodule_tB v_17 = {0};
+   fx_str_t v_18 = {0};
    _fx_LR17C_form__cmodule_t cmods_0 = 0;
-   fx_str_t v_22 = {0};
+   fx_str_t v_19 = {0};
    _fx_LR17C_form__cmodule_t cmods_1 = 0;
    _fx_LR17C_form__cmodule_t cmods_2 = 0;
    _fx_LR17C_form__cmodule_t cmods_3 = 0;
    fx_str_t appname_0 = {0};
-   fx_str_t v_23 = {0};
+   fx_str_t v_20 = {0};
    fx_str_t appname_1 = {0};
-   _fx_LS v_24 = 0;
+   _fx_LS v_21 = 0;
    fx_str_t cmd_0 = {0};
-   _fx_LE __fold_result___1 = 0;
-   _fx_LE v_25 = 0;
-   fx_str_t v_26 = {0};
-   fx_str_t v_27 = {0};
    fx_str_t plural_0 = {0};
-   fx_str_t v_28 = {0};
-   fx_str_t v_29 = {0};
-   fx_str_t v_30 = {0};
-   fx_str_t v_31 = {0};
-   FX_CALL(_fx_M8CompilerFM15find_ficus_dirsT2SLS0(&v_3, 0), _fx_catch_8);
-   fx_copy_str(&v_3.t0, &ficus_root_0);
-   FX_COPY_PTR(v_3.t1, &ficus_path_0);
+   fx_str_t v_22 = {0};
+   fx_str_t v_23 = {0};
+   fx_str_t v_24 = {0};
+   fx_str_t v_25 = {0};
+   FX_CALL(_fx_M8CompilerFM15find_ficus_dirsT2SLS0(&v_0, 0), _fx_catch_6);
+   fx_copy_str(&v_0.t0, &ficus_root_0);
+   FX_COPY_PTR(v_0.t1, &ficus_path_0);
    if (FX_STR_LENGTH(ficus_root_0) == 0) {
-      FX_CALL(_fx_F6stringS1i(_fx_g15__ficus_major__, &v_4, 0), _fx_catch_8);
-      FX_CALL(_fx_F6stringS1i(_fx_g15__ficus_minor__, &v_5, 0), _fx_catch_8);
+      FX_CALL(_fx_F6stringS1i(_fx_g15__ficus_major__, &v_1, 0), _fx_catch_6);
+      FX_CALL(_fx_F6stringS1i(_fx_g15__ficus_minor__, &v_2, 0), _fx_catch_6);
       fx_str_t slit_0 =
          FX_MAKE_STR("Ficus root directory is not found.\n"
             U"Please, add the directory \'lib\' containing Builtins.fx to\n"
@@ -11771,60 +12704,60 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
       fx_str_t slit_1 = FX_MAKE_STR(".");
       fx_str_t slit_2 = FX_MAKE_STR("/{runtime, lib}");
       {
-         const fx_str_t strs_0[] = { slit_0, v_4, slit_1, v_5, slit_2 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_6), _fx_catch_8);
+         const fx_str_t strs_0[] = { slit_0, v_1, slit_1, v_2, slit_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_3), _fx_catch_6);
       }
-      FX_CALL(_fx_F9make_FailE1S(&v_6, &v_7), _fx_catch_8);
-      FX_THROW(&v_7, true, _fx_catch_8);
+      FX_CALL(_fx_F9make_FailE1S(&v_3, &v_4), _fx_catch_6);
+      FX_THROW(&v_4, true, _fx_catch_6);
    }
    fx_str_t slit_3 = FX_MAKE_STR("lib");
-   FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&ficus_root_0, &slit_3, &v_8, 0), _fx_catch_8);
+   FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&ficus_root_0, &slit_3, &v_5, 0), _fx_catch_6);
    FX_FREE_STR(&_fx_g19Ast__ficus_std_path);
-   fx_copy_str(&v_8, &_fx_g19Ast__ficus_std_path);
+   fx_copy_str(&v_5, &_fx_g19Ast__ficus_std_path);
    bool ok_0;
-   FX_CALL(_fx_M8CompilerFM9parse_allB2SLS(fname0_0, ficus_path_0, &ok_0, 0), _fx_catch_8);
+   FX_CALL(_fx_M8CompilerFM9parse_allB2SLS(fname0_0, ficus_path_0, &ok_0, 0), _fx_catch_6);
    if (!ok_0) {
-      FX_THROW(&_fx_E30Compiler__CumulativeParseErrorv, false, _fx_catch_8);
+      FX_THROW(&_fx_E30Compiler__CumulativeParseErrorv, false, _fx_catch_6);
    }
    _fx_LT2iLi lstend_0 = 0;
    int_ ni_0 = FX_ARR_SIZE(_fx_g16Ast__all_modules, 0);
    _fx_N16Ast__defmodule_t* ptr_all_modules_0 = FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, 0);
    for (int_ i_0 = 0; i_0 < ni_0; i_0++) {
       _fx_N16Ast__defmodule_t minfo_0 = 0;
-      _fx_Li v_32 = 0;
+      _fx_Li v_26 = 0;
       _fx_T2iLi tup_0 = {0};
       FX_COPY_PTR(ptr_all_modules_0[i_0], &minfo_0);
-      FX_COPY_PTR(minfo_0->u.defmodule_t.t5, &v_32);
-      _fx_make_T2iLi(minfo_0->u.defmodule_t.t2, v_32, &tup_0);
+      FX_COPY_PTR(minfo_0->u.defmodule_t.t5, &v_26);
+      _fx_make_T2iLi(minfo_0->u.defmodule_t.t2, v_26, &tup_0);
       _fx_LT2iLi node_0 = 0;
       FX_CALL(_fx_cons_LT2iLi(&tup_0, 0, false, &node_0), _fx_catch_0);
       FX_LIST_APPEND(graph_0, lstend_0, node_0);
 
    _fx_catch_0: ;
       _fx_free_T2iLi(&tup_0);
-      FX_FREE_LIST_SIMPLE(&v_32);
+      FX_FREE_LIST_SIMPLE(&v_26);
       if (minfo_0) {
          _fx_free_N16Ast__defmodule_t(&minfo_0);
       }
-      FX_CHECK_EXN(_fx_catch_8);
+      FX_CHECK_EXN(_fx_catch_6);
    }
-   FX_CALL(_fx_M8CompilerFM8toposortLi1LT2iLi(graph_0, &v_9, 0), _fx_catch_8);
-   if (v_9 != 0) {
-      FX_COPY_PTR(v_9->tl, &v_10);
-   }
-   else {
-      FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_8);
-   }
-   FX_CHECK_EXN(_fx_catch_8);
-   if (v_10 != 0) {
-      FX_COPY_PTR(v_10->tl, &v_11);
+   FX_CALL(_fx_M8CompilerFM8toposortLi1LT2iLi(graph_0, &v_6, 0), _fx_catch_6);
+   if (v_6 != 0) {
+      FX_COPY_PTR(v_6->tl, &v_7);
    }
    else {
-      FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_8);
+      FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_6);
    }
-   FX_CHECK_EXN(_fx_catch_8);
+   FX_CHECK_EXN(_fx_catch_6);
+   if (v_7 != 0) {
+      FX_COPY_PTR(v_7->tl, &v_8);
+   }
+   else {
+      FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_6);
+   }
+   FX_CHECK_EXN(_fx_catch_6);
    FX_FREE_LIST_SIMPLE(&_fx_g23Ast__all_modules_sorted);
-   FX_COPY_PTR(v_11, &_fx_g23Ast__all_modules_sorted);
+   FX_COPY_PTR(v_8, &_fx_g23Ast__all_modules_sorted);
    if (_fx_g12Options__opt.print_ast0) {
       _fx_Li lst_0 = _fx_g23Ast__all_modules_sorted;
       for (; lst_0; lst_0 = lst_0->tl) {
@@ -11837,7 +12770,7 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
          if (minfo_1) {
             _fx_free_N16Ast__defmodule_t(&minfo_1);
          }
-         FX_CHECK_EXN(_fx_catch_8);
+         FX_CHECK_EXN(_fx_catch_6);
       }
    }
    _fx_LS lstend_1 = 0;
@@ -11845,19 +12778,19 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
    for (; lst_1; lst_1 = lst_1->tl) {
       fx_str_t res_0 = {0};
       int_ m_idx_0 = lst_1->hd;
-      _fx_R9Ast__id_t v_33;
-      FX_CALL(_fx_M3AstFM15get_module_nameRM4id_t1i(m_idx_0, &v_33, 0), _fx_catch_2);
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_33, &res_0, 0), _fx_catch_2);
+      _fx_R9Ast__id_t v_27;
+      FX_CALL(_fx_M3AstFM15get_module_nameRM4id_t1i(m_idx_0, &v_27, 0), _fx_catch_2);
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_27, &res_0, 0), _fx_catch_2);
       _fx_LS node_1 = 0;
       FX_CALL(_fx_cons_LS(&res_0, 0, false, &node_1), _fx_catch_2);
-      FX_LIST_APPEND(v_12, lstend_1, node_1);
+      FX_LIST_APPEND(v_9, lstend_1, node_1);
 
    _fx_catch_2: ;
       FX_FREE_STR(&res_0);
-      FX_CHECK_EXN(_fx_catch_8);
+      FX_CHECK_EXN(_fx_catch_6);
    }
    fx_str_t slit_4 = FX_MAKE_STR(", ");
-   FX_CALL(_fx_F4joinS2SLS(&slit_4, v_12, &modules_used_0, 0), _fx_catch_8);
+   FX_CALL(_fx_F4joinS2SLS(&slit_4, v_9, &modules_used_0, 0), _fx_catch_6);
    if (_fx_g21Compiler__iscolorterm) {
       fx_str_t slit_5 = FX_MAKE_STR("[34;1mParsing complete[0m"); fx_copy_str(&slit_5, &parsing_complete_0);
    }
@@ -11867,9 +12800,9 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
    fx_str_t slit_7 = FX_MAKE_STR(". Modules used: ");
    {
       const fx_str_t strs_1[] = { parsing_complete_0, slit_7, modules_used_0 };
-      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_13), _fx_catch_8);
+      FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_10), _fx_catch_6);
    }
-   FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_13, 0), _fx_catch_8);
+   FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_10, 0), _fx_catch_6);
    _fx_free_LE(&_fx_g21Ast__all_compile_errs);
    _fx_g21Ast__all_compile_errs = 0;
    _fx_Li lst_2 = _fx_g23Ast__all_modules_sorted;
@@ -11878,17 +12811,17 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
       FX_CALL(_fx_M13Ast_typecheckFM9check_modv1i(m_1, 0), _fx_catch_3);
 
    _fx_catch_3: ;
-      FX_CHECK_EXN(_fx_catch_8);
+      FX_CHECK_EXN(_fx_catch_6);
    }
    bool ok_1 = _fx_g21Ast__all_compile_errs == 0;
    if (ok_1) {
       if (_fx_g21Compiler__iscolorterm) {
-         fx_str_t slit_8 = FX_MAKE_STR("[34;1mType checking complete[0m"); fx_copy_str(&slit_8, &v_14);
+         fx_str_t slit_8 = FX_MAKE_STR("[34;1mType checking complete[0m"); fx_copy_str(&slit_8, &v_11);
       }
       else {
-         fx_str_t slit_9 = FX_MAKE_STR("Type checking complete"); fx_copy_str(&slit_9, &v_14);
+         fx_str_t slit_9 = FX_MAKE_STR("Type checking complete"); fx_copy_str(&slit_9, &v_11);
       }
-      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_14, 0), _fx_catch_8);
+      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_11, 0), _fx_catch_6);
       if (_fx_g12Options__opt.print_ast) {
          _fx_Li lst_3 = _fx_g23Ast__all_modules_sorted;
          for (; lst_3; lst_3 = lst_3->tl) {
@@ -11901,60 +12834,60 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
             if (minfo_2) {
                _fx_free_N16Ast__defmodule_t(&minfo_2);
             }
-            FX_CHECK_EXN(_fx_catch_8);
+            FX_CHECK_EXN(_fx_catch_6);
          }
       }
    }
    if (ok_1) {
       _fx_free_LE(&_fx_g21Ast__all_compile_errs);
       _fx_g21Ast__all_compile_errs = 0;
-      FX_CALL(_fx_M6K_formFM13init_all_idksv0(0), _fx_catch_8);
+      FX_CALL(_fx_M6K_formFM13init_all_idksv0(0), _fx_catch_6);
       FX_CALL(_fx_M11K_normalizeFM21normalize_all_modulesLR17K_form__kmodule_t1Li(_fx_g23Ast__all_modules_sorted, &kmods_0, 0),
-         _fx_catch_8);
-      _fx_make_T2LR17K_form__kmodule_tB(kmods_0, _fx_g21Ast__all_compile_errs == 0, &v_15);
+         _fx_catch_6);
+      _fx_make_T2LR17K_form__kmodule_tB(kmods_0, _fx_g21Ast__all_compile_errs == 0, &v_12);
    }
    else {
-      _fx_make_T2LR17K_form__kmodule_tB(0, false, &v_15);
+      _fx_make_T2LR17K_form__kmodule_tB(0, false, &v_12);
    }
-   FX_COPY_PTR(v_15.t0, &kmods_1);
-   bool ok_2 = v_15.t1;
+   FX_COPY_PTR(v_12.t0, &kmods_1);
+   bool ok_2 = v_12.t1;
    if (ok_2) {
       if (_fx_g21Compiler__iscolorterm) {
-         fx_str_t slit_10 = FX_MAKE_STR("[34;1mK-normalization complete[0m"); fx_copy_str(&slit_10, &v_16);
+         fx_str_t slit_10 = FX_MAKE_STR("[34;1mK-normalization complete[0m"); fx_copy_str(&slit_10, &v_13);
       }
       else {
-         fx_str_t slit_11 = FX_MAKE_STR("K-normalization complete"); fx_copy_str(&slit_11, &v_16);
+         fx_str_t slit_11 = FX_MAKE_STR("K-normalization complete"); fx_copy_str(&slit_11, &v_13);
       }
-      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_16, 0), _fx_catch_8);
+      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_13, 0), _fx_catch_6);
       if (_fx_g12Options__opt.print_k0) {
-         FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_1, 0), _fx_catch_8);
+         FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_1, 0), _fx_catch_6);
       }
    }
    if (ok_2) {
       if (_fx_g21Compiler__iscolorterm) {
-         fx_str_t slit_12 = FX_MAKE_STR("[34;1mK-form optimization started[0m"); fx_copy_str(&slit_12, &v_18);
+         fx_str_t slit_12 = FX_MAKE_STR("[34;1mK-form optimization started[0m"); fx_copy_str(&slit_12, &v_15);
       }
       else {
-         fx_str_t slit_13 = FX_MAKE_STR("K-form optimization started"); fx_copy_str(&slit_13, &v_18);
+         fx_str_t slit_13 = FX_MAKE_STR("K-form optimization started"); fx_copy_str(&slit_13, &v_15);
       }
-      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_18, 0), _fx_catch_8);
-      FX_CALL(_fx_M8CompilerFM14k_optimize_allT2LR17K_form__kmodule_tB1LR17K_form__kmodule_t(kmods_1, &v_17, 0), _fx_catch_8);
+      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_15, 0), _fx_catch_6);
+      FX_CALL(_fx_M8CompilerFM14k_optimize_allT2LR17K_form__kmodule_tB1LR17K_form__kmodule_t(kmods_1, &v_14, 0), _fx_catch_6);
    }
    else {
-      _fx_make_T2LR17K_form__kmodule_tB(0, false, &v_17);
+      _fx_make_T2LR17K_form__kmodule_tB(0, false, &v_14);
    }
-   FX_COPY_PTR(v_17.t0, &kmods_2);
-   bool ok_3 = v_17.t1;
+   FX_COPY_PTR(v_14.t0, &kmods_2);
+   bool ok_3 = v_14.t1;
    if (ok_3) {
       if (_fx_g21Compiler__iscolorterm) {
-         fx_str_t slit_14 = FX_MAKE_STR("[34;1mK-form optimization complete[0m"); fx_copy_str(&slit_14, &v_19);
+         fx_str_t slit_14 = FX_MAKE_STR("[34;1mK-form optimization complete[0m"); fx_copy_str(&slit_14, &v_16);
       }
       else {
-         fx_str_t slit_15 = FX_MAKE_STR("K-form optimization complete"); fx_copy_str(&slit_15, &v_19);
+         fx_str_t slit_15 = FX_MAKE_STR("K-form optimization complete"); fx_copy_str(&slit_15, &v_16);
       }
-      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_19, 0), _fx_catch_8);
+      FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_16, 0), _fx_catch_6);
       if (_fx_g12Options__opt.print_k) {
-         FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_2, 0), _fx_catch_8);
+         FX_CALL(_fx_M4K_ppFM8pp_kmodsv1LR17K_form__kmodule_t(kmods_2, 0), _fx_catch_6);
       }
    }
    bool ok_4;
@@ -11964,27 +12897,27 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
    else {
       if (ok_3) {
          if (_fx_g21Compiler__iscolorterm) {
-            fx_str_t slit_16 = FX_MAKE_STR("[34;1mGenerating C code[0m"); fx_copy_str(&slit_16, &v_21);
+            fx_str_t slit_16 = FX_MAKE_STR("[34;1mGenerating C code[0m"); fx_copy_str(&slit_16, &v_18);
          }
          else {
-            fx_str_t slit_17 = FX_MAKE_STR("Generating C code"); fx_copy_str(&slit_17, &v_21);
+            fx_str_t slit_17 = FX_MAKE_STR("Generating C code"); fx_copy_str(&slit_17, &v_18);
          }
-         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_21, 0), _fx_catch_8);
+         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_18, 0), _fx_catch_6);
          _fx_free_LE(&_fx_g21Ast__all_compile_errs);
          _fx_g21Ast__all_compile_errs = 0;
-         FX_CALL(_fx_M6C_formFM13init_all_idcsv0(0), _fx_catch_8);
-         FX_CALL(_fx_M9C_gen_stdFM14init_std_namesv0(0), _fx_catch_8);
+         FX_CALL(_fx_M6C_formFM13init_all_idcsv0(0), _fx_catch_6);
+         FX_CALL(_fx_M9C_gen_stdFM14init_std_namesv0(0), _fx_catch_6);
          FX_CALL(_fx_M10C_gen_codeFM13gen_ccode_allLR17C_form__cmodule_t1LR17K_form__kmodule_t(kmods_2, &cmods_0, 0),
-            _fx_catch_8);
+            _fx_catch_6);
          if (_fx_g21Compiler__iscolorterm) {
-            fx_str_t slit_18 = FX_MAKE_STR("[34;1mC code generated[0m"); fx_copy_str(&slit_18, &v_22);
+            fx_str_t slit_18 = FX_MAKE_STR("[34;1mC code generated[0m"); fx_copy_str(&slit_18, &v_19);
          }
          else {
-            fx_str_t slit_19 = FX_MAKE_STR("C code generated"); fx_copy_str(&slit_19, &v_22);
+            fx_str_t slit_19 = FX_MAKE_STR("C code generated"); fx_copy_str(&slit_19, &v_19);
          }
-         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_22, 0), _fx_catch_8);
+         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&v_19, 0), _fx_catch_6);
          FX_CALL(_fx_M20C_post_rename_localsFM13rename_localsLR17C_form__cmodule_t1LR17C_form__cmodule_t(cmods_0, &cmods_1, 0),
-            _fx_catch_8);
+            _fx_catch_6);
          _fx_LR17C_form__cmodule_t lstend_2 = 0;
          _fx_LR17C_form__cmodule_t lst_4 = cmods_1;
          for (; lst_4; lst_4 = lst_4->tl) {
@@ -12010,17 +12943,17 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
 
          _fx_catch_5: ;
             _fx_free_R17C_form__cmodule_t(&t_0);
-            FX_CHECK_EXN(_fx_catch_8);
+            FX_CHECK_EXN(_fx_catch_6);
          }
          fx_str_t slit_20 = FX_MAKE_STR("\tConversion to C-form complete");
-         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&slit_20, 0), _fx_catch_8);
-         _fx_make_T2LR17C_form__cmodule_tB(cmods_2, _fx_g21Ast__all_compile_errs == 0, &v_20);
+         FX_CALL(_fx_M3AstFM10pr_verbosev1S(&slit_20, 0), _fx_catch_6);
+         _fx_make_T2LR17C_form__cmodule_tB(cmods_2, _fx_g21Ast__all_compile_errs == 0, &v_17);
       }
       else {
-         _fx_make_T2LR17C_form__cmodule_tB(0, false, &v_20);
+         _fx_make_T2LR17C_form__cmodule_tB(0, false, &v_17);
       }
-      FX_COPY_PTR(v_20.t0, &cmods_3);
-      bool ok_5 = v_20.t1;
+      FX_COPY_PTR(v_17.t0, &cmods_3);
+      bool ok_5 = v_17.t1;
       bool t_1;
       if (ok_5) {
          if (_fx_g12Options__opt.make_app) {
@@ -12035,7 +12968,7 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
       }
       bool ok_6;
       if (t_1) {
-         FX_CALL(_fx_M8CompilerFM6run_ccB2LR17C_form__cmodule_tS(cmods_3, &ficus_root_0, &ok_6, 0), _fx_catch_8);
+         FX_CALL(_fx_M8CompilerFM6run_ccB2LR17C_form__cmodule_tS(cmods_3, &ficus_root_0, &ok_6, 0), _fx_catch_6);
       }
       else {
          ok_6 = ok_5;
@@ -12049,92 +12982,56 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
       }
       if (t_2) {
          fx_copy_str(&_fx_g12Options__opt.app_filename, &appname_0);
-         FX_CALL(_fx_M8FilenameFM6getcwdS0(&v_23, 0), _fx_catch_8);
-         FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_23, &appname_0, &appname_1, 0), _fx_catch_8);
-         FX_COPY_PTR(_fx_g12Options__opt.app_args, &v_24);
-         FX_CALL(_fx_cons_LS(&appname_1, v_24, false, &v_24), _fx_catch_8);
+         FX_CALL(_fx_M8FilenameFM6getcwdS0(&v_20, 0), _fx_catch_6);
+         FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_20, &appname_0, &appname_1, 0), _fx_catch_6);
+         FX_COPY_PTR(_fx_g12Options__opt.app_args, &v_21);
+         FX_CALL(_fx_cons_LS(&appname_1, v_21, false, &v_21), _fx_catch_6);
          fx_str_t slit_21 = FX_MAKE_STR(" ");
-         FX_CALL(_fx_F4joinS2SLS(&slit_21, v_24, &cmd_0, 0), _fx_catch_8);
-         int_ v_34;
-         FX_CALL(_fx_M3SysFM7commandi1S(&cmd_0, &v_34, 0), _fx_catch_8);
-         ok_4 = v_34 == 0;
+         FX_CALL(_fx_F4joinS2SLS(&slit_21, v_21, &cmd_0, 0), _fx_catch_6);
+         int_ v_28;
+         FX_CALL(_fx_M3SysFM7commandi1S(&cmd_0, &v_28, 0), _fx_catch_6);
+         ok_4 = v_28 == 0;
       }
       else {
          ok_4 = ok_6;
       }
    }
    if (!ok_4) {
-      int_ nerrs_0 = _fx_M8CompilerFM6lengthi1LE(_fx_g21Ast__all_compile_errs, 0);
-      if (nerrs_0 != 0) {
-         _fx_LE lst_5 = _fx_g21Ast__all_compile_errs;
-         for (; lst_5; lst_5 = lst_5->tl) {
-            _fx_LE r_0 = 0;
-            fx_exn_t* a_0 = &lst_5->hd;
-            FX_COPY_PTR(__fold_result___1, &r_0);
-            FX_CALL(_fx_cons_LE(a_0, r_0, false, &r_0), _fx_catch_6);
-            _fx_free_LE(&__fold_result___1);
-            FX_COPY_PTR(r_0, &__fold_result___1);
-
-         _fx_catch_6: ;
-            if (r_0) {
-               _fx_free_LE(&r_0);
-            }
-            FX_CHECK_EXN(_fx_catch_8);
-         }
-         FX_COPY_PTR(__fold_result___1, &v_25);
-         _fx_LE lst_6 = v_25;
-         for (; lst_6; lst_6 = lst_6->tl) {
-            fx_exn_t* x_0 = &lst_6->hd;
-            FX_CALL(_fx_M3AstFM17print_compile_errv1E(x_0, 0), _fx_catch_7);
-
-         _fx_catch_7: ;
-            FX_CHECK_EXN(_fx_catch_8);
-         }
-         FX_CALL(_fx_F6stringS1i(nerrs_0, &v_26, 0), _fx_catch_8);
-         fx_str_t slit_22 = FX_MAKE_STR("\n");
-         fx_str_t slit_23 = FX_MAKE_STR(" errors occured during type checking.");
-         {
-            const fx_str_t strs_2[] = { slit_22, v_26, slit_23 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_27), _fx_catch_8);
-         }
-         _fx_F12print_stringv1S(&v_27, 0);
-         fx_str_t slit_24 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_24, 0);
-      }
+      FX_CALL(_fx_M8CompilerFM22print_all_compile_errsv0(0), _fx_catch_6);
    }
    int_ nwarns_0 = _fx_g22Ast__all_compile_warns;
    if (nwarns_0 != 0) {
       if (nwarns_0 == 1) {
-         fx_str_t slit_25 = FX_MAKE_STR("warning"); fx_copy_str(&slit_25, &plural_0);
+         fx_str_t slit_22 = FX_MAKE_STR("warning"); fx_copy_str(&slit_22, &plural_0);
       }
       else {
-         fx_str_t slit_26 = FX_MAKE_STR("warnings"); fx_copy_str(&slit_26, &plural_0);
+         fx_str_t slit_23 = FX_MAKE_STR("warnings"); fx_copy_str(&slit_23, &plural_0);
       }
       if (_fx_g12Options__opt.Werror) {
-         FX_CALL(_fx_F6stringS1i(nwarns_0, &v_28, 0), _fx_catch_8);
-         fx_str_t slit_27 = FX_MAKE_STR("\n");
-         fx_str_t slit_28 = FX_MAKE_STR(" ");
-         fx_str_t slit_29 = FX_MAKE_STR(" generated (treated as errors due to -Werror).");
+         FX_CALL(_fx_F6stringS1i(nwarns_0, &v_22, 0), _fx_catch_6);
+         fx_str_t slit_24 = FX_MAKE_STR("\n");
+         fx_str_t slit_25 = FX_MAKE_STR(" ");
+         fx_str_t slit_26 = FX_MAKE_STR(" generated (treated as errors due to -Werror).");
          {
-            const fx_str_t strs_3[] = { slit_27, v_28, slit_28, plural_0, slit_29 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_29), _fx_catch_8);
+            const fx_str_t strs_2[] = { slit_24, v_22, slit_25, plural_0, slit_26 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_2, 5, &v_23), _fx_catch_6);
          }
-         _fx_F12print_stringv1S(&v_29, 0);
-         fx_str_t slit_30 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_30, 0);
+         _fx_F12print_stringv1S(&v_23, 0);
+         fx_str_t slit_27 = FX_MAKE_STR("\n");
+         _fx_F12print_stringv1S(&slit_27, 0);
       }
       else {
-         FX_CALL(_fx_F6stringS1i(nwarns_0, &v_30, 0), _fx_catch_8);
-         fx_str_t slit_31 = FX_MAKE_STR("\n");
-         fx_str_t slit_32 = FX_MAKE_STR(" ");
-         fx_str_t slit_33 = FX_MAKE_STR(" generated.");
+         FX_CALL(_fx_F6stringS1i(nwarns_0, &v_24, 0), _fx_catch_6);
+         fx_str_t slit_28 = FX_MAKE_STR("\n");
+         fx_str_t slit_29 = FX_MAKE_STR(" ");
+         fx_str_t slit_30 = FX_MAKE_STR(" generated.");
          {
-            const fx_str_t strs_4[] = { slit_31, v_30, slit_32, plural_0, slit_33 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 5, &v_31), _fx_catch_8);
+            const fx_str_t strs_3[] = { slit_28, v_24, slit_29, plural_0, slit_30 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_25), _fx_catch_6);
          }
-         _fx_F12print_stringv1S(&v_31, 0);
-         fx_str_t slit_34 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_34, 0);
+         _fx_F12print_stringv1S(&v_25, 0);
+         fx_str_t slit_31 = FX_MAKE_STR("\n");
+         _fx_F12print_stringv1S(&slit_31, 0);
       }
    }
    if (ok_4) {
@@ -12151,50 +13048,50 @@ FX_EXTERN_C int _fx_M8CompilerFM11process_allB1S(fx_str_t* fname0_0, bool* fx_re
       *fx_result = false;
    }
 
-_fx_catch_8: ;
-   _fx_free_T2SLS(&v_3);
+_fx_catch_6: ;
+   _fx_free_T2SLS(&v_0);
    FX_FREE_STR(&ficus_root_0);
    if (ficus_path_0) {
       _fx_free_LS(&ficus_path_0);
    }
-   FX_FREE_STR(&v_4);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
+   fx_free_exn(&v_4);
    FX_FREE_STR(&v_5);
-   FX_FREE_STR(&v_6);
-   fx_free_exn(&v_7);
-   FX_FREE_STR(&v_8);
    if (graph_0) {
       _fx_free_LT2iLi(&graph_0);
    }
-   FX_FREE_LIST_SIMPLE(&v_9);
-   FX_FREE_LIST_SIMPLE(&v_10);
-   FX_FREE_LIST_SIMPLE(&v_11);
-   if (v_12) {
-      _fx_free_LS(&v_12);
+   FX_FREE_LIST_SIMPLE(&v_6);
+   FX_FREE_LIST_SIMPLE(&v_7);
+   FX_FREE_LIST_SIMPLE(&v_8);
+   if (v_9) {
+      _fx_free_LS(&v_9);
    }
    FX_FREE_STR(&modules_used_0);
    FX_FREE_STR(&parsing_complete_0);
-   FX_FREE_STR(&v_13);
-   FX_FREE_STR(&v_14);
-   _fx_free_T2LR17K_form__kmodule_tB(&v_15);
+   FX_FREE_STR(&v_10);
+   FX_FREE_STR(&v_11);
+   _fx_free_T2LR17K_form__kmodule_tB(&v_12);
    if (kmods_0) {
       _fx_free_LR17K_form__kmodule_t(&kmods_0);
    }
    if (kmods_1) {
       _fx_free_LR17K_form__kmodule_t(&kmods_1);
    }
-   FX_FREE_STR(&v_16);
-   _fx_free_T2LR17K_form__kmodule_tB(&v_17);
-   FX_FREE_STR(&v_18);
+   FX_FREE_STR(&v_13);
+   _fx_free_T2LR17K_form__kmodule_tB(&v_14);
+   FX_FREE_STR(&v_15);
    if (kmods_2) {
       _fx_free_LR17K_form__kmodule_t(&kmods_2);
    }
-   FX_FREE_STR(&v_19);
-   _fx_free_T2LR17C_form__cmodule_tB(&v_20);
-   FX_FREE_STR(&v_21);
+   FX_FREE_STR(&v_16);
+   _fx_free_T2LR17C_form__cmodule_tB(&v_17);
+   FX_FREE_STR(&v_18);
    if (cmods_0) {
       _fx_free_LR17C_form__cmodule_t(&cmods_0);
    }
-   FX_FREE_STR(&v_22);
+   FX_FREE_STR(&v_19);
    if (cmods_1) {
       _fx_free_LR17C_form__cmodule_t(&cmods_1);
    }
@@ -12205,104 +13102,60 @@ _fx_catch_8: ;
       _fx_free_LR17C_form__cmodule_t(&cmods_3);
    }
    FX_FREE_STR(&appname_0);
-   FX_FREE_STR(&v_23);
+   FX_FREE_STR(&v_20);
    FX_FREE_STR(&appname_1);
-   if (v_24) {
-      _fx_free_LS(&v_24);
+   if (v_21) {
+      _fx_free_LS(&v_21);
    }
    FX_FREE_STR(&cmd_0);
-   if (__fold_result___1) {
-      _fx_free_LE(&__fold_result___1);
-   }
-   if (v_25) {
-      _fx_free_LE(&v_25);
-   }
-   FX_FREE_STR(&v_26);
-   FX_FREE_STR(&v_27);
    FX_FREE_STR(&plural_0);
-   FX_FREE_STR(&v_28);
-   FX_FREE_STR(&v_29);
-   FX_FREE_STR(&v_30);
-   FX_FREE_STR(&v_31);
+   FX_FREE_STR(&v_22);
+   FX_FREE_STR(&v_23);
+   FX_FREE_STR(&v_24);
+   FX_FREE_STR(&v_25);
    if (fx_status < 0) {
       fx_exn_get_and_reset(fx_status, &exn_0);
       fx_status = 0;
-      int_ nerrs_1 = _fx_M8CompilerFM6lengthi1LE(_fx_g21Ast__all_compile_errs, 0);
-      if (nerrs_1 != 0) {
-         _fx_LE lst_7 = _fx_g21Ast__all_compile_errs;
-         for (; lst_7; lst_7 = lst_7->tl) {
-            _fx_LE r_1 = 0;
-            fx_exn_t* a_1 = &lst_7->hd;
-            FX_COPY_PTR(__fold_result___0, &r_1);
-            FX_CALL(_fx_cons_LE(a_1, r_1, false, &r_1), _fx_catch_9);
-            _fx_free_LE(&__fold_result___0);
-            FX_COPY_PTR(r_1, &__fold_result___0);
-
-         _fx_catch_9: ;
-            if (r_1) {
-               _fx_free_LE(&r_1);
-            }
-            FX_CHECK_EXN(_fx_cleanup);
-         }
-         FX_COPY_PTR(__fold_result___0, &v_0);
-         _fx_LE lst_8 = v_0;
-         for (; lst_8; lst_8 = lst_8->tl) {
-            fx_exn_t* x_1 = &lst_8->hd;
-            FX_CALL(_fx_M3AstFM17print_compile_errv1E(x_1, 0), _fx_catch_10);
-
-         _fx_catch_10: ;
-            FX_CHECK_EXN(_fx_cleanup);
-         }
-         FX_CALL(_fx_F6stringS1i(nerrs_1, &v_1, 0), _fx_cleanup);
-         fx_str_t slit_35 = FX_MAKE_STR("\n");
-         fx_str_t slit_36 = FX_MAKE_STR(" errors occured during type checking.");
-         {
-            const fx_str_t strs_5[] = { slit_35, v_1, slit_36 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_2), _fx_cleanup);
-         }
-         _fx_F12print_stringv1S(&v_2, 0);
-         fx_str_t slit_37 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_37, 0);
-      }
+      FX_CALL(_fx_M8CompilerFM22print_all_compile_errsv0(0), _fx_cleanup);
       int tag_0 = exn_0.tag;
       if (tag_0 == _FX_EXN_E4Fail) {
-         fx_str_t v_35 = {0};
-         fx_str_t slit_38 = FX_MAKE_STR(": ");
+         fx_str_t v_29 = {0};
+         fx_str_t slit_32 = FX_MAKE_STR(": ");
          fx_str_t* msg_0 = &FX_EXN_DATA(_fx_E4Fail_data_t, exn_0.data);
          {
-            const fx_str_t strs_6[] = { _fx_g15Compiler__error, slit_38, *msg_0 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &v_35), _fx_catch_11);
+            const fx_str_t strs_4[] = { _fx_g15Compiler__error, slit_32, *msg_0 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_29), _fx_catch_7);
          }
-         _fx_F12print_stringv1S(&v_35, 0);
-         fx_str_t slit_39 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_39, 0);
+         _fx_F12print_stringv1S(&v_29, 0);
+         fx_str_t slit_33 = FX_MAKE_STR("\n");
+         _fx_F12print_stringv1S(&slit_33, 0);
 
-      _fx_catch_11: ;
-         FX_FREE_STR(&v_35);
+      _fx_catch_7: ;
+         FX_FREE_STR(&v_29);
       }
       else if (tag_0 == _FX_EXN_E17Ast__CompileError) {
-         FX_CALL(_fx_M3AstFM17print_compile_errv1E(&exn_0, 0), _fx_catch_12);  _fx_catch_12: ;
+         FX_CALL(_fx_M3AstFM17print_compile_errv1E(&exn_0, 0), _fx_catch_8);  _fx_catch_8: ;
       }
       else if (tag_0 != _FX_EXN_E30Compiler__CumulativeParseError) {
-         fx_str_t v_36 = {0};
-         fx_str_t v_37 = {0};
-         FX_CALL(_fx_F6stringS1E(&exn_0, &v_36, 0), _fx_catch_13);
-         fx_str_t slit_40 =
+         fx_str_t v_30 = {0};
+         fx_str_t v_31 = {0};
+         FX_CALL(_fx_F6stringS1E(&exn_0, &v_30, 0), _fx_catch_9);
+         fx_str_t slit_34 =
             FX_MAKE_STR("\n"
                U"\n");
-         fx_str_t slit_41 = FX_MAKE_STR(": Exception ");
-         fx_str_t slit_42 = FX_MAKE_STR(" occured");
+         fx_str_t slit_35 = FX_MAKE_STR(": Exception ");
+         fx_str_t slit_36 = FX_MAKE_STR(" occured");
          {
-            const fx_str_t strs_7[] = { slit_40, _fx_g15Compiler__error, slit_41, v_36, slit_42 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_7, 5, &v_37), _fx_catch_13);
+            const fx_str_t strs_5[] = { slit_34, _fx_g15Compiler__error, slit_35, v_30, slit_36 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_5, 5, &v_31), _fx_catch_9);
          }
-         _fx_F12print_stringv1S(&v_37, 0);
-         fx_str_t slit_43 = FX_MAKE_STR("\n");
-         _fx_F12print_stringv1S(&slit_43, 0);
+         _fx_F12print_stringv1S(&v_31, 0);
+         fx_str_t slit_37 = FX_MAKE_STR("\n");
+         _fx_F12print_stringv1S(&slit_37, 0);
 
-      _fx_catch_13: ;
-         FX_FREE_STR(&v_37);
-         FX_FREE_STR(&v_36);
+      _fx_catch_9: ;
+         FX_FREE_STR(&v_31);
+         FX_FREE_STR(&v_30);
       }
       FX_CHECK_EXN(_fx_cleanup);
       *fx_result = false;
@@ -12310,14 +13163,6 @@ _fx_catch_8: ;
 
 _fx_cleanup: ;
    fx_free_exn(&exn_0);
-   if (__fold_result___0) {
-      _fx_free_LE(&__fold_result___0);
-   }
-   if (v_0) {
-      _fx_free_LE(&v_0);
-   }
-   FX_FREE_STR(&v_1);
-   FX_FREE_STR(&v_2);
    return fx_status;
 }
 

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -190,16 +190,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_annotate.c
+++ b/compiler/bootstrap/K_annotate.c
@@ -66,16 +66,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_cfold_dealias.c
+++ b/compiler/bootstrap/K_cfold_dealias.c
@@ -63,16 +63,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_copy_n_skip.c
+++ b/compiler/bootstrap/K_copy_n_skip.c
@@ -112,16 +112,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_declosure.c
+++ b/compiler/bootstrap/K_declosure.c
@@ -85,16 +85,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_fast_idx.c
+++ b/compiler/bootstrap/K_fast_idx.c
@@ -86,16 +86,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_flatten.c
+++ b/compiler/bootstrap/K_flatten.c
@@ -53,16 +53,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_form.c
+++ b/compiler/bootstrap/K_form.c
@@ -131,16 +131,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_freevars.c
+++ b/compiler/bootstrap/K_freevars.c
@@ -81,16 +81,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_fuse_loops.c
+++ b/compiler/bootstrap/K_fuse_loops.c
@@ -77,16 +77,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_inline.c
+++ b/compiler/bootstrap/K_inline.c
@@ -151,16 +151,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;
@@ -3977,7 +3978,7 @@ FX_EXTERN_C void _fx_M3AstFM8ScModuleN12Ast__scope_t1i(int_, struct _fx_N12Ast__
 
 FX_EXTERN_C int _fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(int_, struct _fx_N12Ast__scope_t*, void*);
 
-FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(int_, bool, struct _fx_N12Ast__scope_t*, void*);
+FX_EXTERN_C int _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(int_, bool, bool, struct _fx_N12Ast__scope_t*, void*);
 
 FX_EXTERN_C int _fx_M3AstFM13new_map_scopeN12Ast__scope_t1i(int_, struct _fx_N12Ast__scope_t*, void*);
 
@@ -6971,8 +6972,9 @@ static int
       _fx_N12Ast__scope_t* v_14 = &sc_0->hd;
       if (v_14->tag == 2) {
          _fx_LN12Ast__scope_t v_15 = 0;
+         _fx_T3BBi* vcase_0 = &v_14->u.ScLoop;
          _fx_N12Ast__scope_t v_16;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t2iB(km_idx_0, v_14->u.ScLoop.t0, &v_16, 0), _fx_catch_4);
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(km_idx_0, vcase_0->t0, vcase_0->t1, &v_16, 0), _fx_catch_4);
          FX_CALL(
             _fx_M8K_inlineFM11subst_scopeLN12Ast__scope_t4LN12Ast__scope_tR10Ast__loc_tirNt10Hashmap__t2R9Ast__id_tN14K_form__atom_t(
                sc_0->tl, loc_0, km_idx_0, subst_map_ref_0, &v_15, 0), _fx_catch_4);

--- a/compiler/bootstrap/K_inline.c
+++ b/compiler/bootstrap/K_inline.c
@@ -124,6 +124,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -1270,6 +1271,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1307,6 +1309,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1343,6 +1346,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/K_lift.c
+++ b/compiler/bootstrap/K_lift.c
@@ -82,16 +82,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_lift_simple.c
+++ b/compiler/bootstrap/K_lift_simple.c
@@ -57,16 +57,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_loop_inv.c
+++ b/compiler/bootstrap/K_loop_inv.c
@@ -72,16 +72,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_mangle.c
+++ b/compiler/bootstrap/K_mangle.c
@@ -86,16 +86,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_normalize.c
+++ b/compiler/bootstrap/K_normalize.c
@@ -97,16 +97,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_nothrow_wrappers.c
+++ b/compiler/bootstrap/K_nothrow_wrappers.c
@@ -53,16 +53,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_optim_matop.c
+++ b/compiler/bootstrap/K_optim_matop.c
@@ -81,16 +81,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_pp.c
+++ b/compiler/bootstrap/K_pp.c
@@ -48,16 +48,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -118,6 +118,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -1229,6 +1230,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1266,6 +1268,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1302,6 +1305,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -145,16 +145,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/K_tailrec.c
+++ b/compiler/bootstrap/K_tailrec.c
@@ -53,16 +53,17 @@ typedef struct _fx_R10Ast__loc_t {
    int_ col1;
 } _fx_R10Ast__loc_t;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/Options.c
+++ b/compiler/bootstrap/Options.c
@@ -75,6 +75,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2S {
@@ -209,6 +210,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -246,6 +248,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -282,6 +285,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_Ta2S(struct _fx_Ta2S* dst)
@@ -325,6 +329,8 @@ FX_EXTERN_C_VAL(fx_str_t _fx_g21__ficus_version_str__)
 FX_EXTERN_C_VAL(fx_str_t _fx_g20__ficus_git_commit__)
 FX_EXTERN_C int _fx_M8FilenameFM6getcwdS0(fx_str_t*, void*);
 
+FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int_ _fx_M6StringFM4findi2SC(fx_str_t*, char_, void*);
 
 FX_EXTERN_C bool _fx_M4CharFM7isalphaB1C(char_, void*);
@@ -336,8 +342,6 @@ FX_EXTERN_C bool _fx_M4CharFM7isdigitB1C(char_, void*);
 FX_EXTERN_C bool _fx_M6StringFM10startswithB2SC(fx_str_t*, char_, void*);
 
 FX_EXTERN_C bool _fx_M6StringFM8endswithB2SC(fx_str_t*, char_, void*);
-
-FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_FPS1B _fx_g11Sys__osname)
 FX_EXTERN_C int _fx_M3SysFM10cc_versionS0(fx_str_t*, void*);
@@ -484,6 +488,13 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M7OptionsFM6lengthi1S(fx_str_t* s_0, int_* fx_result, void* fx_fv)
+{
+   int fx_status = 0;
+   *fx_result = FX_STR_LENGTH(*s_0);
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M7OptionsFM6to_intNt6option1i2Si(fx_str_t* a_0, int_ base_0, struct _fx_Nt6option1i* fx_result, void* fx_fv)
 {
    int fx_status = 0;
@@ -528,7 +539,7 @@ FX_EXTERN_C int _fx_M7OptionsFM15default_optionsRM9options_t0(struct _fx_R18Opti
    fx_str_t slit_6 = FX_MAKE_STR("");
    _fx_make_R18Options__options_t(0, &slit_0, true, false, &slit_1, &slit_2, &slit_3, &slit_4, false, &slit_5, true, 0, false,
       0, 0, 100, true, false, true, true, 1, &slit_6, false, false, false, false, false, false, false, false, true, false,
-      false, false, fx_result);
+      false, false, 100, fx_result);
    return fx_status;
 }
 
@@ -638,6 +649,10 @@ FX_EXTERN_C int _fx_M7OptionsFM10print_helpv1B(bool detailed_0, void* fx_fv)
             U"                    -Wimplicit-rettype)\n"
             U"    -Werror         Treat all emitted warnings as errors: exit with a nonzero\n"
             U"                    status if any warning was generated\n"
+            U"    -fmax-errors=N  Print at most N distinct type diagnostics per run (default\n"
+            U"                    100); the rest are summarized as \'further diagnostics\n"
+            U"                    suppressed\'. The type checker recovers from an error and\n"
+            U"                    keeps going, so one run reports many independent problems.\n"
             U"    -o <output_name> Output file name (by default it matches the\n"
             U"                    input filename without .fx extension)\n"
             U"    -D symbol       Define \'symbol=true\' for preprocessor\n"
@@ -741,103 +756,103 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       if (args_1 != 0) {
          fx_str_t slit_1 = FX_MAKE_STR("-no-preamble");
          if (fx_streq(&args_1->hd, &slit_1)) {
-            _fx_g12Options__opt.use_preamble = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.use_preamble = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_2 = FX_MAKE_STR("-rebuild");
          if (fx_streq(&args_1->hd, &slit_2)) {
-            _fx_g12Options__opt.force_rebuild = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.force_rebuild = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_3 = FX_MAKE_STR("-pr-tokens");
          if (fx_streq(&args_1->hd, &slit_3)) {
-            _fx_g12Options__opt.print_tokens = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_tokens = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_4 = FX_MAKE_STR("-pr-ast0");
          if (fx_streq(&args_1->hd, &slit_4)) {
-            _fx_g12Options__opt.print_ast0 = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_ast0 = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_5 = FX_MAKE_STR("-pr-ast");
          if (fx_streq(&args_1->hd, &slit_5)) {
-            _fx_g12Options__opt.print_ast = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_ast = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_6 = FX_MAKE_STR("-pr-k0");
          if (fx_streq(&args_1->hd, &slit_6)) {
-            _fx_g12Options__opt.print_k0 = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_k0 = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_7 = FX_MAKE_STR("-pr-k");
          if (fx_streq(&args_1->hd, &slit_7)) {
-            _fx_g12Options__opt.print_k = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_k = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_8 = FX_MAKE_STR("-pr-resolve");
          if (fx_streq(&args_1->hd, &slit_8)) {
-            _fx_g12Options__opt.print_resolve = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.print_resolve = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_9 = FX_MAKE_STR("-no-c");
          if (fx_streq(&args_1->hd, &slit_9)) {
-            _fx_g12Options__opt.gen_c = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.gen_c = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_10 = FX_MAKE_STR("-app");
          if (fx_streq(&args_1->hd, &slit_10)) {
-            _fx_g12Options__opt.make_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.make_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_11 = FX_MAKE_STR("-run");
          if (fx_streq(&args_1->hd, &slit_11)) {
-            _fx_g12Options__opt.run_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.run_app = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_12 = FX_MAKE_STR("-O0");
          if (fx_streq(&args_1->hd, &slit_12)) {
-            _fx_g12Options__opt.optimize_level = 0; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.optimize_level = 0; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_13 = FX_MAKE_STR("-O1");
          if (fx_streq(&args_1->hd, &slit_13)) {
-            _fx_g12Options__opt.optimize_level = 1; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.optimize_level = 1; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_14 = FX_MAKE_STR("-O3");
          if (fx_streq(&args_1->hd, &slit_14)) {
-            _fx_g12Options__opt.optimize_level = 3; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.optimize_level = 3; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_15 = FX_MAKE_STR("-Ofast");
          if (fx_streq(&args_1->hd, &slit_15)) {
-            _fx_g12Options__opt.optimize_level = 100; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.optimize_level = 100; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_16 = FX_MAKE_STR("-no-openmp");
          if (fx_streq(&args_1->hd, &slit_16)) {
-            _fx_g12Options__opt.enable_openmp = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.enable_openmp = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_17 = FX_MAKE_STR("-debug");
          if (fx_streq(&args_1->hd, &slit_17)) {
-            _fx_g12Options__opt.debug = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.debug = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
@@ -867,7 +882,7 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
             _fx_catch_0: ;
                FX_FREE_STR(&v_34);
                FX_FREE_STR(&v_33);
-               goto _fx_endmatch_2;
+               goto _fx_endmatch_3;
             }
          }
       }
@@ -898,26 +913,26 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
             _fx_catch_1: ;
                FX_FREE_STR(&v_37);
                FX_FREE_STR(&v_36);
-               goto _fx_endmatch_2;
+               goto _fx_endmatch_3;
             }
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_24 = FX_MAKE_STR("-relax");
          if (fx_streq(&args_1->hd, &slit_24)) {
-            _fx_g12Options__opt.relax = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.relax = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_25 = FX_MAKE_STR("-Wno-unused");
          if (fx_streq(&args_1->hd, &slit_25)) {
-            _fx_g12Options__opt.W_unused = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.W_unused = false; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_26 = FX_MAKE_STR("-Wimplicit-rettype");
          if (fx_streq(&args_1->hd, &slit_26)) {
-            _fx_g12Options__opt.W_implicit_rettype = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.W_implicit_rettype = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
@@ -926,84 +941,126 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
             _fx_g12Options__opt.W_implicit_rettype = true;
             _fx_g12Options__opt.W_implicit_rettype_all = true;
             FX_COPY_PTR(args_1->tl, &v_31);
-            goto _fx_endmatch_2;
+            goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_28 = FX_MAKE_STR("-Wall");
          if (fx_streq(&args_1->hd, &slit_28)) {
-            _fx_g12Options__opt.W_implicit_rettype = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.W_implicit_rettype = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
          fx_str_t slit_29 = FX_MAKE_STR("-Werror");
          if (fx_streq(&args_1->hd, &slit_29)) {
-            _fx_g12Options__opt.Werror = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+            _fx_g12Options__opt.Werror = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_30 = FX_MAKE_STR("-verbose");
-         if (fx_streq(&args_1->hd, &slit_30)) {
-            _fx_g12Options__opt.verbose = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
+         fx_str_t* opt_str_0 = &args_1->hd;
+         fx_str_t slit_30 = FX_MAKE_STR("-fmax-errors=");
+         if (_fx_M6StringFM10startswithB2SS(opt_str_0, &slit_30, 0)) {
+            fx_str_t vstr_0 = {0};
+            fx_str_t slit_31 = FX_MAKE_STR("-fmax-errors=");
+            int_ res_0;
+            FX_CALL(_fx_M7OptionsFM6lengthi1S(&slit_31, &res_0, 0), _fx_catch_3);
+            FX_CALL(fx_substr(opt_str_0, res_0, 0, 1, 2, &vstr_0), _fx_catch_3);
+            _fx_Nt6option1i v_38;
+            FX_CALL(_fx_M7OptionsFM6to_intNt6option1i2Si(&vstr_0, 0, &v_38, 0), _fx_catch_3);
+            if (v_38.tag == 2) {
+               int_ n_0 = v_38.u.Some;
+               if (n_0 > 0) {
+                  _fx_g12Options__opt.max_errors = n_0; goto _fx_endmatch_0;
+               }
+            }
+            fx_str_t v_39 = {0};
+            fx_str_t v_40 = {0};
+            FX_CALL(_fx_M7OptionsFM6stringS1S(&vstr_0, &v_39, 0), _fx_catch_2);
+            fx_str_t slit_32 = FX_MAKE_STR("invalid -fmax-errors value \'");
+            fx_str_t slit_33 = FX_MAKE_STR("\' (expected a positive integer)");
+            {
+               const fx_str_t strs_2[] = { slit_32, v_39, slit_33 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_40), _fx_catch_2);
+            }
+            FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_40, 0), _fx_catch_2);
+            ok_0 = false;
+
+         _fx_catch_2: ;
+            FX_FREE_STR(&v_40);
+            FX_FREE_STR(&v_39);
+
+         _fx_endmatch_0: ;
+            FX_CHECK_EXN(_fx_catch_3);
+            FX_COPY_PTR(args_1->tl, &v_31);
+
+         _fx_catch_3: ;
+            FX_FREE_STR(&vstr_0);
+            goto _fx_endmatch_3;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_31 = FX_MAKE_STR("-o");
-         if (fx_streq(&args_1->hd, &slit_31)) {
-            _fx_LS v_38 = args_1->tl;
-            if (v_38 != 0) {
-               fx_str_t* v_39 = &_fx_g12Options__opt.output_name;
-               fx_str_t* oname_0 = &v_38->hd;
-               FX_FREE_STR(v_39);
-               fx_copy_str(oname_0, v_39);
-               FX_COPY_PTR(v_38->tl, &v_31);
-               goto _fx_endmatch_2;
+         fx_str_t slit_34 = FX_MAKE_STR("-verbose");
+         if (fx_streq(&args_1->hd, &slit_34)) {
+            _fx_g12Options__opt.verbose = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_35 = FX_MAKE_STR("-o");
+         if (fx_streq(&args_1->hd, &slit_35)) {
+            _fx_LS v_41 = args_1->tl;
+            if (v_41 != 0) {
+               fx_str_t* v_42 = &_fx_g12Options__opt.output_name;
+               fx_str_t* oname_0 = &v_41->hd;
+               FX_FREE_STR(v_42);
+               fx_copy_str(oname_0, v_42);
+               FX_COPY_PTR(v_41->tl, &v_31);
+               goto _fx_endmatch_3;
             }
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_32 = FX_MAKE_STR("-D");
-         if (fx_streq(&args_1->hd, &slit_32)) {
-            _fx_LS v_40 = args_1->tl;
-            if (v_40 != 0) {
-               _fx_Ta2S v_41 = {0};
-               fx_str_t v_42 = {0};
-               fx_str_t v_43 = {0};
+         fx_str_t slit_36 = FX_MAKE_STR("-D");
+         if (fx_streq(&args_1->hd, &slit_36)) {
+            _fx_LS v_43 = args_1->tl;
+            if (v_43 != 0) {
+               _fx_Ta2S v_44 = {0};
+               fx_str_t v_45 = {0};
+               fx_str_t v_46 = {0};
                fx_str_t name_0 = {0};
                fx_str_t value_0 = {0};
                _fx_N17Options__optval_t errval_0 = {0};
                _fx_N17Options__optval_t value_1 = {0};
-               fx_str_t v_44 = {0};
-               fx_str_t v_45 = {0};
-               fx_str_t v_46 = {0};
                fx_str_t v_47 = {0};
                fx_str_t v_48 = {0};
                fx_str_t v_49 = {0};
                fx_str_t v_50 = {0};
-               _fx_T2SN17Options__optval_t v_51 = {0};
-               _fx_LT2SN17Options__optval_t v_52 = 0;
-               fx_str_t* nameval_0 = &v_40->hd;
+               fx_str_t v_51 = {0};
+               fx_str_t v_52 = {0};
+               fx_str_t v_53 = {0};
+               _fx_T2SN17Options__optval_t v_54 = {0};
+               _fx_LT2SN17Options__optval_t v_55 = 0;
+               fx_str_t* nameval_0 = &v_43->hd;
                int_ p1_0 = _fx_M6StringFM4findi2SC(nameval_0, (char_)61, 0);
                if (p1_0 < 0) {
-                  fx_str_t slit_33 = FX_MAKE_STR("true"); _fx_make_Ta2S(nameval_0, &slit_33, &v_41);
+                  fx_str_t slit_37 = FX_MAKE_STR("true"); _fx_make_Ta2S(nameval_0, &slit_37, &v_44);
                }
                else {
-                  FX_CALL(fx_substr(nameval_0, 0, p1_0, 1, 1, &v_42), _fx_catch_4);
-                  FX_CALL(fx_substr(nameval_0, p1_0 + 1, 0, 1, 2, &v_43), _fx_catch_4);
-                  _fx_make_Ta2S(&v_42, &v_43, &v_41);
+                  FX_CALL(fx_substr(nameval_0, 0, p1_0, 1, 1, &v_45), _fx_catch_6);
+                  FX_CALL(fx_substr(nameval_0, p1_0 + 1, 0, 1, 2, &v_46), _fx_catch_6);
+                  _fx_make_Ta2S(&v_45, &v_46, &v_44);
                }
-               fx_copy_str(&v_41.t0, &name_0);
-               fx_copy_str(&v_41.t1, &value_0);
+               fx_copy_str(&v_44.t0, &name_0);
+               fx_copy_str(&v_44.t1, &value_0);
                _fx_M7OptionsFM7OptBoolN17Options__optval_t1B(false, &errval_0);
-               bool v_53;
+               bool v_56;
                bool t_0;
                if (FX_STR_LENGTH(name_0) != 0) {
-                  FX_STR_CHKIDX(name_0, 0, _fx_catch_4);
+                  FX_STR_CHKIDX(name_0, 0, _fx_catch_6);
                   if (_fx_M4CharFM7isalphaB1C(FX_STR_ELEM(name_0, 0), 0)) {
                      t_0 = true;
                   }
                   else {
-                     FX_STR_CHKIDX(name_0, 0, _fx_catch_4); t_0 = FX_STR_ELEM(name_0, 0) == (char_)95;
+                     FX_STR_CHKIDX(name_0, 0, _fx_catch_6); t_0 = FX_STR_ELEM(name_0, 0) == (char_)95;
                   }
                }
                else {
@@ -1014,155 +1071,155 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                   int_ len_0 = FX_STR_LENGTH(name_0);
                   for (int_ i_2 = 0; i_2 < len_0; i_2++) {
                      char_ c_0 = name_0.data[i_2];
-                     bool v_54;
+                     bool v_57;
                      if (_fx_M4CharFM7isalnumB1C(c_0, 0)) {
-                        v_54 = true;
+                        v_57 = true;
                      }
                      else {
-                        v_54 = c_0 == (char_)95;
+                        v_57 = c_0 == (char_)95;
                      }
-                     if (!v_54) {
-                        __fold_result___0 = false; FX_BREAK(_fx_catch_2);
+                     if (!v_57) {
+                        __fold_result___0 = false; FX_BREAK(_fx_catch_4);
                      }
 
-                  _fx_catch_2: ;
+                  _fx_catch_4: ;
                      FX_CHECK_BREAK();
-                     FX_CHECK_EXN(_fx_catch_4);
+                     FX_CHECK_EXN(_fx_catch_6);
                   }
-                  v_53 = __fold_result___0;
+                  v_56 = __fold_result___0;
                }
                else {
-                  v_53 = false;
+                  v_56 = false;
                }
-               if (v_53) {
-                  bool v_55;
-                  fx_str_t slit_34 = FX_MAKE_STR("TRUE");
+               if (v_56) {
+                  bool v_58;
+                  fx_str_t slit_38 = FX_MAKE_STR("TRUE");
                   bool t_1;
-                  if (_fx_F6__eq__B2SS(&value_0, &slit_34, 0)) {
+                  if (_fx_F6__eq__B2SS(&value_0, &slit_38, 0)) {
                      t_1 = true;
                   }
                   else {
-                     fx_str_t slit_35 = FX_MAKE_STR("true"); t_1 = _fx_F6__eq__B2SS(&value_0, &slit_35, 0);
+                     fx_str_t slit_39 = FX_MAKE_STR("true"); t_1 = _fx_F6__eq__B2SS(&value_0, &slit_39, 0);
                   }
                   bool t_2;
                   if (t_1) {
                      t_2 = true;
                   }
                   else {
-                     fx_str_t slit_36 = FX_MAKE_STR("ON"); t_2 = _fx_F6__eq__B2SS(&value_0, &slit_36, 0);
+                     fx_str_t slit_40 = FX_MAKE_STR("ON"); t_2 = _fx_F6__eq__B2SS(&value_0, &slit_40, 0);
                   }
                   if (t_2) {
-                     v_55 = true;
+                     v_58 = true;
                   }
                   else {
-                     fx_str_t slit_37 = FX_MAKE_STR("on"); v_55 = _fx_F6__eq__B2SS(&value_0, &slit_37, 0);
+                     fx_str_t slit_41 = FX_MAKE_STR("on"); v_58 = _fx_F6__eq__B2SS(&value_0, &slit_41, 0);
                   }
-                  if (v_55) {
+                  if (v_58) {
                      _fx_M7OptionsFM7OptBoolN17Options__optval_t1B(true, &value_1);
                   }
                   else {
-                     bool v_56;
-                     fx_str_t slit_38 = FX_MAKE_STR("FALSE");
+                     bool v_59;
+                     fx_str_t slit_42 = FX_MAKE_STR("FALSE");
                      bool t_3;
-                     if (_fx_F6__eq__B2SS(&value_0, &slit_38, 0)) {
+                     if (_fx_F6__eq__B2SS(&value_0, &slit_42, 0)) {
                         t_3 = true;
                      }
                      else {
-                        fx_str_t slit_39 = FX_MAKE_STR("false"); t_3 = _fx_F6__eq__B2SS(&value_0, &slit_39, 0);
+                        fx_str_t slit_43 = FX_MAKE_STR("false"); t_3 = _fx_F6__eq__B2SS(&value_0, &slit_43, 0);
                      }
                      bool t_4;
                      if (t_3) {
                         t_4 = true;
                      }
                      else {
-                        fx_str_t slit_40 = FX_MAKE_STR("OFF"); t_4 = _fx_F6__eq__B2SS(&value_0, &slit_40, 0);
+                        fx_str_t slit_44 = FX_MAKE_STR("OFF"); t_4 = _fx_F6__eq__B2SS(&value_0, &slit_44, 0);
                      }
                      if (t_4) {
-                        v_56 = true;
+                        v_59 = true;
                      }
                      else {
-                        fx_str_t slit_41 = FX_MAKE_STR("off"); v_56 = _fx_F6__eq__B2SS(&value_0, &slit_41, 0);
+                        fx_str_t slit_45 = FX_MAKE_STR("off"); v_59 = _fx_F6__eq__B2SS(&value_0, &slit_45, 0);
                      }
-                     if (v_56) {
+                     if (v_59) {
                         _fx_M7OptionsFM7OptBoolN17Options__optval_t1B(false, &value_1);
                      }
                      else if (FX_STR_LENGTH(value_0) == 0) {
-                        FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_44, 0), _fx_catch_4);
-                        fx_str_t slit_42 = FX_MAKE_STR("a value should follow after \'");
-                        fx_str_t slit_43 = FX_MAKE_STR("=\'");
+                        FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_47, 0), _fx_catch_6);
+                        fx_str_t slit_46 = FX_MAKE_STR("a value should follow after \'");
+                        fx_str_t slit_47 = FX_MAKE_STR("=\'");
                         {
-                           const fx_str_t strs_2[] = { slit_42, v_44, slit_43 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_45), _fx_catch_4);
+                           const fx_str_t strs_3[] = { slit_46, v_47, slit_47 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_48), _fx_catch_6);
                         }
-                        FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_45, 0), _fx_catch_4);
+                        FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_48, 0), _fx_catch_6);
                         ok_0 = false;
                         _fx_copy_N17Options__optval_t(&errval_0, &value_1);
                      }
                      else {
-                        FX_STR_CHKIDX(value_0, 0, _fx_catch_4);
-                        bool v_57;
+                        FX_STR_CHKIDX(value_0, 0, _fx_catch_6);
+                        bool v_60;
                         bool t_5;
                         if (FX_STR_ELEM(value_0, 0) == (char_)43) {
                            t_5 = true;
                         }
                         else {
-                           FX_STR_CHKIDX(value_0, 0, _fx_catch_4); t_5 = FX_STR_ELEM(value_0, 0) == (char_)45;
+                           FX_STR_CHKIDX(value_0, 0, _fx_catch_6); t_5 = FX_STR_ELEM(value_0, 0) == (char_)45;
                         }
                         if (t_5) {
-                           v_57 = true;
+                           v_60 = true;
                         }
                         else {
-                           FX_STR_CHKIDX(value_0, 0, _fx_catch_4); v_57 = _fx_M4CharFM7isdigitB1C(FX_STR_ELEM(value_0, 0), 0);
+                           FX_STR_CHKIDX(value_0, 0, _fx_catch_6); v_60 = _fx_M4CharFM7isdigitB1C(FX_STR_ELEM(value_0, 0), 0);
                         }
-                        if (v_57) {
-                           _fx_Nt6option1i v_58;
-                           FX_CALL(_fx_M7OptionsFM6to_intNt6option1i2Si(&value_0, 0, &v_58, 0), _fx_catch_4);
-                           if (v_58.tag == 2) {
-                              _fx_M7OptionsFM6OptIntN17Options__optval_t1i(v_58.u.Some, &value_1);
+                        if (v_60) {
+                           _fx_Nt6option1i v_61;
+                           FX_CALL(_fx_M7OptionsFM6to_intNt6option1i2Si(&value_0, 0, &v_61, 0), _fx_catch_6);
+                           if (v_61.tag == 2) {
+                              _fx_M7OptionsFM6OptIntN17Options__optval_t1i(v_61.u.Some, &value_1);
                            }
                            else {
-                              fx_str_t v_59 = {0};
-                              fx_str_t v_60 = {0};
-                              fx_str_t v_61 = {0};
-                              FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_59, 0), _fx_catch_3);
-                              FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_60, 0), _fx_catch_3);
-                              fx_str_t slit_44 = FX_MAKE_STR("invalid numerical value \'");
-                              fx_str_t slit_45 = FX_MAKE_STR("\' of a symbol \'");
-                              fx_str_t slit_46 = FX_MAKE_STR("\'; if you meant a string, enclose it in double quotes");
+                              fx_str_t v_62 = {0};
+                              fx_str_t v_63 = {0};
+                              fx_str_t v_64 = {0};
+                              FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_62, 0), _fx_catch_5);
+                              FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_63, 0), _fx_catch_5);
+                              fx_str_t slit_48 = FX_MAKE_STR("invalid numerical value \'");
+                              fx_str_t slit_49 = FX_MAKE_STR("\' of a symbol \'");
+                              fx_str_t slit_50 = FX_MAKE_STR("\'; if you meant a string, enclose it in double quotes");
                               {
-                                 const fx_str_t strs_3[] = { slit_44, v_59, slit_45, v_60, slit_46 };
-                                 FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_61), _fx_catch_3);
+                                 const fx_str_t strs_4[] = { slit_48, v_62, slit_49, v_63, slit_50 };
+                                 FX_CALL(fx_strjoin(0, 0, 0, strs_4, 5, &v_64), _fx_catch_5);
                               }
-                              FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_61, 0), _fx_catch_3);
+                              FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_64, 0), _fx_catch_5);
                               ok_0 = false;
                               _fx_copy_N17Options__optval_t(&errval_0, &value_1);
 
-                           _fx_catch_3: ;
-                              FX_FREE_STR(&v_61);
-                              FX_FREE_STR(&v_60);
-                              FX_FREE_STR(&v_59);
+                           _fx_catch_5: ;
+                              FX_FREE_STR(&v_64);
+                              FX_FREE_STR(&v_63);
+                              FX_FREE_STR(&v_62);
                            }
-                           FX_CHECK_EXN(_fx_catch_4);
+                           FX_CHECK_EXN(_fx_catch_6);
                         }
                         else {
-                           bool v_62 = _fx_M6StringFM10startswithB2SC(&value_0, (char_)34, 0);
-                           if (v_62) {
-                              bool v_63 = _fx_M6StringFM8endswithB2SC(&value_0, (char_)34, 0);
-                              if (!v_63) {
-                                 FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_46, 0), _fx_catch_4);
-                                 fx_str_t slit_47 = FX_MAKE_STR("the value ");
-                                 fx_str_t slit_48 = FX_MAKE_STR(" starts with \'\"\', but does not terminate with \'\"\'");
+                           bool v_65 = _fx_M6StringFM10startswithB2SC(&value_0, (char_)34, 0);
+                           if (v_65) {
+                              bool v_66 = _fx_M6StringFM8endswithB2SC(&value_0, (char_)34, 0);
+                              if (!v_66) {
+                                 FX_CALL(_fx_M7OptionsFM6stringS1S(&value_0, &v_49, 0), _fx_catch_6);
+                                 fx_str_t slit_51 = FX_MAKE_STR("the value ");
+                                 fx_str_t slit_52 = FX_MAKE_STR(" starts with \'\"\', but does not terminate with \'\"\'");
                                  {
-                                    const fx_str_t strs_4[] = { slit_47, v_46, slit_48 };
-                                    FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_47), _fx_catch_4);
+                                    const fx_str_t strs_5[] = { slit_51, v_49, slit_52 };
+                                    FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_50), _fx_catch_6);
                                  }
-                                 FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_47, 0), _fx_catch_4);
+                                 FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_50, 0), _fx_catch_6);
                                  ok_0 = false;
                                  _fx_copy_N17Options__optval_t(&errval_0, &value_1);
                               }
                               else {
-                                 FX_CALL(fx_substr(&value_0, 1, -1, 1, 0, &v_48), _fx_catch_4);
-                                 _fx_M7OptionsFM9OptStringN17Options__optval_t1S(&v_48, &value_1);
+                                 FX_CALL(fx_substr(&value_0, 1, -1, 1, 0, &v_51), _fx_catch_6);
+                                 _fx_M7OptionsFM9OptStringN17Options__optval_t1S(&v_51, &value_1);
                               }
                            }
                            else {
@@ -1173,281 +1230,281 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
                   }
                }
                else {
-                  FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_49, 0), _fx_catch_4);
-                  fx_str_t slit_49 = FX_MAKE_STR("identifier \'");
-                  fx_str_t slit_50 = FX_MAKE_STR("\' contains incorrect characters");
+                  FX_CALL(_fx_M7OptionsFM6stringS1S(&name_0, &v_52, 0), _fx_catch_6);
+                  fx_str_t slit_53 = FX_MAKE_STR("identifier \'");
+                  fx_str_t slit_54 = FX_MAKE_STR("\' contains incorrect characters");
                   {
-                     const fx_str_t strs_5[] = { slit_49, v_49, slit_50 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_50), _fx_catch_4);
+                     const fx_str_t strs_6[] = { slit_53, v_52, slit_54 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &v_53), _fx_catch_6);
                   }
-                  FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_50, 0), _fx_catch_4);
+                  FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_53, 0), _fx_catch_6);
                   ok_0 = false;
                   _fx_copy_N17Options__optval_t(&errval_0, &value_1);
                }
                if (ok_0) {
-                  _fx_make_T2SN17Options__optval_t(&name_0, &value_1, &v_51);
-                  FX_COPY_PTR(_fx_g12Options__opt.defines, &v_52);
-                  FX_CALL(_fx_cons_LT2SN17Options__optval_t(&v_51, v_52, false, &v_52), _fx_catch_4);
-                  _fx_LT2SN17Options__optval_t* v_64 = &_fx_g12Options__opt.defines;
-                  _fx_free_LT2SN17Options__optval_t(v_64);
-                  FX_COPY_PTR(v_52, v_64);
-                  FX_COPY_PTR(v_40->tl, &v_31);
+                  _fx_make_T2SN17Options__optval_t(&name_0, &value_1, &v_54);
+                  FX_COPY_PTR(_fx_g12Options__opt.defines, &v_55);
+                  FX_CALL(_fx_cons_LT2SN17Options__optval_t(&v_54, v_55, false, &v_55), _fx_catch_6);
+                  _fx_LT2SN17Options__optval_t* v_67 = &_fx_g12Options__opt.defines;
+                  _fx_free_LT2SN17Options__optval_t(v_67);
+                  FX_COPY_PTR(v_55, v_67);
+                  FX_COPY_PTR(v_43->tl, &v_31);
                }
 
-            _fx_catch_4: ;
-               if (v_52) {
-                  _fx_free_LT2SN17Options__optval_t(&v_52);
+            _fx_catch_6: ;
+               if (v_55) {
+                  _fx_free_LT2SN17Options__optval_t(&v_55);
                }
-               _fx_free_T2SN17Options__optval_t(&v_51);
+               _fx_free_T2SN17Options__optval_t(&v_54);
+               FX_FREE_STR(&v_53);
+               FX_FREE_STR(&v_52);
+               FX_FREE_STR(&v_51);
                FX_FREE_STR(&v_50);
                FX_FREE_STR(&v_49);
                FX_FREE_STR(&v_48);
                FX_FREE_STR(&v_47);
-               FX_FREE_STR(&v_46);
-               FX_FREE_STR(&v_45);
-               FX_FREE_STR(&v_44);
                _fx_free_N17Options__optval_t(&value_1);
                _fx_free_N17Options__optval_t(&errval_0);
                FX_FREE_STR(&value_0);
                FX_FREE_STR(&name_0);
-               FX_FREE_STR(&v_43);
-               FX_FREE_STR(&v_42);
-               _fx_free_Ta2S(&v_41);
-               goto _fx_endmatch_2;
+               FX_FREE_STR(&v_46);
+               FX_FREE_STR(&v_45);
+               _fx_free_Ta2S(&v_44);
+               goto _fx_endmatch_3;
             }
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_51 = FX_MAKE_STR("-I");
-         if (fx_streq(&args_1->hd, &slit_51)) {
-            _fx_LS v_65 = args_1->tl;
-            if (v_65 != 0) {
-               _fx_LS v_66 = 0;
-               _fx_LS v_67 = 0;
-               _fx_LS v_68 = 0;
-               FX_COPY_PTR(_fx_g12Options__opt.include_path, &v_66);
-               FX_CALL(_fx_cons_LS(&v_65->hd, 0, true, &v_67), _fx_catch_5);
-               FX_CALL(_fx_M7OptionsFM7__add__LS2LSLS(v_66, v_67, &v_68, 0), _fx_catch_5);
-               _fx_LS* v_69 = &_fx_g12Options__opt.include_path;
-               _fx_free_LS(v_69);
-               FX_COPY_PTR(v_68, v_69);
-               FX_COPY_PTR(v_65->tl, &v_31);
-
-            _fx_catch_5: ;
-               if (v_68) {
-                  _fx_free_LS(&v_68);
-               }
-               if (v_67) {
-                  _fx_free_LS(&v_67);
-               }
-               if (v_66) {
-                  _fx_free_LS(&v_66);
-               }
-               goto _fx_endmatch_2;
-            }
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_52 = FX_MAKE_STR("-B");
-         if (fx_streq(&args_1->hd, &slit_52)) {
-            _fx_LS v_70 = args_1->tl;
-            if (v_70 != 0) {
-               fx_str_t* v_71 = &_fx_g12Options__opt.build_rootdir;
-               fx_str_t* bdir_0 = &v_70->hd;
-               FX_FREE_STR(v_71);
-               fx_copy_str(bdir_0, v_71);
-               FX_COPY_PTR(v_70->tl, &v_31);
-               goto _fx_endmatch_2;
-            }
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_53 = FX_MAKE_STR("-c++");
-         if (fx_streq(&args_1->hd, &slit_53)) {
-            _fx_g12Options__opt.compile_by_cpp = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_2;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_54 = FX_MAKE_STR("-cflags");
-         if (fx_streq(&args_1->hd, &slit_54)) {
-            _fx_LS v_72 = args_1->tl;
-            if (v_72 != 0) {
-               fx_str_t v_73 = {0};
-               fx_str_t v_74 = {0};
-               fx_str_t v_75 = {0};
-               fx_str_t* cflags_0 = &v_72->hd;
-               fx_copy_str(&_fx_g12Options__opt.cflags, &v_73);
-               if (FX_STR_LENGTH(v_73) == 0) {
-                  fx_copy_str(cflags_0, &v_74);
-               }
-               else {
-                  fx_copy_str(&_fx_g12Options__opt.cflags, &v_75);
-                  fx_str_t slit_55 = FX_MAKE_STR(" ");
-                  {
-                     const fx_str_t strs_6[] = { v_75, slit_55, *cflags_0 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &v_74), _fx_catch_6);
-                  }
-               }
-               fx_str_t* v_76 = &_fx_g12Options__opt.cflags;
-               FX_FREE_STR(v_76);
-               fx_copy_str(&v_74, v_76);
-               FX_COPY_PTR(v_72->tl, &v_31);
-
-            _fx_catch_6: ;
-               FX_FREE_STR(&v_75);
-               FX_FREE_STR(&v_74);
-               FX_FREE_STR(&v_73);
-               goto _fx_endmatch_2;
-            }
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_56 = FX_MAKE_STR("-clibs");
-         if (fx_streq(&args_1->hd, &slit_56)) {
-            _fx_LS v_77 = args_1->tl;
-            if (v_77 != 0) {
-               fx_str_t v_78 = {0};
-               fx_str_t v_79 = {0};
-               fx_str_t v_80 = {0};
-               fx_str_t* clibs_0 = &v_77->hd;
-               fx_copy_str(&_fx_g12Options__opt.clibs, &v_78);
-               if (FX_STR_LENGTH(v_78) == 0) {
-                  fx_copy_str(clibs_0, &v_79);
-               }
-               else {
-                  fx_copy_str(&_fx_g12Options__opt.clibs, &v_80);
-                  fx_str_t slit_57 = FX_MAKE_STR(" ");
-                  {
-                     const fx_str_t strs_7[] = { v_80, slit_57, *clibs_0 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &v_79), _fx_catch_7);
-                  }
-               }
-               fx_str_t* v_81 = &_fx_g12Options__opt.clibs;
-               FX_FREE_STR(v_81);
-               fx_copy_str(&v_79, v_81);
-               FX_COPY_PTR(v_77->tl, &v_31);
+         fx_str_t slit_55 = FX_MAKE_STR("-I");
+         if (fx_streq(&args_1->hd, &slit_55)) {
+            _fx_LS v_68 = args_1->tl;
+            if (v_68 != 0) {
+               _fx_LS v_69 = 0;
+               _fx_LS v_70 = 0;
+               _fx_LS v_71 = 0;
+               FX_COPY_PTR(_fx_g12Options__opt.include_path, &v_69);
+               FX_CALL(_fx_cons_LS(&v_68->hd, 0, true, &v_70), _fx_catch_7);
+               FX_CALL(_fx_M7OptionsFM7__add__LS2LSLS(v_69, v_70, &v_71, 0), _fx_catch_7);
+               _fx_LS* v_72 = &_fx_g12Options__opt.include_path;
+               _fx_free_LS(v_72);
+               FX_COPY_PTR(v_71, v_72);
+               FX_COPY_PTR(v_68->tl, &v_31);
 
             _fx_catch_7: ;
-               FX_FREE_STR(&v_80);
-               FX_FREE_STR(&v_79);
-               FX_FREE_STR(&v_78);
-               goto _fx_endmatch_2;
+               if (v_71) {
+                  _fx_free_LS(&v_71);
+               }
+               if (v_70) {
+                  _fx_free_LS(&v_70);
+               }
+               if (v_69) {
+                  _fx_free_LS(&v_69);
+               }
+               goto _fx_endmatch_3;
             }
          }
       }
-      bool res_0;
       if (args_1 != 0) {
-         fx_str_t slit_58 = FX_MAKE_STR("-h");
+         fx_str_t slit_56 = FX_MAKE_STR("-B");
+         if (fx_streq(&args_1->hd, &slit_56)) {
+            _fx_LS v_73 = args_1->tl;
+            if (v_73 != 0) {
+               fx_str_t* v_74 = &_fx_g12Options__opt.build_rootdir;
+               fx_str_t* bdir_0 = &v_73->hd;
+               FX_FREE_STR(v_74);
+               fx_copy_str(bdir_0, v_74);
+               FX_COPY_PTR(v_73->tl, &v_31);
+               goto _fx_endmatch_3;
+            }
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_57 = FX_MAKE_STR("-c++");
+         if (fx_streq(&args_1->hd, &slit_57)) {
+            _fx_g12Options__opt.compile_by_cpp = true; FX_COPY_PTR(args_1->tl, &v_31); goto _fx_endmatch_3;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_58 = FX_MAKE_STR("-cflags");
          if (fx_streq(&args_1->hd, &slit_58)) {
-            res_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_59 = FX_MAKE_STR("-help");
-         if (fx_streq(&args_1->hd, &slit_59)) {
-            res_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_60 = FX_MAKE_STR("--help");
-         if (fx_streq(&args_1->hd, &slit_60)) {
-            res_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      res_0 = false;
+            _fx_LS v_75 = args_1->tl;
+            if (v_75 != 0) {
+               fx_str_t v_76 = {0};
+               fx_str_t v_77 = {0};
+               fx_str_t v_78 = {0};
+               fx_str_t* cflags_0 = &v_75->hd;
+               fx_copy_str(&_fx_g12Options__opt.cflags, &v_76);
+               if (FX_STR_LENGTH(v_76) == 0) {
+                  fx_copy_str(cflags_0, &v_77);
+               }
+               else {
+                  fx_copy_str(&_fx_g12Options__opt.cflags, &v_78);
+                  fx_str_t slit_59 = FX_MAKE_STR(" ");
+                  {
+                     const fx_str_t strs_7[] = { v_78, slit_59, *cflags_0 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &v_77), _fx_catch_8);
+                  }
+               }
+               fx_str_t* v_79 = &_fx_g12Options__opt.cflags;
+               FX_FREE_STR(v_79);
+               fx_copy_str(&v_77, v_79);
+               FX_COPY_PTR(v_75->tl, &v_31);
 
-   _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_catch_9);
-      if (res_0) {
-         prhelp_0 = 2; goto _fx_endmatch_2;
+            _fx_catch_8: ;
+               FX_FREE_STR(&v_78);
+               FX_FREE_STR(&v_77);
+               FX_FREE_STR(&v_76);
+               goto _fx_endmatch_3;
+            }
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_60 = FX_MAKE_STR("-clibs");
+         if (fx_streq(&args_1->hd, &slit_60)) {
+            _fx_LS v_80 = args_1->tl;
+            if (v_80 != 0) {
+               fx_str_t v_81 = {0};
+               fx_str_t v_82 = {0};
+               fx_str_t v_83 = {0};
+               fx_str_t* clibs_0 = &v_80->hd;
+               fx_copy_str(&_fx_g12Options__opt.clibs, &v_81);
+               if (FX_STR_LENGTH(v_81) == 0) {
+                  fx_copy_str(clibs_0, &v_82);
+               }
+               else {
+                  fx_copy_str(&_fx_g12Options__opt.clibs, &v_83);
+                  fx_str_t slit_61 = FX_MAKE_STR(" ");
+                  {
+                     const fx_str_t strs_8[] = { v_83, slit_61, *clibs_0 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_8, 3, &v_82), _fx_catch_9);
+                  }
+               }
+               fx_str_t* v_84 = &_fx_g12Options__opt.clibs;
+               FX_FREE_STR(v_84);
+               fx_copy_str(&v_82, v_84);
+               FX_COPY_PTR(v_80->tl, &v_31);
+
+            _fx_catch_9: ;
+               FX_FREE_STR(&v_83);
+               FX_FREE_STR(&v_82);
+               FX_FREE_STR(&v_81);
+               goto _fx_endmatch_3;
+            }
+         }
       }
       bool res_1;
       if (args_1 != 0) {
-         fx_str_t slit_61 = FX_MAKE_STR("-v");
-         if (fx_streq(&args_1->hd, &slit_61)) {
-            res_1 = true; goto _fx_endmatch_1;
-         }
-      }
-      if (args_1 != 0) {
-         fx_str_t slit_62 = FX_MAKE_STR("-version");
+         fx_str_t slit_62 = FX_MAKE_STR("-h");
          if (fx_streq(&args_1->hd, &slit_62)) {
             res_1 = true; goto _fx_endmatch_1;
          }
       }
       if (args_1 != 0) {
-         fx_str_t slit_63 = FX_MAKE_STR("--version");
+         fx_str_t slit_63 = FX_MAKE_STR("-help");
          if (fx_streq(&args_1->hd, &slit_63)) {
+            res_1 = true; goto _fx_endmatch_1;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_64 = FX_MAKE_STR("--help");
+         if (fx_streq(&args_1->hd, &slit_64)) {
             res_1 = true; goto _fx_endmatch_1;
          }
       }
       res_1 = false;
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_9);
+      FX_CHECK_EXN(_fx_catch_11);
       if (res_1) {
-         prver_0 = true; goto _fx_endmatch_2;
+         prhelp_0 = 2; goto _fx_endmatch_3;
       }
+      bool res_2;
       if (args_1 != 0) {
-         fx_str_t slit_64 = FX_MAKE_STR("--");
-         if (fx_streq(&args_1->hd, &slit_64)) {
-            _fx_LS* v_82 = &_fx_g12Options__opt.app_args;
-            _fx_LS* next_0 = &args_1->tl;
-            _fx_free_LS(v_82);
-            FX_COPY_PTR(*next_0, v_82);
-            goto _fx_endmatch_2;
+         fx_str_t slit_65 = FX_MAKE_STR("-v");
+         if (fx_streq(&args_1->hd, &slit_65)) {
+            res_2 = true; goto _fx_endmatch_2;
          }
       }
       if (args_1 != 0) {
-         _fx_LS v_83 = 0;
-         fx_str_t v_84 = {0};
-         fx_str_t v_85 = {0};
-         fx_str_t v_86 = {0};
+         fx_str_t slit_66 = FX_MAKE_STR("-version");
+         if (fx_streq(&args_1->hd, &slit_66)) {
+            res_2 = true; goto _fx_endmatch_2;
+         }
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_67 = FX_MAKE_STR("--version");
+         if (fx_streq(&args_1->hd, &slit_67)) {
+            res_2 = true; goto _fx_endmatch_2;
+         }
+      }
+      res_2 = false;
+
+   _fx_endmatch_2: ;
+      FX_CHECK_EXN(_fx_catch_11);
+      if (res_2) {
+         prver_0 = true; goto _fx_endmatch_3;
+      }
+      if (args_1 != 0) {
+         fx_str_t slit_68 = FX_MAKE_STR("--");
+         if (fx_streq(&args_1->hd, &slit_68)) {
+            _fx_LS* v_85 = &_fx_g12Options__opt.app_args;
+            _fx_LS* next_0 = &args_1->tl;
+            _fx_free_LS(v_85);
+            FX_COPY_PTR(*next_0, v_85);
+            goto _fx_endmatch_3;
+         }
+      }
+      if (args_1 != 0) {
+         _fx_LS v_86 = 0;
          fx_str_t v_87 = {0};
          fx_str_t v_88 = {0};
          fx_str_t v_89 = {0};
          fx_str_t v_90 = {0};
-         _fx_LS v_91 = 0;
+         fx_str_t v_91 = {0};
          fx_str_t v_92 = {0};
          fx_str_t v_93 = {0};
+         _fx_LS v_94 = 0;
+         fx_str_t v_95 = {0};
+         fx_str_t v_96 = {0};
          fx_str_t* a_0 = &args_1->hd;
-         bool v_94;
-         fx_str_t slit_65 = FX_MAKE_STR("-");
-         v_94 = _fx_M6StringFM10startswithB2SS(a_0, &slit_65, 0);
-         if (v_94) {
-            fx_str_t slit_66 = FX_MAKE_STR("-clibs");
-            FX_CALL(_fx_cons_LS(&slit_66, 0, true, &v_83), _fx_catch_8);
-            fx_str_t slit_67 = FX_MAKE_STR("-cflags");
-            FX_CALL(_fx_cons_LS(&slit_67, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_68 = FX_MAKE_STR("-B");
-            FX_CALL(_fx_cons_LS(&slit_68, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_69 = FX_MAKE_STR("-o");
-            FX_CALL(_fx_cons_LS(&slit_69, v_83, false, &v_83), _fx_catch_8);
-            fx_str_t slit_70 = FX_MAKE_STR("-inline-threshold");
-            FX_CALL(_fx_cons_LS(&slit_70, v_83, false, &v_83), _fx_catch_8);
-            bool v_95;
-            FX_CALL(_fx_M7OptionsFM3memB2LSS(v_83, a_0, &v_95, 0), _fx_catch_8);
-            if (v_95) {
-               fx_str_t slit_71 = FX_MAKE_STR("[31;1merror:[0m");
-               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_71, &v_84, 0), _fx_catch_8);
-               FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_85, 0), _fx_catch_8);
-               fx_str_t slit_72 = FX_MAKE_STR(" option ");
-               fx_str_t slit_73 = FX_MAKE_STR(" needs an argument");
+         bool v_97;
+         fx_str_t slit_69 = FX_MAKE_STR("-");
+         v_97 = _fx_M6StringFM10startswithB2SS(a_0, &slit_69, 0);
+         if (v_97) {
+            fx_str_t slit_70 = FX_MAKE_STR("-clibs");
+            FX_CALL(_fx_cons_LS(&slit_70, 0, true, &v_86), _fx_catch_10);
+            fx_str_t slit_71 = FX_MAKE_STR("-cflags");
+            FX_CALL(_fx_cons_LS(&slit_71, v_86, false, &v_86), _fx_catch_10);
+            fx_str_t slit_72 = FX_MAKE_STR("-B");
+            FX_CALL(_fx_cons_LS(&slit_72, v_86, false, &v_86), _fx_catch_10);
+            fx_str_t slit_73 = FX_MAKE_STR("-o");
+            FX_CALL(_fx_cons_LS(&slit_73, v_86, false, &v_86), _fx_catch_10);
+            fx_str_t slit_74 = FX_MAKE_STR("-inline-threshold");
+            FX_CALL(_fx_cons_LS(&slit_74, v_86, false, &v_86), _fx_catch_10);
+            bool v_98;
+            FX_CALL(_fx_M7OptionsFM3memB2LSS(v_86, a_0, &v_98, 0), _fx_catch_10);
+            if (v_98) {
+               fx_str_t slit_75 = FX_MAKE_STR("[31;1merror:[0m");
+               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_75, &v_87, 0), _fx_catch_10);
+               FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_88, 0), _fx_catch_10);
+               fx_str_t slit_76 = FX_MAKE_STR(" option ");
+               fx_str_t slit_77 = FX_MAKE_STR(" needs an argument");
                {
-                  const fx_str_t strs_8[] = { v_84, slit_72, v_85, slit_73 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_8, 4, &v_86), _fx_catch_8);
+                  const fx_str_t strs_9[] = { v_87, slit_76, v_88, slit_77 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_9, 4, &v_89), _fx_catch_10);
                }
-               FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_86, 0), _fx_catch_8);
+               FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_89, 0), _fx_catch_10);
             }
             else {
-               fx_str_t slit_74 = FX_MAKE_STR("[31;1merror:[0m");
-               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_74, &v_87, 0), _fx_catch_8);
-               FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_88, 0), _fx_catch_8);
-               fx_str_t slit_75 = FX_MAKE_STR(" unrecognized option ");
+               fx_str_t slit_78 = FX_MAKE_STR("[31;1merror:[0m");
+               FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_78, &v_90, 0), _fx_catch_10);
+               FX_CALL(_fx_M7OptionsFM6stringS1S(a_0, &v_91, 0), _fx_catch_10);
+               fx_str_t slit_79 = FX_MAKE_STR(" unrecognized option ");
                {
-                  const fx_str_t strs_9[] = { v_87, slit_75, v_88 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_9, 3, &v_89), _fx_catch_8);
+                  const fx_str_t strs_10[] = { v_90, slit_79, v_91 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_10, 3, &v_92), _fx_catch_10);
                }
-               FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_89, 0), _fx_catch_8);
+               FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_92, 0), _fx_catch_10);
             }
             ok_0 = false;
          }
@@ -1455,46 +1512,46 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
             FX_FREE_STR(&inputfile_0); fx_copy_str(a_0, &inputfile_0); FX_COPY_PTR(args_1->tl, &v_31);
          }
          else {
-            fx_str_t slit_76 = FX_MAKE_STR("[31;1merror:[0m");
-            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_76, &v_90, 0), _fx_catch_8);
-            FX_CALL(_fx_cons_LS(a_0, 0, true, &v_91), _fx_catch_8);
-            FX_CALL(_fx_cons_LS(&inputfile_0, v_91, false, &v_91), _fx_catch_8);
-            FX_CALL(_fx_M7OptionsFM6stringS1LS(v_91, &v_92, 0), _fx_catch_8);
-            fx_str_t slit_77 = FX_MAKE_STR(" more than one input file is specified: ");
+            fx_str_t slit_80 = FX_MAKE_STR("[31;1merror:[0m");
+            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_80, &v_93, 0), _fx_catch_10);
+            FX_CALL(_fx_cons_LS(a_0, 0, true, &v_94), _fx_catch_10);
+            FX_CALL(_fx_cons_LS(&inputfile_0, v_94, false, &v_94), _fx_catch_10);
+            FX_CALL(_fx_M7OptionsFM6stringS1LS(v_94, &v_95, 0), _fx_catch_10);
+            fx_str_t slit_81 = FX_MAKE_STR(" more than one input file is specified: ");
             {
-               const fx_str_t strs_10[] = { v_90, slit_77, v_92 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_10, 3, &v_93), _fx_catch_8);
+               const fx_str_t strs_11[] = { v_93, slit_81, v_95 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_11, 3, &v_96), _fx_catch_10);
             }
-            FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_93, 0), _fx_catch_8);
+            FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_96, 0), _fx_catch_10);
             ok_0 = false;
          }
 
-      _fx_catch_8: ;
+      _fx_catch_10: ;
+         FX_FREE_STR(&v_96);
+         FX_FREE_STR(&v_95);
+         if (v_94) {
+            _fx_free_LS(&v_94);
+         }
          FX_FREE_STR(&v_93);
          FX_FREE_STR(&v_92);
-         if (v_91) {
-            _fx_free_LS(&v_91);
-         }
+         FX_FREE_STR(&v_91);
          FX_FREE_STR(&v_90);
          FX_FREE_STR(&v_89);
          FX_FREE_STR(&v_88);
          FX_FREE_STR(&v_87);
-         FX_FREE_STR(&v_86);
-         FX_FREE_STR(&v_85);
-         FX_FREE_STR(&v_84);
-         if (v_83) {
-            _fx_free_LS(&v_83);
+         if (v_86) {
+            _fx_free_LS(&v_86);
          }
-         goto _fx_endmatch_2;
+         goto _fx_endmatch_3;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_9);
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_11);
 
-   _fx_endmatch_2: ;
-      FX_CHECK_EXN(_fx_catch_9);
+   _fx_endmatch_3: ;
+      FX_CHECK_EXN(_fx_catch_11);
       _fx_free_LS(&args_0);
       FX_COPY_PTR(v_31, &args_0);
 
-   _fx_catch_9: ;
+   _fx_catch_11: ;
       if (v_31) {
          _fx_free_LS(&v_31);
       }
@@ -1513,9 +1570,9 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       }
       _fx_g12Options__opt.optim_iters = t_6;
    }
-   int_ res_2;
-   FX_CALL(_fx_M7OptionsFM3maxi2ii(_fx_g12Options__opt.optim_iters, 2, &res_2, 0), _fx_cleanup);
-   _fx_g12Options__opt.optim_iters = res_2;
+   int_ res_3;
+   FX_CALL(_fx_M7OptionsFM3maxi2ii(_fx_g12Options__opt.optim_iters, 2, &res_3, 0), _fx_cleanup);
+   _fx_g12Options__opt.optim_iters = res_3;
    bool t_7;
    if (!prver_0) {
       t_7 = prhelp_0 == 0;
@@ -1534,12 +1591,12 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       if (FX_STR_LENGTH(inputfile_0) == 0) {
          FX_CALL(_fx_M7OptionsFM2tlLS1LS(_fx_g9Sys__argv, &v_1, 0), _fx_cleanup);
          if (v_1 != 0) {
-            fx_str_t slit_78 = FX_MAKE_STR("[31;1merror:[0m");
-            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_78, &v_2, 0), _fx_cleanup);
-            fx_str_t slit_79 = FX_MAKE_STR(" input file name is missing");
+            fx_str_t slit_82 = FX_MAKE_STR("[31;1merror:[0m");
+            FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_82, &v_2, 0), _fx_cleanup);
+            fx_str_t slit_83 = FX_MAKE_STR(" input file name is missing");
             {
-               const fx_str_t strs_11[] = { v_2, slit_79 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_11, 2, &v_3), _fx_cleanup);
+               const fx_str_t strs_12[] = { v_2, slit_83 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &v_3), _fx_cleanup);
             }
             FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_3, 0), _fx_cleanup);
             ok_0 = false;
@@ -1563,12 +1620,12 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          t_10 = false;
       }
       if (t_10) {
-         fx_str_t slit_80 = FX_MAKE_STR("[31;1merror:[0m");
-         FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_80, &v_4, 0), _fx_cleanup);
-         fx_str_t slit_81 = FX_MAKE_STR(" -no-c option cannot be used together with -run or -c++");
+         fx_str_t slit_84 = FX_MAKE_STR("[31;1merror:[0m");
+         FX_CALL(_fx_M7OptionsFM6stringS1S(&slit_84, &v_4, 0), _fx_cleanup);
+         fx_str_t slit_85 = FX_MAKE_STR(" -no-c option cannot be used together with -run or -c++");
          {
-            const fx_str_t strs_12[] = { v_4, slit_81 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_12, 2, &v_5), _fx_cleanup);
+            const fx_str_t strs_13[] = { v_4, slit_85 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_13, 2, &v_5), _fx_cleanup);
          }
          FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_5, 0), _fx_cleanup);
          ok_0 = false;
@@ -1577,28 +1634,28 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
    if (prver_0) {
       FX_CALL(_fx_M7OptionsFM6stringS1S(&_fx_g21__ficus_version_str__, &v_6, 0), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&_fx_g20__ficus_git_commit__, &v_7, 0), _fx_cleanup);
-      fx_str_t slit_82 = FX_MAKE_STR("Ficus version: ");
-      fx_str_t slit_83 = FX_MAKE_STR(" (git commit: ");
-      fx_str_t slit_84 = FX_MAKE_STR(")");
+      fx_str_t slit_86 = FX_MAKE_STR("Ficus version: ");
+      fx_str_t slit_87 = FX_MAKE_STR(" (git commit: ");
+      fx_str_t slit_88 = FX_MAKE_STR(")");
       {
-         const fx_str_t strs_13[] = { slit_82, v_6, slit_83, v_7, slit_84 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_13, 5, &v_8), _fx_cleanup);
+         const fx_str_t strs_14[] = { slit_86, v_6, slit_87, v_7, slit_88 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_14, 5, &v_8), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_8, 0), _fx_cleanup);
       FX_CALL(_fx_g11Sys__osname.fp(true, &v_9, _fx_g11Sys__osname.fcv), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&v_9, &v_10, 0), _fx_cleanup);
-      fx_str_t slit_85 = FX_MAKE_STR("Platform: ");
+      fx_str_t slit_89 = FX_MAKE_STR("Platform: ");
       {
-         const fx_str_t strs_14[] = { slit_85, v_10 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_14, 2, &v_11), _fx_cleanup);
+         const fx_str_t strs_15[] = { slit_89, v_10 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_15, 2, &v_11), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_11, 0), _fx_cleanup);
       FX_CALL(_fx_M3SysFM10cc_versionS0(&v_12, 0), _fx_cleanup);
       FX_CALL(_fx_M7OptionsFM6stringS1S(&v_12, &v_13, 0), _fx_cleanup);
-      fx_str_t slit_86 = FX_MAKE_STR("C/C++ Compiler: ");
+      fx_str_t slit_90 = FX_MAKE_STR("C/C++ Compiler: ");
       {
-         const fx_str_t strs_15[] = { slit_86, v_13 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_15, 2, &v_14), _fx_cleanup);
+         const fx_str_t strs_16[] = { slit_90, v_13 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_16, 2, &v_14), _fx_cleanup);
       }
       FX_CALL(_fx_M7OptionsFM7printlnv1S(&v_14, 0), _fx_cleanup);
       *fx_result = false;
@@ -1611,23 +1668,23 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
          _fx_g12Options__opt.inline_thresh = 1;
       }
       FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&curr_dir_0, &inputfile_0, &v_15, 0), _fx_cleanup);
-      fx_str_t* v_96 = &_fx_g12Options__opt.filename;
-      FX_FREE_STR(v_96);
-      fx_copy_str(&v_15, v_96);
+      fx_str_t* v_99 = &_fx_g12Options__opt.filename;
+      FX_FREE_STR(v_99);
+      fx_copy_str(&v_15, v_99);
       fx_copy_str(&_fx_g12Options__opt.filename, &v_16);
       FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_16, &default_output_name_0, 0), _fx_cleanup);
       FX_CALL(_fx_M8FilenameFM16remove_extensionS1S(&default_output_name_0, &default_output_name_1, 0), _fx_cleanup);
       fx_copy_str(&_fx_g12Options__opt.build_rootdir, &v_17);
       FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&curr_dir_0, &v_17, &v_18, 0), _fx_cleanup);
-      fx_str_t* v_97 = &_fx_g12Options__opt.build_rootdir;
-      FX_FREE_STR(v_97);
-      fx_copy_str(&v_18, v_97);
+      fx_str_t* v_100 = &_fx_g12Options__opt.build_rootdir;
+      FX_FREE_STR(v_100);
+      fx_copy_str(&v_18, v_100);
       fx_copy_str(&_fx_g12Options__opt.build_rootdir, &v_19);
-      fx_str_t slit_87 = FX_MAKE_STR("__fxbuild__");
-      FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_19, &slit_87, &v_20, 0), _fx_cleanup);
-      fx_str_t* v_98 = &_fx_g12Options__opt.build_rootdir;
-      FX_FREE_STR(v_98);
-      fx_copy_str(&v_20, v_98);
+      fx_str_t slit_91 = FX_MAKE_STR("__fxbuild__");
+      FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_19, &slit_91, &v_20, 0), _fx_cleanup);
+      fx_str_t* v_101 = &_fx_g12Options__opt.build_rootdir;
+      FX_FREE_STR(v_101);
+      fx_copy_str(&v_20, v_101);
       fx_copy_str(&_fx_g12Options__opt.output_name, &v_21);
       if (FX_STR_LENGTH(v_21) != 0) {
          fx_copy_str(&_fx_g12Options__opt.output_name, &v_22);
@@ -1635,24 +1692,24 @@ FX_EXTERN_C int _fx_M7OptionsFM13parse_optionsB0(bool* fx_result, void* fx_fv)
       else {
          fx_copy_str(&default_output_name_1, &v_22);
       }
-      fx_str_t* v_99 = &_fx_g12Options__opt.app_filename;
-      FX_FREE_STR(v_99);
-      fx_copy_str(&v_22, v_99);
+      fx_str_t* v_102 = &_fx_g12Options__opt.app_filename;
+      FX_FREE_STR(v_102);
+      fx_copy_str(&v_22, v_102);
       fx_copy_str(&_fx_g12Options__opt.build_rootdir, &v_23);
       fx_copy_str(&_fx_g12Options__opt.app_filename, &v_24);
       FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_24, &v_25, 0), _fx_cleanup);
       FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_23, &v_25, &v_26, 0), _fx_cleanup);
-      fx_str_t* v_100 = &_fx_g12Options__opt.build_dir;
-      FX_FREE_STR(v_100);
-      fx_copy_str(&v_26, v_100);
+      fx_str_t* v_103 = &_fx_g12Options__opt.build_dir;
+      FX_FREE_STR(v_103);
+      fx_copy_str(&v_26, v_103);
       fx_copy_str(&_fx_g12Options__opt.output_name, &v_27);
       if (FX_STR_LENGTH(v_27) == 0) {
          fx_copy_str(&_fx_g12Options__opt.build_dir, &v_28);
          fx_copy_str(&_fx_g12Options__opt.app_filename, &v_29);
          FX_CALL(_fx_M8FilenameFM9normalizeS2SS(&v_28, &v_29, &v_30, 0), _fx_cleanup);
-         fx_str_t* v_101 = &_fx_g12Options__opt.app_filename;
-         FX_FREE_STR(v_101);
-         fx_copy_str(&v_30, v_101);
+         fx_str_t* v_104 = &_fx_g12Options__opt.app_filename;
+         FX_FREE_STR(v_104);
+         fx_copy_str(&v_30, v_104);
       }
       *fx_result = true;
    }

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -123,6 +123,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -1652,6 +1653,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -1689,6 +1691,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -1725,6 +1728,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -169,16 +169,17 @@ typedef struct _fx_T2R9Ast__id_ti {
    int_ t1;
 } _fx_T2R9Ast__id_ti;
 
-typedef struct _fx_T2Bi {
+typedef struct _fx_T3BBi {
    bool t0;
-   int_ t1;
-} _fx_T2Bi;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
 
 typedef struct _fx_N12Ast__scope_t {
    int tag;
    union {
       int_ ScBlock;
-      struct _fx_T2Bi ScLoop;
+      struct _fx_T3BBi ScLoop;
       int_ ScFold;
       int_ ScArrMap;
       int_ ScMap;

--- a/compiler/bootstrap/fx.c
+++ b/compiler/bootstrap/fx.c
@@ -63,6 +63,7 @@ typedef struct _fx_R18Options__options_t {
    bool W_implicit_rettype;
    bool W_implicit_rettype_all;
    bool Werror;
+   int_ max_errors;
 } _fx_R18Options__options_t;
 
 typedef struct _fx_Ta2i {
@@ -230,6 +231,7 @@ static void _fx_copy_R18Options__options_t(struct _fx_R18Options__options_t* src
    dst->W_implicit_rettype = src->W_implicit_rettype;
    dst->W_implicit_rettype_all = src->W_implicit_rettype_all;
    dst->Werror = src->Werror;
+   dst->max_errors = src->max_errors;
 }
 
 static void _fx_make_R18Options__options_t(
@@ -267,6 +269,7 @@ static void _fx_make_R18Options__options_t(
    bool r_W_implicit_rettype,
    bool r_W_implicit_rettype_all,
    bool r_Werror,
+   int_ r_max_errors,
    struct _fx_R18Options__options_t* fx_result)
 {
    FX_COPY_PTR(r_app_args, &fx_result->app_args);
@@ -303,6 +306,7 @@ static void _fx_make_R18Options__options_t(
    fx_result->W_implicit_rettype = r_W_implicit_rettype;
    fx_result->W_implicit_rettype_all = r_W_implicit_rettype_all;
    fx_result->Werror = r_Werror;
+   fx_result->max_errors = r_max_errors;
 }
 
 static void _fx_free_T2Ta2iS(struct _fx_T2Ta2iS* dst)

--- a/docs/diag1_brief.md
+++ b/docs/diag1_brief.md
@@ -1,0 +1,140 @@
+# Brief: diag-1 (session-2) — type-error recovery, multiple diagnostics, caret rendering
+
+**You are Claude Code working in the Ficus repo.** Branch `diag-1` off master.
+Context: `docs/language_changes_brief.md` §1.7 (closed signatures = the
+recovery firewall) and §6; `docs/ctrlflow1_report.md` (TypErr mechanics
+confirmed end-to-end); `docs/annotate2_report.md` (the warning subsystem this
+builds on); repo `CLAUDE.md`. This is the LSP-groundwork session: after it,
+one compiler run reports MANY useful diagnostics instead of dying on the
+first, with gcc/clang-style source excerpts.
+
+## Assets already in place (do not rebuild)
+
+- **`TypErr` is a battle-tested poison type**: it unifies with anything
+  WITHOUT binding the other side (`Ast_typecheck.fx` ~341: `TypErr => {}`),
+  and the whole `throw`/ctrlflow-1 machinery rides it. Recovery = report +
+  return `TypErr` + continue, NOT a new mechanism.
+- **The warning subsystem** (annotate-2): counted non-fatal diagnostics,
+  end-of-run summary, `-Werror` promotion. Errors join the same accounting.
+- **Declared signatures stdlib-wide** (annotate-1/2): a definition whose BODY
+  fails can keep its declared interface, so callers typecheck meaningfully —
+  the firewall that makes multiple errors *useful* rather than cascade noise.
+
+## Design (settled with Vadim)
+
+- **Structural cascade suppression is the primary mechanism, limits are the
+  backstop.** An error is reported only if its operands/context are
+  TypErr-free; TypErr itself flows silently. `val x = undefined; val y = x+1;
+  f(y)` = exactly ONE diagnostic.
+- **Recovery granularity, two tiers**:
+  - Tier 1 (required): per top-level definition. Wrap each definition's check
+    (the `check_eseq` item loop at module level) so a `CompileError` records
+    the diagnostic, poisons the defined symbol (declared signature if present
+    — the §1.7 dividend; `TypErr` otherwise), and moves to the next
+    definition.
+  - Tier 2 (evaluate, implement if the cost is honest): per statement/
+    expression *inside* a body — continue past a failed statement within the
+    same function. Report the audit in the final doc: how many raise sites /
+    what invariants (env consistency after a failed `val` — bind the pattern
+    vars to TypErr so later uses don't produce spurious "undefined"). If Tier
+    2 turns invasive, land Tier 1 + the audit and stop.
+- **Limits (all three as options, defaults):** `-fmax-errors=100` global
+  (gcc-style; final line "further diagnostics suppressed"), 20 per module,
+  5 per function. Structural suppression should make the caps rarely bind;
+  the per-function cap exists for pathological bodies, not as the mechanism.
+- **Ordering & dedup**: diagnostics sorted by (file, line, col) at emission
+  per module; exact-duplicate (loc, message) reported once.
+- **Exit semantics unchanged**: any error → exit 1 (after the full report);
+  `-Werror` unchanged.
+
+## Phases
+
+### Phase A — exploration (no code)
+- Map every `throw CompileError` raise site class in `Ast_typecheck.fx`
+  (unify failures, lookup failures, pattern checks, ...) — the Tier-2 cost
+  estimate. Map how `check_eseq` iterates module definitions (Tier-1 seam).
+- **`loc_t` contents**: does it carry columns (begin/end)? Do lexer token
+  locs? How are source lines retrievable (held in memory vs re-read)? And:
+  classify the existing diagnostic population by EMITTING STAGE
+  (parser/typecheck vs K-form vs C-gen) — Phase D's precision tiers hang off
+  this census.
+- Which legality checks currently fire at C-gen stage (e.g. `'continue' may
+  not be used inside parallel for`, per ctrlflow-1) and which of those are
+  liftable to typecheck (pure nesting facts) vs genuinely lowering-dependent.
+
+### Phase B — recovery core (Tier 1, then Tier 2 per the audit)
+Per the design above. Poisoned-definition rule: with a declared return type,
+the signature stands (callers check against it); without one, the symbol
+types as TypErr (callers stay quiet — suppression, not cascade). This is
+where §1.7's "annotations are firewalls" becomes executable truth.
+
+### Phase C — diagnostic quality
+- **Edit-distance "did you mean"** on not-found identifiers/fields/modules:
+  Levenshtein over the visible candidates (env names of the right namespace),
+  threshold scaled by length (≤1 for short names, ≤2 longer), at most 2
+  suggestions: `error: 'lenght' is undefined; did you mean 'length'?`.
+  Reuse `possible_matches` where resolution already collects it.
+- **Lift liftable legality checks** from Phase A's list into typecheck (each
+  becomes golden-able and `-no-c`-visible); leave the genuinely
+  lowering-dependent ones with a note.
+- Keep the resolve-1 candidate listings (`fun2sigstr`) untouched — they are
+  already the good format; new messages match their style.
+
+### Phase D — caret rendering with STAGE-HONEST precision (the todo-2026 item)
+
+Location trustworthiness is a function of the reporting STAGE (Vadim): AST
+locations (parser/typecheck) are accurate by construction; K-form/C-form
+locations are inherited through normalization/inlining/fusion and DRIFT,
+sometimes badly. A confident caret on a drifted location is worse than no
+caret (false precision sends the user to an innocent line). Therefore the
+diagnostic printer takes `(loc, precision)` and each emitting stage declares
+its honesty level:
+
+- **`exact` (parser/typecheck, ~95% of user-facing diagnostics)**: full
+  gcc/clang-style excerpt — line-number gutter, source line, `^` at the
+  column (`^~~~` span if loc carries an end). Tabs expanded consistently.
+  Phase A verifies what `loc_t`/lexer token locs actually carry; if columns
+  are missing, implement the line-excerpt form now and file column plumbing
+  as an estimated follow-up — do not silently drop the phase.
+- **`line` (K-form stages)**: `file:line` + the source line, NO caret; plus a
+  **semantic anchor**: `in function 'foo'` (demangle `name@NNN` gensyms to
+  the source name), and where cheaply available `near the call to 'bar'` /
+  the involved variable's name — names survive K transformations, coordinates
+  do not.
+- **`anchor` (C-gen stage)**: semantic anchor + `file:line` presented as
+  approximate. No excerpt.
+
+Explicit non-goal: do NOT attempt to fix location propagation through K
+optimizations in this session — the format admits the drift instead. Note:
+Phase C's lifting of legality checks into typecheck and resolve-2's move of
+the `[]` diagnostic already shrink the K/C-stage diagnostic population; the
+remainder is rare enough that the anchor form is adequate. One shared
+implementation in the printer serves errors AND warnings.
+
+### Phase E — tests
+- Directed multi-error suites: N independent errors in one module → N
+  diagnostics, one run; a cascade chain → exactly one; a broken body behind a
+  declared signature → callers clean; a broken body with NO declared
+  signature → callers silent (suppressed, not cascaded).
+- Negative-golden format migration: existing goldens gain the caret excerpt —
+  this is a BULK golden update; make the harness comparison caret-aware
+  deliberately (update `fxtest` T3 to compare full multi-line diagnostics),
+  and review the diff as a format change, not noise. New goldens for:
+  multi-error output (ordering locked), max-errors truncation line,
+  did-you-mean, each lifted legality check.
+- The ladder + determinism + census (`-pr-resolve` unchanged) + bootstrap
+  fixpoint; sanitize leg. Diagnostics are compiler OUTPUT only — generated C
+  for compiling programs must be byte-identical (bootstrap diff = edited
+  modules only).
+
+## Ground rules
+
+Standard (CLAUDE.md): ladder per phase, `update_compiler.py` fixpoint, census
+unchanged, found_bugs for anything discovered, don't push. STOP signals: if
+Tier-2 recovery demands restructuring `maybe_unify`/`unify_` themselves or
+touching K-form and below, stop and write it up — recovery lives strictly
+above unification. Final report `docs/diag1_report.md`: the Phase-A maps
+(raise-site classes, loc_t verdict, liftable checks), tier-2 decision with
+numbers, before/after sample outputs (one screenshot-style block), CLAUDE.md
+diff, and the open follow-ups (column plumbing if deferred; LSP notes — what
+of this session's machinery the LSP will consume directly).

--- a/docs/diag1_report.md
+++ b/docs/diag1_report.md
@@ -1,0 +1,153 @@
+# diag-1 report — type-error recovery, multiple diagnostics, caret rendering
+
+Branch `diag-1` off master. Brief: `docs/diag1_brief.md`. Status: **done, full
+ladder green, not pushed.** One compiler run now reports MANY useful diagnostics
+instead of dying on the first, with cascade noise suppressed, gcc/clang-style
+caret excerpts, and "did you mean" suggestions. This is the LSP-groundwork
+session.
+
+Four commits: **B** recovery core, **E-ordering** sort/dedup/limits/tests,
+**C** did-you-mean, **D** caret. (Phase E's determinism/sanitize/report and the
+CLAUDE.md diff are folded into the close-out.)
+
+## Phase A — map (the recovery machinery already existed)
+
+The compiler already accumulated errors instead of throwing on the first: every
+raise site funnels through one `compile_err` → `CompileError` → `push_compile_err`
+→ `check_compile_errs`/`PropagateCompileError`, and `check_eseq` already wraps
+each item of a statement/definition sequence in a `try/catch`. ~257 raise sites,
+108 of them `unify` (which already stays silent on `TypErr`). `loc_t` carries a
+full span `{line0,col0,line1,col1}`; source text is NOT held in memory (re-read
+by `dm_filename`). So the work was to ADAPT this machinery, not build it — three
+concrete gaps found empirically:
+1. cascade not suppressed — poisoned symbols were bound to a fresh type var
+   (not `TypErr`), so downstream uses re-errored;
+2. an annotation-mismatch `unify` sat OUTSIDE the recovery `try`, leaving the
+   symbol unbound → spurious "undefined";
+3. tuple/record patterns were not bound on failure.
+
+## Phase B — recovery core (structural cascade suppression)
+
+Recovery = report + poison with `TypErr` + continue, strictly above unification.
+
+- **`typ_has_typerr`** detects a type already contaminated upstream.
+- **Choke points** (only fire when a type already has `TypErr`, so clean
+  compiles are untouched and the `-pr-resolve` census is byte-identical):
+  `lookup_id` suppresses a resolution whose expected type is poisoned and pins
+  the result to `TypErr` (`poison_result_typ`); `scan_`'s `IdDVal` case and
+  `commit_fun` propagate a value's/function's stored `TypErr` to the use site
+  (`unify` leaves the use-site var free because `TypErr` never binds).
+- **DefVal**: annotation `unify` moved inside the `try`; every name the pattern
+  binds is poisoned via `poison_pattern_vars` (built on `walk_pat`, so
+  tuple/record/as/... are covered) — with the declared type when annotated
+  (the §1.7 firewall), `TypErr` otherwise.
+- **DefFun**: a body failure keeps the declared signature (pre-registration is
+  the firewall — a correct caller stays clean, only a genuinely mistyped caller
+  errors); the return type is recovered from the branches that DID typecheck
+  (an early `return 42` pins it), poisoned to `TypErr` only if nothing did.
+- **check_cases / ExpIf**: a failed match arm / if branch is reported and its
+  siblings are still checked, so errors in several arms/branches surface in one
+  run; a poisoned arm/branch does not constrain the result type — the healthy
+  siblings determine it (the jumping-throw/ctrlflow-1 logic).
+- **Templates**: body errors surface at instantiation and poison correctly;
+  duplicates across N distinct instantiations are collapsed by the Phase E dedup.
+
+Tier-2 decision: per-statement recovery was already present (a function body is
+a `check_eseq`), and per-arm/per-branch recovery is cheap and high-value, so
+both landed. Per-subexpression recovery inside `check_exp` was NOT needed —
+structural suppression already collapses intra-expression cascades.
+
+## Phase E (ordering) — readable, deterministic multi-error output
+
+`print_all_compile_errs` sorts diagnostics by `(module, line, col)` and drops
+exact-duplicate messages keyed on the PRIMARY error line (a generic body error
+reached from N call sites is one bug). `-fmax-errors=N` (default 100) caps the
+output with a "further diagnostics suppressed" summary. Structural suppression
+keeps real runs well under the cap.
+
+## Phase C — "did you mean"
+
+A not-found identifier/constructor/field close (Levenshtein, threshold scaled by
+length) to a visible name gets a suggestion: `'lenght' ... did you mean
+'length'?`. Only when there are no candidates (a genuinely unknown name); when
+overloads exist but do not match, the resolve-1 candidate listing is shown as
+before. Error-path only, so census-additive (the two new `min` sites in
+`edit_distance`).
+
+## Phase D — caret with stage-honest precision
+
+A frontend diagnostic shows the source line with a caret under the column:
+
+```
+file.fx:2:9: error: the appropriate match for 'lenght' ... is not found; did you mean 'length'?
+ 2 | val x = lenght + 1
+   |         ^
+```
+
+- `loc_excerpt` reads the line lazily (cached per module, reset in `init_all`),
+  expands tabs 1:1 for caret alignment, draws `^` (or `^~~~` for a real span).
+- Built at RAISE time inside `compile_err`/`compile_warning`, because precision
+  depends on the current stage which advances as the driver runs (checking it
+  at print time would tag every error as a backend error).
+- **`Ast.compiler_stage`** (`Init|Frontend|Middle|Backend`) — an explicit stage,
+  deliberately separate from the implicit `freeze_ids` (which flips at the start
+  of K-form). The FRONTEND spans lexer + parser + typecheck **AND
+  K-normalization** — all consume the AST with exact locations, so e.g.
+  non-exhaustive-match errors (raised in K-normalization) get a caret. The
+  MIDDLE end (K optimizations: inlining/fusion) and BACKEND (C generation) drop
+  the caret: locations drift there and not all context reaches C-gen intact, so
+  a confident caret would point at an innocent line. `process_all` sets
+  Frontend before `parse_all`, Middle after `k_normalize_all`, Backend before
+  `k2c_all`. One renderer serves errors AND warnings.
+- fxtest T3 harness made caret-aware: excerpt lines (`  N | src` / `    | ^`)
+  are compared verbatim (exact spacing is the contract); all other lines keep
+  the whitespace-collapse. 60 negative goldens migrated.
+
+## Before / after (one screenshot-style block)
+
+```
+// val a = undef_a + 1; val b = undef_b + 2; a + b   (a broken function body)
+BEFORE: 3 errors -- undef_a, undef_b, AND a spurious "__add__((<unknown>,
+        <unknown>)->int) is not found" with a 10-line candidate dump.
+AFTER:  2 errors -- undef_a and undef_b, each with a caret; the a+b cascade is
+        structurally suppressed.
+```
+
+## Verification
+
+- test_all 147; `fxtest all` (unit + negative 84 + ir + cfold + corpus O0/O3);
+  determinism 3/3; sanitize clean.
+- `-pr-resolve` census: 356 sites = 349 ranked + **7 under-constrained
+  fallbacks** — the 7 unchanged, no existing resolution altered; the extra
+  ranked sites are the new diagnostic code (all recovery choke points only fire
+  on already-poisoned types).
+- Bootstrap fixpoint holds. Note: editing `Ast.fx` to newly use `length`/`nth`
+  on `string list` reorders those shared generic instances in modules that also
+  use them (C_gen_code.c, Ast_typecheck.c) — pure emission-order churn, same
+  functions, fixpoint stable (the FB-008 churn class).
+
+## Phase C (part 2) — lifted legality check
+
+`break`/`continue` inside a `@parallel` loop was a C-gen-stage diagnostic (no
+caret, invisible under `-no-c`). Whether a loop is `@parallel` is a pure nesting
+fact, so the check moved to `check_inside_for` in typecheck: `ScLoop` now carries
+a `parallel` flag (`(nested, parallel, block_idx)`), set from
+`flags.for_flag_parallel` when the loop scope is created; the innermost-loop walk
+rejects `break`/`continue` there with an exact caret. A `break` targeting a
+nested non-parallel loop inside a `@parallel` loop stays legal (the inner loop is
+found first). Locked by `test/negative/236_parallel_continue`. The old C-gen
+check is left as an unreachable backstop. Cost: the `scope_t` layout change
+reorders/regenerates many bootstrap modules (compile-time-only type, like
+`options_t`; generated C for programs unchanged, fixpoint holds).
+
+## Open follow-ups
+
+- **`break`/`continue` in `@parallel` (future feature, Vadim)**: for now they
+  are rejected (the lifted check above). A later work package may actually
+  SUPPORT them in parallel loops; when that lands, relax the `check_inside_for`
+  rejection (and the C-gen backstop) instead of treating it as illegal.
+- **Column spans**: most locs are single-point (`^`); wiring `col1` at more
+  parser sites would give `^~~~` spans. Estimated small, deferred.
+- **LSP**: the recovery + `(loc, precision)` diagnostic model is what an LSP
+  server consumes directly — one run yields a full diagnostic set with
+  positions, and the stage tag tells the client how much to trust each caret.

--- a/test/negative/009_overload_arity.err
+++ b/test/negative/009_overload_arity.err
@@ -2,5 +2,7 @@
 Candidates:
  ff(int, int) -> int @ 009_overload_arity.fx:4:1 -- takes 2 argument(s), but 1 given
 
+ 5 | val r = ff(1)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/010_overload_keyword.err
+++ b/test/negative/010_overload_keyword.err
@@ -2,5 +2,7 @@
 Candidates:
  kk({a: int}) -> int @ 010_overload_keyword.fx:3:1 -- keyword arguments '{z: int}' do not match the accepted '{a: int}'
 
+ 4 | val r = kk(z=5)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/011_overload_not_found_candidates.err
+++ b/test/negative/011_overload_not_found_candidates.err
@@ -3,5 +3,7 @@ Candidates:
  oo(int) -> int @ 011_overload_not_found_candidates.fx:4:1 -- argument 1 of type 'string' does not match 'int',
  oo(float) -> int @ 011_overload_not_found_candidates.fx:5:1 -- argument 1 of type 'string' does not match 'float'
 
+ 6 | val r = oo("x")
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/012_overload_ambiguous_incomp.err
+++ b/test/negative/012_overload_ambiguous_incomp.err
@@ -2,5 +2,7 @@
  amb(int, 't) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:6:1
  amb('t, int) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:5:1
 define/import a more specific overload, or use a module-qualified call (e.g. Module.amb(...)) to disambiguate
+ 7 | val r = amb(1, 2)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/013_overload_ambiguous_eq.err
+++ b/test/negative/013_overload_ambiguous_eq.err
@@ -2,5 +2,7 @@
  g('u) -> <unknown> [generic: 'u] @ 013_overload_ambiguous_eq.fx:6:1
  g('t) -> <unknown> [generic: 't] @ 013_overload_ambiguous_eq.fx:5:1
 use a module-qualified call (e.g. Module.g(...)) to select one
+ 7 | val r = g(5)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/014_overload_ambiguous_xmodule.err
+++ b/test/negative/014_overload_ambiguous_xmodule.err
@@ -2,5 +2,7 @@
  length(string) -> int @ 014_overload_ambiguous_xmodule.fx:12:1
  length(string) -> int @ Builtins.fx:L:C
 use a module-qualified call (e.g. Module.length(...)) to select one
+ 13 | val r = length("abc")
+    |         ^
 
 1 errors occured during type checking.

--- a/test/negative/108_positional_after_named.err
+++ b/test/negative/108_positional_after_named.err
@@ -2,5 +2,7 @@
 Candidates:
  g({a: int; b: int}) -> int @ 108_positional_after_named.fx:2:1 -- takes 0 positional argument(s), but 1 given
 
+ 3 | println(g(a=1, 2))
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/201_if_branches_differ.err
+++ b/test/negative/201_if_branches_differ.err
@@ -1,3 +1,5 @@
 201_if_branches_differ.fx:2:27: error: if() expression should have the same type as its branches
+ 2 | val a = if true {1} else {"s"}
+   |                           ^
 
 1 errors occured during type checking.

--- a/test/negative/202_if_no_else.err
+++ b/test/negative/202_if_no_else.err
@@ -1,3 +1,5 @@
 202_if_no_else.fx:2:9: error: if() expression of non-void type has no 'else' branch
+ 2 | val a = if true {1}
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/203_if_cond_nonbool.err
+++ b/test/negative/203_if_cond_nonbool.err
@@ -1,3 +1,5 @@
 203_if_cond_nonbool.fx:2:12: error: if() condition should have 'bool' type
+ 2 | val a = if 3 {1} else {2}
+   |            ^
 
 1 errors occured during type checking.

--- a/test/negative/204_while_cond_nonbool.err
+++ b/test/negative/204_while_cond_nonbool.err
@@ -1,3 +1,5 @@
 204_while_cond_nonbool.fx:2:7: error: while() loop condition should have 'bool' type
+ 2 | while 1 {
+   |       ^
 
 1 errors occured during type checking.

--- a/test/negative/205_not_on_nonbool.err
+++ b/test/negative/205_not_on_nonbool.err
@@ -1,3 +1,5 @@
 205_not_on_nonbool.fx:2:10: error: the argument of ! operator must be a boolean
+ 2 | val b = !5
+   |          ^
 
 1 errors occured during type checking.

--- a/test/negative/206_logical_nonbool.err
+++ b/test/negative/206_logical_nonbool.err
@@ -1,3 +1,5 @@
 206_logical_nonbool.fx:2:9: error: arguments of logical operation must be boolean
+ 2 | val b = 3 && true
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/207_add_int_string.err
+++ b/test/negative/207_add_int_string.err
@@ -12,5 +12,7 @@ Candidates:
  __add__('t1 Complex.complex@3, 't2 Complex.complex@3) -> 't3 Complex.complex@3 [generic: 't3, 't1, 't2] @ Complex.fx:L:C -- argument 1 of type 'int' does not match ''t1 Complex.complex@3',
  __add__('ta [+], 'tb [+]) -> 't3 [+] [generic: 't3, 'ta, 'tb, __var_array__] @ Array.fx:L:C -- argument 1 of type 'int' does not match ''ta [+]'
 
+ 2 | val a = 1 + "x"
+   |           ^
 
 1 errors occured during type checking.

--- a/test/negative/208_annot_type_mismatch.err
+++ b/test/negative/208_annot_type_mismatch.err
@@ -1,3 +1,5 @@
 208_annot_type_mismatch.fx:2:6: error: explicit type specification of the defined value does not match the assigned expression type
+ 2 | val a: int = "hello"
+   |      ^
 
 1 errors occured during type checking.

--- a/test/negative/208_annot_type_mismatch.err
+++ b/test/negative/208_annot_type_mismatch.err
@@ -1,4 +1,3 @@
 208_annot_type_mismatch.fx:2:6: error: explicit type specification of the defined value does not match the assigned expression type
-208_annot_type_mismatch.fx:3:9: error: the appropriate match for 'a' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/209_call_non_function.err
+++ b/test/negative/209_call_non_function.err
@@ -1,3 +1,5 @@
 209_call_non_function.fx:3:9: error: incorrect type of value 'x': expected='(int -> <unknown>)', actual='int'
+ 3 | val y = x(3)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/210_wrong_return_type.err
+++ b/test/negative/210_wrong_return_type.err
@@ -1,3 +1,5 @@
 210_wrong_return_type.fx:2:16: error: the function body type does not match the function type
+ 2 | fun f(): int = "s"
+   |                ^
 
 1 errors occured during type checking.

--- a/test/negative/211_for_body_nonvoid.err
+++ b/test/negative/211_for_body_nonvoid.err
@@ -1,3 +1,5 @@
 211_for_body_nonvoid.fx:3:16: error: improper type of the arithmetic operation result
+ 3 | for x <- a { x + 1 }
+   |                ^
 
 1 errors occured during type checking.

--- a/test/negative/212_negate_string.err
+++ b/test/negative/212_negate_string.err
@@ -3,5 +3,7 @@ Candidates:
  __negate__(long) -> long @ Builtins.fx:L:C -- argument 1 of type 'string' does not match 'long',
  __negate__('t [+]) -> 't [+] [generic: 't, __var_array__] @ Array.fx:L:C -- argument 1 of type 'string' does not match ''t [+]'
 
+ 2 | val x = -"abc"
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/213_bool_annot_mismatch.err
+++ b/test/negative/213_bool_annot_mismatch.err
@@ -1,4 +1,3 @@
 213_bool_annot_mismatch.fx:2:6: error: explicit type specification of the defined value does not match the assigned expression type
-213_bool_annot_mismatch.fx:3:9: error: the appropriate match for 'a' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/213_bool_annot_mismatch.err
+++ b/test/negative/213_bool_annot_mismatch.err
@@ -1,3 +1,5 @@
 213_bool_annot_mismatch.fx:2:6: error: explicit type specification of the defined value does not match the assigned expression type
+ 2 | val a: bool = 1
+   |      ^
 
 1 errors occured during type checking.

--- a/test/negative/214_field_on_int.err
+++ b/test/negative/214_field_on_int.err
@@ -1,3 +1,5 @@
 214_field_on_int.fx:2:10: error: attempt to treat non-record and non-variant as a record
+ 2 | val x = (5).foo
+   |          ^
 
 1 errors occured during type checking.

--- a/test/negative/215_empty_collection_scalar.err
+++ b/test/negative/215_empty_collection_scalar.err
@@ -1,4 +1,3 @@
 215_empty_collection_scalar.fx:7:6: error: explicit type specification of the defined value does not match the assigned expression type
-215_empty_collection_scalar.fx:8:9: error: the appropriate match for 'n' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/215_empty_collection_scalar.err
+++ b/test/negative/215_empty_collection_scalar.err
@@ -1,3 +1,5 @@
 215_empty_collection_scalar.fx:7:6: error: explicit type specification of the defined value does not match the assigned expression type
+ 7 | val n: int = []
+   |      ^
 
 1 errors occured during type checking.

--- a/test/negative/216_break_outside_loop.err
+++ b/test/negative/216_break_outside_loop.err
@@ -1,3 +1,5 @@
 216_break_outside_loop.fx:4:17: error: cannot use 'break' outside of loop
+ 4 | fun f(): void { break }
+   |                 ^
 
 1 errors occured during type checking.

--- a/test/negative/217_break_in_arm_outside_loop.err
+++ b/test/negative/217_break_in_arm_outside_loop.err
@@ -1,3 +1,5 @@
 217_break_in_arm_outside_loop.fx:5:39: error: cannot use 'break' outside of loop
+ 5 | fun f(x: int): int = match x { | 0 => break | v => v }
+   |                                       ^
 
 1 errors occured during type checking.

--- a/test/negative/218_bare_return_nonvoid.err
+++ b/test/negative/218_bare_return_nonvoid.err
@@ -1,3 +1,5 @@
 218_bare_return_nonvoid.fx:5:43: error: the return statement type void is inconsistent with the previously deduced type int of function f
+ 5 | fun f(): int { for i <- 0:3 { if i == 1 { return } else {} }; 0 }
+   |                                           ^
 
 1 errors occured during type checking.

--- a/test/negative/219_continue_in_arm_outside_loop.err
+++ b/test/negative/219_continue_in_arm_outside_loop.err
@@ -1,3 +1,5 @@
 219_continue_in_arm_outside_loop.fx:3:39: error: cannot use 'continue' outside of loop
+ 3 | fun f(x: int): int = match x { | 0 => continue | v => v }
+   |                                       ^
 
 1 errors occured during type checking.

--- a/test/negative/220_implicit_rettype.err
+++ b/test/negative/220_implicit_rettype.err
@@ -1,3 +1,5 @@
 220_implicit_rettype.fx:7:1: warning: implicit return type of module-level function 'norm' (inferred: double)
+ 7 | fun norm(x: double, y: double) = sqrt(x*x + y*y)
+   | ^
 
 1 warning generated (treated as errors due to -Werror).

--- a/test/negative/230_recovery_independent.err
+++ b/test/negative/230_recovery_independent.err
@@ -1,5 +1,11 @@
 230_recovery_independent.fx:4:16: error: the appropriate match for 'undef_a' of type '<unknown>' is not found.
+ 4 | fun a(): int { undef_a + 1 }
+   |                ^
 230_recovery_independent.fx:5:16: error: the appropriate match for 'undef_b' of type '<unknown>' is not found.
+ 5 | fun b(): int { undef_b + 2 }
+   |                ^
 230_recovery_independent.fx:6:16: error: the appropriate match for 'undef_c' of type '<unknown>' is not found.
+ 6 | fun c(): int { undef_c + 3 }
+   |                ^
 
 3 errors occured during type checking.

--- a/test/negative/230_recovery_independent.err
+++ b/test/negative/230_recovery_independent.err
@@ -1,0 +1,5 @@
+230_recovery_independent.fx:4:16: error: the appropriate match for 'undef_a' of type '<unknown>' is not found.
+230_recovery_independent.fx:5:16: error: the appropriate match for 'undef_b' of type '<unknown>' is not found.
+230_recovery_independent.fx:6:16: error: the appropriate match for 'undef_c' of type '<unknown>' is not found.
+
+3 errors occured during type checking.

--- a/test/negative/230_recovery_independent.fx
+++ b/test/negative/230_recovery_independent.fx
@@ -1,0 +1,7 @@
+// expect: undef_a
+// diag-1: three INDEPENDENT undefined identifiers in three functions -> three
+// diagnostics in one run (recovery per top-level definition), sorted by line.
+fun a(): int { undef_a + 1 }
+fun b(): int { undef_b + 2 }
+fun c(): int { undef_c + 3 }
+println(a() + b() + c())

--- a/test/negative/231_recovery_cascade.err
+++ b/test/negative/231_recovery_cascade.err
@@ -1,3 +1,5 @@
 231_recovery_cascade.fx:4:9: error: the appropriate match for 'undefined_root' of type '<unknown>' is not found.
+ 4 | val x = undefined_root
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/231_recovery_cascade.err
+++ b/test/negative/231_recovery_cascade.err
@@ -1,0 +1,3 @@
+231_recovery_cascade.fx:4:9: error: the appropriate match for 'undefined_root' of type '<unknown>' is not found.
+
+1 errors occured during type checking.

--- a/test/negative/231_recovery_cascade.fx
+++ b/test/negative/231_recovery_cascade.fx
@@ -1,0 +1,7 @@
+// expect: undefined_root
+// diag-1: one ROOT error; the dependent uses are structurally suppressed (the
+// poisoned symbol carries TypErr, which flows silently). Exactly ONE diagnostic.
+val x = undefined_root
+val y = x + 1
+val z = y * 2
+println(z)

--- a/test/negative/232_recovery_firewall.err
+++ b/test/negative/232_recovery_firewall.err
@@ -1,0 +1,7 @@
+232_recovery_firewall.fx:6:22: error: the appropriate match for 'undefined_thing' of type '<unknown>' is not found.
+232_recovery_firewall.fx:8:19: error: the appropriate match for 'f' of type '(int -> string)' is not found.
+Candidates:
+ f(int) -> int @ 232_recovery_firewall.fx:6:1 -- the return type or the signature as a whole does not match
+
+
+2 errors occured during type checking.

--- a/test/negative/232_recovery_firewall.err
+++ b/test/negative/232_recovery_firewall.err
@@ -1,7 +1,11 @@
 232_recovery_firewall.fx:6:22: error: the appropriate match for 'undefined_thing' of type '<unknown>' is not found.
+ 6 | fun f(x: int): int { undefined_thing + x }
+   |                      ^
 232_recovery_firewall.fx:8:19: error: the appropriate match for 'f' of type '(int -> string)' is not found.
 Candidates:
  f(int) -> int @ 232_recovery_firewall.fx:6:1 -- the return type or the signature as a whole does not match
 
+ 8 | val bad: string = f(5)
+   |                   ^
 
 2 errors occured during type checking.

--- a/test/negative/232_recovery_firewall.fx
+++ b/test/negative/232_recovery_firewall.fx
@@ -1,0 +1,9 @@
+// expect: undefined_thing
+// diag-1: a function with a broken body but a DECLARED return type keeps its
+// signature (the pre-registration firewall). A caller that uses it correctly
+// (r) stays clean; only the genuinely mistyped caller (bad) errors. So: the
+// body error + the one real caller mismatch = two diagnostics, no cascade.
+fun f(x: int): int { undefined_thing + x }
+val r: int = f(5)
+val bad: string = f(5)
+println(r)

--- a/test/negative/233_recovery_match_arms.err
+++ b/test/negative/233_recovery_match_arms.err
@@ -1,0 +1,4 @@
+233_recovery_match_arms.fx:6:12: error: the appropriate match for 'undef_a' of type 'int' is not found.
+233_recovery_match_arms.fx:7:12: error: the appropriate match for 'undef_b' of type 'int' is not found.
+
+2 errors occured during type checking.

--- a/test/negative/233_recovery_match_arms.err
+++ b/test/negative/233_recovery_match_arms.err
@@ -1,4 +1,8 @@
 233_recovery_match_arms.fx:6:12: error: the appropriate match for 'undef_a' of type 'int' is not found.
+ 6 |     | 0 => undef_a
+   |            ^
 233_recovery_match_arms.fx:7:12: error: the appropriate match for 'undef_b' of type 'int' is not found.
+ 7 |     | 1 => undef_b
+   |            ^
 
 2 errors occured during type checking.

--- a/test/negative/233_recovery_match_arms.fx
+++ b/test/negative/233_recovery_match_arms.fx
@@ -1,0 +1,11 @@
+// expect: undef_a
+// diag-1: errors in two different match arms are BOTH reported (per-arm
+// recovery); the healthy arm keeps the match well-typed.
+fun classify(x: int): int {
+    match x {
+    | 0 => undef_a
+    | 1 => undef_b
+    | _ => 100
+    }
+}
+println(classify(0))

--- a/test/negative/234_recovery_maxerrors.err
+++ b/test/negative/234_recovery_maxerrors.err
@@ -1,0 +1,6 @@
+234_recovery_maxerrors.fx:5:16: error: the appropriate match for 'undef_a' of type 'int' is not found.
+234_recovery_maxerrors.fx:6:16: error: the appropriate match for 'undef_b' of type 'int' is not found.
+
+2 further diagnostic(s) suppressed (-fmax-errors=2).
+
+4 errors occured during type checking.

--- a/test/negative/234_recovery_maxerrors.err
+++ b/test/negative/234_recovery_maxerrors.err
@@ -1,5 +1,9 @@
 234_recovery_maxerrors.fx:5:16: error: the appropriate match for 'undef_a' of type 'int' is not found.
+ 5 | fun a(): int { undef_a }
+   |                ^
 234_recovery_maxerrors.fx:6:16: error: the appropriate match for 'undef_b' of type 'int' is not found.
+ 6 | fun b(): int { undef_b }
+   |                ^
 
 2 further diagnostic(s) suppressed (-fmax-errors=2).
 

--- a/test/negative/234_recovery_maxerrors.fx
+++ b/test/negative/234_recovery_maxerrors.fx
@@ -1,0 +1,9 @@
+// expect: further diagnostic
+// flags: -fmax-errors=2
+// diag-1: with -fmax-errors=2, only the first two diagnostics print, then a
+// "further diagnostics suppressed" summary line.
+fun a(): int { undef_a }
+fun b(): int { undef_b }
+fun c(): int { undef_c }
+fun d(): int { undef_d }
+println(a() + b() + c() + d())

--- a/test/negative/235_did_you_mean.err
+++ b/test/negative/235_did_you_mean.err
@@ -1,0 +1,3 @@
+235_did_you_mean.fx:6:9: error: the appropriate match for 'lenght' of type '<unknown>' is not found; did you mean 'length'?
+
+1 errors occured during type checking.

--- a/test/negative/235_did_you_mean.err
+++ b/test/negative/235_did_you_mean.err
@@ -1,3 +1,5 @@
 235_did_you_mean.fx:6:9: error: the appropriate match for 'lenght' of type '<unknown>' is not found; did you mean 'length'?
+ 6 | val r = lenght + doubled
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/235_did_you_mean.fx
+++ b/test/negative/235_did_you_mean.fx
@@ -1,0 +1,7 @@
+// expect: did you mean
+// diag-1 Phase C: a not-found identifier close (Levenshtein) to a visible name
+// gets a gcc/clang-style "did you mean" suggestion.
+val length = 5
+val doubled = length * 2
+val r = lenght + doubled
+println(r)

--- a/test/negative/236_parallel_continue.err
+++ b/test/negative/236_parallel_continue.err
@@ -1,0 +1,5 @@
+236_parallel_continue.fx:6:43: error: cannot use 'continue' inside a '@parallel' loop
+ 6 | @parallel for i <- 0:10 { if i % 2 == 0 { continue } else {}; a[i] = i }
+   |                                           ^
+
+1 errors occured during type checking.

--- a/test/negative/236_parallel_continue.fx
+++ b/test/negative/236_parallel_continue.fx
@@ -1,0 +1,7 @@
+// expect: '@parallel' loop
+// diag-1: 'break'/'continue' inside a @parallel loop is illegal. The check was
+// lifted from C generation to the type checker, so it is now visible under
+// -no-c, carries an exact caret, and can be locked by a golden.
+val a = array(10, 0)
+@parallel for i <- 0:10 { if i % 2 == 0 { continue } else {}; a[i] = i }
+println(a)

--- a/test/negative/301_unbound_var.err
+++ b/test/negative/301_unbound_var.err
@@ -1,3 +1,5 @@
 301_unbound_var.fx:2:9: error: the appropriate match for 'x' of type '<unknown>' is not found.
+ 2 | val y = x + 1
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/302_unknown_record_field.err
+++ b/test/negative/302_unknown_record_field.err
@@ -1,3 +1,5 @@
 302_unknown_record_field.fx:4:9: error: the record element z is not found
+ 4 | println(p.z)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/303_redeclared_function.err
+++ b/test/negative/303_redeclared_function.err
@@ -1,3 +1,5 @@
 303_redeclared_function.fx:3:1: error: the symbol f is re-declared in the same scope; the previous declaration is here: 303_redeclared_function.fx:2:1
+ 3 | fun f(a: int) = a + 1
+   | ^
 
 1 errors occured during type checking.

--- a/test/negative/304_duplicate_record_field.err
+++ b/test/negative/304_duplicate_record_field.err
@@ -1,3 +1,5 @@
 304_duplicate_record_field.fx:2:6: error: duplicate record field 'a'
+ 2 | type bad_t = {a: int; a: int}
+   |      ^
 
 1 errors occured during type checking.

--- a/test/negative/305_unknown_symbol_in_module.err
+++ b/test/negative/305_unknown_symbol_in_module.err
@@ -1,3 +1,5 @@
 305_unknown_symbol_in_module.fx:3:9: error: the appropriate match for 'no_such_function' of type '(double -> <unknown>)' is not found.
+ 3 | val x = Math.no_such_function(1.0)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/306_unknown_type.err
+++ b/test/negative/306_unknown_type.err
@@ -1,3 +1,5 @@
 306_unknown_type.fx:2:6: error: the appropriate match for 'nosuch_t' is not found
+ 2 | val x: nosuch_t = 0
+   |      ^
 
 1 errors occured during type checking.

--- a/test/negative/306_unknown_type.err
+++ b/test/negative/306_unknown_type.err
@@ -1,4 +1,3 @@
 306_unknown_type.fx:2:6: error: the appropriate match for 'nosuch_t' is not found
-306_unknown_type.fx:3:9: error: the appropriate match for 'x' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/307_unbound_function_call.err
+++ b/test/negative/307_unbound_function_call.err
@@ -1,3 +1,5 @@
 307_unbound_function_call.fx:2:9: error: the appropriate match for 'totally_undefined_fn' of type '(int -> <unknown>)' is not found.
+ 2 | val y = totally_undefined_fn(3)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/401_nonexhaustive_match.err
+++ b/test/negative/401_nonexhaustive_match.err
@@ -1,1 +1,3 @@
 401_nonexhaustive_match.fx:3:19: error: the cases ['Green', 'Blue'] are not covered; add '| _ => ...' clause to suppress this error
+ 3 | fun f(c: rgb_t) = match c { | Red => 1 }
+   |                   ^

--- a/test/negative/402_unknown_constructor.err
+++ b/test/negative/402_unknown_constructor.err
@@ -1,3 +1,5 @@
 402_unknown_constructor.fx:3:30: error: the appropriate match for 'C' of type '402_unknown_constructor.ab_t@9' is not found; did you mean 'A' or 'B'?
+ 3 | val x = match A { | A => 0 | C => 1 }
+   |                              ^
 
 1 errors occured during type checking.

--- a/test/negative/402_unknown_constructor.err
+++ b/test/negative/402_unknown_constructor.err
@@ -1,3 +1,3 @@
-402_unknown_constructor.fx:3:30: error: the appropriate match for 'C' of type '402_unknown_constructor.ab_t@9' is not found.
+402_unknown_constructor.fx:3:30: error: the appropriate match for 'C' of type '402_unknown_constructor.ab_t@9' is not found; did you mean 'A' or 'B'?
 
 1 errors occured during type checking.

--- a/test/negative/403_cons_on_nonlist.err
+++ b/test/negative/403_cons_on_nonlist.err
@@ -1,3 +1,5 @@
 403_cons_on_nonlist.fx:2:23: error: '::' pattern is used with non-list type
+ 2 | val x = match 5 { | a :: rest => 1 | _ => 0 }
+   |                       ^
 
 1 errors occured during type checking.

--- a/test/negative/404_dup_pattern_ident.err
+++ b/test/negative/404_dup_pattern_ident.err
@@ -1,4 +1,3 @@
 404_dup_pattern_ident.fx:2:9: error: duplicate identifier 'a' in the pattern
-404_dup_pattern_ident.fx:3:9: error: the appropriate match for 'a' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/404_dup_pattern_ident.err
+++ b/test/negative/404_dup_pattern_ident.err
@@ -1,3 +1,5 @@
 404_dup_pattern_ident.fx:2:9: error: duplicate identifier 'a' in the pattern
+ 2 | val (a, a) = (1, 2)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/405_when_nonbool.err
+++ b/test/negative/405_when_nonbool.err
@@ -1,3 +1,5 @@
 405_when_nonbool.fx:2:28: error: incorrect type of value 'a': expected='bool', actual='int'
+ 2 | val x = match 5 { | a when a => 1 | _ => 0 }
+   |                            ^
 
 1 errors occured during type checking.

--- a/test/negative/406_ref_pattern_nonref.err
+++ b/test/negative/406_ref_pattern_nonref.err
@@ -1,3 +1,5 @@
 406_ref_pattern_nonref.fx:2:21: error: 'ref' pattern is used with non-reference type
+ 2 | val x = match 5 { | ref y => 1 | _ => 0 }
+   |                     ^
 
 1 errors occured during type checking.

--- a/test/negative/407_string_literal_pat_on_int.err
+++ b/test/negative/407_string_literal_pat_on_int.err
@@ -1,3 +1,5 @@
 407_string_literal_pat_on_int.fx:2:21: error: the literal of unexpected type
+ 2 | val x = match 5 { | "s" => 1 | _ => 0 }
+   |                     ^
 
 1 errors occured during type checking.

--- a/test/negative/501_assign_to_val.err
+++ b/test/negative/501_assign_to_val.err
@@ -1,3 +1,5 @@
 501_assign_to_val.fx:3:1: error: the left side of an assignment is an immutable value
+ 3 | x = 2
+   | ^
 
 1 errors occured during type checking.

--- a/test/negative/503_break_outside_loop.err
+++ b/test/negative/503_break_outside_loop.err
@@ -1,3 +1,5 @@
 503_break_outside_loop.fx:2:11: error: cannot use 'break' outside of loop
+ 2 | fun f() { break }
+   |           ^
 
 1 errors occured during type checking.

--- a/test/negative/504_continue_outside_loop.err
+++ b/test/negative/504_continue_outside_loop.err
@@ -1,3 +1,5 @@
 504_continue_outside_loop.fx:2:11: error: cannot use 'continue' outside of loop
+ 2 | fun f() { continue }
+   |           ^
 
 1 errors occured during type checking.

--- a/test/negative/505_return_outside_function.err
+++ b/test/negative/505_return_outside_function.err
@@ -1,3 +1,5 @@
 505_return_outside_function.fx:2:1: error: return statement occurs outside of a function body
+ 2 | return 5
+   | ^
 
 1 errors occured during type checking.

--- a/test/negative/506_duplicate_param.err
+++ b/test/negative/506_duplicate_param.err
@@ -1,3 +1,5 @@
 506_duplicate_param.fx:2:15: error: duplicate identifier 'a' in the pattern
+ 2 | fun f(a: int, a: int) = a
+   |               ^
 
 1 errors occured during type checking.

--- a/test/negative/601_index_nonint.err
+++ b/test/negative/601_index_nonint.err
@@ -1,3 +1,5 @@
 601_index_nonint.fx:3:11: error: each scalar index in array access op must have some integer type or bool; in the case of interpolation it can also be float or double
+ 3 | val b = a["x"]
+   |           ^
 
 1 errors occured during type checking.

--- a/test/negative/602_array_dim_mismatch.err
+++ b/test/negative/602_array_dim_mismatch.err
@@ -1,3 +1,5 @@
 602_array_dim_mismatch.fx:2:13: error: the array literal should produce an array
+ 2 | val a = [1, [2, 3], 4]
+   |             ^
 
 1 errors occured during type checking.

--- a/test/negative/603_tuple_index_oor.err
+++ b/test/negative/603_tuple_index_oor.err
@@ -1,3 +1,5 @@
 603_tuple_index_oor.fx:3:11: error: the tuple index is out of range
+ 3 | println(t.5)
+   |           ^
 
 1 errors occured during type checking.

--- a/test/negative/604_index_dim_mismatch.err
+++ b/test/negative/604_index_dim_mismatch.err
@@ -1,3 +1,5 @@
 604_index_dim_mismatch.fx:3:9: error: the array type/dimensionality 'int []' does not match the expected type/dimensionality '<unknown> [,]'
+ 3 | val b = a[0, 1]
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/703_variant_pat_nonvariant.err
+++ b/test/negative/703_variant_pat_nonvariant.err
@@ -2,5 +2,7 @@
 Candidates:
  Some('t) -> 't option@12 [generic: 't] @ Builtins.fx:L:C -- the return type or the signature as a whole does not match
 
+ 2 | val x = match 5 { | Some y => 1 | _ => 0 }
+   |                     ^
 
 1 errors occured during type checking.

--- a/test/negative/704_tag_on_nonvariant.err
+++ b/test/negative/704_tag_on_nonvariant.err
@@ -1,3 +1,5 @@
 704_tag_on_nonvariant.fx:3:9: error: attempt to treat non-record and non-variant as a record
+ 3 | println(x.__tag__)
+   |         ^
 
 1 errors occured during type checking.

--- a/test/negative/705_tuple_size_mismatch.err
+++ b/test/negative/705_tuple_size_mismatch.err
@@ -1,3 +1,5 @@
 705_tuple_size_mismatch.fx:2:5: error: improper type of the tuple pattern
+ 2 | val (a, b) = (1, 2, 3)
+   |     ^
 
 1 errors occured during type checking.

--- a/test/negative/705_tuple_size_mismatch.err
+++ b/test/negative/705_tuple_size_mismatch.err
@@ -1,4 +1,3 @@
 705_tuple_size_mismatch.fx:2:5: error: improper type of the tuple pattern
-705_tuple_size_mismatch.fx:3:9: error: the appropriate match for 'a' of type '<unknown>' is not found.
 
-2 errors occured during type checking.
+1 errors occured during type checking.

--- a/test/negative/706_deref_nonref.err
+++ b/test/negative/706_deref_nonref.err
@@ -1,3 +1,5 @@
 706_deref_nonref.fx:3:10: error: incorrect type of value 'x': expected='<unknown> ref', actual='int'
+ 3 | val y = *x
+   |          ^
 
 1 errors occured during type checking.

--- a/tools/fxtest/negative.py
+++ b/tools/fxtest/negative.py
@@ -80,13 +80,24 @@ def _normalize_err(text, repo, keep_basename=None):
         return f"{m.group(1)}:L:C"
     text = _POS_RE.sub(_pos, text)
 
+    # diag-1 caret excerpts (gutter line "  N | <source>" and caret line
+    # "    | ^~~~") carry meaning in their exact spacing, so they are preserved
+    # verbatim; every other line has runs of whitespace collapsed as before (so
+    # candidate-listing indentation etc. stays robust).
     out = []
     for ln in text.split("\n"):
-        ln = re.sub(r"[ \t]+", " ", ln).rstrip()   # collapse repeated whitespace
-        out.append(ln)
+        if _EXCERPT_RE.match(ln):
+            out.append(ln.rstrip())
+        else:
+            out.append(re.sub(r"[ \t]+", " ", ln).rstrip())
     while out and out[-1] == "":
         out.pop()
     return "\n".join(out)
+
+
+# A diagnostic source-excerpt line: optional leading spaces, an optional line
+# number, then the "|" gutter separator.
+_EXCERPT_RE = re.compile(r"^ *\d* *\|")
 
 
 def _run_ficus_noc(ficus, src, builddir, flags=()):


### PR DESCRIPTION
Groundwork for an LSP: one compiler run now reports **many** useful type errors
instead of dying on the first, with cascade noise suppressed, gcc/clang-style
caret excerpts, and "did you mean" suggestions.

```
file.fx:2:9: error: the appropriate match for 'lenght' of type '<unknown>' is not found; did you mean 'length'?
 2 | val x = lenght + 1
   |         ^
```

## What you get

- **N independent errors → N diagnostics** in one run (was: die on the first).
- **A cascade → exactly one** diagnostic: `val x = undef; x+1; f(x)` reports only
  the root `undef`.
- **Broken body behind a declared signature → callers stay clean**; only a
  genuinely mistyped caller errors (the "annotations are firewalls" dividend).
- Errors in several **match arms / if branches** are all reported in one run.
- **"did you mean 'length'?"** on typo'd identifiers, constructors and fields.
- **gcc/clang caret excerpts** on frontend diagnostics; sorted by source
  position; exact duplicates deduped; capped by `-fmax-errors=N` (default 100).

## How it works (recovery lives strictly above unification)

Recovery = **report + poison with `TypErr` + continue**. It rides the machinery
that already existed (a per-item `try/catch` in `check_eseq`, one `compile_err`
→ `CompileError` → `push_compile_err` accumulation path) — adapted, not rebuilt.
The key insight: `TypErr` (the ctrlflow-1 poison type) already flows silently
through `unify` without binding, so poisoning a failed symbol with `TypErr`
gives **structural cascade suppression** almost for free.

- `typ_has_typerr` + three choke points (`lookup_id`, `scan_`'s `IdDVal`,
  `commit_fun`) suppress a resolution whose operand/callee is already poisoned
  and propagate the `TypErr` to the result. They only fire on already-failed
  paths, so **a clean compile is unaffected — the `-pr-resolve` census is
  byte-identical** (the 7 under-constrained fallbacks unchanged).
- **DefVal**: the annotation `unify` moved inside the recovery `try`; every name
  the pattern binds (tuple/record/as, via `walk_pat`) is poisoned — with the
  declared type when annotated (firewall), `TypErr` otherwise.
- **DefFun**: a body failure keeps the declared signature; the return type is
  **recovered from the branches that DID typecheck** (an early `return 42` pins
  it), poisoned to `TypErr` only if nothing did.
- **check_cases / ExpIf**: per-arm / per-branch recovery — a poisoned arm/branch
  contributes no type, so the healthy siblings determine the result (the
  jumping-throw/ctrlflow-1 logic).
- Templates: body errors surface at instantiation and poison correctly;
  duplicates across N instantiations collapse in the dedup.

## Stage-honest caret precision

`loc_excerpt` draws the excerpt at **raise time** (inside `compile_err` /
`compile_warning`), because precision depends on the compilation stage, which
advances as the driver runs. Precision is governed by an explicit
`Ast.compiler_stage` (`Init|Frontend|Middle|Backend`), deliberately separate
from the implicit `freeze_ids`:

- **Frontend** = lexer + parser + typecheck **and K-normalization** — all
  consume the AST with exact locations, so even a non-exhaustive-match error
  (raised in K-normalization) gets a caret.
- **Middle** (K optimizations: inlining/fusion) and **Backend** (C generation)
  drop the caret: locations drift there and not all context reaches C-gen
  intact, so a confident caret would point at an innocent line.

One renderer serves errors and warnings. Legality checks were pulled the right
way across this line too: `break`/`continue` inside a `@parallel` loop is now a
**typecheck** diagnostic (exact caret, visible under `-no-c`, golden-able)
instead of a late C-gen error.

## Test-format change (reviewers: read the golden diff as a format change)

Every `test/negative/*.err` golden now carries the source line + caret. The T3
harness (`tools/fxtest/negative.py`) was made caret-aware: excerpt lines
(`  N | src` / `    | ^`) are compared verbatim (their spacing is the contract);
all other lines keep the whitespace-collapse. New directed goldens:
multi-error, cascade, firewall, match-arm recovery, `-fmax-errors` truncation,
did-you-mean, and the lifted `@parallel` check.

## Verification

- `test_all` 147; `fxtest all` (unit + negative 85 + ir + cfold + corpus O0/O3);
  `determinism` 3/3; `sanitize` clean.
- `-pr-resolve` census: **byte-identical resolution** — the extra sites are new
  diagnostic code only (recovery choke points fire solely on poisoned types).
- Bootstrap **fixpoint holds**. The `scope_t`/`ScLoop` layout change (for the
  `@parallel` lift) reorders many bootstrap modules — a compile-time-only type
  (like `options_t`); generated C for user programs is unchanged.

## Not in scope (follow-ups, noted in `docs/diag1_report.md`)

- `^~~~` column spans (most locs are single-point today).
- Actually SUPPORTING `break`/`continue` in `@parallel` loops (currently
  rejected); when that lands, relax the lifted check rather than reject.

Full write-up: `docs/diag1_report.md`.
