### PR TITLE
# reform-prep-1: parser spans + import/function diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,18 +24,18 @@ bin/ficus -o name file.fx                 # binary at ./name (rm it after),
   module; the file under test is the **last** section. Gensyms: `name@1234`.
 - `$CC`/`$CXX` pick the C compiler (default `cc`). macOS OpenMP is bundled at
   `runtime/lib/macos_arm64/libomp.a`.
-- Build dirs self-invalidate (`.fxstamp`: compiler identity + codegen options),
-  and fxtest wipes `build/fxtest` when `bin/ficus` changes — no manual `rm -rf`
-  between measurements is ever needed.
+- Build dirs self-invalidate (`.fxstamp`), and fxtest wipes `build/fxtest` on a
+  compiler change — no manual `rm -rf` between measurements is ever needed.
 
 **Bootstrap regen** — after editing any `compiler/*.fx` OR any of the 54
 bootstrap stdlib modules (`ls compiler/bootstrap/` when in doubt): run
-`python3 tools/update_compiler.py`. It regenerates `compiler/bootstrap/*.c`,
-copies only changed modules, and asserts the self-hosting **fixpoint**
-(non-zero exit = determinism regression). `--check` = CI dry run (runs on
-every push touching compiler/lib/runtime — a stale bootstrap is a red master).
-This is the only routine self-build of the compiler, so it also catches stdlib
-changes that break compiling the compiler; `fxtest all` cannot.
+`python3 tools/update_compiler.py`; it copies only changed modules and asserts
+the self-hosting **fixpoint** (non-zero exit = determinism regression).
+`--check` = dry run; CI runs it on every push touching compiler/lib/runtime —
+a stale bootstrap is a red master. This is the only routine self-build of the
+compiler, so it alone catches stdlib changes that break compiling the compiler.
+Compile-time-only record layout changes (`options_t`, `scope_t`) legitimately
+regenerate many bootstrap modules; generated C for *programs* must not change.
 
 ## Testing — the fxtest ladder (tools/fxtest/README.md)
 
@@ -50,23 +50,31 @@ Layers: T2 corpus differential (O0 vs O3), T3 golden diagnostics
 Harness is Python-3-stdlib-only. Compiler bugs found while on another task are
 recorded and fenced (not fixed) in `docs/found_bugs.md`.
 
-**Diagnostics (diag-1).** The type checker RECOVERS: one run reports many
-independent errors, not just the first. A failed definition/arm/branch is
-reported and its symbol is poisoned with `TypErr` (declared type when
-annotated — the annotation firewall); `typ_has_typerr` then suppresses
-cascades structurally (a `TypErr` operand makes the whole expression `TypErr`
-silently), so `val x = undef; x+1; f(x)` = ONE diagnostic. Reporting: sorted by
-`(module,line,col)`, exact-duplicate primary lines deduped (a generic-body
-error hit from N call sites → once), capped by `-fmax-errors=N` (default 100).
-A not-found name close (Levenshtein) to a visible one gets `did you mean 'x'?`.
-Frontend diagnostics (lexer/parser/typecheck **and K-normalization** — gated by
-`Ast.compiler_stage`, NOT `freeze_ids`) carry a gcc-style caret excerpt; middle/
-backend ones don't (locations drift). The excerpt is built at RAISE time in
-`compile_err`/`compile_warning`. So **every `test/negative/` golden now includes
-the source line + `^`**; the T3 harness compares excerpt lines (`N | src` /
-`  | ^`) verbatim (exact spacing) and collapses whitespace elsewhere — when
-adding a negative case, `--update-golden` captures the caret. New legality
-checks belong in typecheck (caret + `-no-c`-visible), not C-gen.
+**Diagnostics (diag-1).** The type checker recovers and reports MANY errors
+per run: a failed definition/arm/branch is reported, its symbol poisoned with
+`TypErr` (the declared type when annotated — the annotation firewall), and
+`TypErr` operands suppress cascades structurally (`val x = undef; x+1` = ONE
+diagnostic). Output: sorted by `(module,line,col)`, primary-line dedup,
+`-fmax-errors=N` cap (default 100), Levenshtein `did you mean 'x'?` for
+unknown names. Frontend diagnostics (lexer/parser/typecheck/K-normalization,
+gated by `Ast.compiler_stage`) carry a gcc-style caret excerpt; middle/backend
+ones don't (locations drift). **Every `test/negative/` golden includes the
+excerpt**; the T3 harness compares excerpt lines verbatim — use
+`--update-golden` when adding cases. New legality checks belong in typecheck
+(caret + `-no-c`-visible), not C-gen.
+
+**Spans (reform-prep-1).** `loc_t` is a true span now, not a point: the lexer
+returns each batch's `(begin, end)` and the parser stamps every token with it,
+so a caret shows the token width (`^~~~`) and `loclist2loc` folds real node
+spans. Diagnostics point at the NAME: a function's own errors at its name (not
+`fun`), an unknown import at the whole (dotted) module name (with a
+Levenshtein module `did you mean`, candidates globbed from the include path),
+parse errors now carry carets too. Helper `consumed_loc(before, after)` folds a
+node's span out to the end of a sub-parser that returns no loc. **Gotcha
+(FB-020): `typ_t` carries NO source location** — type-name diagnostics land on
+the preceding `:`, and a span-based migrator cannot locate type occurrences
+(`'t`, `half`, `vector`) via the AST. `docs/problematic_spans_log.txt` audits
+which reform constructs have usable spans.
 
 ## Writing Ficus (.fx) — gotchas
 
@@ -78,110 +86,88 @@ intuition — read `doc/ficustut.md` and existing code. Verified traps:
 - Casts parenthesize *with* the operand: `(x :> uint8)`, chained
   `((x :> uint32) :> int32)`. Simple types also work functionally: `uint32(x)`.
 - `println` takes ONE argument: `println(f"{a} {b}")` / `println((a, b))`.
-- f-string `{}` interpolation: write nested string literals UNESCAPED —
-  `f"{find("x")}"` works; the escaped `f"{find(\"x\")}"` fails with a
-  misleading "braces are not closed".
-- Record *type* fields use `;` (`{x: int; y: int}`); *construction* uses `,`
-  (`pt_t {x=1, y=2}`).
-- Small unsigned ints promote to `int` for arithmetic (`200u8 + 100u8 == 300`);
-  wrap explicitly: `((a + b) :> uint8)`. `uint64` wraps natively.
-- Integer `/` truncates toward zero; `%` takes the sign of the dividend
+- f-string `{}` interpolation: nested string literals go UNESCAPED —
+  `f"{find("x")}"` works; the escaped `\"` spelling fails misleadingly.
+- Record *type* fields use `;`; *construction* uses `,` (`pt_t {x=1, y=2}`).
+- Small unsigned ints promote to `int` (`200u8 + 100u8 == 300`); wrap
+  explicitly: `((a + b) :> uint8)`. `uint64` wraps natively.
+- `/` truncates toward zero; `%` takes the sign of the dividend
   (`-17 % 5 == -2`). `int(x)` truncates. `floor`/`ceil`/`trunc`/`round`
   return `int` **by design** (array forms: `int [+]`).
 - Border access: mode before the bracket — `a.clip[i]`, `a.wrap[i]`,
   `a.zero[i]` (arrays, Vector, strings).
 - Comprehensions: 1D `[for i <- 0:n {..}]`; 2D `[for i <- 0:m for j <- 0:n
-  {..}]`; zip is comma `for x <- a, y <- b`; index binding `for x@i <- a` /
-  `for x@(i,j) <- m`; fold `fold acc=init for x <- a {..}`. Lists:
-  `[:: 1, 2, 3]`, cons `::`, list-comp `[:: for x <- l {..}]`.
+  {..}]`; zip is comma; index binding `for x@i <- a` / `for x@(i,j) <- m`;
+  fold `fold acc=init for x <- a {..}`. Lists: `[:: 1, 2, 3]`, cons `::`,
+  list-comp `[:: for x <- l {..}]`.
 - Strings are UTF-32: `s.length()` counts chars, `s[i]` is a `char`,
   `s[i:j]` a substring; `string([for c <- cs {c}])` builds from chars.
-- Use `String.fx` / `Re.fx` instead of hand-rolling string processing
-  (`find/replace/split/join/strip/...`; `Re.compile` + `replace/findall/...`).
+- Use `String.fx` / `Re.fx` instead of hand-rolling string processing.
+  `String.fx` is Python-like string processing. `Re.fx` is regexp engine,
+  more limited than Perl or Python, but containing enough good stuff, see `test/test_re.fx`.
 - `array(n, init)` / `array((m, n), init)`; ranges `a:b`, `a:b:step`; slices
   `a[i:j]`, `a[::-1]`. `Sys.getenv(name, defval)`; `s.to_int(): int?`.
 - A `match` arm body may be a block: `| pat => val r = ...; expr`.
-- `break`/`continue`/`return` (with a value or bare) are legal in *expression*
-  position — as a `match`-arm or `if`-branch value (`| _ => continue`,
-  `if c {..} else {break}`, `| 0 => return v`) — exactly like `throw`
-  (ctrlflow-1/FB-015). A jumping arm/branch has pseudo-type `TypErr`, so it
-  unifies with any value-producing sibling; K-form/codegen unchanged (they
-  still lower to void jumps and route through the block cleanup chain, so
-  ref-counted locals live at the jump are freed). Legality is unchanged and
-  gives targeted messages: `break`/`continue` need an enclosing loop
-  (`cannot use 'break' outside of loop`); `break`/`continue` in `fold` or
-  `@parallel` bodies stay rejected in BOTH positions (no widening); a bare
-  `return` in a non-void function is a return-type mismatch, not a parse error.
-- Shift count must be `int`: write `x >> int(n)` for a non-int count.
+- `break`/`continue`/`return` (bare or with a value) are legal as a
+  `match`-arm / `if`-branch value, exactly like `throw` (pseudo-type `TypErr`
+  unifies with valued siblings; lowering unchanged, cleanup runs). Legality
+  is positional-agnostic: they need an enclosing loop; rejected inside `fold`
+  and `@parallel` bodies; bare `return` in a non-void function is a
+  return-type mismatch.
+- Shift count must be `int`: write `x >> int(n)`.
 - **Overload resolution: the least-generic viable candidate wins**, regardless
   of declaration/import order. No unique winner at a fully-determined call =
-  ambiguity error; disambiguate with a qualified call (`Module.__mul__(a, b)`;
-  `Module.(*)` does not parse yet). With free type vars in the argument
-  types, ties fall back to first-match — don't rely on that in new code.
-  Exact keywordless match beats a candidate viable only via defaulted
-  keyword args.
-- `[]` is typed "some collection" (list/vector/array): `val n: int = []` is a
-  typecheck error; if the kind is never pinned, K-normalization asks for an
-  annotation.
-- **Return annotations on generic operators/functions are viability filters,
-  not decoration**: a free (inferred) return type unifies with any expected
-  type and can steal under-constrained call sites. Annotate operators with a
-  FRESH var (`: 't3 complex`, `: 't3 [+]`, `: ('t3 ...)` — "returns SOME
-  such") to keep mixed-type widening while rejecting foreign contexts.
-  Enforced: `tools/lint_op_returns.py lib` (CI).
-- `-Wimplicit-rettype` warns on module-level functions with inferred returns
-  (nested/lambdas/@ccode/auto-generated exempt). Scope: all USER modules;
-  `=all` includes stdlib (self-gate: `tools/rettype_gate.sh`, CI; keep clean
-  when adding stdlib functions — scope excludes NN/Onnx/Protobuf/OpenCV).
-  `-Wall` = umbrella; `-Werror` promotes all warnings to a nonzero exit.
-  Return annotations erase in K-form (byte-identical generated C). The
-  compiler sources are not gated yet (annotate-3, ~340 functions).
-- Annotation spellings: nullary function type is `(void -> T)`, not
-  `(() -> T)`; a module's own type parses bare (`t`) or qualified (`Date.t`);
-  uniform tuple return `(int...)`; any-dims array `T [+]`; when the result
-  scalar type varies with input (widening via `*0.f`), a fresh `: 't3` is the
-  honest annotation (safe when the arguments are already pinned).
-- Comparing `-pr-resolve` censuses: normalize first — gate on the
-  (name | winner | outcome) multiset, not raw text (line:col shifts and
-  expected-type sharpening are noise).
+  ambiguity error; disambiguate with `Module.__mul__(a, b)` (`Module.(*)`
+  doesn't parse yet). Free type vars in the argument types → tie falls back
+  to first-match; don't rely on it. Exact keywordless match beats an
+  all-defaulted-keywords candidate.
+- `[]` is "some collection" (list/vector/array): `val n: int = []` is a
+  typecheck error; unpinned kind → K-normalization asks for an annotation.
+- **Return annotations are viability filters**: an inferred (free) return
+  unifies with any expected type and can steal under-constrained sites.
+  Generic operators annotate with a FRESH var (`: 't3 complex`, `: 't3 [+]`,
+  `: ('t3 ...)`); enforced by `tools/lint_op_returns.py lib` (CI).
+  `-Wimplicit-rettype` warns on module-level functions with inferred returns
+  (user modules by default; `=all` adds stdlib — self-gated by
+  `tools/rettype_gate.sh`, scope excludes NN/Onnx/Protobuf/OpenCV; keep it
+  clean). `-Wall` umbrella; `-Werror` promotes. Annotations erase in K-form.
+  Compiler sources not gated yet (annotate-3, ~340).
+- Annotation spellings: nullary fn type is `(void -> T)` not `(() -> T)`; a
+  module's own type parses bare or qualified; uniform tuple `(int...)`;
+  any-dims array `T [+]`; input-dependent widened scalar → fresh `: 't3`.
+- Comparing `-pr-resolve` censuses: gate on the (name | winner | outcome)
+  multiset, not raw text (line:col shifts and expected-type sharpening are
+  noise).
 
 ## Measurement traps
 
-- Signed overflow **wraps** (built with `-fwrapv`, folder matches). Don't rely
+- Signed overflow **wraps** (`-fwrapv` everywhere, folder matches). Don't rely
   on UB; don't drop the flag.
 - UB signature at -O2/-O3: a value *prints* right but a branch on it goes
-  wrong → the C compiler exploited UB (the predicate folded, the value
-  materialized). Repro in pure C; `-fwrapv`/`-fno-strict-*` to confirm.
-- ASan+UBSan: `-cflags "-fsanitize=address,undefined -fno-omit-frame-pointer"
-  -clibs "<same>"` (or `fxtest.py sanitize`). Note: over-reads into valid
-  adjacent heap may NOT trap — reference-checked suites are the complement.
+  wrong → the C compiler exploited UB. Repro in pure C; `-fwrapv`/
+  `-fno-strict-*` to confirm.
+- ASan+UBSan: `fxtest.py sanitize` (or the -cflags/-clibs sanitize combo).
+  Over-reads into valid adjacent heap may NOT trap — reference-checked suites
+  are the complement.
 - IR snapshot fails on CI only, `:ast` differs but `:k0`/`:k` match → suspect
-  the harness's header extraction (path-length wrap, FB-013), not the
-  compiler.
+  the harness's header extraction (path-length wrap), not the compiler.
 
 **Iterate tiny**: 10–20 lines → `bin/ficus -run f.fx` → fix → extend. Compiler
 errors are ground truth; if it rejects something the tutorial calls legal,
 minimal repro into `docs/found_bugs.md` and route around (don't fix
 `compiler/` unless asked).
 
-**Compiler code style — prefer functional over imperative.** Most of the
-compiler is accumulator recursion / immutable bindings / `match`, and that is
-the house style to match: historically more robust (fewer side effects → fewer
-state bugs, easier to reason about, safer under the atomic-refcount runtime).
-An imperative rewrite is not automatically an improvement — e.g. converting an
-accumulator recursion to a `for`-loop with `break`/`continue` is more
-imperative but *not* faster (often micro-slower: `break`/`continue` are checked
-in each block's cleanup section) and longer to write than `{}`. Reach for
-mutation/loops only where the functional form is genuinely awkward; when in
-doubt, mirror the surrounding module.
+**Compiler code style — functional over imperative.** The house style is
+accumulator recursion / immutable bindings / `match`: fewer side effects,
+safer under the atomic-refcount runtime. An imperative rewrite is not an
+improvement by default (`break`/`continue` are checked in each block's cleanup
+section — often micro-slower). Mirror the surrounding module.
 
 Test-file naming: a test `.fx` must not collide case-insensitively with a
-stdlib module (`char.fx` shadows `Char`); numeric prefixes (`001_name.fx`)
-are safe. Subdir modules import as `Dir.Module`; same-dir siblings by bare
-name.
+stdlib module (`char.fx` shadows `Char`); numeric prefixes are safe. Subdir
+modules import as `Dir.Module`; same-dir siblings by bare name.
 
 ## Environment notes
 
-- macOS python is 3.9 (no `tomllib` — the harness ships a fallback parser);
-  Linux is fresher.
+- macOS python is 3.9 (no `tomllib` — the harness ships a fallback parser).
 - macOS `sed` is BSD (no `\b`) — use `perl -pe` for word-boundary edits.

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -560,6 +560,29 @@ fun id2str_m(i: id_t): string =
 fun string(i: id_t): string = id2str_(i, false)
 fun pp(i: id_t): string = id2str_(i, true)
 
+// Levenshtein edit distance (two-row DP), shared by the "did you mean"
+// suggestions in the type checker (unknown identifiers) and the parser (unknown
+// imported modules). Only ever called on an error path, so cost is irrelevant.
+fun edit_distance(a: string, b: string): int {
+    val la = a.length(), lb = b.length()
+    if la == 0 { lb }
+    else if lb == 0 { la }
+    else {
+        val prev = array(lb+1, 0), curr = array(lb+1, 0)
+        for j <- 0:lb+1 { prev[j] = j }
+        for i <- 1:la+1 {
+            curr[0] = i
+            val ai = a[i-1]
+            for j <- 1:lb+1 {
+                val cost = if ai == b[j-1] { 0 } else { 1 }
+                curr[j] = min(min(prev[j]+1, curr[j-1]+1), prev[j-1]+cost)
+            }
+            for j <- 0:lb+1 { prev[j] = curr[j] }
+        }
+        prev[lb]
+    }
+}
+
 fun compile_err(loc: loc_t, msg: string) {
     // Build the source excerpt HERE, at raise time, not at print time: the
     // precision (caret vs none) depends on compiler_stage, which advances as

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -993,28 +993,6 @@ fun is_real_typ(t: typ_t) {
     !have_typ_vars
 }
 
-// diag-1: Levenshtein edit distance (two-row DP). Only ever called on the
-// error path (building a not-found diagnostic), so cost is irrelevant.
-fun edit_distance(a: string, b: string): int {
-    val la = a.length(), lb = b.length()
-    if la == 0 { lb }
-    else if lb == 0 { la }
-    else {
-        val prev = array(lb+1, 0), curr = array(lb+1, 0)
-        for j <- 0:lb+1 { prev[j] = j }
-        for i <- 1:la+1 {
-            curr[0] = i
-            val ai = a[i-1]
-            for j <- 1:lb+1 {
-                val cost = if ai == b[j-1] { 0 } else { 1 }
-                curr[j] = min(min(prev[j]+1, curr[j-1]+1), prev[j-1]+cost)
-            }
-            for j <- 0:lb+1 { prev[j] = curr[j] }
-        }
-        prev[lb]
-    }
-}
-
 // diag-1: up to two visible names closest to `n` within an edit-distance
 // threshold (scaled by length), as a "; did you mean 'x'?" tail -- gcc/clang
 // style. Empty when nothing is close. Skips the name itself and compiler

--- a/compiler/Compiler.fx
+++ b/compiler/Compiler.fx
@@ -217,7 +217,10 @@ fun parse_all(fname0: string, ficus_path: string list): bool
             | Lxu.LexerError((l, c), msg) =>
                 println(f"{mfname}:{l}:{c}: error: {msg}\n"); ok = false
             | Parser.ParseError(loc, msg) =>
-                println(f"{loc}: error: {msg}\n"); ok = false
+                // parse errors are frontend, so a caret excerpt is honest and
+                // helpful (esp. import not-found: the underline lands on the
+                // module name). reform-prep-1.
+                println(f"{loc}: error: {msg}{Ast.loc_excerpt(loc)}\n"); ok = false
             | e => println(f"{mfname}: exception {e} occured"); ok = false
             }
         }

--- a/compiler/Lexer.fx
+++ b/compiler/Lexer.fx
@@ -238,7 +238,7 @@ var ficus_keywords = Hashmap.from_list("", (FUN, 0),
         { STRING("") RPAREN } RPAREN
     where {} denotes groups that are returned together by nexttokens().
 */
-fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
+fun make_lexer(strm: stream_t): (void -> ((token_t, lloc_t) list, lloc_t, lloc_t))
 {
     var new_exp = true  // Ficus is the language with optional ';' separators between
                         // expressions in a block, tha's why we need to distinguish
@@ -340,7 +340,11 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
         }
     }
 
-    fun nexttokens(): (token_t, lloc_t) list
+    // Returns (tokens, batch_begin_loc, batch_end_loc). All tokens in one batch
+    // share the batch span; batches are single-token except a few synthetic
+    // expansions (numeric-suffix, string interpolation, ...), where one span
+    // over the whole literal is the right answer anyway.
+    fun nexttokens(): ((token_t, lloc_t) list, lloc_t, lloc_t)
     {
         val buf = strm.buf
         val len = buf.length()
@@ -374,6 +378,7 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
 
         val loc = getloc(pos)
 
+        val tokens =
         if '0' <= c <= '9' {
             val (p, (t, c)) = getnumber(buf, pos, loc, prev_dot, !prev_dot)
             match t {
@@ -584,7 +589,7 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                        i.e. '|' goes immediately after '{', it's represented
                        as 'BAR', not 'BITWISE_OR'
                     */
-                    (LBRACE, loc) :: (match nexttokens() {
+                    (LBRACE, loc) :: (match nexttokens().0 {
                     | (BITWISE_OR, p) :: rest =>
                         paren_stack = (BAR, p) :: paren_stack
                         (BAR, p) :: rest
@@ -639,7 +644,7 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                 else if c1 == '>' {pos += 1; [:: (ARROW, loc)]}
                 else if !prev_ne {[:: (MINUS(false), loc)]} else {
                     expect_neg_number = !expect_neg_number
-                    val ts = nexttokens()
+                    val ts = nexttokens().0
                     expect_neg_number = !expect_neg_number
                     match ts {
                     | (LITERAL(Ast.LitInt(x)), _) :: rest => (LITERAL(Ast.LitInt(-x)), loc) :: rest
@@ -728,7 +733,7 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                     if buf.zero[pos] != '}' {
                         throw Lxu.LexerError(getloc(pos), "'}' is expected after ':...' inside interpolated expression")
                     }
-                    nexttokens()
+                    nexttokens().0
                 | _ =>
                     if c1 == ':' {
                         pos += 1
@@ -806,6 +811,8 @@ fun make_lexer(strm: stream_t): (void -> (token_t, lloc_t) list)
                 throw Lxu.LexerError(loc, f"unrecognized character '{c}'")
             }
         }
+        val endloc = getloc(pos)
+        (tokens, loc, endloc)
     }
     nexttokens
 }

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -2498,13 +2498,17 @@ fun parse(m_idx: int, preamble: token_t list, inc_dirs: string list): bool
     var all_tokens: (Lexer.token_t, Ast.loc_t) list = []
     var prev_lineno = -1
     while true {
-        val more_tokens = lexer()
-        for (t, (lineno, col)) <- more_tokens {
-            val loc = Ast.loc_t {m_idx=dm.dm_idx, line0=lineno, col0=col, line1=lineno, col1=col}
+        // The lexer returns a batch of tokens plus the batch's begin/end point
+        // locs (reform-prep-1); every token in the batch gets that span, so an
+        // AST node built from a single token already carries a true span
+        // ({line0,col0}..{line1,col1}), not a point.
+        val (more_tokens, (bline, bcol), (eline, ecol)) = lexer()
+        val loc = Ast.loc_t {m_idx=dm.dm_idx, line0=bline, col0=bcol, line1=eline, col1=ecol}
+        for (t, _) <- more_tokens {
             if Options.opt.print_tokens {
-                if lineno != prev_lineno {
-                    print(f"\n{pp(fname_id)}:{lineno}: ")
-                    prev_lineno = lineno
+                if bline != prev_lineno {
+                    print(f"\n{pp(fname_id)}:{bline}: ")
+                    prev_lineno = bline
                 }
                 print(f"{Lexer.tok2str(t).0} ")
             }

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -24,6 +24,25 @@ type parser_ctx_t =
 
 var parser_ctx = parser_ctx_t { m_idx=-1, filename="", deps=[], inc_dirs=[], default_loc=noloc }
 
+// "did you mean" for a not-found imported module: the candidate hypotheses are
+// the *.fx files visible on the include path (each file name is a module name).
+// A misspelled stdlib import ('Strig' -> 'String') is a common error. The
+// alphabetical tie-break keeps the suggestion deterministic regardless of glob
+// order (golden stability). reform-prep-1.
+fun suggest_module(mname: string, inc_dirs: string list): string {
+    val tlen = mname.length()
+    val thresh = if tlen <= 4 { 1 } else { 2 }
+    val (best_d, best) =
+        fold (bd, b) = (thresh + 1, "") for d <- inc_dirs {
+            fold (bd, b) = (bd, b) for path <- Filename.glob(Filename.concat(d, "*.fx")) {
+                val nm = Filename.remove_extension(Filename.basename(path))
+                val dist = if nm == mname { bd + 1 } else { edit_distance(mname, nm) }
+                if dist < bd || (dist == bd && nm < b) { (dist, nm) } else { (bd, b) }
+            }
+        }
+    if tlen > 0 && best_d <= thresh && best != "" { f"; did you mean '{best}'?" } else { "" }
+}
+
 fun add_to_imported_modules(mname: id_t, loc: loc_t): int
 {
     val mfname = pp(mname)
@@ -38,7 +57,9 @@ fun add_to_imported_modules(mname: id_t, loc: loc_t): int
                 Filename.locate(Filename.concat(mfname, "init.fx"), parser_ctx.inc_dirs)
             }
             catch {
-            | NotFoundError => throw ParseError(loc, f"module {mname} is not found")
+            | NotFoundError =>
+                throw ParseError(loc, f"module {mname} is not found\
+                                       {suggest_module(pp(mname), parser_ctx.inc_dirs)}")
             }
         }
     var dirname = mfname

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -1257,8 +1257,12 @@ fun parse_defun(ts: tklist_t): (tklist_t, exp_t)
         | (INLINE, _) :: rest =>
             if is_inline {throw parse_err(ts, "duplicate @inline attribute")}
             is_inline = true; vts = rest
-        | (FUN, l1) :: (IDENT(_, i), _) :: _ =>
+        | (FUN, l1) :: (IDENT(_, i), name_l0) :: _ =>
             val (ts, f) = parse_dot_ident(vts.tl(), false, "")
+            // point a function's own diagnostics (redeclaration, implicit-return
+            // warning, ...) at its NAME, not the 'fun' keyword. The name may be
+            // dotted (Class.method), so span from its first token to its last.
+            val name_loc = loclist2loc([:: name_l0, consumed_loc(vts.tl(), ts)], name_l0)
             val dot_pos = f.rfind('.')
             val (class_id_, fname_) =
                 if dot_pos >= 0 {(get_id(f[:dot_pos]), get_id(f[dot_pos+1:]))}
@@ -1267,9 +1271,10 @@ fun parse_defun(ts: tklist_t): (tklist_t, exp_t)
                 | (LPAREN(_), _) :: rest => rest
                 | _ => throw parse_err(ts, "'(' is expected after function name")
                 }
-            class_id = class_id_; fname = fname_; loc = l1; break
+            class_id = class_id_; fname = fname_; loc = name_loc; break
         | (OPERATOR, l1) :: (t, l2) :: (LPAREN _, _) :: rest =>
-            vts = rest; fname = get_opname(t); loc = l1
+            // the operator symbol is the name: span 'operator X'.
+            vts = rest; fname = get_opname(t); loc = loclist2loc([:: l1, l2], l1)
             if fname == noid { throw ParseError(l2, "invalid operator name") }
             break
         | _ =>

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -860,13 +860,18 @@ fun parse_expseq(ts: tklist_t, toplevel: bool): (tklist_t, exp_t list)
                 | (IDENT(_, _), loc_i) :: _ =>
                     if expect_comma { (ts, result.rev()) }
                     else {
-                        val (ts, i) = parse_dot_ident(ts, false, "")
+                        val (ts1, i) = parse_dot_ident(ts, false, "")
+                        // span the WHOLE (possibly dotted) module name, not just
+                        // its first token: import errors -- misspelled or
+                        // off-path module -- are common and should underline the
+                        // full name. reform-prep-1.
+                        val name_loc = loclist2loc([:: loc_i, consumed_loc(ts, ts1)], loc_i)
                         val i = get_id(i)
-                        val (ts, j) = match ts {
+                        val (ts, j) = match ts1 {
                             | (AS, _) :: (IDENT(_, j), _) :: rest => (rest, get_id(j))
-                            | _ => (ts, i)
+                            | _ => (ts1, i)
                             }
-                        val i_ = add_to_imported_modules(i, loc_i)
+                        val i_ = add_to_imported_modules(i, name_loc)
                         parse_imported_(ts, true, (i_, j) :: result)
                     }
                 | _ =>
@@ -878,8 +883,11 @@ fun parse_expseq(ts: tklist_t, toplevel: bool): (tklist_t, exp_t list)
         | (FROM, l1) :: rest =>
             if !toplevel {throw parse_err(ts, "import directives can only be used at the module level")}
             val (ts, m_) = parse_dot_ident(rest, false, "")
+            // point a 'from <module> import ...' not-found error at the module
+            // name, not at the 'from' keyword (reform-prep-1).
+            val name_loc = match rest { | (_, l0) :: _ => loclist2loc([:: l0, consumed_loc(rest, ts)], l0) | _ => l1 }
             val m = get_id(m_)
-            val m_ = add_to_imported_modules(m, l1)
+            val m_ = add_to_imported_modules(m, name_loc)
             match ts {
             | (IMPORT _, _) :: (STAR _, _) :: rest =>
                 extend_expseq_(rest, DirImportFrom(m_, [], l1) :: result)

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -237,6 +237,15 @@ fun expseq2exp(eseq: exp_t list, loc: loc_t) =
         ExpSeq(eseq, (make_new_typ(), loc))
     }
 
+// loc of the last token consumed between `before` and `after` (a suffix of
+// `before`); noloc if nothing was consumed. Lets a node fold its span out to
+// the end of a sub-construct parsed by a helper that returns no loc of its own
+// (e.g. parse_typespec — types carry no source location). reform-prep-1.
+fun consumed_loc(before: tklist_t, after: tklist_t): loc_t {
+    val n = before.length() - after.length()
+    if n <= 0 { noloc } else { before.nth(n-1).1 }
+}
+
 fun match_paren((ts: tklist_t, e: exp_t), ct: token_t, ol: loc_t): (tklist_t, exp_t)
 {
     match ts {
@@ -1330,10 +1339,12 @@ fun parse_typed_exp(ts: tklist_t): (tklist_t, exp_t) {
     match ts {
     | (COLON, _) :: rest =>
         val (ts, t) = parse_typespec(rest)
-        (ts, ExpTyped(e, t, make_new_ctx(get_exp_loc(e))))
+        val loc = loclist2loc([:: get_exp_loc(e), consumed_loc(rest, ts)], get_exp_loc(e))
+        (ts, ExpTyped(e, t, make_new_ctx(loc)))
     | (CAST, _) :: rest =>
         val (ts, t) = parse_typespec(rest)
-        (ts, ExpCast(e, t, (make_new_typ(), get_exp_loc(e))))
+        val loc = loclist2loc([:: get_exp_loc(e), consumed_loc(rest, ts)], get_exp_loc(e))
+        (ts, ExpCast(e, t, (make_new_typ(), loc)))
     | _ => (ts, e)
     }
 }

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -8811,6 +8811,99 @@ _fx_cleanup: ;
    return fx_status;
 }
 
+FX_EXTERN_C int _fx_M3AstFM13edit_distancei2SS(fx_str_t* a_0, fx_str_t* b_0, int_* fx_result, void* fx_fv)
+{
+   fx_arr_t prev_0 = {0};
+   fx_arr_t curr_0 = {0};
+   int fx_status = 0;
+   int_ la_0 = FX_STR_LENGTH(*a_0);
+   int_ lb_0 = FX_STR_LENGTH(*b_0);
+   if (la_0 == 0) {
+      *fx_result = lb_0;
+   }
+   else if (lb_0 == 0) {
+      *fx_result = la_0;
+   }
+   else {
+      int_* dstptr_0 = 0;
+      int_ v_0 = lb_0 + 1;
+      {
+         const int_ shape_0[] = { v_0 };
+         FX_CALL(fx_make_arr(1, shape_0, sizeof(int_), 0, 0, 0, &prev_0), _fx_cleanup);
+      }
+      dstptr_0 = (int_*)prev_0.data;
+      for (int_ i_0 = 0; i_0 < v_0; i_0++, dstptr_0++) {
+         *dstptr_0 = 0;
+      }
+      int_* dstptr_1 = 0;
+      int_ v_1 = lb_0 + 1;
+      {
+         const int_ shape_1[] = { v_1 };
+         FX_CALL(fx_make_arr(1, shape_1, sizeof(int_), 0, 0, 0, &curr_0), _fx_cleanup);
+      }
+      dstptr_1 = (int_*)curr_0.data;
+      for (int_ i_1 = 0; i_1 < v_1; i_1++, dstptr_1++) {
+         *dstptr_1 = 0;
+      }
+      int_ v_2 = lb_0 + 1;
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_2, 1, 1, 0, _fx_cleanup);
+      int_* ptr_0 = FX_PTR_1D(int_, prev_0, 0);
+      for (int_ j_0 = 0; j_0 < v_2; j_0++) {
+         ptr_0[j_0] = j_0;
+      }
+      int_ v_3 = la_0 + 1;
+      int_ v_4 = lb_0 + 1;
+      int_ v_5 = lb_0 + 1;
+      FX_CHKIDX_RANGE(FX_STR_LENGTH(*a_0), 1, v_3, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_SCALAR(FX_ARR_SIZE(curr_0, 0), 0, _fx_cleanup);
+      int_ size_0 = FX_ARR_SIZE(curr_0, 0);
+      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, 0, _fx_cleanup);
+      int_ size_1 = FX_ARR_SIZE(prev_0, 0);
+      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, 0, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_STR_LENGTH(*b_0), 1, v_4, 1, 1, -1, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
+      FX_CHKIDX_RANGE(FX_ARR_SIZE(curr_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
+      int_* ptr_1 = FX_PTR_1D(int_, curr_0, 0);
+      int_* ptr_2 = FX_PTR_1D(int_, prev_0, 0);
+      int_ n_0 = FX_LOOP_COUNT(1, v_3, 1);
+      for (int_ i_2 = 0; i_2 < n_0; i_2++) {
+         int_ i_3 = 1 + i_2 * 1;
+         ptr_1[0] = i_3;
+         char_ ai_0 = FX_STR_ELEM(*a_0, i_3 + -1);
+         int_ n_1 = FX_LOOP_COUNT(1, v_4, 1);
+         for (int_ j_1 = 0; j_1 < n_1; j_1++) {
+            int_ j_2 = 1 + j_1 * 1;
+            int_ cost_0;
+            if (ai_0 == FX_STR_ELEM(*b_0, j_2 + -1)) {
+               cost_0 = 0;
+            }
+            else {
+               cost_0 = 1;
+            }
+            ptr_1[j_2] = fx_mini(fx_mini(ptr_2[j_2] + 1, ptr_1[j_2 + -1] + 1), ptr_2[j_2 + -1] + cost_0);
+
+         _fx_catch_0: ;
+            FX_CHECK_EXN(_fx_catch_1);
+         }
+         for (int_ j_3 = 0; j_3 < v_5; j_3++) {
+            ptr_2[j_3] = ptr_1[j_3];
+         }
+
+      _fx_catch_1: ;
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      FX_CHKIDX(FX_CHKIDX1(prev_0, 0, lb_0), _fx_cleanup);
+      *fx_result = *FX_PTR_1D(int_, prev_0, lb_0);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&prev_0);
+   FX_FREE_ARR(&curr_0);
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M3AstFM11compile_errE2RM5loc_tS(
    struct _fx_R10Ast__loc_t* loc_0,
    fx_str_t* msg_0,

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -6704,6 +6704,8 @@ static int _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry
 
 FX_EXTERN_C bool _fx_M6StringFM10startswithB2SS(fx_str_t*, fx_str_t*, void*);
 
+FX_EXTERN_C int _fx_M3AstFM13edit_distancei2SS(fx_str_t*, fx_str_t*, int_*, void*);
+
 FX_EXTERN_C int _fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M3AstFM14get_idinfo_typN10Ast__typ_t2N14Ast__id_info_tRM5loc_t(
@@ -17409,99 +17411,6 @@ FX_EXTERN_C int _fx_M13Ast_typecheckFM9make_fp2_FPN10Ast__typ_t2N10Ast__typ_tR16
    return 0;
 }
 
-FX_EXTERN_C int _fx_M13Ast_typecheckFM13edit_distancei2SS(fx_str_t* a_0, fx_str_t* b_0, int_* fx_result, void* fx_fv)
-{
-   fx_arr_t prev_0 = {0};
-   fx_arr_t curr_0 = {0};
-   int fx_status = 0;
-   int_ la_0 = FX_STR_LENGTH(*a_0);
-   int_ lb_0 = FX_STR_LENGTH(*b_0);
-   if (la_0 == 0) {
-      *fx_result = lb_0;
-   }
-   else if (lb_0 == 0) {
-      *fx_result = la_0;
-   }
-   else {
-      int_* dstptr_0 = 0;
-      int_ v_0 = lb_0 + 1;
-      {
-         const int_ shape_0[] = { v_0 };
-         FX_CALL(fx_make_arr(1, shape_0, sizeof(int_), 0, 0, 0, &prev_0), _fx_cleanup);
-      }
-      dstptr_0 = (int_*)prev_0.data;
-      for (int_ i_0 = 0; i_0 < v_0; i_0++, dstptr_0++) {
-         *dstptr_0 = 0;
-      }
-      int_* dstptr_1 = 0;
-      int_ v_1 = lb_0 + 1;
-      {
-         const int_ shape_1[] = { v_1 };
-         FX_CALL(fx_make_arr(1, shape_1, sizeof(int_), 0, 0, 0, &curr_0), _fx_cleanup);
-      }
-      dstptr_1 = (int_*)curr_0.data;
-      for (int_ i_1 = 0; i_1 < v_1; i_1++, dstptr_1++) {
-         *dstptr_1 = 0;
-      }
-      int_ v_2 = lb_0 + 1;
-      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_2, 1, 1, 0, _fx_cleanup);
-      int_* ptr_0 = FX_PTR_1D(int_, prev_0, 0);
-      for (int_ j_0 = 0; j_0 < v_2; j_0++) {
-         ptr_0[j_0] = j_0;
-      }
-      int_ v_3 = la_0 + 1;
-      int_ v_4 = lb_0 + 1;
-      int_ v_5 = lb_0 + 1;
-      FX_CHKIDX_RANGE(FX_STR_LENGTH(*a_0), 1, v_3, 1, 1, -1, _fx_cleanup);
-      FX_CHKIDX_SCALAR(FX_ARR_SIZE(curr_0, 0), 0, _fx_cleanup);
-      int_ size_0 = FX_ARR_SIZE(curr_0, 0);
-      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, 0, _fx_cleanup);
-      int_ size_1 = FX_ARR_SIZE(prev_0, 0);
-      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, -1, _fx_cleanup);
-      FX_CHKIDX_RANGE(size_0, 1, v_4, 1, 1, -1, _fx_cleanup);
-      FX_CHKIDX_RANGE(size_1, 1, v_4, 1, 1, 0, _fx_cleanup);
-      FX_CHKIDX_RANGE(FX_STR_LENGTH(*b_0), 1, v_4, 1, 1, -1, _fx_cleanup);
-      FX_CHKIDX_RANGE(FX_ARR_SIZE(prev_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
-      FX_CHKIDX_RANGE(FX_ARR_SIZE(curr_0, 0), 0, v_5, 1, 1, 0, _fx_cleanup);
-      int_* ptr_1 = FX_PTR_1D(int_, curr_0, 0);
-      int_* ptr_2 = FX_PTR_1D(int_, prev_0, 0);
-      int_ n_0 = FX_LOOP_COUNT(1, v_3, 1);
-      for (int_ i_2 = 0; i_2 < n_0; i_2++) {
-         int_ i_3 = 1 + i_2 * 1;
-         ptr_1[0] = i_3;
-         char_ ai_0 = FX_STR_ELEM(*a_0, i_3 + -1);
-         int_ n_1 = FX_LOOP_COUNT(1, v_4, 1);
-         for (int_ j_1 = 0; j_1 < n_1; j_1++) {
-            int_ j_2 = 1 + j_1 * 1;
-            int_ cost_0;
-            if (ai_0 == FX_STR_ELEM(*b_0, j_2 + -1)) {
-               cost_0 = 0;
-            }
-            else {
-               cost_0 = 1;
-            }
-            ptr_1[j_2] = fx_mini(fx_mini(ptr_2[j_2] + 1, ptr_1[j_2 + -1] + 1), ptr_2[j_2 + -1] + cost_0);
-
-         _fx_catch_0: ;
-            FX_CHECK_EXN(_fx_catch_1);
-         }
-         for (int_ j_3 = 0; j_3 < v_5; j_3++) {
-            ptr_2[j_3] = ptr_1[j_3];
-         }
-
-      _fx_catch_1: ;
-         FX_CHECK_EXN(_fx_cleanup);
-      }
-      FX_CHKIDX(FX_CHKIDX1(prev_0, 0, lb_0), _fx_cleanup);
-      *fx_result = *FX_PTR_1D(int_, prev_0, lb_0);
-   }
-
-_fx_cleanup: ;
-   FX_FREE_ARR(&prev_0);
-   FX_FREE_ARR(&curr_0);
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M13Ast_typecheckFM10__lambda__B2T2iST2iS(
    struct _fx_T2iS* arg0_0,
    struct _fx_T2iS* arg1_0,
@@ -17885,7 +17794,7 @@ static int _fx_M13Ast_typecheckFM10__lambda__LT2iS3R9Ast__id_tLN16Ast__env_entry
    }
    else {
       int_ d_0;
-      FX_CALL(_fx_M13Ast_typecheckFM13edit_distancei2SS(target_0, &nm_0, &d_0, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM13edit_distancei2SS(target_0, &nm_0, &d_0, 0), _fx_cleanup);
       if (d_0 <= cv_0->t1) {
          _fx_make_T2iS(d_0, &nm_0, &v_0); FX_CALL(_fx_cons_LT2iS(&v_0, acc_0, true, fx_result), _fx_cleanup);
       }

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -8440,6 +8440,8 @@ FX_EXTERN_C_VAL(int _FX_EXN_E22LexerUtils__LexerError)
 FX_EXTERN_C_VAL(int _FX_EXN_E18Parser__ParseError)
 FX_EXTERN_C int _fx_M3AstFM6stringS1RM5loc_t(struct _fx_R10Ast__loc_t*, fx_str_t*, void*);
 
+FX_EXTERN_C int _fx_M3AstFM11loc_excerptS1RM5loc_t(struct _fx_R10Ast__loc_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int _fx_F6stringS1E(fx_exn_t*, fx_str_t*, void*);
 
 static int _fx_M8CompilerFM3dfsv5iLiA1LiA1BrLi(
@@ -10280,42 +10282,46 @@ FX_EXTERN_C int _fx_M8CompilerFM9parse_allB2SLS(
             else if (tag_0 == _FX_EXN_E18Parser__ParseError) {
                fx_str_t v_19 = {0};
                fx_str_t v_20 = {0};
+               fx_str_t v_21 = {0};
                _fx_T2R10Ast__loc_tS* vcase_1 = &FX_EXN_DATA(_fx_E18Parser__ParseError_data_t, exn_0.data);
-               FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(&vcase_1->t0, &v_19, 0), _fx_catch_11);
+               _fx_R10Ast__loc_t* loc_0 = &vcase_1->t0;
+               FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_19, 0), _fx_catch_11);
+               FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_20, 0), _fx_catch_11);
                fx_str_t slit_5 = FX_MAKE_STR(": error: ");
                fx_str_t* msg_1 = &vcase_1->t1;
                fx_str_t slit_6 = FX_MAKE_STR("\n");
                {
-                  const fx_str_t strs_1[] = { v_19, slit_5, *msg_1, slit_6 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 4, &v_20), _fx_catch_11);
+                  const fx_str_t strs_1[] = { v_19, slit_5, *msg_1, v_20, slit_6 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 5, &v_21), _fx_catch_11);
                }
-               _fx_F12print_stringv1S(&v_20, 0);
+               _fx_F12print_stringv1S(&v_21, 0);
                fx_str_t slit_7 = FX_MAKE_STR("\n");
                _fx_F12print_stringv1S(&slit_7, 0);
                ok_0 = false;
 
             _fx_catch_11: ;
+               FX_FREE_STR(&v_21);
                FX_FREE_STR(&v_20);
                FX_FREE_STR(&v_19);
             }
             else {
-               fx_str_t v_21 = {0};
                fx_str_t v_22 = {0};
-               FX_CALL(_fx_F6stringS1E(&exn_0, &v_21, 0), _fx_catch_12);
+               fx_str_t v_23 = {0};
+               FX_CALL(_fx_F6stringS1E(&exn_0, &v_22, 0), _fx_catch_12);
                fx_str_t slit_8 = FX_MAKE_STR(": exception ");
                fx_str_t slit_9 = FX_MAKE_STR(" occured");
                {
-                  const fx_str_t strs_2[] = { mfname_0, slit_8, v_21, slit_9 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 4, &v_22), _fx_catch_12);
+                  const fx_str_t strs_2[] = { mfname_0, slit_8, v_22, slit_9 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_2, 4, &v_23), _fx_catch_12);
                }
-               _fx_F12print_stringv1S(&v_22, 0);
+               _fx_F12print_stringv1S(&v_23, 0);
                fx_str_t slit_10 = FX_MAKE_STR("\n");
                _fx_F12print_stringv1S(&slit_10, 0);
                ok_0 = false;
 
             _fx_catch_12: ;
+               FX_FREE_STR(&v_23);
                FX_FREE_STR(&v_22);
-               FX_FREE_STR(&v_21);
             }
             FX_CHECK_EXN(_fx_catch_13);
          }

--- a/compiler/bootstrap/Filename.c
+++ b/compiler/bootstrap/Filename.c
@@ -31,10 +31,20 @@ typedef struct _fx_Nt6option1S {
    } u;
 } _fx_Nt6option1S;
 
+typedef struct _fx_FPB2SS {
+   int (*fp)(fx_str_t*, fx_str_t*, bool*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPB2SS;
+
 typedef struct _fx_Ta2S {
    fx_str_t t0;
    fx_str_t t1;
 } _fx_Ta2S;
+
+typedef struct _fx_T2A1SB {
+   fx_arr_t t0;
+   bool t1;
+} _fx_T2A1SB;
 
 typedef struct {
    int_ rc;
@@ -96,7 +106,28 @@ static void _fx_make_Ta2S(fx_str_t* t0, fx_str_t* t1, struct _fx_Ta2S* fx_result
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2A1SB(struct _fx_T2A1SB* dst)
+{
+   fx_free_arr(&dst->t0);
+}
+
+static void _fx_copy_T2A1SB(struct _fx_T2A1SB* src, struct _fx_T2A1SB* dst)
+{
+   fx_copy_arr(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
+}
+
+static void _fx_make_T2A1SB(fx_arr_t* t0, bool t1, struct _fx_T2A1SB* fx_result)
+{
+   fx_copy_arr(t0, &fx_result->t0);
+   fx_result->t1 = t1;
+}
+
 _fx_Nt6option1S _fx_g14Filename__None = { 1 };
+FX_EXTERN_C int_ _fx_F7__cmp__i2SS(fx_str_t*, fx_str_t*, void*);
+
+static int _fx_M8FilenameFM6qsort_v5iiA1SFPB2SSi(int_, int_, fx_arr_t*, struct _fx_FPB2SS*, int_, void*);
+
 FX_EXTERN_C int _fx_F6assertv1B(bool, void*);
 
 FX_EXTERN_C bool _fx_M6StringFM8endswithB2SS(fx_str_t*, fx_str_t*, void*);
@@ -113,6 +144,240 @@ FX_EXTERN_C void _fx_M8FilenameFM4SomeNt6option1S1S(fx_str_t* arg0, struct _fx_N
 {
    fx_result->tag = 2;
    fx_copy_str(arg0, &fx_result->u.Some);
+}
+
+FX_EXTERN_C int _fx_M8FilenameFM6__lt__B2SS(fx_str_t* a_0, fx_str_t* b_0, bool* fx_result, void* fx_fv)
+{
+   int fx_status = 0;
+   int_ v_0 = _fx_F7__cmp__i2SS(a_0, b_0, 0);
+   *fx_result = v_0 < 0;
+   return fx_status;
+}
+
+FX_EXTERN_C void _fx_M8FilenameFM6_swap_v3A1Sii(fx_arr_t* arr, int_ i, int_ j, void* fx_fv)
+{
+   
+size_t esz = arr->dim[0].step;
+    if(esz % sizeof(int) == 0) {
+        int* ptr0 = (int*)(arr->data + i*esz);
+        int* ptr1 = (int*)(arr->data + j*esz);
+        esz /= sizeof(int);
+        for( size_t k = 0; k < esz; k++ ) {
+            int t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    } else {
+        char* ptr0 = arr->data + i*esz;
+        char* ptr1 = arr->data + j*esz;
+        for( size_t k = 0; k < esz; k++ ) {
+            char t0 = ptr0[k], t1 = ptr1[k];
+            ptr0[k] = t1; ptr1[k] = t0;
+        }
+    }
+
+}
+
+FX_EXTERN_C int _fx_M8FilenameFM4sortv3A1SFPB2SSi(fx_arr_t* arr_0, struct _fx_FPB2SS* lt_0, int_ prefix_0, void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(_fx_M8FilenameFM6qsort_v5iiA1SFPB2SSi(0, FX_ARR_SIZE(*arr_0, 0) - 1, arr_0, lt_0, prefix_0, 0), _fx_cleanup);
+
+_fx_cleanup: ;
+   return fx_status;
+}
+
+static int _fx_M8FilenameFM6qsort_v5iiA1SFPB2SSi(
+   int_ lo_0,
+   int_ hi_0,
+   fx_arr_t* arr_0,
+   struct _fx_FPB2SS* lt_0,
+   int_ prefix_0,
+   void* fx_fv)
+{
+   int fx_status = 0;
+   FX_CALL(fx_check_stack(), _fx_cleanup);
+   int_ lo_1 = lo_0;
+   int_ hi_1 = hi_0;
+   for (;;) {
+      fx_str_t a_0 = {0};
+      fx_str_t b_0 = {0};
+      fx_str_t p_0 = {0};
+      fx_str_t p_1 = {0};
+      fx_str_t a_1 = {0};
+      fx_str_t a_2 = {0};
+      fx_str_t b_1 = {0};
+      int_ lo_2 = lo_1;
+      int_ hi_2 = hi_1;
+      if (lo_2 + 1 < hi_2) {
+         int_ m_0 = (lo_2 + hi_2) / 2;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, lo_2), &a_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, m_0), &b_0);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, hi_2), &p_0);
+         bool v_0;
+         FX_CALL(lt_0->fp(&a_0, &b_0, &v_0, lt_0->fcv), _fx_catch_2);
+         if (v_0) {
+            bool v_1;
+            FX_CALL(lt_0->fp(&b_0, &p_0, &v_1, lt_0->fcv), _fx_catch_2);
+            if (v_1) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+               fx_str_t* v_2 = FX_PTR_1D(fx_str_t, *arr_0, m_0);
+               FX_FREE_STR(v_2);
+               fx_copy_str(&p_0, v_2);
+               fx_copy_str(&b_0, &p_1);
+            }
+            else {
+               bool v_3;
+               FX_CALL(lt_0->fp(&a_0, &p_0, &v_3, lt_0->fcv), _fx_catch_2);
+               if (v_3) {
+                  fx_copy_str(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+                  fx_str_t* v_4 = FX_PTR_1D(fx_str_t, *arr_0, lo_2);
+                  FX_FREE_STR(v_4);
+                  fx_copy_str(&p_0, v_4);
+                  fx_copy_str(&a_0, &p_1);
+               }
+            }
+         }
+         else {
+            bool v_5;
+            FX_CALL(lt_0->fp(&a_0, &p_0, &v_5, lt_0->fcv), _fx_catch_2);
+            if (v_5) {
+               FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+               fx_str_t* v_6 = FX_PTR_1D(fx_str_t, *arr_0, lo_2);
+               FX_FREE_STR(v_6);
+               fx_copy_str(&p_0, v_6);
+               fx_copy_str(&a_0, &p_1);
+            }
+            else {
+               bool v_7;
+               FX_CALL(lt_0->fp(&b_0, &p_0, &v_7, lt_0->fcv), _fx_catch_2);
+               if (v_7) {
+                  fx_copy_str(&p_0, &p_1);
+               }
+               else {
+                  FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, m_0), _fx_catch_2);
+                  fx_str_t* v_8 = FX_PTR_1D(fx_str_t, *arr_0, m_0);
+                  FX_FREE_STR(v_8);
+                  fx_copy_str(&p_0, v_8);
+                  fx_copy_str(&b_0, &p_1);
+               }
+            }
+         }
+         int_ __fold_result___0 = lo_2;
+         int_ n_0 = FX_LOOP_COUNT(lo_2, hi_2, 1);
+         for (int_ j_0 = 0; j_0 < n_0; j_0++) {
+            fx_str_t v_9 = {0};
+            int_ j_1 = lo_2 + j_0 * 1;
+            int_ i0_0 = __fold_result___0;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, j_1), _fx_catch_0);
+            fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, j_1), &v_9);
+            bool v_10;
+            FX_CALL(lt_0->fp(&v_9, &p_1, &v_10, lt_0->fcv), _fx_catch_0);
+            int_ v_11;
+            if (v_10) {
+               _fx_M8FilenameFM6_swap_v3A1Sii(arr_0, i0_0, j_1, 0); v_11 = i0_0 + 1;
+            }
+            else {
+               v_11 = i0_0;
+            }
+            __fold_result___0 = v_11;
+
+         _fx_catch_0: ;
+            FX_FREE_STR(&v_9);
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         int_ i0_1 = __fold_result___0;
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, i0_1), &a_1);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_str_t* v_12 = FX_PTR_1D(fx_str_t, *arr_0, hi_2);
+         FX_FREE_STR(v_12);
+         fx_copy_str(&a_1, v_12);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, i0_1), _fx_catch_2);
+         fx_str_t* v_13 = FX_PTR_1D(fx_str_t, *arr_0, i0_1);
+         FX_FREE_STR(v_13);
+         fx_copy_str(&p_1, v_13);
+         int_ i1_0 = hi_2;
+         int_ n_1 = FX_LOOP_COUNT(i0_1, hi_2, 1);
+         for (int_ j_2 = 0; j_2 < n_1; j_2++) {
+            fx_str_t v_14 = {0};
+            int_ j_3 = i0_1 + j_2 * 1;
+            int_ v_15 = j_3 + 1;
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, v_15), _fx_catch_1);
+            fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, v_15), &v_14);
+            bool v_16;
+            FX_CALL(lt_0->fp(&p_1, &v_14, &v_16, lt_0->fcv), _fx_catch_1);
+            if (v_16) {
+               i1_0 = j_3; FX_BREAK(_fx_catch_1);
+            }
+
+         _fx_catch_1: ;
+            FX_FREE_STR(&v_14);
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_2);
+         }
+         if (i0_1 - lo_2 < hi_2 - i1_0) {
+            if (i1_0 < prefix_0) {
+               FX_CALL(_fx_M8FilenameFM6qsort_v5iiA1SFPB2SSi(i1_0 + 1, hi_2, arr_0, lt_0, prefix_0, 0), _fx_catch_2);
+            }
+            lo_1 = lo_2;
+            hi_1 = i0_1 - 1;
+         }
+         else {
+            FX_CALL(_fx_M8FilenameFM6qsort_v5iiA1SFPB2SSi(lo_2, i0_1 - 1, arr_0, lt_0, prefix_0, 0), _fx_catch_2);
+            if (i1_0 < prefix_0) {
+               lo_1 = i1_0 + 1; hi_1 = hi_2;
+            }
+            else {
+               FX_BREAK(_fx_catch_2);
+            }
+         }
+      }
+      else if (lo_2 < hi_2) {
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, lo_2), &a_2);
+         FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+         fx_copy_str(FX_PTR_1D(fx_str_t, *arr_0, hi_2), &b_1);
+         bool v_17;
+         FX_CALL(lt_0->fp(&b_1, &a_2, &v_17, lt_0->fcv), _fx_catch_2);
+         if (v_17) {
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, hi_2), _fx_catch_2);
+            fx_str_t* v_18 = FX_PTR_1D(fx_str_t, *arr_0, hi_2);
+            FX_FREE_STR(v_18);
+            fx_copy_str(&a_2, v_18);
+            FX_CHKIDX(FX_CHKIDX1(*arr_0, 0, lo_2), _fx_catch_2);
+            fx_str_t* v_19 = FX_PTR_1D(fx_str_t, *arr_0, lo_2);
+            FX_FREE_STR(v_19);
+            fx_copy_str(&b_1, v_19);
+            FX_BREAK(_fx_catch_2);
+         }
+         else {
+            FX_BREAK(_fx_catch_2);
+         }
+      }
+      else {
+         FX_BREAK(_fx_catch_2);
+      }
+
+   _fx_catch_2: ;
+      FX_FREE_STR(&b_1);
+      FX_FREE_STR(&a_2);
+      FX_FREE_STR(&a_1);
+      FX_FREE_STR(&p_1);
+      FX_FREE_STR(&p_0);
+      FX_FREE_STR(&b_0);
+      FX_FREE_STR(&a_0);
+      FX_CHECK_BREAK();
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   return fx_status;
 }
 
 FX_EXTERN_C int _fx_M8FilenameFM7dir_sepS0(fx_str_t* fx_result, void* fx_fv)
@@ -606,6 +871,106 @@ _fx_cleanup: ;
    FX_FREE_STR(&v_0);
    FX_FREE_STR(&sep_0);
    FX_FREE_STR(&v_1);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M8FilenameFM5glob_T2A1SB2SA1S(
+   fx_str_t* pattern,
+   fx_arr_t* strarr,
+   struct _fx_T2A1SB* fx_result,
+   void* fx_fv)
+{
+   
+fx_cstr_t cpattern;
+        int fx_status = fx_str2cstr(pattern, &cpattern, 0, 0);
+        if (fx_status < 0) return fx_status;
+#if defined _WIN32 || defined WINCE
+        fx_result->t1 = false;
+        int_ i, capacity = 0, nentries = 0;
+        fx_str_t* buf = 0, *newbuf = 0;
+        struct _finddata_t fd;
+        intptr_t h = _findfirst(cpattern.data, &fd);
+        fx_free_cstr(&cpattern);
+        if (h == -1L) {
+            if (errno == ENOENT)
+                return FX_OK;
+            FX_FAST_THROW_RET(FX_EXN_IOError);
+        }
+        for(;;) {
+            if (nentries >= capacity) {
+                capacity *= 2;
+                if (capacity < 256) capacity = 256;
+                newbuf = (fx_str_t*)fx_realloc(buf, capacity*sizeof(buf[0]));
+                if (!newbuf) {
+                    FX_SET_EXN_FAST(FX_EXN_OutOfMemError);
+                    break;
+                }
+                buf = newbuf;
+            }
+            fx_status = fx_cstr2str(fd.name, -1, buf + nentries);
+            if (fx_status < 0) break;
+            nentries++;
+            if (_findnext(h, &fd) != 0)
+                break;
+        }
+        _findclose(h);
+        if (fx_status >= 0) {
+            fx_status = fx_make_arr(1, &nentries, sizeof(fx_str_t), strarr->free_elem, strarr->copy_elem, 0, &fx_result->t0);
+            if (fx_status >= 0) {
+                memcpy(fx_result->t0.data, buf, nentries*sizeof(buf[0]));
+                nentries = 0;
+            }
+        }
+        for (i = 0; i < nentries; i++)
+            fx_free_str(buf + i);
+        fx_free(buf);
+#else
+        fx_result->t1 = true;
+        glob_t globbuf;
+        globbuf.gl_offs = 0;
+        int glob_err = glob(cpattern.data, GLOB_TILDE, NULL, &globbuf);
+        int_ nentries = (int_)globbuf.gl_pathc;
+        fx_free_cstr(&cpattern);
+        if (glob_err != 0) {
+            if (glob_err == GLOB_NOMATCH)
+                return FX_OK;
+            FX_FAST_THROW_RET(FX_EXN_IOError);
+        }
+        fx_status = fx_make_arr(1, &nentries, sizeof(fx_str_t), strarr->free_elem, strarr->copy_elem, 0, &fx_result->t0);
+        if (fx_status >= 0) {
+            fx_str_t* data = (fx_str_t*)(fx_result->t0.data);
+            for(int_ i = 0; i < nentries && fx_status >= 0; i++, data++) {
+                fx_status = fx_cstr2str(globbuf.gl_pathv[i], -1, data);
+            }
+        }
+        globfree(&globbuf);
+#endif
+        return fx_status;
+
+}
+
+FX_EXTERN_C int _fx_M8FilenameFM4globA1S1S(fx_str_t* pattern_0, fx_arr_t* fx_result, void* fx_fv)
+{
+   fx_arr_t z_0 = {0};
+   _fx_T2A1SB v_0 = {0};
+   fx_arr_t files_0 = {0};
+   _fx_FPB2SS __lt___0 = {0};
+   int fx_status = 0;
+   FX_CALL(_fx_M8FilenameFM5glob_T2A1SB2SA1S(pattern_0, &z_0, &v_0, 0), _fx_cleanup);
+   fx_copy_arr(&v_0.t0, &files_0);
+   bool sorted_0 = v_0.t1;
+   if (!sorted_0) {
+      _fx_FPB2SS __lt___fp_0 = { _fx_M8FilenameFM6__lt__B2SS, 0 };
+      FX_COPY_FP(&__lt___fp_0, &__lt___0);
+      FX_CALL(_fx_M8FilenameFM4sortv3A1SFPB2SSi(&files_0, &__lt___0, FX_ARR_SIZE(files_0, 0), 0), _fx_cleanup);
+   }
+   fx_copy_arr(&files_0, fx_result);
+
+_fx_cleanup: ;
+   FX_FREE_ARR(&z_0);
+   _fx_free_T2A1SB(&v_0);
+   FX_FREE_ARR(&files_0);
+   FX_FREE_FP(&__lt___0);
    return fx_status;
 }
 

--- a/compiler/bootstrap/Lexer.c
+++ b/compiler/bootstrap/Lexer.c
@@ -256,10 +256,16 @@ typedef struct _fx_T2iT2N14Lexer__token_tC {
    struct _fx_T2N14Lexer__token_tC t1;
 } _fx_T2iT2N14Lexer__token_tC;
 
-typedef struct _fx_FPLT2N14Lexer__token_tTa2i0 {
-   int (*fp)(struct _fx_LT2N14Lexer__token_tTa2i_data_t**, void*);
+typedef struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i {
+   struct _fx_LT2N14Lexer__token_tTa2i_data_t* t0;
+   struct _fx_Ta2i t1;
+   struct _fx_Ta2i t2;
+} _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i;
+
+typedef struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0 {
+   int (*fp)(struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i*, void*);
    fx_fcv_t* fcv;
-} _fx_FPLT2N14Lexer__token_tTa2i0;
+} _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0;
 
 typedef struct _fx_rLT2N14Lexer__token_tTa2i_data_t {
    int_ rc;
@@ -747,6 +753,31 @@ static void _fx_make_T2iT2N14Lexer__token_tC(
    _fx_copy_T2N14Lexer__token_tC(t1, &fx_result->t1);
 }
 
+static void _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* dst)
+{
+   _fx_free_LT2N14Lexer__token_tTa2i(&dst->t0);
+}
+
+static void _fx_copy_T3LT2N14Lexer__token_tTa2iTa2iTa2i(
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* src,
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* dst)
+{
+   FX_COPY_PTR(src->t0, &dst->t0);
+   dst->t1 = src->t1;
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3LT2N14Lexer__token_tTa2iTa2iTa2i(
+   struct _fx_LT2N14Lexer__token_tTa2i_data_t* t0,
+   struct _fx_Ta2i* t1,
+   struct _fx_Ta2i* t2,
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* fx_result)
+{
+   FX_COPY_PTR(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
+   fx_result->t2 = *t2;
+}
+
 static void _fx_free_rLT2N14Lexer__token_tTa2i(struct _fx_rLT2N14Lexer__token_tTa2i_data_t** dst)
 {
    FX_FREE_REF_IMPL(_fx_rLT2N14Lexer__token_tTa2i, _fx_free_LT2N14Lexer__token_tTa2i);
@@ -952,7 +983,7 @@ FX_EXTERN_C void _fx_M3AstFM7LitBoolN10Ast__lit_t1B(bool, struct _fx_N10Ast__lit
 FX_EXTERN_C void _fx_M3AstFM7LitCharN10Ast__lit_t1C(char_, struct _fx_N10Ast__lit_t*);
 
 FX_EXTERN_C int
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+   _fx_M5LexerFM7make_fpFPT3LT2N14Lexer__token_tTa2iTa2iTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
    struct _fx_rTa2i_data_t*,
    struct _fx_ri_data_t*,
    struct _fx_rB_data_t*,
@@ -962,7 +993,7 @@ FX_EXTERN_C int
    struct _fx_ri_data_t*,
    struct _fx_rB_data_t*,
    struct _fx_N20LexerUtils__stream_t_data_t*,
-   struct _fx_FPLT2N14Lexer__token_tTa2i0*);
+   struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0*);
 
 FX_EXTERN_C int _fx_F6stringS1i(int_, fx_str_t*, void*);
 
@@ -985,7 +1016,7 @@ FX_EXTERN_C int _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(
 
 FX_EXTERN_C int _fx_M6StringFM4copyS1S(fx_str_t*, fx_str_t*, void*);
 
-static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(struct _fx_LT2N14Lexer__token_tTa2i_data_t**, void*);
+static int _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i*, void*);
 
 FX_EXTERN_C bool _fx_M4CharFM7isspaceB1C(char_, void*);
 
@@ -1013,10 +1044,10 @@ typedef struct {
    struct _fx_ri_data_t* t6;
    struct _fx_rB_data_t* t7;
    struct _fx_N20LexerUtils__stream_t_data_t* t8;
-} _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t;
+} _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0_cldata_t;
 
-FX_EXTERN_C void _fx_free_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
-   _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t* dst)
+FX_EXTERN_C void _fx_free_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(
+   _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0_cldata_t* dst)
 {
    FX_FREE_REF_SIMPLE(&dst->t0);
    FX_FREE_REF_SIMPLE(&dst->t1);
@@ -3343,9 +3374,9 @@ FX_EXTERN_C int _fx_M5LexerFM10fmt2tokensLT2N14Lexer__token_tTa2i2Nt6option1R8fo
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUtils__stream_t(
+FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPT3LT2N14Lexer__token_tTa2iTa2iTa2i01N20LexerUtils__stream_t(
    struct _fx_N20LexerUtils__stream_t_data_t* strm_0,
-   struct _fx_FPLT2N14Lexer__token_tTa2i0* fx_result,
+   struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0* fx_result,
    void* fx_fv)
 {
    _fx_rB new_exp_ref_0 = 0;
@@ -3366,7 +3397,7 @@ FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUti
    FX_CALL(_fx_make_rTa2i(&backquote_loc_arg_0, &backquote_loc_ref_0), _fx_cleanup);
    FX_CALL(_fx_make_rNt6option1R8format_t(&_fx_g13Lexer__None1_, &fmt_ref_0), _fx_cleanup);
    FX_CALL(_fx_make_rB(false, &expect_neg_number_ref_0), _fx_cleanup);
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+   _fx_M5LexerFM7make_fpFPT3LT2N14Lexer__token_tTa2iTa2iTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
       backquote_loc_ref_0, backquote_pos_ref_0, expect_neg_number_ref_0, fmt_ref_0, new_exp_ref_0, paren_stack_ref_0, pos_ref_0,
       prev_dot_ref_0, strm_0, fx_result);
 
@@ -3543,2972 +3574,2325 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-static int _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(
-   struct _fx_LT2N14Lexer__token_tTa2i_data_t** fx_result,
+static int _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* fx_result,
    void* fx_fv)
 {
-   _fx_LT2N14Lexer__token_tTa2i result_0 = 0;
+   fx_str_t buf_0 = {0};
+   _fx_LT2N14Lexer__token_tTa2i paren_stack_0 = 0;
+   _fx_LT2N14Lexer__token_tTa2i tokens_0 = 0;
+   _fx_T2iT2N14Lexer__token_tC v_0 = {0};
+   _fx_N14Lexer__token_t t_0 = {0};
+   _fx_N14Lexer__token_t v_1 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_2 = {0};
+   _fx_N14Lexer__token_t v_3 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_4 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_5 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_6 = {0};
+   _fx_LT2N14Lexer__token_tTa2i v_7 = 0;
+   _fx_N10Ast__lit_t zero_0 = {0};
+   _fx_N14Lexer__token_t v_8 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_9 = {0};
+   _fx_N14Lexer__token_t v_10 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_11 = {0};
+   _fx_N14Lexer__token_t v_12 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_13 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_14 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_15 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_16 = {0};
+   _fx_LT2N14Lexer__token_tTa2i v_17 = 0;
+   _fx_T2N14Lexer__token_tTa2i v_18 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_19 = {0};
+   fx_str_t v_20 = {0};
+   fx_str_t tyvar_0 = {0};
+   _fx_N14Lexer__token_t v_21 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_22 = {0};
+   _fx_T4iSiB v_23 = {0};
+   fx_str_t res_0 = {0};
+   fx_exn_t v_24 = {0};
+   _fx_N10Ast__lit_t v_25 = {0};
+   _fx_N14Lexer__token_t v_26 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_27 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_28 = {0};
+   _fx_LT2N14Lexer__token_tTa2i v_29 = 0;
+   _fx_LN14Lexer__token_t v_30 = 0;
+   _fx_N14Lexer__token_t v_31 = {0};
+   _fx_N14Lexer__token_t v_32 = {0};
+   _fx_N10Ast__lit_t v_33 = {0};
+   _fx_N14Lexer__token_t v_34 = {0};
+   _fx_N14Lexer__token_t v_35 = {0};
+   _fx_LN14Lexer__token_t v_36 = 0;
+   _fx_N14Lexer__token_t v_37 = {0};
+   _fx_N14Lexer__token_t v_38 = {0};
+   _fx_LN14Lexer__token_t v_39 = 0;
+   _fx_LN14Lexer__token_t v_40 = 0;
+   _fx_N10Ast__lit_t v_41 = {0};
+   _fx_N14Lexer__token_t v_42 = {0};
+   _fx_T2N14Lexer__token_tTa2i v_43 = {0};
+   fx_str_t v_44 = {0};
+   fx_str_t ident_0 = {0};
+   _fx_Nt6option1T2N14Lexer__token_ti v_45 = {0};
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
-   _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t* cv_0 =
-      (_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t*)fx_fv;
+   _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0_cldata_t* cv_0 =
+      (_fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0_cldata_t*)fx_fv;
    _fx_N20LexerUtils__stream_t strm_0 = cv_0->t8;
    _fx_Ta2i* backquote_loc_0 = &cv_0->t0->data;
    int_* backquote_pos_0 = &cv_0->t1->data;
    bool* expect_neg_number_0 = &cv_0->t2->data;
    _fx_Nt6option1R8format_t* fmt_0 = &cv_0->t3->data;
    bool* new_exp_0 = &cv_0->t4->data;
-   _fx_LT2N14Lexer__token_tTa2i* paren_stack_0 = &cv_0->t5->data;
+   _fx_LT2N14Lexer__token_tTa2i* paren_stack_1 = &cv_0->t5->data;
    int_* pos_0 = &cv_0->t6->data;
    bool* prev_dot_0 = &cv_0->t7->data;
-   for (;;) {
-      fx_str_t buf_0 = {0};
-      _fx_LT2N14Lexer__token_tTa2i paren_stack_1 = 0;
-      _fx_T2iT2N14Lexer__token_tC v_0 = {0};
-      _fx_N14Lexer__token_t t_0 = {0};
-      _fx_N14Lexer__token_t v_1 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_2 = {0};
-      _fx_N14Lexer__token_t v_3 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_4 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_5 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_6 = {0};
-      _fx_LT2N14Lexer__token_tTa2i v_7 = 0;
-      _fx_N10Ast__lit_t zero_0 = {0};
-      _fx_N14Lexer__token_t v_8 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_9 = {0};
-      _fx_N14Lexer__token_t v_10 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_11 = {0};
-      _fx_N14Lexer__token_t v_12 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_13 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_14 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_15 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_16 = {0};
-      _fx_LT2N14Lexer__token_tTa2i v_17 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_18 = {0};
-      _fx_LT2N14Lexer__token_tTa2i result_1 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_19 = {0};
-      _fx_LT2N14Lexer__token_tTa2i result_2 = 0;
-      fx_str_t v_20 = {0};
-      fx_str_t tyvar_0 = {0};
-      _fx_N14Lexer__token_t v_21 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_22 = {0};
-      _fx_LT2N14Lexer__token_tTa2i result_3 = 0;
-      _fx_T4iSiB v_23 = {0};
-      fx_str_t res_0 = {0};
-      fx_exn_t v_24 = {0};
-      _fx_N10Ast__lit_t v_25 = {0};
-      _fx_N14Lexer__token_t v_26 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_27 = {0};
-      _fx_LT2N14Lexer__token_tTa2i result_4 = 0;
-      _fx_T2N14Lexer__token_tTa2i v_28 = {0};
-      _fx_LT2N14Lexer__token_tTa2i v_29 = 0;
-      _fx_LN14Lexer__token_t v_30 = 0;
-      _fx_N14Lexer__token_t v_31 = {0};
-      _fx_N14Lexer__token_t v_32 = {0};
-      _fx_N10Ast__lit_t v_33 = {0};
-      _fx_N14Lexer__token_t v_34 = {0};
-      _fx_N14Lexer__token_t v_35 = {0};
-      _fx_LN14Lexer__token_t v_36 = 0;
-      _fx_N14Lexer__token_t v_37 = {0};
-      _fx_N14Lexer__token_t v_38 = {0};
-      _fx_LN14Lexer__token_t v_39 = 0;
-      _fx_LN14Lexer__token_t v_40 = 0;
-      _fx_LT2N14Lexer__token_tTa2i result_5 = 0;
-      _fx_N10Ast__lit_t v_41 = {0};
-      _fx_N14Lexer__token_t v_42 = {0};
-      _fx_T2N14Lexer__token_tTa2i v_43 = {0};
-      _fx_LT2N14Lexer__token_tTa2i result_6 = 0;
-      fx_str_t v_44 = {0};
-      fx_str_t ident_0 = {0};
-      _fx_Nt6option1T2N14Lexer__token_ti v_45 = {0};
-      fx_copy_str(&strm_0->u.stream_t.t3, &buf_0);
-      int_ len_0;
-      FX_CALL(_fx_M5LexerFM6lengthi1S(&buf_0, &len_0, 0), _fx_catch_66);
-      char_ c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
-      int_ v_46 = *pos_0 + 1;
-      char_ c1_0 = FX_STR_ELEM_ZERO(buf_0, v_46);
-      bool v_47;
-      if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
+   fx_copy_str(&strm_0->u.stream_t.t3, &buf_0);
+   int_ len_0;
+   FX_CALL(_fx_M5LexerFM6lengthi1S(&buf_0, &len_0, 0), _fx_cleanup);
+   char_ c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
+   int_ v_46 = *pos_0 + 1;
+   char_ c1_0 = FX_STR_ELEM_ZERO(buf_0, v_46);
+   bool v_47;
+   if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
+      v_47 = true;
+   }
+   else if (c_0 == (char_)47) {
+      if (c1_0 == (char_)47) {
          v_47 = true;
       }
-      else if (c_0 == (char_)47) {
-         if (c1_0 == (char_)47) {
-            v_47 = true;
+      else {
+         v_47 = c1_0 == (char_)42;
+      }
+   }
+   else {
+      v_47 = false;
+   }
+   if (v_47) {
+      _fx_T3CiB v_48;
+      FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_48, 0), _fx_cleanup);
+      char_ c__0 = v_48.t0;
+      int_ p_0 = v_48.t1;
+      bool nl_0 = v_48.t2;
+      c_0 = c__0;
+      if (nl_0) {
+         FX_COPY_PTR(*paren_stack_1, &paren_stack_0);
+         bool res_1;
+         if (paren_stack_0 != 0) {
+            if (paren_stack_0->hd.t0.tag == 44) {
+               res_1 = true; goto _fx_endmatch_0;
+            }
          }
-         else {
-            v_47 = c1_0 == (char_)42;
+         if (paren_stack_0 != 0) {
+            if (paren_stack_0->hd.t0.tag == 47) {
+               res_1 = true; goto _fx_endmatch_0;
+            }
          }
+         res_1 = false;
+
+      _fx_endmatch_0: ;
+         FX_CHECK_EXN(_fx_cleanup);
+         if (res_1) {
+            goto _fx_endmatch_1;
+         }
+         *new_exp_0 = true;
+
+      _fx_endmatch_1: ;
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      *pos_0 = p_0;
+      int_ v_49 = *pos_0 + 1;
+      c1_0 = FX_STR_ELEM_ZERO(buf_0, v_49);
+   }
+   _fx_Ta2i loc_0;
+   FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &loc_0, 0), _fx_cleanup);
+   if ((bool)(((char_)48 <= c_0) & (c_0 <= (char_)57))) {
+      FX_CALL(
+         _fx_M5LexerFM9getnumberT2iT2N14Lexer__token_tC5SiTa2iBB(&buf_0, *pos_0, &loc_0, *prev_dot_0, !*prev_dot_0, &v_0, 0),
+         _fx_cleanup);
+      int_ p_1 = v_0.t0;
+      _fx_T2N14Lexer__token_tC* v_50 = &v_0.t1;
+      _fx_copy_N14Lexer__token_t(&v_50->t0, &t_0);
+      char_ c_1 = v_50->t1;
+      int tag_0 = t_0.tag;
+      if (tag_0 == 1) {
+         _fx_N10Ast__lit_t* v_51 = &t_0.u.LITERAL;
+         if (v_51->tag == 1) {
+            fx_exn_t v_52 = {0};
+            bool t_1;
+            if (v_51->u.LitInt < 0LL) {
+               t_1 = !*expect_neg_number_0;
+            }
+            else {
+               t_1 = false;
+            }
+            if (t_1) {
+               _fx_Ta2i v_53;
+               FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_53, 0), _fx_catch_0);
+               fx_str_t slit_0 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
+               FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_53, &slit_0, &v_52), _fx_catch_0);
+               FX_THROW(&v_52, true, _fx_catch_0);
+            }
+
+         _fx_catch_0: ;
+            fx_free_exn(&v_52);
+            goto _fx_endmatch_2;
+         }
+      }
+      if (tag_0 == 1) {
+         _fx_N10Ast__lit_t* v_54 = &t_0.u.LITERAL;
+         if (v_54->tag == 2) {
+            fx_exn_t v_55 = {0};
+            bool t_2;
+            if (v_54->u.LitSInt.t1 < 0LL) {
+               t_2 = !*expect_neg_number_0;
+            }
+            else {
+               t_2 = false;
+            }
+            if (t_2) {
+               _fx_Ta2i v_56;
+               FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_56, 0), _fx_catch_1);
+               fx_str_t slit_1 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
+               FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_56, &slit_1, &v_55), _fx_catch_1);
+               FX_THROW(&v_55, true, _fx_catch_1);
+            }
+
+         _fx_catch_1: ;
+            fx_free_exn(&v_55);
+            goto _fx_endmatch_2;
+         }
+      }
+      if (tag_0 == 1) {
+         if (t_0.u.LITERAL.tag == 3) {
+            fx_exn_t v_57 = {0};
+            if (*expect_neg_number_0) {
+               _fx_Ta2i v_58;
+               FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_58, 0), _fx_catch_2);
+               fx_str_t slit_2 = FX_MAKE_STR("\'-\' in front of unsigned integer literal");
+               FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_58, &slit_2, &v_57), _fx_catch_2);
+               FX_THROW(&v_57, true, _fx_catch_2);
+            }
+
+         _fx_catch_2: ;
+            fx_free_exn(&v_57);
+            goto _fx_endmatch_2;
+         }
+      }
+
+   _fx_endmatch_2: ;
+      FX_CHECK_EXN(_fx_cleanup);
+      *new_exp_0 = false;
+      *prev_dot_0 = false;
+      *pos_0 = p_1;
+      if (c_1 == (char_)108) {
+         fx_str_t slit_3 = FX_MAKE_STR("long");
+         _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_3, &v_1);
+         _fx_make_T2N14Lexer__token_tTa2i(&v_1, &loc_0, &v_2);
+         _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_3);
+         _fx_make_T2N14Lexer__token_tTa2i(&v_3, &loc_0, &v_4);
+         _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_5);
+         _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_6);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_6, 0, true, &v_7), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_5, v_7, false, &v_7), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_4, v_7, false, &v_7), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_2, v_7, true, &tokens_0), _fx_cleanup);
+      }
+      else if (c_1 == (char_)99) {
+         if (t_0.tag == 1) {
+            _fx_N10Ast__lit_t* v_59 = &t_0.u.LITERAL;
+            if (v_59->tag == 4) {
+               _fx_M3AstFM8LitFloatN10Ast__lit_t2id(v_59->u.LitFloat.t0, 0.0, &zero_0); goto _fx_endmatch_3;
+            }
+         }
+         _fx_M3AstFM6LitIntN10Ast__lit_t1l(0LL, &zero_0);
+
+      _fx_endmatch_3: ;
+         FX_CHECK_EXN(_fx_cleanup);
+         fx_str_t slit_4 = FX_MAKE_STR("complex");
+         _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_4, &v_8);
+         _fx_make_T2N14Lexer__token_tTa2i(&v_8, &loc_0, &v_9);
+         _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_10);
+         _fx_make_T2N14Lexer__token_tTa2i(&v_10, &loc_0, &v_11);
+         _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&zero_0, &v_12);
+         _fx_make_T2N14Lexer__token_tTa2i(&v_12, &loc_0, &v_13);
+         _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_14);
+         _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_15);
+         _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_16);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, 0, true, &v_17), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_17, false, &v_17), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_17, false, &v_17), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_13, v_17, false, &v_17), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_17, false, &v_17), _fx_cleanup);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_17, true, &tokens_0), _fx_cleanup);
       }
       else {
-         v_47 = false;
+         _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_18);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_18, 0, true, &tokens_0), _fx_cleanup);
       }
-      if (v_47) {
-         _fx_T3CiB v_48;
-         FX_CALL(_fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_48, 0), _fx_catch_66);
-         char_ c__0 = v_48.t0;
-         int_ p_0 = v_48.t1;
-         bool nl_0 = v_48.t2;
-         c_0 = c__0;
-         if (nl_0) {
-            FX_COPY_PTR(*paren_stack_0, &paren_stack_1);
-            bool res_1;
-            if (paren_stack_1 != 0) {
-               if (paren_stack_1->hd.t0.tag == 44) {
-                  res_1 = true; goto _fx_endmatch_0;
-               }
-            }
-            if (paren_stack_1 != 0) {
-               if (paren_stack_1->hd.t0.tag == 47) {
-                  res_1 = true; goto _fx_endmatch_0;
-               }
-            }
-            res_1 = false;
-
-         _fx_endmatch_0: ;
-            FX_CHECK_EXN(_fx_catch_66);
-            if (res_1) {
-               goto _fx_endmatch_1;
-            }
-            *new_exp_0 = true;
-
-         _fx_endmatch_1: ;
-            FX_CHECK_EXN(_fx_catch_66);
-         }
-         *pos_0 = p_0;
-         int_ v_49 = *pos_0 + 1;
-         c1_0 = FX_STR_ELEM_ZERO(buf_0, v_49);
+   }
+   else {
+      bool t_3;
+      if (c_0 == (char_)39) {
+         t_3 = !*new_exp_0;
       }
-      _fx_Ta2i loc_0;
-      FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &loc_0, 0), _fx_catch_66);
-      if ((bool)(((char_)48 <= c_0) & (c_0 <= (char_)57))) {
-         FX_CALL(
-            _fx_M5LexerFM9getnumberT2iT2N14Lexer__token_tC5SiTa2iBB(&buf_0, *pos_0, &loc_0, *prev_dot_0, !*prev_dot_0, &v_0, 0),
-            _fx_catch_66);
-         int_ p_1 = v_0.t0;
-         _fx_T2N14Lexer__token_tC* v_50 = &v_0.t1;
-         _fx_copy_N14Lexer__token_t(&v_50->t0, &t_0);
-         char_ c_1 = v_50->t1;
-         int tag_0 = t_0.tag;
-         if (tag_0 == 1) {
-            _fx_N10Ast__lit_t* v_51 = &t_0.u.LITERAL;
-            if (v_51->tag == 1) {
-               fx_exn_t v_52 = {0};
-               bool t_1;
-               if (v_51->u.LitInt < 0LL) {
-                  t_1 = !*expect_neg_number_0;
-               }
-               else {
-                  t_1 = false;
-               }
-               if (t_1) {
-                  _fx_Ta2i v_53;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_53, 0), _fx_catch_0);
-                  fx_str_t slit_0 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_53, &slit_0, &v_52), _fx_catch_0);
-                  FX_THROW(&v_52, true, _fx_catch_0);
-               }
-
-            _fx_catch_0: ;
-               fx_free_exn(&v_52);
-               goto _fx_endmatch_2;
-            }
-         }
-         if (tag_0 == 1) {
-            _fx_N10Ast__lit_t* v_54 = &t_0.u.LITERAL;
-            if (v_54->tag == 2) {
-               fx_exn_t v_55 = {0};
-               bool t_2;
-               if (v_54->u.LitSInt.t1 < 0LL) {
-                  t_2 = !*expect_neg_number_0;
-               }
-               else {
-                  t_2 = false;
-               }
-               if (t_2) {
-                  _fx_Ta2i v_56;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_56, 0), _fx_catch_1);
-                  fx_str_t slit_1 = FX_MAKE_STR("the numeric literal is out of range for the specified type");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_56, &slit_1, &v_55), _fx_catch_1);
-                  FX_THROW(&v_55, true, _fx_catch_1);
-               }
-
-            _fx_catch_1: ;
-               fx_free_exn(&v_55);
-               goto _fx_endmatch_2;
-            }
-         }
-         if (tag_0 == 1) {
-            if (t_0.u.LITERAL.tag == 3) {
-               fx_exn_t v_57 = {0};
-               if (*expect_neg_number_0) {
-                  _fx_Ta2i v_58;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_58, 0), _fx_catch_2);
-                  fx_str_t slit_2 = FX_MAKE_STR("\'-\' in front of unsigned integer literal");
-                  FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_58, &slit_2, &v_57), _fx_catch_2);
-                  FX_THROW(&v_57, true, _fx_catch_2);
-               }
-
-            _fx_catch_2: ;
-               fx_free_exn(&v_57);
-               goto _fx_endmatch_2;
-            }
-         }
-
-      _fx_endmatch_2: ;
-         FX_CHECK_EXN(_fx_catch_66);
-         *new_exp_0 = false;
+      else {
+         t_3 = false;
+      }
+      if (t_3) {
          *prev_dot_0 = false;
-         *pos_0 = p_1;
-         if (c_1 == (char_)108) {
-            fx_str_t slit_3 = FX_MAKE_STR("long");
-            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_3, &v_1);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_1, &loc_0, &v_2);
-            _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_3);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_3, &loc_0, &v_4);
-            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_5);
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_6);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_6, 0, true, &v_7), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_5, v_7, false, &v_7), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_4, v_7, false, &v_7), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_2, v_7, false, &v_7), _fx_catch_66);
-            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-            FX_COPY_PTR(v_7, &result_0);
-            FX_BREAK(_fx_catch_66);
-         }
-         else if (c_1 == (char_)99) {
-            if (t_0.tag == 1) {
-               _fx_N10Ast__lit_t* v_59 = &t_0.u.LITERAL;
-               if (v_59->tag == 4) {
-                  _fx_M3AstFM8LitFloatN10Ast__lit_t2id(v_59->u.LitFloat.t0, 0.0, &zero_0); goto _fx_endmatch_3;
-               }
-            }
-            _fx_M3AstFM6LitIntN10Ast__lit_t1l(0LL, &zero_0);
-
-         _fx_endmatch_3: ;
-            FX_CHECK_EXN(_fx_catch_66);
-            fx_str_t slit_4 = FX_MAKE_STR("complex");
-            _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_4, &v_8);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_8, &loc_0, &v_9);
-            _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_10);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_10, &loc_0, &v_11);
-            _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&zero_0, &v_12);
-            _fx_make_T2N14Lexer__token_tTa2i(&v_12, &loc_0, &v_13);
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_14);
-            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_15);
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_16);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_16, 0, true, &v_17), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_15, v_17, false, &v_17), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_14, v_17, false, &v_17), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_13, v_17, false, &v_17), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_11, v_17, false, &v_17), _fx_catch_66);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_9, v_17, false, &v_17), _fx_catch_66);
-            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-            FX_COPY_PTR(v_17, &result_0);
-            FX_BREAK(_fx_catch_66);
-         }
-         else {
-            _fx_make_T2N14Lexer__token_tTa2i(&t_0, &loc_0, &v_18);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_18, 0, true, &result_1), _fx_catch_66);
-            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-            FX_COPY_PTR(result_1, &result_0);
-            FX_BREAK(_fx_catch_66);
-         }
+         *pos_0 = *pos_0 + 1;
+         _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__APOS, &loc_0, &v_19);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &tokens_0), _fx_cleanup);
       }
       else {
-         bool t_3;
+         bool v_60;
+         bool t_4;
          if (c_0 == (char_)39) {
-            t_3 = !*new_exp_0;
+            t_4 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
          }
          else {
-            t_3 = false;
+            t_4 = false;
          }
-         if (t_3) {
-            *prev_dot_0 = false;
-            *pos_0 = *pos_0 + 1;
-            _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__APOS, &loc_0, &v_19);
-            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_19, 0, true, &result_2), _fx_catch_66);
-            _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-            FX_COPY_PTR(result_2, &result_0);
-            FX_BREAK(_fx_catch_66);
+         if (t_4) {
+            int_ v_61 = *pos_0 + 2; v_60 = FX_STR_ELEM_ZERO(buf_0, v_61) != (char_)39;
          }
          else {
-            bool v_60;
-            bool t_4;
-            if (c_0 == (char_)39) {
-               t_4 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
-            }
-            else {
-               t_4 = false;
-            }
-            if (t_4) {
-               int_ v_61 = *pos_0 + 2; v_60 = FX_STR_ELEM_ZERO(buf_0, v_61) != (char_)39;
-            }
-            else {
-               v_60 = false;
-            }
-            if (v_60) {
-               int_ p_2 = *pos_0 + 1;
-               while (p_2 < len_0) {
-                  FX_STR_CHKIDX(buf_0, p_2, _fx_catch_3);
-                  char_ cp_0 = FX_STR_ELEM(buf_0, p_2);
-                  bool v_62 = _fx_M4CharFM7isalnumB1C(cp_0, 0);
-                  bool t_5;
-                  if (!v_62) {
-                     t_5 = cp_0 != (char_)95;
-                  }
-                  else {
-                     t_5 = false;
-                  }
-                  if (t_5) {
-                     FX_BREAK(_fx_catch_3);
-                  }
-                  p_2 = p_2 + 1;
-
-               _fx_catch_3: ;
-                  FX_CHECK_BREAK();
-                  FX_CHECK_EXN(_fx_catch_66);
+            v_60 = false;
+         }
+         if (v_60) {
+            int_ p_2 = *pos_0 + 1;
+            while (p_2 < len_0) {
+               FX_STR_CHKIDX(buf_0, p_2, _fx_catch_3);
+               char_ cp_0 = FX_STR_ELEM(buf_0, p_2);
+               bool v_62 = _fx_M4CharFM7isalnumB1C(cp_0, 0);
+               bool t_5;
+               if (!v_62) {
+                  t_5 = cp_0 != (char_)95;
                }
-               FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_20), _fx_catch_66);
-               FX_CALL(_fx_M6StringFM4copyS1S(&v_20, &tyvar_0, 0), _fx_catch_66);
-               *pos_0 = p_2;
+               else {
+                  t_5 = false;
+               }
+               if (t_5) {
+                  FX_BREAK(_fx_catch_3);
+               }
+               p_2 = p_2 + 1;
+
+            _fx_catch_3: ;
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_cleanup);
+            }
+            FX_CALL(fx_substr(&buf_0, *pos_0, p_2, 1, 0, &v_20), _fx_cleanup);
+            FX_CALL(_fx_M6StringFM4copyS1S(&v_20, &tyvar_0, 0), _fx_cleanup);
+            *pos_0 = p_2;
+            *new_exp_0 = false;
+            *prev_dot_0 = false;
+            _fx_M5LexerFM5TYVARN14Lexer__token_t1S(&tyvar_0, &v_21);
+            _fx_make_T2N14Lexer__token_tTa2i(&v_21, &loc_0, &v_22);
+            FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_22, 0, true, &tokens_0), _fx_cleanup);
+         }
+         else {
+            bool t_6;
+            if (c_0 == (char_)34) {
+               t_6 = true;
+            }
+            else {
+               t_6 = c_0 == (char_)39;
+            }
+            bool t_7;
+            if (t_6) {
+               t_7 = true;
+            }
+            else {
+               bool t_8;
+               if (c_0 == (char_)102) {
+                  t_8 = true;
+               }
+               else {
+                  t_8 = c_0 == (char_)114;
+               }
+               if (t_8) {
+                  t_7 = c1_0 == (char_)34;
+               }
+               else {
+                  t_7 = false;
+               }
+            }
+            if (t_7) {
+               bool t_9;
+               if (c_0 == (char_)102) {
+                  t_9 = true;
+               }
+               else {
+                  t_9 = c_0 == (char_)114;
+               }
+               int_ termpos_0;
+               if (t_9) {
+                  termpos_0 = *pos_0 + 1;
+               }
+               else {
+                  termpos_0 = *pos_0;
+               }
+               char_ term_0 = FX_STR_ELEM_ZERO(buf_0, termpos_0);
+               _fx_Ta2i v_63;
+               FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(termpos_0 + 1, strm_0, &v_63, 0), _fx_cleanup);
+               FX_CALL(
+                  _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, termpos_0 + 1, &v_63, term_0, c_0 == (char_)114,
+                     c_0 == (char_)102, &v_23, 0), _fx_cleanup);
+               int_ p_3 = v_23.t0;
+               fx_copy_str(&v_23.t1, &res_0);
+               int_ dl_0 = v_23.t2;
+               bool inline_exp_0 = v_23.t3;
+               int_ prev_pos_0 = *pos_0;
+               strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_0;
+               *pos_0 = p_3;
                *new_exp_0 = false;
                *prev_dot_0 = false;
-               _fx_M5LexerFM5TYVARN14Lexer__token_t1S(&tyvar_0, &v_21);
-               _fx_make_T2N14Lexer__token_tTa2i(&v_21, &loc_0, &v_22);
-               FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_22, 0, true, &result_3), _fx_catch_66);
-               _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-               FX_COPY_PTR(result_3, &result_0);
-               FX_BREAK(_fx_catch_66);
+               if (term_0 == (char_)39) {
+                  int_ res_2;
+                  FX_CALL(_fx_M5LexerFM6lengthi1S(&res_0, &res_2, 0), _fx_cleanup);
+                  if (res_2 != 1) {
+                     _fx_Ta2i v_64;
+                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_64, 0), _fx_cleanup);
+                     fx_str_t slit_5 = FX_MAKE_STR("character literal should contain exactly one character");
+                     FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_64, &slit_5, &v_24), _fx_cleanup);
+                     FX_THROW(&v_24, true, _fx_cleanup);
+                  }
+                  FX_STR_CHKIDX(res_0, 0, _fx_cleanup);
+                  _fx_M3AstFM7LitCharN10Ast__lit_t1C(FX_STR_ELEM(res_0, 0), &v_25);
+                  _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_25, &v_26);
+                  _fx_make_T2N14Lexer__token_tTa2i(&v_26, &loc_0, &v_27);
+                  FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_27, 0, true, &tokens_0), _fx_cleanup);
+               }
+               else if (inline_exp_0) {
+                  _fx_Ta2i v_65;
+                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(prev_pos_0, strm_0, &v_65, 0), _fx_cleanup);
+                  _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_65, &v_28);
+                  FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, *paren_stack_1, true, &v_29), _fx_cleanup);
+                  _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                  FX_COPY_PTR(v_29, paren_stack_1);
+                  *new_exp_0 = true;
+                  *fmt_0 = _fx_g13Lexer__None1_;
+                  if (FX_STR_LENGTH(res_0) == 0) {
+                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_31);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_31, 0, true, &v_30), _fx_cleanup);
+                  }
+                  else {
+                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_32);
+                     _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_33);
+                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_33, &v_34);
+                     _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_35);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, 0, true, &v_36), _fx_cleanup);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_34, v_36, false, &v_36), _fx_cleanup);
+                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, v_36, true, &v_30), _fx_cleanup);
+                  }
+                  fx_str_t slit_6 = FX_MAKE_STR("string");
+                  _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_6, &v_37);
+                  _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_38);
+                  FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, 0, true, &v_39), _fx_cleanup);
+                  FX_CALL(_fx_cons_LN14Lexer__token_t(&v_37, v_39, false, &v_39), _fx_cleanup);
+                  FX_CALL(_fx_M5LexerFM7__add__LN14Lexer__token_t2LN14Lexer__token_tLN14Lexer__token_t(v_30, v_39, &v_40, 0),
+                     _fx_cleanup);
+                  FX_CALL(_fx_M5LexerFM6addlocLT2N14Lexer__token_tTa2i2Ta2iLN14Lexer__token_t(&loc_0, v_40, &tokens_0, 0),
+                     _fx_cleanup);
+               }
+               else {
+                  _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_41);
+                  _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_41, &v_42);
+                  _fx_make_T2N14Lexer__token_tTa2i(&v_42, &loc_0, &v_43);
+                  FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_43, 0, true, &tokens_0), _fx_cleanup);
+               }
             }
             else {
-               bool t_6;
-               if (c_0 == (char_)34) {
-                  t_6 = true;
+               bool v_66;
+               bool t_10;
+               if (_fx_M4CharFM7isalphaB1C(c_0, 0)) {
+                  t_10 = true;
                }
                else {
-                  t_6 = c_0 == (char_)39;
+                  t_10 = c_0 == (char_)95;
                }
-               bool t_7;
-               if (t_6) {
-                  t_7 = true;
+               if (t_10) {
+                  v_66 = true;
+               }
+               else if (c_0 == (char_)64) {
+                  v_66 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
                }
                else {
-                  bool t_8;
-                  if (c_0 == (char_)102) {
-                     t_8 = true;
-                  }
-                  else {
-                     t_8 = c_0 == (char_)114;
-                  }
-                  if (t_8) {
-                     t_7 = c1_0 == (char_)34;
-                  }
-                  else {
-                     t_7 = false;
-                  }
+                  v_66 = false;
                }
-               if (t_7) {
-                  bool t_9;
-                  if (c_0 == (char_)102) {
-                     t_9 = true;
-                  }
-                  else {
-                     t_9 = c_0 == (char_)114;
-                  }
-                  int_ termpos_0;
-                  if (t_9) {
-                     termpos_0 = *pos_0 + 1;
-                  }
-                  else {
-                     termpos_0 = *pos_0;
-                  }
-                  char_ term_0 = FX_STR_ELEM_ZERO(buf_0, termpos_0);
-                  _fx_Ta2i v_63;
-                  FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(termpos_0 + 1, strm_0, &v_63, 0), _fx_catch_66);
-                  FX_CALL(
-                     _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, termpos_0 + 1, &v_63, term_0, c_0 == (char_)114,
-                        c_0 == (char_)102, &v_23, 0), _fx_catch_66);
-                  int_ p_3 = v_23.t0;
-                  fx_copy_str(&v_23.t1, &res_0);
-                  int_ dl_0 = v_23.t2;
-                  bool inline_exp_0 = v_23.t3;
-                  int_ prev_pos_0 = *pos_0;
-                  strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_0;
-                  *pos_0 = p_3;
-                  *new_exp_0 = false;
-                  *prev_dot_0 = false;
-                  if (term_0 == (char_)39) {
-                     int_ res_2;
-                     FX_CALL(_fx_M5LexerFM6lengthi1S(&res_0, &res_2, 0), _fx_catch_66);
-                     if (res_2 != 1) {
-                        _fx_Ta2i v_64;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_64, 0), _fx_catch_66);
-                        fx_str_t slit_5 = FX_MAKE_STR("character literal should contain exactly one character");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_64, &slit_5, &v_24), _fx_catch_66);
-                        FX_THROW(&v_24, true, _fx_catch_66);
-                     }
-                     FX_STR_CHKIDX(res_0, 0, _fx_catch_66);
-                     _fx_M3AstFM7LitCharN10Ast__lit_t1C(FX_STR_ELEM(res_0, 0), &v_25);
-                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_25, &v_26);
-                     _fx_make_T2N14Lexer__token_tTa2i(&v_26, &loc_0, &v_27);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_27, 0, true, &result_4), _fx_catch_66);
-                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                     FX_COPY_PTR(result_4, &result_0);
-                     FX_BREAK(_fx_catch_66);
-                  }
-                  else if (inline_exp_0) {
-                     _fx_Ta2i v_65;
-                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(prev_pos_0, strm_0, &v_65, 0), _fx_catch_66);
-                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_65, &v_28);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_28, *paren_stack_0, true, &v_29), _fx_catch_66);
-                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                     FX_COPY_PTR(v_29, paren_stack_0);
-                     *new_exp_0 = true;
-                     *fmt_0 = _fx_g13Lexer__None1_;
-                     if (FX_STR_LENGTH(res_0) == 0) {
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_31);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_31, 0, true, &v_30), _fx_catch_66);
+               if (v_66) {
+                  int_ p_4 = *pos_0 + 1;
+                  while (p_4 < len_0) {
+                     FX_STR_CHKIDX(buf_0, p_4, _fx_catch_4);
+                     char_ cp_1 = FX_STR_ELEM(buf_0, p_4);
+                     bool v_67 = _fx_M4CharFM7isalnumB1C(cp_1, 0);
+                     bool t_11;
+                     if (!v_67) {
+                        t_11 = cp_1 != (char_)95;
                      }
                      else {
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_32);
-                        _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_33);
-                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_33, &v_34);
-                        _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_35);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_35, 0, true, &v_36), _fx_catch_66);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_34, v_36, false, &v_36), _fx_catch_66);
-                        FX_CALL(_fx_cons_LN14Lexer__token_t(&v_32, v_36, true, &v_30), _fx_catch_66);
+                        t_11 = false;
                      }
-                     fx_str_t slit_6 = FX_MAKE_STR("string");
-                     _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_6, &v_37);
-                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_38);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_38, 0, true, &v_39), _fx_catch_66);
-                     FX_CALL(_fx_cons_LN14Lexer__token_t(&v_37, v_39, false, &v_39), _fx_catch_66);
-                     FX_CALL(_fx_M5LexerFM7__add__LN14Lexer__token_t2LN14Lexer__token_tLN14Lexer__token_t(v_30, v_39, &v_40, 0),
-                        _fx_catch_66);
-                     FX_CALL(_fx_M5LexerFM6addlocLT2N14Lexer__token_tTa2i2Ta2iLN14Lexer__token_t(&loc_0, v_40, &result_5, 0),
-                        _fx_catch_66);
-                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                     FX_COPY_PTR(result_5, &result_0);
-                     FX_BREAK(_fx_catch_66);
-                  }
-                  else {
-                     _fx_M3AstFM9LitStringN10Ast__lit_t1S(&res_0, &v_41);
-                     _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_41, &v_42);
-                     _fx_make_T2N14Lexer__token_tTa2i(&v_42, &loc_0, &v_43);
-                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_43, 0, true, &result_6), _fx_catch_66);
-                     _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                     FX_COPY_PTR(result_6, &result_0);
-                     FX_BREAK(_fx_catch_66);
-                  }
-               }
-               else {
-                  bool v_66;
-                  bool t_10;
-                  if (_fx_M4CharFM7isalphaB1C(c_0, 0)) {
-                     t_10 = true;
-                  }
-                  else {
-                     t_10 = c_0 == (char_)95;
-                  }
-                  if (t_10) {
-                     v_66 = true;
-                  }
-                  else if (c_0 == (char_)64) {
-                     v_66 = _fx_M4CharFM7isalphaB1C(c1_0, 0);
-                  }
-                  else {
-                     v_66 = false;
-                  }
-                  if (v_66) {
-                     int_ p_4 = *pos_0 + 1;
-                     while (p_4 < len_0) {
-                        FX_STR_CHKIDX(buf_0, p_4, _fx_catch_4);
-                        char_ cp_1 = FX_STR_ELEM(buf_0, p_4);
-                        bool v_67 = _fx_M4CharFM7isalnumB1C(cp_1, 0);
-                        bool t_11;
-                        if (!v_67) {
-                           t_11 = cp_1 != (char_)95;
-                        }
-                        else {
-                           t_11 = false;
-                        }
-                        if (t_11) {
-                           FX_BREAK(_fx_catch_4);
-                        }
-                        p_4 = p_4 + 1;
-
-                     _fx_catch_4: ;
-                        FX_CHECK_BREAK();
-                        FX_CHECK_EXN(_fx_catch_66);
+                     if (t_11) {
+                        FX_BREAK(_fx_catch_4);
                      }
-                     FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_44), _fx_catch_66);
-                     FX_CALL(_fx_M6StringFM4copyS1S(&v_44, &ident_0, 0), _fx_catch_66);
-                     *pos_0 = p_4;
-                     *prev_dot_0 = false;
-                     FX_CALL(
-                        _fx_M5LexerFM8find_optNt6option1T2N14Lexer__token_ti2Nt10Hashmap__t2ST2N14Lexer__token_tiS(
-                           _fx_g21Lexer__ficus_keywords, &ident_0, &v_45, 0), _fx_catch_66);
-                     if (v_45.tag == 2) {
-                        _fx_N14Lexer__token_t t_12 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_68 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_7 = 0;
-                        _fx_T2N14Lexer__token_ti* v_69 = &v_45.u.Some;
-                        int_ n_0 = v_69->t1;
-                        _fx_N14Lexer__token_t* t_13 = &v_69->t0;
-                        if (t_13->tag == 9) {
-                           _fx_T2N14Lexer__token_tTa2i v_70 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i v_71 = 0;
-                           fx_str_t slit_7 = FX_MAKE_STR("ccode");
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &slit_7, 0), _fx_catch_5);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__CCODE, &loc_0, &v_70);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_70, *paren_stack_0, true, &v_71), _fx_catch_5);
-                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_71, paren_stack_0);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                     p_4 = p_4 + 1;
 
-                        _fx_catch_5: ;
-                           if (v_71) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&v_71);
-                           }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_70);
-                        }
-                        else if (t_13->tag == 19) {
-                           _fx_N14Lexer__token_t t_14 = {0};
-                           _fx_M5LexerFM3FORN14Lexer__token_t1B(*new_exp_0, &t_14);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_14, &t_12);
-                           _fx_free_N14Lexer__token_t(&t_14);
-                        }
-                        else if (t_13->tag == 23) {
-                           _fx_N14Lexer__token_t t_15 = {0};
-                           _fx_M5LexerFM6IMPORTN14Lexer__token_t1B(*new_exp_0, &t_15);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_15, &t_12);
-                           _fx_free_N14Lexer__token_t(&t_15);
-                        }
-                        else if (t_13->tag == 42) {
-                           _fx_N14Lexer__token_t t_16 = {0};
-                           _fx_M5LexerFM5WHILEN14Lexer__token_t1B(*new_exp_0, &t_16);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(&t_16, &t_12);
-                           _fx_free_N14Lexer__token_t(&t_16);
-                        }
-                        else if (t_13->tag == 26) {
-                           _fx_T2N14Lexer__token_tTa2i v_72 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i v_73 = 0;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__MATCH, &loc_0, &v_72);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_72, *paren_stack_0, true, &v_73), _fx_catch_6);
-                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_73, paren_stack_0);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                  _fx_catch_4: ;
+                     FX_CHECK_BREAK();
+                     FX_CHECK_EXN(_fx_cleanup);
+                  }
+                  FX_CALL(fx_substr(&buf_0, *pos_0, p_4, 1, 0, &v_44), _fx_cleanup);
+                  FX_CALL(_fx_M6StringFM4copyS1S(&v_44, &ident_0, 0), _fx_cleanup);
+                  *pos_0 = p_4;
+                  *prev_dot_0 = false;
+                  FX_CALL(
+                     _fx_M5LexerFM8find_optNt6option1T2N14Lexer__token_ti2Nt10Hashmap__t2ST2N14Lexer__token_tiS(
+                        _fx_g21Lexer__ficus_keywords, &ident_0, &v_45, 0), _fx_cleanup);
+                  if (v_45.tag == 2) {
+                     _fx_N14Lexer__token_t t_12 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_68 = {0};
+                     _fx_T2N14Lexer__token_ti* v_69 = &v_45.u.Some;
+                     int_ n_0 = v_69->t1;
+                     _fx_N14Lexer__token_t* t_13 = &v_69->t0;
+                     if (t_13->tag == 9) {
+                        _fx_T2N14Lexer__token_tTa2i v_70 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_71 = 0;
+                        fx_str_t slit_7 = FX_MAKE_STR("ccode");
+                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &slit_7, 0), _fx_catch_5);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__CCODE, &loc_0, &v_70);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_70, *paren_stack_1, true, &v_71), _fx_catch_5);
+                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                        FX_COPY_PTR(v_71, paren_stack_1);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(t_13, &t_12);
 
-                        _fx_catch_6: ;
-                           if (v_73) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&v_73);
-                           }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_72);
+                     _fx_catch_5: ;
+                        if (v_71) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_71);
                         }
-                        else if (t_13->tag == 33) {
-                           _fx_M5LexerFM3REFN14Lexer__token_t1B(*new_exp_0, &t_12);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_70);
+                     }
+                     else if (t_13->tag == 19) {
+                        _fx_N14Lexer__token_t t_14 = {0};
+                        _fx_M5LexerFM3FORN14Lexer__token_t1B(*new_exp_0, &t_14);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(&t_14, &t_12);
+                        _fx_free_N14Lexer__token_t(&t_14);
+                     }
+                     else if (t_13->tag == 23) {
+                        _fx_N14Lexer__token_t t_15 = {0};
+                        _fx_M5LexerFM6IMPORTN14Lexer__token_t1B(*new_exp_0, &t_15);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(&t_15, &t_12);
+                        _fx_free_N14Lexer__token_t(&t_15);
+                     }
+                     else if (t_13->tag == 42) {
+                        _fx_N14Lexer__token_t t_16 = {0};
+                        _fx_M5LexerFM5WHILEN14Lexer__token_t1B(*new_exp_0, &t_16);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(&t_16, &t_12);
+                        _fx_free_N14Lexer__token_t(&t_16);
+                     }
+                     else if (t_13->tag == 26) {
+                        _fx_T2N14Lexer__token_tTa2i v_72 = {0};
+                        _fx_LT2N14Lexer__token_tTa2i v_73 = 0;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__MATCH, &loc_0, &v_72);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_72, *paren_stack_1, true, &v_73), _fx_catch_6);
+                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                        FX_COPY_PTR(v_73, paren_stack_1);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(t_13, &t_12);
+
+                     _fx_catch_6: ;
+                        if (v_73) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&v_73);
                         }
-                        else if (t_13->tag == 100) {
-                           *new_exp_0 = false; _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_72);
+                     }
+                     else if (t_13->tag == 33) {
+                        _fx_M5LexerFM3REFN14Lexer__token_t1B(*new_exp_0, &t_12);
+                     }
+                     else if (t_13->tag == 100) {
+                        *new_exp_0 = false; _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                     }
+                     else if (t_13->tag == 34) {
+                        _fx_LT2N14Lexer__token_tTa2i paren_stack_2 = 0;
+                        c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
+                        int_ v_74 = *pos_0 + 1;
+                        c1_0 = FX_STR_ELEM_ZERO(buf_0, v_74);
+                        bool v_75;
+                        if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
+                           v_75 = true;
                         }
-                        else if (t_13->tag == 34) {
-                           _fx_LT2N14Lexer__token_tTa2i paren_stack_2 = 0;
-                           c_0 = FX_STR_ELEM_ZERO(buf_0, *pos_0);
-                           int_ v_74 = *pos_0 + 1;
-                           c1_0 = FX_STR_ELEM_ZERO(buf_0, v_74);
-                           bool v_75;
-                           if (_fx_M4CharFM7isspaceB1C(c_0, 0)) {
+                        else if (c_0 == (char_)47) {
+                           if (c1_0 == (char_)47) {
                               v_75 = true;
                            }
-                           else if (c_0 == (char_)47) {
-                              if (c1_0 == (char_)47) {
-                                 v_75 = true;
-                              }
-                              else {
-                                 v_75 = c1_0 == (char_)42;
-                              }
-                           }
                            else {
-                              v_75 = false;
+                              v_75 = c1_0 == (char_)42;
                            }
-                           bool may_have_arg_0;
-                           if (v_75) {
-                              _fx_T3CiB v_76;
-                              FX_CALL(
-                                 _fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_76,
-                                    0), _fx_catch_7);
-                              char_ c__1 = v_76.t0;
-                              int_ p_5 = v_76.t1;
-                              bool nl_1 = v_76.t2;
-                              c_0 = c__1;
-                              *pos_0 = p_5;
-                              if (nl_1) {
-                                 FX_COPY_PTR(*paren_stack_0, &paren_stack_2);
-                                 bool res_3;
-                                 if (paren_stack_2 != 0) {
-                                    if (paren_stack_2->hd.t0.tag == 44) {
-                                       res_3 = true; goto _fx_endmatch_4;
-                                    }
+                        }
+                        else {
+                           v_75 = false;
+                        }
+                        bool may_have_arg_0;
+                        if (v_75) {
+                           _fx_T3CiB v_76;
+                           FX_CALL(
+                              _fx_M10LexerUtilsFM11skip_spacesT3CiB3N20LexerUtils__stream_tiB(strm_0, *pos_0, true, &v_76, 0),
+                              _fx_catch_7);
+                           char_ c__1 = v_76.t0;
+                           int_ p_5 = v_76.t1;
+                           bool nl_1 = v_76.t2;
+                           c_0 = c__1;
+                           *pos_0 = p_5;
+                           if (nl_1) {
+                              FX_COPY_PTR(*paren_stack_1, &paren_stack_2);
+                              bool res_3;
+                              if (paren_stack_2 != 0) {
+                                 if (paren_stack_2->hd.t0.tag == 44) {
+                                    res_3 = true; goto _fx_endmatch_4;
                                  }
-                                 if (paren_stack_2 != 0) {
-                                    if (paren_stack_2->hd.t0.tag == 47) {
-                                       res_3 = true; goto _fx_endmatch_4;
-                                    }
-                                 }
-                                 res_3 = false;
-
-                              _fx_endmatch_4: ;
-                                 FX_CHECK_EXN(_fx_catch_7);
-                                 if (res_3) {
-                                    may_have_arg_0 = true; goto _fx_endmatch_5;
-                                 }
-                                 may_have_arg_0 = false;
-
-                              _fx_endmatch_5: ;
-                                 FX_CHECK_EXN(_fx_catch_7);
                               }
-                              else {
-                                 may_have_arg_0 = true;
+                              if (paren_stack_2 != 0) {
+                                 if (paren_stack_2->hd.t0.tag == 47) {
+                                    res_3 = true; goto _fx_endmatch_4;
+                                 }
                               }
+                              res_3 = false;
+
+                           _fx_endmatch_4: ;
+                              FX_CHECK_EXN(_fx_catch_7);
+                              if (res_3) {
+                                 may_have_arg_0 = true; goto _fx_endmatch_5;
+                              }
+                              may_have_arg_0 = false;
+
+                           _fx_endmatch_5: ;
+                              FX_CHECK_EXN(_fx_catch_7);
                            }
                            else {
                               may_have_arg_0 = true;
                            }
-                           *new_exp_0 = true;
-                           bool bare_0;
-                           bool t_17;
-                           if (c_0 == (char_)59) {
-                              t_17 = true;
-                           }
-                           else {
-                              t_17 = c_0 == (char_)125;
-                           }
-                           bool t_18;
-                           if (t_17) {
-                              t_18 = true;
-                           }
-                           else {
-                              t_18 = c_0 == (char_)41;
-                           }
-                           bool t_19;
-                           if (t_18) {
-                              t_19 = true;
-                           }
-                           else {
-                              t_19 = c_0 == (char_)93;
-                           }
-                           bool t_20;
-                           if (t_19) {
-                              t_20 = true;
-                           }
-                           else {
-                              t_20 = c_0 == (char_)44;
-                           }
-                           if (t_20) {
-                              bare_0 = true;
-                           }
-                           else {
-                              bare_0 = c_0 == (char_)124;
-                           }
-                           bool t_21;
-                           if (may_have_arg_0) {
-                              t_21 = !bare_0;
-                           }
-                           else {
-                              t_21 = false;
-                           }
-                           _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_21, &t_12);
-
-                        _fx_catch_7: ;
-                           if (paren_stack_2) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_2);
-                           }
-                        }
-                        else if (n_0 == -1) {
-                           fx_str_t v_77 = {0};
-                           fx_str_t v_78 = {0};
-                           fx_exn_t v_79 = {0};
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_77, 0), _fx_catch_8);
-                           fx_str_t slit_8 = FX_MAKE_STR("Identifier \'");
-                           fx_str_t slit_9 = FX_MAKE_STR("\' is reserved and cannot be used");
-                           {
-                              const fx_str_t strs_0[] = { slit_8, v_77, slit_9 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_78), _fx_catch_8);
-                           }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_78, &v_79), _fx_catch_8);
-                           FX_THROW(&v_79, true, _fx_catch_8);
-
-                        _fx_catch_8: ;
-                           fx_free_exn(&v_79);
-                           FX_FREE_STR(&v_78);
-                           FX_FREE_STR(&v_77);
-                        }
-                        else if (n_0 == 0) {
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_9);
-                           *new_exp_0 = false;
-                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
-
-                        _fx_catch_9: ;
-                        }
-                        else if (n_0 == 1) {
-                           *new_exp_0 = true; _fx_copy_N14Lexer__token_t(t_13, &t_12);
-                        }
-                        else if (n_0 == 2) {
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_10);
-                           *new_exp_0 = true;
-                           _fx_copy_N14Lexer__token_t(t_13, &t_12);
-
-                        _fx_catch_10: ;
                         }
                         else {
-                           fx_str_t v_80 = {0};
-                           fx_str_t v_81 = {0};
-                           fx_exn_t v_82 = {0};
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_80, 0), _fx_catch_11);
-                           fx_str_t slit_10 = FX_MAKE_STR("Unexpected keyword \'");
-                           fx_str_t slit_11 = FX_MAKE_STR("\'");
-                           {
-                              const fx_str_t strs_1[] = { slit_10, v_80, slit_11 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_81), _fx_catch_11);
-                           }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_81, &v_82), _fx_catch_11);
-                           FX_THROW(&v_82, true, _fx_catch_11);
-
-                        _fx_catch_11: ;
-                           fx_free_exn(&v_82);
-                           FX_FREE_STR(&v_81);
-                           FX_FREE_STR(&v_80);
+                           may_have_arg_0 = true;
                         }
-                        FX_CHECK_EXN(_fx_catch_12);
-                        _fx_make_T2N14Lexer__token_tTa2i(&t_12, &loc_0, &v_68);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_68, 0, true, &result_7), _fx_catch_12);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_7, &result_0);
-                        FX_BREAK(_fx_catch_12);
-
-                     _fx_catch_12: ;
-                        if (result_7) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_7);
+                        *new_exp_0 = true;
+                        bool bare_0;
+                        bool t_17;
+                        if (c_0 == (char_)59) {
+                           t_17 = true;
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_68);
-                        _fx_free_N14Lexer__token_t(&t_12);
+                        else {
+                           t_17 = c_0 == (char_)125;
+                        }
+                        bool t_18;
+                        if (t_17) {
+                           t_18 = true;
+                        }
+                        else {
+                           t_18 = c_0 == (char_)41;
+                        }
+                        bool t_19;
+                        if (t_18) {
+                           t_19 = true;
+                        }
+                        else {
+                           t_19 = c_0 == (char_)93;
+                        }
+                        bool t_20;
+                        if (t_19) {
+                           t_20 = true;
+                        }
+                        else {
+                           t_20 = c_0 == (char_)44;
+                        }
+                        if (t_20) {
+                           bare_0 = true;
+                        }
+                        else {
+                           bare_0 = c_0 == (char_)124;
+                        }
+                        bool t_21;
+                        if (may_have_arg_0) {
+                           t_21 = !bare_0;
+                        }
+                        else {
+                           t_21 = false;
+                        }
+                        _fx_M5LexerFM6RETURNN14Lexer__token_t1B(t_21, &t_12);
+
+                     _fx_catch_7: ;
+                        if (paren_stack_2) {
+                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_2);
+                        }
+                     }
+                     else if (n_0 == -1) {
+                        fx_str_t v_77 = {0};
+                        fx_str_t v_78 = {0};
+                        fx_exn_t v_79 = {0};
+                        FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_77, 0), _fx_catch_8);
+                        fx_str_t slit_8 = FX_MAKE_STR("Identifier \'");
+                        fx_str_t slit_9 = FX_MAKE_STR("\' is reserved and cannot be used");
+                        {
+                           const fx_str_t strs_0[] = { slit_8, v_77, slit_9 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_78), _fx_catch_8);
+                        }
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_78, &v_79), _fx_catch_8);
+                        FX_THROW(&v_79, true, _fx_catch_8);
+
+                     _fx_catch_8: ;
+                        fx_free_exn(&v_79);
+                        FX_FREE_STR(&v_78);
+                        FX_FREE_STR(&v_77);
+                     }
+                     else if (n_0 == 0) {
+                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_9);
+                        *new_exp_0 = false;
+                        _fx_copy_N14Lexer__token_t(t_13, &t_12);
+
+                     _fx_catch_9: ;
+                     }
+                     else if (n_0 == 1) {
+                        *new_exp_0 = true; _fx_copy_N14Lexer__token_t(t_13, &t_12);
+                     }
+                     else if (n_0 == 2) {
+                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(*new_exp_0, &loc_0, &ident_0, 0), _fx_catch_10);
+                        *new_exp_0 = true;
+                        _fx_copy_N14Lexer__token_t(t_13, &t_12);
+
+                     _fx_catch_10: ;
                      }
                      else {
-                        fx_str_t v_83 = {0};
-                        _fx_N14Lexer__token_t t_22 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_84 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_85 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_86 = 0;
-                        _fx_N14Lexer__token_t t_23 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_87 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_8 = 0;
-                        if (c_0 == (char_)64) {
-                           FX_CALL(fx_substr(&ident_0, 1, 0, 1, 2, &v_83), _fx_catch_13);
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_83, &t_22);
-                           *new_exp_0 = false;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_84);
-                           _fx_Ta2i v_88;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 + 1, strm_0, &v_88, 0),
-                              _fx_catch_13);
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_22, &v_88, &v_85);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_85, 0, true, &v_86), _fx_catch_13);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_84, v_86, false, &v_86), _fx_catch_13);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(v_86, &result_0);
-                           FX_BREAK(_fx_catch_13);
+                        fx_str_t v_80 = {0};
+                        fx_str_t v_81 = {0};
+                        fx_exn_t v_82 = {0};
+                        FX_CALL(_fx_M5LexerFM6stringS1S(&ident_0, &v_80, 0), _fx_catch_11);
+                        fx_str_t slit_10 = FX_MAKE_STR("Unexpected keyword \'");
+                        fx_str_t slit_11 = FX_MAKE_STR("\'");
+                        {
+                           const fx_str_t strs_1[] = { slit_10, v_80, slit_11 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_81), _fx_catch_11);
                         }
-                        else {
-                           _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_23);
-                           *new_exp_0 = false;
-                           _fx_make_T2N14Lexer__token_tTa2i(&t_23, &loc_0, &v_87);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_87, 0, true, &result_8), _fx_catch_13);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_8, &result_0);
-                           FX_BREAK(_fx_catch_13);
-                        }
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_81, &v_82), _fx_catch_11);
+                        FX_THROW(&v_82, true, _fx_catch_11);
 
-                     _fx_catch_13: ;
-                        if (result_8) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_8);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_87);
-                        _fx_free_N14Lexer__token_t(&t_23);
-                        if (v_86) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_86);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_85);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_84);
-                        _fx_free_N14Lexer__token_t(&t_22);
-                        FX_FREE_STR(&v_83);
+                     _fx_catch_11: ;
+                        fx_free_exn(&v_82);
+                        FX_FREE_STR(&v_81);
+                        FX_FREE_STR(&v_80);
                      }
-                     FX_CHECK_EXN(_fx_catch_66);
+                     FX_CHECK_EXN(_fx_catch_12);
+                     _fx_make_T2N14Lexer__token_tTa2i(&t_12, &loc_0, &v_68);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_68, 0, true, &tokens_0), _fx_catch_12);
+
+                  _fx_catch_12: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_68);
+                     _fx_free_N14Lexer__token_t(&t_12);
                   }
                   else {
-                     bool prev_ne_0 = *new_exp_0;
-                     *prev_dot_0 = false;
-                     *new_exp_0 = true;
-                     int_ res_4;
-                     FX_CALL(_fx_M5LexerFM3mini2ii(*pos_0 + 1, len_0, &res_4, 0), _fx_catch_66);
-                     *pos_0 = res_4;
-                     int_ v_89 = *pos_0 + 1;
-                     char_ c2_0 = FX_STR_ELEM_ZERO(buf_0, v_89);
-                     int_ v_90 = *pos_0 + 2;
-                     char_ c3_0 = FX_STR_ELEM_ZERO(buf_0, v_90);
-                     char_ c_2 = c_0;
-                     if (c_2 == (char_)40) {
-                        _fx_N14Lexer__token_t v_91 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_92 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_93 = 0;
-                        _fx_N14Lexer__token_t v_94 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_95 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_9 = 0;
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_91);
-                        _fx_Ta2i v_96;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_96, 0), _fx_catch_14);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_91, &v_96, &v_92);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_92, *paren_stack_0, true, &v_93), _fx_catch_14);
-                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                        FX_COPY_PTR(v_93, paren_stack_0);
-                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_94);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_94, &loc_0, &v_95);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_95, 0, true, &result_9), _fx_catch_14);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_9, &result_0);
-                        FX_BREAK(_fx_catch_14);
-
-                     _fx_catch_14: ;
-                        if (result_9) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_9);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_95);
-                        _fx_free_N14Lexer__token_t(&v_94);
-                        if (v_93) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_93);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_92);
-                        _fx_free_N14Lexer__token_t(&v_91);
-                     }
-                     else if (c_2 == (char_)41) {
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_3 = 0;
+                     fx_str_t v_83 = {0};
+                     _fx_N14Lexer__token_t t_22 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_84 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_85 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_86 = 0;
+                     _fx_N14Lexer__token_t t_23 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_87 = {0};
+                     if (c_0 == (char_)64) {
+                        FX_CALL(fx_substr(&ident_0, 1, 0, 1, 2, &v_83), _fx_catch_13);
+                        _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &v_83, &t_22);
                         *new_exp_0 = false;
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_3);
-                        if (paren_stack_3 != 0) {
-                           if (paren_stack_3->hd.t0.tag == 44) {
-                              _fx_T2N14Lexer__token_tTa2i v_97 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i result_10 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i* rest_0 = &paren_stack_3->tl;
-                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(*rest_0, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_97);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_97, 0, true, &result_10), _fx_catch_15);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_10, &result_0);
-                              FX_BREAK(_fx_catch_15);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_84);
+                        _fx_Ta2i v_88;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 + 1, strm_0, &v_88, 0), _fx_catch_13);
+                        _fx_make_T2N14Lexer__token_tTa2i(&t_22, &v_88, &v_85);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_85, 0, true, &v_86), _fx_catch_13);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_84, v_86, true, &tokens_0), _fx_catch_13);
+                     }
+                     else {
+                        _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(*new_exp_0, &ident_0, &t_23);
+                        *new_exp_0 = false;
+                        _fx_make_T2N14Lexer__token_tTa2i(&t_23, &loc_0, &v_87);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_87, 0, true, &tokens_0), _fx_catch_13);
+                     }
 
-                           _fx_catch_15: ;
-                              if (result_10) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_10);
+                  _fx_catch_13: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_87);
+                     _fx_free_N14Lexer__token_t(&t_23);
+                     if (v_86) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_86);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_85);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_84);
+                     _fx_free_N14Lexer__token_t(&t_22);
+                     FX_FREE_STR(&v_83);
+                  }
+                  FX_CHECK_EXN(_fx_cleanup);
+               }
+               else {
+                  bool prev_ne_0 = *new_exp_0;
+                  *prev_dot_0 = false;
+                  *new_exp_0 = true;
+                  int_ res_4;
+                  FX_CALL(_fx_M5LexerFM3mini2ii(*pos_0 + 1, len_0, &res_4, 0), _fx_cleanup);
+                  *pos_0 = res_4;
+                  int_ v_89 = *pos_0 + 1;
+                  char_ c2_0 = FX_STR_ELEM_ZERO(buf_0, v_89);
+                  int_ v_90 = *pos_0 + 2;
+                  char_ c3_0 = FX_STR_ELEM_ZERO(buf_0, v_90);
+                  char_ c_2 = c_0;
+                  if (c_2 == (char_)40) {
+                     _fx_N14Lexer__token_t v_91 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_92 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_93 = 0;
+                     _fx_N14Lexer__token_t v_94 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_95 = {0};
+                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_91);
+                     _fx_Ta2i v_96;
+                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_96, 0), _fx_catch_14);
+                     _fx_make_T2N14Lexer__token_tTa2i(&v_91, &v_96, &v_92);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_92, *paren_stack_1, true, &v_93), _fx_catch_14);
+                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                     FX_COPY_PTR(v_93, paren_stack_1);
+                     _fx_M5LexerFM6LPARENN14Lexer__token_t1B(prev_ne_0, &v_94);
+                     _fx_make_T2N14Lexer__token_tTa2i(&v_94, &loc_0, &v_95);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_95, 0, true, &tokens_0), _fx_catch_14);
+
+                  _fx_catch_14: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_95);
+                     _fx_free_N14Lexer__token_t(&v_94);
+                     if (v_93) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_93);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_92);
+                     _fx_free_N14Lexer__token_t(&v_91);
+                  }
+                  else if (c_2 == (char_)41) {
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_3 = 0;
+                     *new_exp_0 = false;
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_3);
+                     if (paren_stack_3 != 0) {
+                        if (paren_stack_3->hd.t0.tag == 44) {
+                           _fx_T2N14Lexer__token_tTa2i v_97 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i* rest_0 = &paren_stack_3->tl;
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                           FX_COPY_PTR(*rest_0, paren_stack_1);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_97);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_97, 0, true, &tokens_0), _fx_catch_15);
+
+                        _fx_catch_15: ;
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_97);
+                           goto _fx_endmatch_6;
+                        }
+                     }
+                     fx_exn_t v_98 = {0};
+                     fx_str_t slit_12 = FX_MAKE_STR("Unexpected \')\', check parens");
+                     FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_12, &v_98), _fx_catch_16);
+                     FX_THROW(&v_98, true, _fx_catch_16);
+
+                  _fx_catch_16: ;
+                     fx_free_exn(&v_98);
+
+                  _fx_endmatch_6: ;
+                     FX_CHECK_EXN(_fx_catch_17);
+
+                  _fx_catch_17: ;
+                     if (paren_stack_3) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_3);
+                     }
+                  }
+                  else if (c_2 == (char_)91) {
+                     _fx_N14Lexer__token_t v_99 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_100 = {0};
+                     _fx_N14Lexer__token_t v_101 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_102 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_103 = 0;
+                     _fx_N14Lexer__token_t v_104 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_105 = {0};
+                     bool t_24;
+                     if (prev_ne_0) {
+                        t_24 = c1_0 == (char_)93;
+                     }
+                     else {
+                        t_24 = false;
+                     }
+                     if (t_24) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&_fx_g15Lexer__LitEmpty, &v_99);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_99, &loc_0, &v_100);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_100, 0, true, &tokens_0), _fx_catch_18);
+                     }
+                     else {
+                        _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_101);
+                        _fx_Ta2i v_106;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_106, 0), _fx_catch_18);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_101, &v_106, &v_102);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_102, *paren_stack_1, true, &v_103), _fx_catch_18);
+                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                        FX_COPY_PTR(v_103, paren_stack_1);
+                        _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_104);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_104, &loc_0, &v_105);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_105, 0, true, &tokens_0), _fx_catch_18);
+                     }
+
+                  _fx_catch_18: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_105);
+                     _fx_free_N14Lexer__token_t(&v_104);
+                     if (v_103) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_103);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_102);
+                     _fx_free_N14Lexer__token_t(&v_101);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_100);
+                     _fx_free_N14Lexer__token_t(&v_99);
+                  }
+                  else if (c_2 == (char_)93) {
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_4 = 0;
+                     *new_exp_0 = false;
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_4);
+                     if (paren_stack_4 != 0) {
+                        if (paren_stack_4->hd.t0.tag == 47) {
+                           _fx_T2N14Lexer__token_tTa2i v_107 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i* rest_1 = &paren_stack_4->tl;
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                           FX_COPY_PTR(*rest_1, paren_stack_1);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__RSQUARE, &loc_0, &v_107);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_107, 0, true, &tokens_0), _fx_catch_19);
+
+                        _fx_catch_19: ;
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_107);
+                           goto _fx_endmatch_7;
+                        }
+                     }
+                     fx_exn_t v_108 = {0};
+                     fx_str_t slit_13 = FX_MAKE_STR("Unexpected \']\', check parens");
+                     FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_13, &v_108), _fx_catch_20);
+                     FX_THROW(&v_108, true, _fx_catch_20);
+
+                  _fx_catch_20: ;
+                     fx_free_exn(&v_108);
+
+                  _fx_endmatch_7: ;
+                     FX_CHECK_EXN(_fx_catch_21);
+
+                  _fx_catch_21: ;
+                     if (paren_stack_4) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_4);
+                     }
+                  }
+                  else if (c_2 == (char_)123) {
+                     _fx_T2N14Lexer__token_tTa2i v_109 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_110 = 0;
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_5 = 0;
+                     _fx_Ta2i v_111;
+                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_111, 0), _fx_catch_26);
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &v_111, &v_109);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_109, *paren_stack_1, true, &v_110), _fx_catch_26);
+                     _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                     FX_COPY_PTR(v_110, paren_stack_1);
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_5);
+                     if (paren_stack_5 != 0) {
+                        if (paren_stack_5->hd.t0.tag == 49) {
+                           _fx_LT2N14Lexer__token_tTa2i v_112 = paren_stack_5->tl;
+                           if (v_112 != 0) {
+                              if (v_112->hd.t0.tag == 9) {
+                                 _fx_T2iS v_113 = {0};
+                                 fx_str_t s_0 = {0};
+                                 fx_str_t v_114 = {0};
+                                 _fx_N10Ast__lit_t v_115 = {0};
+                                 _fx_N14Lexer__token_t v_116 = {0};
+                                 _fx_T2N14Lexer__token_tTa2i v_117 = {0};
+                                 *new_exp_0 = false;
+                                 _fx_LT2N14Lexer__token_tTa2i* rest_2 = &v_112->tl;
+                                 _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                                 FX_COPY_PTR(*rest_2, paren_stack_1);
+                                 FX_CALL(_fx_M5LexerFM9get_ccodeT2iS2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_113, 0),
+                                    _fx_catch_22);
+                                 int_ p_6 = v_113.t0;
+                                 fx_copy_str(&v_113.t1, &s_0);
+                                 *pos_0 = p_6;
+                                 FX_CALL(_fx_M6StringFM5stripS1S(&s_0, &v_114, 0), _fx_catch_22);
+                                 _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_114, &v_115);
+                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_115, &v_116);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_116, &loc_0, &v_117);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_117, 0, true, &tokens_0), _fx_catch_22);
+
+                              _fx_catch_22: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_117);
+                                 _fx_free_N14Lexer__token_t(&v_116);
+                                 _fx_free_N10Ast__lit_t(&v_115);
+                                 FX_FREE_STR(&v_114);
+                                 FX_FREE_STR(&s_0);
+                                 _fx_free_T2iS(&v_113);
+                                 goto _fx_endmatch_9;
                               }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_97);
-                              goto _fx_endmatch_6;
                            }
                         }
-                        fx_exn_t v_98 = {0};
-                        fx_str_t slit_12 = FX_MAKE_STR("Unexpected \')\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_12, &v_98), _fx_catch_16);
-                        FX_THROW(&v_98, true, _fx_catch_16);
-
-                     _fx_catch_16: ;
-                        fx_free_exn(&v_98);
-
-                     _fx_endmatch_6: ;
-                        FX_CHECK_EXN(_fx_catch_17);
-
-                     _fx_catch_17: ;
-                        if (paren_stack_3) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_3);
-                        }
                      }
-                     else if (c_2 == (char_)91) {
-                        _fx_N14Lexer__token_t v_99 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_100 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_11 = 0;
-                        _fx_N14Lexer__token_t v_101 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_102 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_103 = 0;
-                        _fx_N14Lexer__token_t v_104 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_105 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_12 = 0;
-                        bool t_24;
-                        if (prev_ne_0) {
-                           t_24 = c1_0 == (char_)93;
-                        }
-                        else {
-                           t_24 = false;
-                        }
-                        if (t_24) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&_fx_g15Lexer__LitEmpty, &v_99);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_99, &loc_0, &v_100);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_100, 0, true, &result_11), _fx_catch_18);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_11, &result_0);
-                           FX_BREAK(_fx_catch_18);
-                        }
-                        else {
-                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_101);
-                           _fx_Ta2i v_106;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_106, 0),
-                              _fx_catch_18);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_101, &v_106, &v_102);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_102, *paren_stack_0, true, &v_103), _fx_catch_18);
-                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_103, paren_stack_0);
-                           _fx_M5LexerFM7LSQUAREN14Lexer__token_t1B(prev_ne_0, &v_104);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_104, &loc_0, &v_105);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_105, 0, true, &result_12), _fx_catch_18);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_12, &result_0);
-                           FX_BREAK(_fx_catch_18);
-                        }
+                     if (paren_stack_5 != 0) {
+                        _fx_LT2N14Lexer__token_tTa2i v_118 = paren_stack_5->tl;
+                        if (v_118 != 0) {
+                           if (v_118->hd.t0.tag == 26) {
+                              _fx_T2N14Lexer__token_tTa2i* v_119 = &paren_stack_5->hd;
+                              if (v_119->t0.tag == 49) {
+                                 _fx_T2N14Lexer__token_tTa2i v_120 = {0};
+                                 _fx_T2N14Lexer__token_tTa2i v_121 = {0};
+                                 _fx_LT2N14Lexer__token_tTa2i v_122 = 0;
+                                 _fx_T2N14Lexer__token_tTa2i v_123 = {0};
+                                 _fx_Ta2i* l1_0 = &v_119->t1;
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, l1_0, &v_120);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_121);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_121, v_118->tl, true, &v_122), _fx_catch_23);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_120, v_122, false, &v_122), _fx_catch_23);
+                                 _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                                 FX_COPY_PTR(v_122, paren_stack_1);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_123);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_123, 0, true, &tokens_0), _fx_catch_23);
 
-                     _fx_catch_18: ;
-                        if (result_12) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_12);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_105);
-                        _fx_free_N14Lexer__token_t(&v_104);
-                        if (v_103) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_103);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_102);
-                        _fx_free_N14Lexer__token_t(&v_101);
-                        if (result_11) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_11);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_100);
-                        _fx_free_N14Lexer__token_t(&v_99);
-                     }
-                     else if (c_2 == (char_)93) {
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_4 = 0;
-                        *new_exp_0 = false;
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_4);
-                        if (paren_stack_4 != 0) {
-                           if (paren_stack_4->hd.t0.tag == 47) {
-                              _fx_T2N14Lexer__token_tTa2i v_107 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i result_13 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i* rest_1 = &paren_stack_4->tl;
-                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(*rest_1, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__RSQUARE, &loc_0, &v_107);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_107, 0, true, &result_13), _fx_catch_19);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_13, &result_0);
-                              FX_BREAK(_fx_catch_19);
-
-                           _fx_catch_19: ;
-                              if (result_13) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_13);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_107);
-                              goto _fx_endmatch_7;
-                           }
-                        }
-                        fx_exn_t v_108 = {0};
-                        fx_str_t slit_13 = FX_MAKE_STR("Unexpected \']\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_13, &v_108), _fx_catch_20);
-                        FX_THROW(&v_108, true, _fx_catch_20);
-
-                     _fx_catch_20: ;
-                        fx_free_exn(&v_108);
-
-                     _fx_endmatch_7: ;
-                        FX_CHECK_EXN(_fx_catch_21);
-
-                     _fx_catch_21: ;
-                        if (paren_stack_4) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_4);
-                        }
-                     }
-                     else if (c_2 == (char_)123) {
-                        _fx_T2N14Lexer__token_tTa2i v_109 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_110 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_5 = 0;
-                        _fx_Ta2i v_111;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_111, 0), _fx_catch_26);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &v_111, &v_109);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_109, *paren_stack_0, true, &v_110), _fx_catch_26);
-                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                        FX_COPY_PTR(v_110, paren_stack_0);
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_5);
-                        if (paren_stack_5 != 0) {
-                           if (paren_stack_5->hd.t0.tag == 49) {
-                              _fx_LT2N14Lexer__token_tTa2i v_112 = paren_stack_5->tl;
-                              if (v_112 != 0) {
-                                 if (v_112->hd.t0.tag == 9) {
-                                    _fx_T2iS v_113 = {0};
-                                    fx_str_t s_0 = {0};
-                                    fx_str_t v_114 = {0};
-                                    _fx_N10Ast__lit_t v_115 = {0};
-                                    _fx_N14Lexer__token_t v_116 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_117 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_14 = 0;
-                                    *new_exp_0 = false;
-                                    _fx_LT2N14Lexer__token_tTa2i* rest_2 = &v_112->tl;
-                                    _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                    FX_COPY_PTR(*rest_2, paren_stack_0);
-                                    FX_CALL(_fx_M5LexerFM9get_ccodeT2iS2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_113, 0),
-                                       _fx_catch_22);
-                                    int_ p_6 = v_113.t0;
-                                    fx_copy_str(&v_113.t1, &s_0);
-                                    *pos_0 = p_6;
-                                    FX_CALL(_fx_M6StringFM5stripS1S(&s_0, &v_114, 0), _fx_catch_22);
-                                    _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_114, &v_115);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_115, &v_116);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_116, &loc_0, &v_117);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_117, 0, true, &result_14), _fx_catch_22);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_14, &result_0);
-                                    FX_BREAK(_fx_catch_22);
-
-                                 _fx_catch_22: ;
-                                    if (result_14) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_14);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_117);
-                                    _fx_free_N14Lexer__token_t(&v_116);
-                                    _fx_free_N10Ast__lit_t(&v_115);
-                                    FX_FREE_STR(&v_114);
-                                    FX_FREE_STR(&s_0);
-                                    _fx_free_T2iS(&v_113);
-                                    goto _fx_endmatch_9;
+                              _fx_catch_23: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_123);
+                                 if (v_122) {
+                                    _fx_free_LT2N14Lexer__token_tTa2i(&v_122);
                                  }
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_121);
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_120);
+                                 goto _fx_endmatch_9;
                               }
                            }
                         }
-                        if (paren_stack_5 != 0) {
-                           _fx_LT2N14Lexer__token_tTa2i v_118 = paren_stack_5->tl;
-                           if (v_118 != 0) {
-                              if (v_118->hd.t0.tag == 26) {
-                                 _fx_T2N14Lexer__token_tTa2i* v_119 = &paren_stack_5->hd;
-                                 if (v_119->t0.tag == 49) {
-                                    _fx_T2N14Lexer__token_tTa2i v_120 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_121 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i v_122 = 0;
-                                    _fx_T2N14Lexer__token_tTa2i v_123 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_15 = 0;
-                                    _fx_Ta2i* l1_0 = &v_119->t1;
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, l1_0, &v_120);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_121);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_121, v_118->tl, true, &v_122), _fx_catch_23);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_120, v_122, false, &v_122), _fx_catch_23);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                    FX_COPY_PTR(v_122, paren_stack_0);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, l1_0, &v_123);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_123, 0, true, &result_15), _fx_catch_23);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_15, &result_0);
-                                    FX_BREAK(_fx_catch_23);
-
-                                 _fx_catch_23: ;
-                                    if (result_15) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_15);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_123);
-                                    if (v_122) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&v_122);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_121);
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_120);
-                                    goto _fx_endmatch_9;
-                                 }
-                              }
-                           }
-                        }
-                        _fx_T2N14Lexer__token_tTa2i v_124 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_125 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i v_126 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i result_16 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &loc_0, &v_124);
-                        FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&v_125, fx_fv), _fx_catch_25);
-                        if (v_125 != 0) {
-                           _fx_T2N14Lexer__token_tTa2i* v_127 = &v_125->hd;
-                           if (v_127->t0.tag == 81) {
-                              _fx_T2N14Lexer__token_tTa2i v_128 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_129 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_130 = {0};
-                              _fx_Ta2i* p_7 = &v_127->t1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_128);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_128, *paren_stack_0, true, &v_129), _fx_catch_24);
-                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(v_129, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_130);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_130, v_125->tl, true, &v_126), _fx_catch_24);
-
-                           _fx_catch_24: ;
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_130);
-                              if (v_129) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_129);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_128);
-                              goto _fx_endmatch_8;
-                           }
-                        }
-                        FX_COPY_PTR(v_125, &v_126);
-
-                     _fx_endmatch_8: ;
-                        FX_CHECK_EXN(_fx_catch_25);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_124, v_126, true, &result_16), _fx_catch_25);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_16, &result_0);
-                        FX_BREAK(_fx_catch_25);
-
-                     _fx_catch_25: ;
-                        if (result_16) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_16);
-                        }
-                        if (v_126) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_126);
-                        }
-                        if (v_125) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_125);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_124);
-
-                     _fx_endmatch_9: ;
-                        FX_CHECK_EXN(_fx_catch_26);
-
-                     _fx_catch_26: ;
-                        if (paren_stack_5) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_5);
-                        }
-                        if (v_110) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_110);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_109);
                      }
-                     else if (c_2 == (char_)125) {
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_6 = 0;
-                        *new_exp_0 = false;
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_6);
-                        if (paren_stack_6 != 0) {
-                           if (paren_stack_6->hd.t0.tag == 45) {
-                              _fx_T4iSiB v_131 = {0};
-                              fx_str_t s_1 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_132 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i v_133 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_134 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_135 = {0};
-                              _fx_N14Lexer__token_t v_136 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_137 = {0};
-                              _fx_N10Ast__lit_t v_138 = {0};
-                              _fx_N14Lexer__token_t v_139 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_140 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_141 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i v_142 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_143 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_144 = 0;
-                              _fx_N14Lexer__token_t v_145 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_146 = {0};
-                              _fx_N14Lexer__token_t v_147 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_148 = {0};
-                              _fx_N14Lexer__token_t v_149 = {0};
-                              _fx_T2N14Lexer__token_tTa2i v_150 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_151 = 0;
-                              _fx_T2N14Lexer__token_tTa2i v_152 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i v_153 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i result_17 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i* rest_3 = &paren_stack_6->tl;
-                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(*rest_3, paren_stack_0);
-                              _fx_Ta2i v_154;
-                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_154, 0),
+                     _fx_T2N14Lexer__token_tTa2i v_124 = {0};
+                     _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i v_125 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_126 = 0;
+                     _fx_LT2N14Lexer__token_tTa2i v_127 = 0;
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__LBRACE, &loc_0, &v_124);
+                     FX_CALL(_fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(&v_125, fx_fv), _fx_catch_25);
+                     FX_COPY_PTR(v_125.t0, &v_126);
+                     if (v_126 != 0) {
+                        _fx_T2N14Lexer__token_tTa2i* v_128 = &v_126->hd;
+                        if (v_128->t0.tag == 81) {
+                           _fx_T2N14Lexer__token_tTa2i v_129 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_130 = 0;
+                           _fx_T2N14Lexer__token_tTa2i v_131 = {0};
+                           _fx_Ta2i* p_7 = &v_128->t1;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_129);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_129, *paren_stack_1, true, &v_130), _fx_catch_24);
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                           FX_COPY_PTR(v_130, paren_stack_1);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, p_7, &v_131);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_131, v_126->tl, true, &v_127), _fx_catch_24);
+
+                        _fx_catch_24: ;
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_131);
+                           if (v_130) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_130);
+                           }
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_129);
+                           goto _fx_endmatch_8;
+                        }
+                     }
+                     FX_COPY_PTR(v_126, &v_127);
+
+                  _fx_endmatch_8: ;
+                     FX_CHECK_EXN(_fx_catch_25);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_124, v_127, true, &tokens_0), _fx_catch_25);
+
+                  _fx_catch_25: ;
+                     if (v_127) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_127);
+                     }
+                     if (v_126) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_126);
+                     }
+                     _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(&v_125);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_124);
+
+                  _fx_endmatch_9: ;
+                     FX_CHECK_EXN(_fx_catch_26);
+
+                  _fx_catch_26: ;
+                     if (paren_stack_5) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_5);
+                     }
+                     if (v_110) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_110);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_109);
+                  }
+                  else if (c_2 == (char_)125) {
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_6 = 0;
+                     *new_exp_0 = false;
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_6);
+                     if (paren_stack_6 != 0) {
+                        if (paren_stack_6->hd.t0.tag == 45) {
+                           _fx_T4iSiB v_132 = {0};
+                           fx_str_t s_1 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_133 = 0;
+                           _fx_LT2N14Lexer__token_tTa2i v_134 = 0;
+                           _fx_T2N14Lexer__token_tTa2i v_135 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_136 = {0};
+                           _fx_N14Lexer__token_t v_137 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_138 = {0};
+                           _fx_N10Ast__lit_t v_139 = {0};
+                           _fx_N14Lexer__token_t v_140 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_141 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_142 = 0;
+                           _fx_LT2N14Lexer__token_tTa2i v_143 = 0;
+                           _fx_T2N14Lexer__token_tTa2i v_144 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_145 = 0;
+                           _fx_N14Lexer__token_t v_146 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_147 = {0};
+                           _fx_N14Lexer__token_t v_148 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_149 = {0};
+                           _fx_N14Lexer__token_t v_150 = {0};
+                           _fx_T2N14Lexer__token_tTa2i v_151 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_152 = 0;
+                           _fx_T2N14Lexer__token_tTa2i v_153 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i v_154 = 0;
+                           _fx_LT2N14Lexer__token_tTa2i* rest_3 = &paren_stack_6->tl;
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                           FX_COPY_PTR(*rest_3, paren_stack_1);
+                           _fx_Ta2i v_155;
+                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_155, 0), _fx_catch_27);
+                           char_ res_5;
+                           FX_CALL(_fx_F3chrC1i(34, &res_5, 0), _fx_catch_27);
+                           FX_CALL(
+                              _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, *pos_0, &v_155, res_5, false, true, &v_132,
+                                 0), _fx_catch_27);
+                           int_ p_8 = v_132.t0;
+                           fx_copy_str(&v_132.t1, &s_1);
+                           int_ dl_1 = v_132.t2;
+                           bool inline_exp_1 = v_132.t3;
+                           strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_1;
+                           *pos_0 = p_8;
+                           _fx_Nt6option1R8format_t fmt_curr_0 = *fmt_0;
+                           *fmt_0 = _fx_g13Lexer__None1_;
+                           FX_CALL(
+                              _fx_M5LexerFM10fmt2tokensLT2N14Lexer__token_tTa2i2Nt6option1R8format_tTa2i(&fmt_curr_0, &loc_0,
+                                 &v_133, 0), _fx_catch_27);
+                           if (FX_STR_LENGTH(s_1) == 0) {
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_135);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_135, 0, true, &v_134), _fx_catch_27);
+                           }
+                           else {
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_136);
+                              _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_137);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_137, &loc_0, &v_138);
+                              _fx_M3AstFM9LitStringN10Ast__lit_t1S(&s_1, &v_139);
+                              _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_139, &v_140);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_140, &loc_0, &v_141);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_141, 0, true, &v_142), _fx_catch_27);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_138, v_142, false, &v_142), _fx_catch_27);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_136, v_142, true, &v_134), _fx_catch_27);
+                           }
+                           if (inline_exp_1) {
+                              *new_exp_0 = true;
+                              _fx_Ta2i v_156;
+                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_156, 0),
                                  _fx_catch_27);
-                              char_ res_5;
-                              FX_CALL(_fx_F3chrC1i(34, &res_5, 0), _fx_catch_27);
-                              FX_CALL(
-                                 _fx_M10LexerUtilsFM9getstringT4iSiB6SiTa2iCBB(&buf_0, *pos_0, &v_154, res_5, false, true,
-                                    &v_131, 0), _fx_catch_27);
-                              int_ p_8 = v_131.t0;
-                              fx_copy_str(&v_131.t1, &s_1);
-                              int_ dl_1 = v_131.t2;
-                              bool inline_exp_1 = v_131.t3;
-                              strm_0->u.stream_t.t1 = strm_0->u.stream_t.t1 + dl_1;
-                              *pos_0 = p_8;
-                              _fx_Nt6option1R8format_t fmt_curr_0 = *fmt_0;
-                              *fmt_0 = _fx_g13Lexer__None1_;
-                              FX_CALL(
-                                 _fx_M5LexerFM10fmt2tokensLT2N14Lexer__token_tTa2i2Nt6option1R8format_tTa2i(&fmt_curr_0, &loc_0,
-                                    &v_132, 0), _fx_catch_27);
-                              if (FX_STR_LENGTH(s_1) == 0) {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_134);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_134, 0, true, &v_133), _fx_catch_27);
-                              }
-                              else {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_135);
-                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_136);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_136, &loc_0, &v_137);
-                                 _fx_M3AstFM9LitStringN10Ast__lit_t1S(&s_1, &v_138);
-                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_138, &v_139);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_139, &loc_0, &v_140);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_140, 0, true, &v_141), _fx_catch_27);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_137, v_141, false, &v_141), _fx_catch_27);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_135, v_141, true, &v_133), _fx_catch_27);
-                              }
-                              if (inline_exp_1) {
-                                 *new_exp_0 = true;
-                                 _fx_Ta2i v_155;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_155, 0),
-                                    _fx_catch_27);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_155, &v_143);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_143, *paren_stack_0, true, &v_144), _fx_catch_27);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                 FX_COPY_PTR(v_144, paren_stack_0);
-                                 _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_145);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_145, &loc_0, &v_146);
-                                 fx_str_t slit_14 = FX_MAKE_STR("string");
-                                 _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_14, &v_147);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_147, &loc_0, &v_148);
-                                 _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_149);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_149, &loc_0, &v_150);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_150, 0, true, &v_151), _fx_catch_27);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_148, v_151, false, &v_151), _fx_catch_27);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_146, v_151, true, &v_142), _fx_catch_27);
-                              }
-                              else {
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_152);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_152, 0, true, &v_142), _fx_catch_27);
-                              }
-                              FX_CALL(
-                                 _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
-                                    v_133, v_142, &v_153, 0), _fx_catch_27);
-                              FX_CALL(
-                                 _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
-                                    v_132, v_153, &result_17, 0), _fx_catch_27);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_17, &result_0);
-                              FX_BREAK(_fx_catch_27);
-
-                           _fx_catch_27: ;
-                              if (result_17) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_17);
-                              }
-                              if (v_153) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_153);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_152);
-                              if (v_151) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_151);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_150);
-                              _fx_free_N14Lexer__token_t(&v_149);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_148);
-                              _fx_free_N14Lexer__token_t(&v_147);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_146);
-                              _fx_free_N14Lexer__token_t(&v_145);
-                              if (v_144) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_144);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_143);
-                              if (v_142) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_142);
-                              }
-                              if (v_141) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_141);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_140);
-                              _fx_free_N14Lexer__token_t(&v_139);
-                              _fx_free_N10Ast__lit_t(&v_138);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_137);
-                              _fx_free_N14Lexer__token_t(&v_136);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_135);
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_134);
-                              if (v_133) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_133);
-                              }
-                              if (v_132) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&v_132);
-                              }
-                              FX_FREE_STR(&s_1);
-                              _fx_free_T4iSiB(&v_131);
-                              goto _fx_endmatch_10;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g24Lexer__STR_INTERP_LPAREN, &v_156, &v_144);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_144, *paren_stack_1, true, &v_145), _fx_catch_27);
+                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                              FX_COPY_PTR(v_145, paren_stack_1);
+                              _fx_M5LexerFM4PLUSN14Lexer__token_t1B(false, &v_146);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_146, &loc_0, &v_147);
+                              fx_str_t slit_14 = FX_MAKE_STR("string");
+                              _fx_M5LexerFM5IDENTN14Lexer__token_t2BS(true, &slit_14, &v_148);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_148, &loc_0, &v_149);
+                              _fx_M5LexerFM6LPARENN14Lexer__token_t1B(false, &v_150);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_150, &loc_0, &v_151);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_151, 0, true, &v_152), _fx_catch_27);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_149, v_152, false, &v_152), _fx_catch_27);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_147, v_152, true, &v_143), _fx_catch_27);
                            }
-                        }
-                        if (paren_stack_6 != 0) {
-                           if (paren_stack_6->hd.t0.tag == 55) {
-                              _fx_LT2N14Lexer__token_tTa2i v_156 = paren_stack_6->tl;
-                              if (v_156 != 0) {
-                                 if (v_156->hd.t0.tag == 49) {
-                                    _fx_T2N14Lexer__token_tTa2i v_157 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_18 = 0;
-                                    _fx_LT2N14Lexer__token_tTa2i* rest_4 = &v_156->tl;
-                                    _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                    FX_COPY_PTR(*rest_4, paren_stack_0);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_157);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_157, 0, true, &result_18), _fx_catch_28);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_18, &result_0);
-                                    FX_BREAK(_fx_catch_28);
-
-                                 _fx_catch_28: ;
-                                    if (result_18) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_18);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_157);
-                                    goto _fx_endmatch_10;
-                                 }
-                              }
+                           else {
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &loc_0, &v_153);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_153, 0, true, &v_143), _fx_catch_27);
                            }
-                        }
-                        if (paren_stack_6 != 0) {
-                           if (paren_stack_6->hd.t0.tag == 49) {
-                              _fx_T2N14Lexer__token_tTa2i v_158 = {0};
-                              _fx_LT2N14Lexer__token_tTa2i result_19 = 0;
-                              _fx_LT2N14Lexer__token_tTa2i* rest_5 = &paren_stack_6->tl;
-                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                              FX_COPY_PTR(*rest_5, paren_stack_0);
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_158);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_158, 0, true, &result_19), _fx_catch_29);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_19, &result_0);
-                              FX_BREAK(_fx_catch_29);
+                           FX_CALL(
+                              _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
+                                 v_134, v_143, &v_154, 0), _fx_catch_27);
+                           FX_CALL(
+                              _fx_M5LexerFM7__add__LT2N14Lexer__token_tTa2i2LT2N14Lexer__token_tTa2iLT2N14Lexer__token_tTa2i(
+                                 v_133, v_154, &tokens_0, 0), _fx_catch_27);
 
-                           _fx_catch_29: ;
-                              if (result_19) {
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_19);
-                              }
-                              _fx_free_T2N14Lexer__token_tTa2i(&v_158);
-                              goto _fx_endmatch_10;
+                        _fx_catch_27: ;
+                           if (v_154) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_154);
                            }
-                        }
-                        fx_exn_t v_159 = {0};
-                        fx_str_t slit_15 = FX_MAKE_STR("Unexpected \'}\', check parens");
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_15, &v_159), _fx_catch_30);
-                        FX_THROW(&v_159, true, _fx_catch_30);
-
-                     _fx_catch_30: ;
-                        fx_free_exn(&v_159);
-
-                     _fx_endmatch_10: ;
-                        FX_CHECK_EXN(_fx_catch_31);
-
-                     _fx_catch_31: ;
-                        if (paren_stack_6) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_6);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_153);
+                           if (v_152) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_152);
+                           }
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_151);
+                           _fx_free_N14Lexer__token_t(&v_150);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_149);
+                           _fx_free_N14Lexer__token_t(&v_148);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_147);
+                           _fx_free_N14Lexer__token_t(&v_146);
+                           if (v_145) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_145);
+                           }
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_144);
+                           if (v_143) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_143);
+                           }
+                           if (v_142) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_142);
+                           }
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_141);
+                           _fx_free_N14Lexer__token_t(&v_140);
+                           _fx_free_N10Ast__lit_t(&v_139);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_138);
+                           _fx_free_N14Lexer__token_t(&v_137);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_136);
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_135);
+                           if (v_134) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_134);
+                           }
+                           if (v_133) {
+                              _fx_free_LT2N14Lexer__token_tTa2i(&v_133);
+                           }
+                           FX_FREE_STR(&s_1);
+                           _fx_free_T4iSiB(&v_132);
+                           goto _fx_endmatch_10;
                         }
                      }
-                     else if (c_2 == (char_)124) {
-                        _fx_N14Lexer__token_t v_160 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_161 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_20 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_162 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_21 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_7 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpBitwiseOr, &v_160);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_160, &loc_0, &v_161);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_161, 0, true, &result_20), _fx_catch_34);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_20, &result_0);
-                           FX_BREAK(_fx_catch_34);
-                        }
-                        else if (c1_0 == (char_)124) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__LOGICAL_OR, &loc_0, &v_162);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_162, 0, true, &result_21), _fx_catch_34);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_21, &result_0);
-                           FX_BREAK(_fx_catch_34);
-                        }
-                        else {
-                           FX_COPY_PTR(*paren_stack_0, &paren_stack_7);
-                           if (paren_stack_7 != 0) {
-                              _fx_LT2N14Lexer__token_tTa2i v_163 = paren_stack_7->tl;
-                              if (v_163 != 0) {
-                                 if (paren_stack_7->hd.t0.tag == 55) {
-                                    if (v_163->hd.t0.tag == 49) {
-                                       _fx_T2N14Lexer__token_tTa2i v_164 = {0};
-                                       _fx_LT2N14Lexer__token_tTa2i result_22 = 0;
-                                       _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, &loc_0, &v_164);
-                                       FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_164, 0, true, &result_22), _fx_catch_32);
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                       FX_COPY_PTR(result_22, &result_0);
-                                       FX_BREAK(_fx_catch_32);
+                     if (paren_stack_6 != 0) {
+                        if (paren_stack_6->hd.t0.tag == 55) {
+                           _fx_LT2N14Lexer__token_tTa2i v_157 = paren_stack_6->tl;
+                           if (v_157 != 0) {
+                              if (v_157->hd.t0.tag == 49) {
+                                 _fx_T2N14Lexer__token_tTa2i v_158 = {0};
+                                 _fx_LT2N14Lexer__token_tTa2i* rest_4 = &v_157->tl;
+                                 _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                                 FX_COPY_PTR(*rest_4, paren_stack_1);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_158);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_158, 0, true, &tokens_0), _fx_catch_28);
 
-                                    _fx_catch_32: ;
-                                       if (result_22) {
-                                          _fx_free_LT2N14Lexer__token_tTa2i(&result_22);
-                                       }
-                                       _fx_free_T2N14Lexer__token_tTa2i(&v_164);
-                                       goto _fx_endmatch_11;
-                                    }
-                                 }
+                              _fx_catch_28: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_158);
+                                 goto _fx_endmatch_10;
                               }
                            }
-                           _fx_T2N14Lexer__token_tTa2i v_165 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i result_23 = 0;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BITWISE_OR, &loc_0, &v_165);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_165, 0, true, &result_23), _fx_catch_33);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_23, &result_0);
-                           FX_BREAK(_fx_catch_33);
-
-                        _fx_catch_33: ;
-                           if (result_23) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_23);
-                           }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_165);
-
-                        _fx_endmatch_11: ;
-                           FX_CHECK_EXN(_fx_catch_34);
                         }
-
-                     _fx_catch_34: ;
-                        if (paren_stack_7) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_7);
-                        }
-                        if (result_21) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_21);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_162);
-                        if (result_20) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_20);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_161);
-                        _fx_free_N14Lexer__token_t(&v_160);
                      }
-                     else if (c_2 == (char_)43) {
-                        _fx_N14Lexer__token_t v_166 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_167 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_24 = 0;
-                        _fx_N14Lexer__token_t v_168 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_169 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_25 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpAdd, &v_166);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_166, &loc_0, &v_167);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_167, 0, true, &result_24), _fx_catch_35);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_24, &result_0);
-                           FX_BREAK(_fx_catch_35);
-                        }
-                        else {
-                           _fx_M5LexerFM4PLUSN14Lexer__token_t1B(prev_ne_0, &v_168);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_168, &loc_0, &v_169);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_169, 0, true, &result_25), _fx_catch_35);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_25, &result_0);
-                           FX_BREAK(_fx_catch_35);
-                        }
+                     if (paren_stack_6 != 0) {
+                        if (paren_stack_6->hd.t0.tag == 49) {
+                           _fx_T2N14Lexer__token_tTa2i v_159 = {0};
+                           _fx_LT2N14Lexer__token_tTa2i* rest_5 = &paren_stack_6->tl;
+                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                           FX_COPY_PTR(*rest_5, paren_stack_1);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RBRACE, &loc_0, &v_159);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_159, 0, true, &tokens_0), _fx_catch_29);
 
-                     _fx_catch_35: ;
-                        if (result_25) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_25);
+                        _fx_catch_29: ;
+                           _fx_free_T2N14Lexer__token_tTa2i(&v_159);
+                           goto _fx_endmatch_10;
                         }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_169);
-                        _fx_free_N14Lexer__token_t(&v_168);
-                        if (result_24) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_24);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_167);
-                        _fx_free_N14Lexer__token_t(&v_166);
                      }
-                     else if (c_2 == (char_)45) {
-                        _fx_N14Lexer__token_t v_170 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_171 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_26 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_172 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_27 = 0;
-                        _fx_N14Lexer__token_t v_173 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_174 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_28 = 0;
-                        _fx_LT2N14Lexer__token_tTa2i ts_0 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpSub, &v_170);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_170, &loc_0, &v_171);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_171, 0, true, &result_26), _fx_catch_40);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_26, &result_0);
-                           FX_BREAK(_fx_catch_40);
-                        }
-                        else if (c1_0 == (char_)62) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__ARROW, &loc_0, &v_172);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_172, 0, true, &result_27), _fx_catch_40);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_27, &result_0);
-                           FX_BREAK(_fx_catch_40);
-                        }
-                        else if (!prev_ne_0) {
-                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(false, &v_173);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_173, &loc_0, &v_174);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_174, 0, true, &result_28), _fx_catch_40);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_28, &result_0);
-                           FX_BREAK(_fx_catch_40);
-                        }
-                        else {
-                           *expect_neg_number_0 = !*expect_neg_number_0;
-                           FX_CALL(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0(&ts_0, fx_fv), _fx_catch_40);
-                           *expect_neg_number_0 = !*expect_neg_number_0;
-                           if (ts_0 != 0) {
-                              _fx_N14Lexer__token_t* v_175 = &ts_0->hd.t0;
-                              if (v_175->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_176 = &v_175->u.LITERAL;
-                                 if (v_176->tag == 1) {
-                                    _fx_N10Ast__lit_t v_177 = {0};
-                                    _fx_N14Lexer__token_t v_178 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_179 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_29 = 0;
-                                    _fx_M3AstFM6LitIntN10Ast__lit_t1l(-v_176->u.LitInt, &v_177);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_177, &v_178);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_178, &loc_0, &v_179);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_179, ts_0->tl, true, &result_29),
-                                       _fx_catch_36);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_29, &result_0);
-                                    FX_BREAK(_fx_catch_36);
+                     fx_exn_t v_160 = {0};
+                     fx_str_t slit_15 = FX_MAKE_STR("Unexpected \'}\', check parens");
+                     FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_15, &v_160), _fx_catch_30);
+                     FX_THROW(&v_160, true, _fx_catch_30);
 
-                                 _fx_catch_36: ;
-                                    if (result_29) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_29);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_179);
-                                    _fx_free_N14Lexer__token_t(&v_178);
-                                    _fx_free_N10Ast__lit_t(&v_177);
-                                    goto _fx_endmatch_12;
-                                 }
-                              }
-                           }
-                           if (ts_0 != 0) {
-                              _fx_N14Lexer__token_t* v_180 = &ts_0->hd.t0;
-                              if (v_180->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_181 = &v_180->u.LITERAL;
-                                 if (v_181->tag == 2) {
-                                    _fx_N10Ast__lit_t v_182 = {0};
-                                    _fx_N14Lexer__token_t v_183 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_184 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_30 = 0;
-                                    _fx_T2il* vcase_0 = &v_181->u.LitSInt;
-                                    _fx_M3AstFM7LitSIntN10Ast__lit_t2il(vcase_0->t0, -vcase_0->t1, &v_182);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_182, &v_183);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_183, &loc_0, &v_184);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_184, ts_0->tl, true, &result_30),
-                                       _fx_catch_37);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_30, &result_0);
-                                    FX_BREAK(_fx_catch_37);
+                  _fx_catch_30: ;
+                     fx_free_exn(&v_160);
 
-                                 _fx_catch_37: ;
-                                    if (result_30) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_30);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_184);
-                                    _fx_free_N14Lexer__token_t(&v_183);
-                                    _fx_free_N10Ast__lit_t(&v_182);
-                                    goto _fx_endmatch_12;
-                                 }
-                              }
-                           }
-                           if (ts_0 != 0) {
-                              _fx_N14Lexer__token_t* v_185 = &ts_0->hd.t0;
-                              if (v_185->tag == 1) {
-                                 _fx_N10Ast__lit_t* v_186 = &v_185->u.LITERAL;
-                                 if (v_186->tag == 4) {
-                                    _fx_N10Ast__lit_t v_187 = {0};
-                                    _fx_N14Lexer__token_t v_188 = {0};
-                                    _fx_T2N14Lexer__token_tTa2i v_189 = {0};
-                                    _fx_LT2N14Lexer__token_tTa2i result_31 = 0;
-                                    _fx_T2id* vcase_1 = &v_186->u.LitFloat;
-                                    _fx_M3AstFM8LitFloatN10Ast__lit_t2id(vcase_1->t0, -vcase_1->t1, &v_187);
-                                    _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_187, &v_188);
-                                    _fx_make_T2N14Lexer__token_tTa2i(&v_188, &loc_0, &v_189);
-                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_189, ts_0->tl, true, &result_31),
-                                       _fx_catch_38);
-                                    _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                    FX_COPY_PTR(result_31, &result_0);
-                                    FX_BREAK(_fx_catch_38);
+                  _fx_endmatch_10: ;
+                     FX_CHECK_EXN(_fx_catch_31);
 
-                                 _fx_catch_38: ;
-                                    if (result_31) {
-                                       _fx_free_LT2N14Lexer__token_tTa2i(&result_31);
-                                    }
-                                    _fx_free_T2N14Lexer__token_tTa2i(&v_189);
-                                    _fx_free_N14Lexer__token_t(&v_188);
-                                    _fx_free_N10Ast__lit_t(&v_187);
-                                    goto _fx_endmatch_12;
-                                 }
-                              }
-                           }
-                           _fx_N14Lexer__token_t v_190 = {0};
-                           _fx_T2N14Lexer__token_tTa2i v_191 = {0};
-                           _fx_LT2N14Lexer__token_tTa2i result_32 = 0;
-                           _fx_M5LexerFM5MINUSN14Lexer__token_t1B(true, &v_190);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_190, &loc_0, &v_191);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_191, ts_0, true, &result_32), _fx_catch_39);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_32, &result_0);
-                           FX_BREAK(_fx_catch_39);
-
-                        _fx_catch_39: ;
-                           if (result_32) {
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_32);
-                           }
-                           _fx_free_T2N14Lexer__token_tTa2i(&v_191);
-                           _fx_free_N14Lexer__token_t(&v_190);
-
-                        _fx_endmatch_12: ;
-                           FX_CHECK_EXN(_fx_catch_40);
-                        }
-
-                     _fx_catch_40: ;
-                        if (ts_0) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&ts_0);
-                        }
-                        if (result_28) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_28);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_174);
-                        _fx_free_N14Lexer__token_t(&v_173);
-                        if (result_27) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_27);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_172);
-                        if (result_26) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_26);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_171);
-                        _fx_free_N14Lexer__token_t(&v_170);
+                  _fx_catch_31: ;
+                     if (paren_stack_6) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_6);
                      }
-                     else if (c_2 == (char_)42) {
+                  }
+                  else if (c_2 == (char_)124) {
+                     _fx_N14Lexer__token_t v_161 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_162 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_163 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_7 = 0;
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpBitwiseOr, &v_161);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_161, &loc_0, &v_162);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_162, 0, true, &tokens_0), _fx_catch_34);
+                     }
+                     else if (c1_0 == (char_)124) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__LOGICAL_OR, &loc_0, &v_163);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_163, 0, true, &tokens_0), _fx_catch_34);
+                     }
+                     else {
+                        FX_COPY_PTR(*paren_stack_1, &paren_stack_7);
+                        if (paren_stack_7 != 0) {
+                           _fx_LT2N14Lexer__token_tTa2i v_164 = paren_stack_7->tl;
+                           if (v_164 != 0) {
+                              if (paren_stack_7->hd.t0.tag == 55) {
+                                 if (v_164->hd.t0.tag == 49) {
+                                    _fx_T2N14Lexer__token_tTa2i v_165 = {0};
+                                    _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__BAR, &loc_0, &v_165);
+                                    FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_165, 0, true, &tokens_0), _fx_catch_32);
+
+                                 _fx_catch_32: ;
+                                    _fx_free_T2N14Lexer__token_tTa2i(&v_165);
+                                    goto _fx_endmatch_11;
+                                 }
+                              }
+                           }
+                        }
+                        _fx_T2N14Lexer__token_tTa2i v_166 = {0};
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BITWISE_OR, &loc_0, &v_166);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_166, 0, true, &tokens_0), _fx_catch_33);
+
+                     _fx_catch_33: ;
+                        _fx_free_T2N14Lexer__token_tTa2i(&v_166);
+
+                     _fx_endmatch_11: ;
+                        FX_CHECK_EXN(_fx_catch_34);
+                     }
+
+                  _fx_catch_34: ;
+                     if (paren_stack_7) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_7);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_163);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_162);
+                     _fx_free_N14Lexer__token_t(&v_161);
+                  }
+                  else if (c_2 == (char_)43) {
+                     _fx_N14Lexer__token_t v_167 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_168 = {0};
+                     _fx_N14Lexer__token_t v_169 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_170 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpAdd, &v_167);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_167, &loc_0, &v_168);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_168, 0, true, &tokens_0), _fx_catch_35);
+                     }
+                     else {
+                        _fx_M5LexerFM4PLUSN14Lexer__token_t1B(prev_ne_0, &v_169);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_169, &loc_0, &v_170);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_170, 0, true, &tokens_0), _fx_catch_35);
+                     }
+
+                  _fx_catch_35: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_170);
+                     _fx_free_N14Lexer__token_t(&v_169);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_168);
+                     _fx_free_N14Lexer__token_t(&v_167);
+                  }
+                  else if (c_2 == (char_)45) {
+                     _fx_N14Lexer__token_t v_171 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_172 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_173 = {0};
+                     _fx_N14Lexer__token_t v_174 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_175 = {0};
+                     _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i v_176 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i ts_0 = 0;
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpSub, &v_171);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_171, &loc_0, &v_172);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_172, 0, true, &tokens_0), _fx_catch_40);
+                     }
+                     else if (c1_0 == (char_)62) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__ARROW, &loc_0, &v_173);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_173, 0, true, &tokens_0), _fx_catch_40);
+                     }
+                     else if (!prev_ne_0) {
+                        _fx_M5LexerFM5MINUSN14Lexer__token_t1B(false, &v_174);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_174, &loc_0, &v_175);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_175, 0, true, &tokens_0), _fx_catch_40);
+                     }
+                     else {
+                        *expect_neg_number_0 = !*expect_neg_number_0;
+                        FX_CALL(_fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(&v_176, fx_fv), _fx_catch_40);
+                        FX_COPY_PTR(v_176.t0, &ts_0);
+                        *expect_neg_number_0 = !*expect_neg_number_0;
+                        if (ts_0 != 0) {
+                           _fx_N14Lexer__token_t* v_177 = &ts_0->hd.t0;
+                           if (v_177->tag == 1) {
+                              _fx_N10Ast__lit_t* v_178 = &v_177->u.LITERAL;
+                              if (v_178->tag == 1) {
+                                 _fx_N10Ast__lit_t v_179 = {0};
+                                 _fx_N14Lexer__token_t v_180 = {0};
+                                 _fx_T2N14Lexer__token_tTa2i v_181 = {0};
+                                 _fx_M3AstFM6LitIntN10Ast__lit_t1l(-v_178->u.LitInt, &v_179);
+                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_179, &v_180);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_180, &loc_0, &v_181);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_181, ts_0->tl, true, &tokens_0), _fx_catch_36);
+
+                              _fx_catch_36: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_181);
+                                 _fx_free_N14Lexer__token_t(&v_180);
+                                 _fx_free_N10Ast__lit_t(&v_179);
+                                 goto _fx_endmatch_12;
+                              }
+                           }
+                        }
+                        if (ts_0 != 0) {
+                           _fx_N14Lexer__token_t* v_182 = &ts_0->hd.t0;
+                           if (v_182->tag == 1) {
+                              _fx_N10Ast__lit_t* v_183 = &v_182->u.LITERAL;
+                              if (v_183->tag == 2) {
+                                 _fx_N10Ast__lit_t v_184 = {0};
+                                 _fx_N14Lexer__token_t v_185 = {0};
+                                 _fx_T2N14Lexer__token_tTa2i v_186 = {0};
+                                 _fx_T2il* vcase_0 = &v_183->u.LitSInt;
+                                 _fx_M3AstFM7LitSIntN10Ast__lit_t2il(vcase_0->t0, -vcase_0->t1, &v_184);
+                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_184, &v_185);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_185, &loc_0, &v_186);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_186, ts_0->tl, true, &tokens_0), _fx_catch_37);
+
+                              _fx_catch_37: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_186);
+                                 _fx_free_N14Lexer__token_t(&v_185);
+                                 _fx_free_N10Ast__lit_t(&v_184);
+                                 goto _fx_endmatch_12;
+                              }
+                           }
+                        }
+                        if (ts_0 != 0) {
+                           _fx_N14Lexer__token_t* v_187 = &ts_0->hd.t0;
+                           if (v_187->tag == 1) {
+                              _fx_N10Ast__lit_t* v_188 = &v_187->u.LITERAL;
+                              if (v_188->tag == 4) {
+                                 _fx_N10Ast__lit_t v_189 = {0};
+                                 _fx_N14Lexer__token_t v_190 = {0};
+                                 _fx_T2N14Lexer__token_tTa2i v_191 = {0};
+                                 _fx_T2id* vcase_1 = &v_188->u.LitFloat;
+                                 _fx_M3AstFM8LitFloatN10Ast__lit_t2id(vcase_1->t0, -vcase_1->t1, &v_189);
+                                 _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_189, &v_190);
+                                 _fx_make_T2N14Lexer__token_tTa2i(&v_190, &loc_0, &v_191);
+                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_191, ts_0->tl, true, &tokens_0), _fx_catch_38);
+
+                              _fx_catch_38: ;
+                                 _fx_free_T2N14Lexer__token_tTa2i(&v_191);
+                                 _fx_free_N14Lexer__token_t(&v_190);
+                                 _fx_free_N10Ast__lit_t(&v_189);
+                                 goto _fx_endmatch_12;
+                              }
+                           }
+                        }
                         _fx_N14Lexer__token_t v_192 = {0};
                         _fx_T2N14Lexer__token_tTa2i v_193 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_33 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_194 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_34 = 0;
-                        _fx_N14Lexer__token_t v_195 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_196 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_35 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMul, &v_192);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_192, &loc_0, &v_193);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_193, 0, true, &result_33), _fx_catch_41);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_33, &result_0);
-                           FX_BREAK(_fx_catch_41);
-                        }
-                        else {
-                           bool t_25;
-                           if (c1_0 == (char_)42) {
-                              t_25 = !prev_ne_0;
-                           }
-                           else {
-                              t_25 = false;
-                           }
-                           if (t_25) {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__POWER, &loc_0, &v_194);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_194, 0, true, &result_34), _fx_catch_41);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_34, &result_0);
-                              FX_BREAK(_fx_catch_41);
-                           }
-                           else {
-                              _fx_M5LexerFM4STARN14Lexer__token_t1B(prev_ne_0, &v_195);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_195, &loc_0, &v_196);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_196, 0, true, &result_35), _fx_catch_41);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_35, &result_0);
-                              FX_BREAK(_fx_catch_41);
-                           }
-                        }
+                        _fx_M5LexerFM5MINUSN14Lexer__token_t1B(true, &v_192);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_192, &loc_0, &v_193);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_193, ts_0, true, &tokens_0), _fx_catch_39);
 
-                     _fx_catch_41: ;
-                        if (result_35) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_35);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_196);
-                        _fx_free_N14Lexer__token_t(&v_195);
-                        if (result_34) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_34);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_194);
-                        if (result_33) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_33);
-                        }
+                     _fx_catch_39: ;
                         _fx_free_T2N14Lexer__token_tTa2i(&v_193);
                         _fx_free_N14Lexer__token_t(&v_192);
+
+                     _fx_endmatch_12: ;
+                        FX_CHECK_EXN(_fx_catch_40);
                      }
-                     else if (c_2 == (char_)47) {
-                        _fx_N14Lexer__token_t v_197 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_198 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_36 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_199 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_37 = 0;
-                        if (c1_0 == (char_)61) {
+
+                  _fx_catch_40: ;
+                     if (ts_0) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&ts_0);
+                     }
+                     _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(&v_176);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_175);
+                     _fx_free_N14Lexer__token_t(&v_174);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_173);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_172);
+                     _fx_free_N14Lexer__token_t(&v_171);
+                  }
+                  else if (c_2 == (char_)42) {
+                     _fx_N14Lexer__token_t v_194 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_195 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_196 = {0};
+                     _fx_N14Lexer__token_t v_197 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_198 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMul, &v_194);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_194, &loc_0, &v_195);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_195, 0, true, &tokens_0), _fx_catch_41);
+                     }
+                     else {
+                        bool t_25;
+                        if (c1_0 == (char_)42) {
+                           t_25 = !prev_ne_0;
+                        }
+                        else {
+                           t_25 = false;
+                        }
+                        if (t_25) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpDiv, &v_197);
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__POWER, &loc_0, &v_196);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_196, 0, true, &tokens_0), _fx_catch_41);
+                        }
+                        else {
+                           _fx_M5LexerFM4STARN14Lexer__token_t1B(prev_ne_0, &v_197);
                            _fx_make_T2N14Lexer__token_tTa2i(&v_197, &loc_0, &v_198);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_198, 0, true, &result_36), _fx_catch_42);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_36, &result_0);
-                           FX_BREAK(_fx_catch_42);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_198, 0, true, &tokens_0), _fx_catch_41);
+                        }
+                     }
+
+                  _fx_catch_41: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_198);
+                     _fx_free_N14Lexer__token_t(&v_197);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_196);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_195);
+                     _fx_free_N14Lexer__token_t(&v_194);
+                  }
+                  else if (c_2 == (char_)47) {
+                     _fx_N14Lexer__token_t v_199 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_200 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_201 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpDiv, &v_199);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_199, &loc_0, &v_200);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_200, 0, true, &tokens_0), _fx_catch_42);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__SLASH, &loc_0, &v_201);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_201, 0, true, &tokens_0), _fx_catch_42);
+                     }
+
+                  _fx_catch_42: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_201);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_200);
+                     _fx_free_N14Lexer__token_t(&v_199);
+                  }
+                  else if (c_2 == (char_)37) {
+                     _fx_N14Lexer__token_t v_202 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_203 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_204 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMod, &v_202);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_202, &loc_0, &v_203);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_203, 0, true, &tokens_0), _fx_catch_43);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__PERCENT, &loc_0, &v_204);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_204, 0, true, &tokens_0), _fx_catch_43);
+                     }
+
+                  _fx_catch_43: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_204);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_203);
+                     _fx_free_N14Lexer__token_t(&v_202);
+                  }
+                  else if (c_2 == (char_)61) {
+                     _fx_T2N14Lexer__token_tTa2i v_205 = {0};
+                     _fx_N14Lexer__token_t v_206 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_207 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_208 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_209 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        if (c2_0 == (char_)61) {
+                           *pos_0 = *pos_0 + 1;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__SAME, &loc_0, &v_205);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_205, 0, true, &tokens_0), _fx_catch_44);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__SLASH, &loc_0, &v_199);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_199, 0, true, &result_37), _fx_catch_42);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_37, &result_0);
-                           FX_BREAK(_fx_catch_42);
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_206);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_206, &loc_0, &v_207);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_207, 0, true, &tokens_0), _fx_catch_44);
                         }
-
-                     _fx_catch_42: ;
-                        if (result_37) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_37);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_199);
-                        if (result_36) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_36);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_198);
-                        _fx_free_N14Lexer__token_t(&v_197);
                      }
-                     else if (c_2 == (char_)37) {
-                        _fx_N14Lexer__token_t v_200 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_201 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_38 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_202 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_39 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g12Lexer__OpMod, &v_200);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_200, &loc_0, &v_201);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_201, 0, true, &result_38), _fx_catch_43);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_38, &result_0);
-                           FX_BREAK(_fx_catch_43);
+                     else if (c1_0 == (char_)62) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g19Lexer__DOUBLE_ARROW, &loc_0, &v_208);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_208, 0, true, &tokens_0), _fx_catch_44);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__EQUAL, &loc_0, &v_209);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_209, 0, true, &tokens_0), _fx_catch_44);
+                     }
+
+                  _fx_catch_44: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_209);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_208);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_207);
+                     _fx_free_N14Lexer__token_t(&v_206);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_205);
+                  }
+                  else if (c_2 == (char_)94) {
+                     _fx_N14Lexer__token_t v_210 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_211 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_212 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseXor, &v_210);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_210, &loc_0, &v_211);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_211, 0, true, &tokens_0), _fx_catch_45);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_XOR, &loc_0, &v_212);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_212, 0, true, &tokens_0), _fx_catch_45);
+                     }
+
+                  _fx_catch_45: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_212);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_211);
+                     _fx_free_N14Lexer__token_t(&v_210);
+                  }
+                  else if (c_2 == (char_)38) {
+                     _fx_N14Lexer__token_t v_213 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_214 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_215 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_216 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseAnd, &v_213);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_213, &loc_0, &v_214);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_214, 0, true, &tokens_0), _fx_catch_46);
+                     }
+                     else if (c1_0 == (char_)38) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_AND, &loc_0, &v_215);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_215, 0, true, &tokens_0), _fx_catch_46);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_AND, &loc_0, &v_216);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_216, 0, true, &tokens_0), _fx_catch_46);
+                     }
+
+                  _fx_catch_46: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_216);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_215);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_214);
+                     _fx_free_N14Lexer__token_t(&v_213);
+                  }
+                  else if (c_2 == (char_)126) {
+                     _fx_T2N14Lexer__token_tTa2i v_217 = {0};
+                     _fx_Ta2i v_218;
+                     FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_218, 0), _fx_catch_47);
+                     fx_str_t slit_16 = FX_MAKE_STR("~");
+                     FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_218, &slit_16, 0), _fx_catch_47);
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__TILDE, &loc_0, &v_217);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_217, 0, true, &tokens_0), _fx_catch_47);
+
+                  _fx_catch_47: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_217);
+                  }
+                  else if (c_2 == (char_)64) {
+                     _fx_T2N14Lexer__token_tTa2i v_219 = {0};
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_219);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_219, 0, true, &tokens_0), _fx_catch_48);
+
+                  _fx_catch_48: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_219);
+                  }
+                  else if (c_2 == (char_)92) {
+                     _fx_N14Lexer__token_t v_220 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_221 = {0};
+                     _fx_M5LexerFM9BACKSLASHN14Lexer__token_t1B(prev_ne_0, &v_220);
+                     _fx_make_T2N14Lexer__token_tTa2i(&v_220, &loc_0, &v_221);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_221, 0, true, &tokens_0), _fx_catch_49);
+
+                  _fx_catch_49: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_221);
+                     _fx_free_N14Lexer__token_t(&v_220);
+                  }
+                  else if (c_2 == (char_)46) {
+                     _fx_N14Lexer__token_t v_222 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_223 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_224 = {0};
+                     _fx_N14Lexer__token_t v_225 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_226 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_227 = {0};
+                     _fx_N14Lexer__token_t v_228 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_229 = {0};
+                     _fx_N14Lexer__token_t v_230 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_231 = {0};
+                     _fx_N14Lexer__token_t v_232 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_233 = {0};
+                     _fx_N14Lexer__token_t v_234 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_235 = {0};
+                     _fx_N14Lexer__token_t v_236 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_237 = {0};
+                     _fx_N14Lexer__token_t v_238 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_239 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_240 = {0};
+                     _fx_N14Lexer__token_t v_241 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_242 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_243 = {0};
+                     _fx_N14Lexer__token_t v_244 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_245 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_246 = {0};
+                     _fx_N14Lexer__token_t v_247 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_248 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_249 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_250 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_251 = {0};
+                     if (c1_0 == (char_)61) {
+                        if (c2_0 == (char_)61) {
+                           *pos_0 = *pos_0 + 2;
+                           _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_222);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_222, &loc_0, &v_223);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_223, 0, true, &tokens_0), _fx_catch_50);
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g14Lexer__PERCENT, &loc_0, &v_202);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_202, 0, true, &result_39), _fx_catch_43);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_39, &result_0);
-                           FX_BREAK(_fx_catch_43);
+                           *pos_0 = *pos_0 + 1;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_EQUAL, &loc_0, &v_224);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_224, 0, true, &tokens_0), _fx_catch_50);
                         }
-
-                     _fx_catch_43: ;
-                        if (result_39) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_39);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_202);
-                        if (result_38) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_38);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_201);
-                        _fx_free_N14Lexer__token_t(&v_200);
                      }
-                     else if (c_2 == (char_)61) {
-                        _fx_T2N14Lexer__token_tTa2i v_203 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_40 = 0;
-                        _fx_N14Lexer__token_t v_204 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_205 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_41 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_206 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_42 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_207 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_43 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           if (c2_0 == (char_)61) {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__SAME, &loc_0, &v_203);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_203, 0, true, &result_40), _fx_catch_44);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_40, &result_0);
-                              FX_BREAK(_fx_catch_44);
-                           }
-                           else {
-                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_204);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_204, &loc_0, &v_205);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_205, 0, true, &result_41), _fx_catch_44);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_41, &result_0);
-                              FX_BREAK(_fx_catch_44);
-                           }
-                        }
-                        else if (c1_0 == (char_)62) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g19Lexer__DOUBLE_ARROW, &loc_0, &v_206);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_206, 0, true, &result_42), _fx_catch_44);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_42, &result_0);
-                           FX_BREAK(_fx_catch_44);
+                     else {
+                        bool t_26;
+                        if (c1_0 == (char_)33) {
+                           t_26 = c2_0 == (char_)61;
                         }
                         else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__EQUAL, &loc_0, &v_207);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_207, 0, true, &result_43), _fx_catch_44);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_43, &result_0);
-                           FX_BREAK(_fx_catch_44);
+                           t_26 = false;
                         }
-
-                     _fx_catch_44: ;
-                        if (result_43) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_43);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_207);
-                        if (result_42) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_42);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_206);
-                        if (result_41) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_41);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_205);
-                        _fx_free_N14Lexer__token_t(&v_204);
-                        if (result_40) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_40);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_203);
-                     }
-                     else if (c_2 == (char_)94) {
-                        _fx_N14Lexer__token_t v_208 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_209 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_44 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_210 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_45 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseXor, &v_208);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_208, &loc_0, &v_209);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_209, 0, true, &result_44), _fx_catch_45);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_44, &result_0);
-                           FX_BREAK(_fx_catch_45);
-                        }
-                        else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_XOR, &loc_0, &v_210);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_210, 0, true, &result_45), _fx_catch_45);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_45, &result_0);
-                           FX_BREAK(_fx_catch_45);
-                        }
-
-                     _fx_catch_45: ;
-                        if (result_45) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_45);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_210);
-                        if (result_44) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_44);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_209);
-                        _fx_free_N14Lexer__token_t(&v_208);
-                     }
-                     else if (c_2 == (char_)38) {
-                        _fx_N14Lexer__token_t v_211 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_212 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_46 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_213 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_47 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_214 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_48 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpBitwiseAnd, &v_211);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_211, &loc_0, &v_212);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_212, 0, true, &result_46), _fx_catch_46);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_46, &result_0);
-                           FX_BREAK(_fx_catch_46);
-                        }
-                        else if (c1_0 == (char_)38) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_AND, &loc_0, &v_213);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_213, 0, true, &result_47), _fx_catch_46);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_47, &result_0);
-                           FX_BREAK(_fx_catch_46);
-                        }
-                        else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__BITWISE_AND, &loc_0, &v_214);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_214, 0, true, &result_48), _fx_catch_46);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_48, &result_0);
-                           FX_BREAK(_fx_catch_46);
-                        }
-
-                     _fx_catch_46: ;
-                        if (result_48) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_48);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_214);
-                        if (result_47) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_47);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_213);
-                        if (result_46) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_46);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_212);
-                        _fx_free_N14Lexer__token_t(&v_211);
-                     }
-                     else if (c_2 == (char_)126) {
-                        _fx_T2N14Lexer__token_tTa2i v_215 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_49 = 0;
-                        _fx_Ta2i v_216;
-                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_216, 0), _fx_catch_47);
-                        fx_str_t slit_16 = FX_MAKE_STR("~");
-                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_216, &slit_16, 0), _fx_catch_47);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__TILDE, &loc_0, &v_215);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_215, 0, true, &result_49), _fx_catch_47);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_49, &result_0);
-                        FX_BREAK(_fx_catch_47);
-
-                     _fx_catch_47: ;
-                        if (result_49) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_49);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_215);
-                     }
-                     else if (c_2 == (char_)64) {
-                        _fx_T2N14Lexer__token_tTa2i v_217 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_50 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g9Lexer__AT, &loc_0, &v_217);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_217, 0, true, &result_50), _fx_catch_48);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_50, &result_0);
-                        FX_BREAK(_fx_catch_48);
-
-                     _fx_catch_48: ;
-                        if (result_50) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_50);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_217);
-                     }
-                     else if (c_2 == (char_)92) {
-                        _fx_N14Lexer__token_t v_218 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_219 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_51 = 0;
-                        _fx_M5LexerFM9BACKSLASHN14Lexer__token_t1B(prev_ne_0, &v_218);
-                        _fx_make_T2N14Lexer__token_tTa2i(&v_218, &loc_0, &v_219);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_219, 0, true, &result_51), _fx_catch_49);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_51, &result_0);
-                        FX_BREAK(_fx_catch_49);
-
-                     _fx_catch_49: ;
-                        if (result_51) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_51);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_219);
-                        _fx_free_N14Lexer__token_t(&v_218);
-                     }
-                     else if (c_2 == (char_)46) {
-                        _fx_N14Lexer__token_t v_220 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_221 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_52 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_222 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_53 = 0;
-                        _fx_N14Lexer__token_t v_223 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_224 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_54 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_225 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_55 = 0;
-                        _fx_N14Lexer__token_t v_226 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_227 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_56 = 0;
-                        _fx_N14Lexer__token_t v_228 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_229 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_57 = 0;
-                        _fx_N14Lexer__token_t v_230 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_231 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_58 = 0;
-                        _fx_N14Lexer__token_t v_232 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_233 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_59 = 0;
-                        _fx_N14Lexer__token_t v_234 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_235 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_60 = 0;
-                        _fx_N14Lexer__token_t v_236 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_237 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_61 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_238 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_62 = 0;
-                        _fx_N14Lexer__token_t v_239 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_240 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_63 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_241 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_64 = 0;
-                        _fx_N14Lexer__token_t v_242 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_243 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_65 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_244 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_66 = 0;
-                        _fx_N14Lexer__token_t v_245 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_246 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_67 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_247 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_68 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_248 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_69 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_249 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_70 = 0;
-                        if (c1_0 == (char_)61) {
-                           if (c2_0 == (char_)61) {
-                              *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpEQ, &v_220);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_220, &loc_0, &v_221);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_221, 0, true, &result_52), _fx_catch_50);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_52, &result_0);
-                              FX_BREAK(_fx_catch_50);
-                           }
-                           else {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_EQUAL, &loc_0, &v_222);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_222, 0, true, &result_53), _fx_catch_50);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_53, &result_0);
-                              FX_BREAK(_fx_catch_50);
-                           }
-                        }
-                        else {
-                           bool t_26;
-                           if (c1_0 == (char_)33) {
-                              t_26 = c2_0 == (char_)61;
-                           }
-                           else {
-                              t_26 = false;
-                           }
-                           if (t_26) {
-                              *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_223);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_223, &loc_0, &v_224);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_224, 0, true, &result_54), _fx_catch_50);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_54, &result_0);
-                              FX_BREAK(_fx_catch_50);
-                           }
-                           else if (c1_0 == (char_)60) {
-                              bool t_27;
-                              if (c2_0 == (char_)61) {
-                                 t_27 = c3_0 == (char_)62;
-                              }
-                              else {
-                                 t_27 = false;
-                              }
-                              if (t_27) {
-                                 *pos_0 = *pos_0 + 3;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g20Lexer__DOT_SPACESHIP, &loc_0, &v_225);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_225, 0, true, &result_55), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_55, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else if (c2_0 == (char_)61) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_226);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_226, &loc_0, &v_227);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_227, 0, true, &result_56), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_56, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *pos_0 = *pos_0 + 1;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_228);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_228, &loc_0, &v_229);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_229, 0, true, &result_57), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_57, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                           else if (c1_0 == (char_)62) {
-                              if (c2_0 == (char_)61) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_230);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_230, &loc_0, &v_231);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_231, 0, true, &result_58), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_58, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *pos_0 = *pos_0 + 1;
-                                 _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_232);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_232, &loc_0, &v_233);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_233, 0, true, &result_59), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_59, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                           else if (c1_0 == (char_)43) {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM8DOT_PLUSN14Lexer__token_t1B(prev_ne_0, &v_234);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_234, &loc_0, &v_235);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_235, 0, true, &result_60), _fx_catch_50);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_60, &result_0);
-                              FX_BREAK(_fx_catch_50);
-                           }
-                           else if (c1_0 == (char_)45) {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM9DOT_MINUSN14Lexer__token_t1B(prev_ne_0, &v_236);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_236, &loc_0, &v_237);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_237, 0, true, &result_61), _fx_catch_50);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_61, &result_0);
-                              FX_BREAK(_fx_catch_50);
-                           }
-                           else if (c1_0 == (char_)42) {
-                              if (c2_0 == (char_)42) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_POWER, &loc_0, &v_238);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_238, 0, true, &result_62), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_62, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else if (c2_0 == (char_)61) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMul, &v_239);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_239, &loc_0, &v_240);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_240, 0, true, &result_63), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_63, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__DOT_STAR, &loc_0, &v_241);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_241, 0, true, &result_64), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_64, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                           else if (c1_0 == (char_)47) {
-                              if (c2_0 == (char_)61) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotDiv, &v_242);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_242, &loc_0, &v_243);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_243, 0, true, &result_65), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_65, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_SLASH, &loc_0, &v_244);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_244, 0, true, &result_66), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_66, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                           else if (c1_0 == (char_)37) {
-                              if (c2_0 == (char_)61) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMod, &v_245);
-                                 _fx_make_T2N14Lexer__token_tTa2i(&v_245, &loc_0, &v_246);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_246, 0, true, &result_67), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_67, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *pos_0 = *pos_0 + 1;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__DOT_PERCENT, &loc_0, &v_247);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_247, 0, true, &result_68), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_68, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                           else {
-                              bool t_28;
-                              if (c1_0 == (char_)46) {
-                                 t_28 = c2_0 == (char_)46;
-                              }
-                              else {
-                                 t_28 = false;
-                              }
-                              if (t_28) {
-                                 *pos_0 = *pos_0 + 2;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__ELLIPSIS, &loc_0, &v_248);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_248, 0, true, &result_69), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_69, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                              else {
-                                 *prev_dot_0 = true;
-                                 _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__DOT, &loc_0, &v_249);
-                                 FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_249, 0, true, &result_70), _fx_catch_50);
-                                 _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                                 FX_COPY_PTR(result_70, &result_0);
-                                 FX_BREAK(_fx_catch_50);
-                              }
-                           }
-                        }
-
-                     _fx_catch_50: ;
-                        if (result_70) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_70);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_249);
-                        if (result_69) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_69);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_248);
-                        if (result_68) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_68);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_247);
-                        if (result_67) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_67);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_246);
-                        _fx_free_N14Lexer__token_t(&v_245);
-                        if (result_66) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_66);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_244);
-                        if (result_65) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_65);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_243);
-                        _fx_free_N14Lexer__token_t(&v_242);
-                        if (result_64) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_64);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_241);
-                        if (result_63) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_63);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_240);
-                        _fx_free_N14Lexer__token_t(&v_239);
-                        if (result_62) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_62);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_238);
-                        if (result_61) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_61);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_237);
-                        _fx_free_N14Lexer__token_t(&v_236);
-                        if (result_60) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_60);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_235);
-                        _fx_free_N14Lexer__token_t(&v_234);
-                        if (result_59) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_59);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_233);
-                        _fx_free_N14Lexer__token_t(&v_232);
-                        if (result_58) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_58);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_231);
-                        _fx_free_N14Lexer__token_t(&v_230);
-                        if (result_57) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_57);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_229);
-                        _fx_free_N14Lexer__token_t(&v_228);
-                        if (result_56) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_56);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_227);
-                        _fx_free_N14Lexer__token_t(&v_226);
-                        if (result_55) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_55);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_225);
-                        if (result_54) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_54);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_224);
-                        _fx_free_N14Lexer__token_t(&v_223);
-                        if (result_53) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_53);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_222);
-                        if (result_52) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_52);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_221);
-                        _fx_free_N14Lexer__token_t(&v_220);
-                     }
-                     else if (c_2 == (char_)44) {
-                        _fx_T2N14Lexer__token_tTa2i v_250 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_71 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_250);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_250, 0, true, &result_71), _fx_catch_51);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_71, &result_0);
-                        FX_BREAK(_fx_catch_51);
-
-                     _fx_catch_51: ;
-                        if (result_71) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_71);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_250);
-                     }
-                     else if (c_2 == (char_)59) {
-                        _fx_T2N14Lexer__token_tTa2i v_251 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_72 = 0;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SEMICOLON, &loc_0, &v_251);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_251, 0, true, &result_72), _fx_catch_52);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_72, &result_0);
-                        FX_BREAK(_fx_catch_52);
-
-                     _fx_catch_52: ;
-                        if (result_72) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_72);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_251);
-                     }
-                     else if (c_2 == (char_)58) {
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_8 = 0;
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_8);
-                        if (paren_stack_8 != 0) {
-                           if (paren_stack_8->hd.t0.tag == 45) {
-                              fx_exn_t curr_exn_0 = {0};
-                              fx_exn_t v_252 = {0};
-                              fx_exn_t v_253 = {0};
-                              _fx_T2R8format_ti v_254;
-                              FX_CALL(_fx_F12parse_formatT2R8format_ti2Si(&buf_0, *pos_0, &v_254, 0), _fx_catch_53);
-
-                           _fx_catch_53: ;
-                              if (fx_status < 0) {
-                                 fx_exn_get_and_reset(fx_status, &curr_exn_0);
-                                 fx_status = 0;
-                                 _fx_Ta2i v_255;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_255, 0),
-                                    _fx_catch_54);
-                                 fx_str_t slit_17 = FX_MAKE_STR("invalid format specification");
-                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_255, &slit_17, &v_252), _fx_catch_54);
-                                 FX_THROW(&v_252, true, _fx_catch_54);
-                              }
-                              _fx_R8format_t fmt__0 = v_254.t0;
-                              int_ end_0 = v_254.t1;
-                              _fx_Nt6option1R8format_t v_256;
-                              _fx_M5LexerFM4SomeNt6option1R8format_t1R8format_t(&fmt__0, &v_256);
-                              *fmt_0 = v_256;
-                              *pos_0 = end_0;
-                              if (FX_STR_ELEM_ZERO(buf_0, *pos_0) != (char_)125) {
-                                 _fx_Ta2i v_257;
-                                 FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_257, 0),
-                                    _fx_catch_54);
-                                 fx_str_t slit_18 =
-                                    FX_MAKE_STR("\'}\' is expected after \':...\' inside interpolated expression");
-                                 FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_257, &slit_18, &v_253), _fx_catch_54);
-                                 FX_THROW(&v_253, true, _fx_catch_54);
-                              }
-
-                           _fx_catch_54: ;
-                              fx_free_exn(&v_253);
-                              fx_free_exn(&v_252);
-                              fx_free_exn(&curr_exn_0);
-                              goto _fx_endmatch_13;
-                           }
-                        }
-                        _fx_T2N14Lexer__token_tTa2i v_258 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_73 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_259 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_74 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_260 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_75 = 0;
-                        if (c1_0 == (char_)58) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CONS, &loc_0, &v_258);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_258, 0, true, &result_73), _fx_catch_55);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_73, &result_0);
-                           FX_BREAK(_fx_catch_55);
-                        }
-                        else if (c1_0 == (char_)62) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CAST, &loc_0, &v_259);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_259, 0, true, &result_74), _fx_catch_55);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_74, &result_0);
-                           FX_BREAK(_fx_catch_55);
-                        }
-                        else {
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COLON, &loc_0, &v_260);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_260, 0, true, &result_75), _fx_catch_55);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_75, &result_0);
-                           FX_BREAK(_fx_catch_55);
-                        }
-
-                     _fx_catch_55: ;
-                        if (result_75) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_75);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_260);
-                        if (result_74) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_74);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_259);
-                        if (result_73) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_73);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_258);
-
-                     _fx_endmatch_13: ;
-                        FX_CHECK_EXN(_fx_catch_56);
-
-                     _fx_catch_56: ;
-                        if (paren_stack_8) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_8);
-                        }
-                     }
-                     else if (c_2 == (char_)33) {
-                        _fx_N14Lexer__token_t v_261 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_262 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_76 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_263 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_77 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_261);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_261, &loc_0, &v_262);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_262, 0, true, &result_76), _fx_catch_57);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_76, &result_0);
-                           FX_BREAK(_fx_catch_57);
-                        }
-                        else {
-                           _fx_Ta2i v_264;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_264, 0),
-                              _fx_catch_57);
-                           fx_str_t slit_19 = FX_MAKE_STR("!");
-                           FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_264, &slit_19, 0), _fx_catch_57);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_NOT, &loc_0, &v_263);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_263, 0, true, &result_77), _fx_catch_57);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_77, &result_0);
-                           FX_BREAK(_fx_catch_57);
-                        }
-
-                     _fx_catch_57: ;
-                        if (result_77) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_77);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_263);
-                        if (result_76) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_76);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_262);
-                        _fx_free_N14Lexer__token_t(&v_261);
-                     }
-                     else if (c_2 == (char_)63) {
-                        _fx_T2N14Lexer__token_tTa2i v_265 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_78 = 0;
-                        *new_exp_0 = false;
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__QUESTION, &loc_0, &v_265);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_265, 0, true, &result_78), _fx_catch_58);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_78, &result_0);
-                        FX_BREAK(_fx_catch_58);
-
-                     _fx_catch_58: ;
-                        if (result_78) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_78);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_265);
-                     }
-                     else if (c_2 == (char_)60) {
-                        _fx_T2N14Lexer__token_tTa2i v_266 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_79 = 0;
-                        _fx_N14Lexer__token_t v_267 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_268 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_80 = 0;
-                        _fx_N14Lexer__token_t v_269 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_270 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_81 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_271 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_82 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_272 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_83 = 0;
-                        _fx_N14Lexer__token_t v_273 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_274 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_84 = 0;
-                        if (c1_0 == (char_)61) {
-                           if (c2_0 == (char_)62) {
-                              *pos_0 = *pos_0 + 2;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SPACESHIP, &loc_0, &v_266);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_266, 0, true, &result_79), _fx_catch_59);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_79, &result_0);
-                              FX_BREAK(_fx_catch_59);
-                           }
-                           else {
-                              *pos_0 = *pos_0 + 1;
-                              _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_267);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_267, &loc_0, &v_268);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_268, 0, true, &result_80), _fx_catch_59);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_80, &result_0);
-                              FX_BREAK(_fx_catch_59);
-                           }
+                        if (t_26) {
+                           *pos_0 = *pos_0 + 2;
+                           _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_225);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_225, &loc_0, &v_226);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_226, 0, true, &tokens_0), _fx_catch_50);
                         }
                         else if (c1_0 == (char_)60) {
+                           bool t_27;
                            if (c2_0 == (char_)61) {
+                              t_27 = c3_0 == (char_)62;
+                           }
+                           else {
+                              t_27 = false;
+                           }
+                           if (t_27) {
+                              *pos_0 = *pos_0 + 3;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g20Lexer__DOT_SPACESHIP, &loc_0, &v_227);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_227, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else if (c2_0 == (char_)61) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpShiftLeft, &v_269);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_269, &loc_0, &v_270);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_270, 0, true, &result_81), _fx_catch_59);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_81, &result_0);
-                              FX_BREAK(_fx_catch_59);
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_228);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_228, &loc_0, &v_229);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_229, 0, true, &tokens_0), _fx_catch_50);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__SHIFT_LEFT, &loc_0, &v_271);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_271, 0, true, &result_82), _fx_catch_59);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_82, &result_0);
-                              FX_BREAK(_fx_catch_59);
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_230);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_230, &loc_0, &v_231);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_231, 0, true, &tokens_0), _fx_catch_50);
                            }
+                        }
+                        else if (c1_0 == (char_)62) {
+                           if (c2_0 == (char_)61) {
+                              *pos_0 = *pos_0 + 2;
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_232);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_232, &loc_0, &v_233);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_233, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else {
+                              *pos_0 = *pos_0 + 1;
+                              _fx_M5LexerFM7DOT_CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_234);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_234, &loc_0, &v_235);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_235, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                        }
+                        else if (c1_0 == (char_)43) {
+                           *pos_0 = *pos_0 + 1;
+                           _fx_M5LexerFM8DOT_PLUSN14Lexer__token_t1B(prev_ne_0, &v_236);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_236, &loc_0, &v_237);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_237, 0, true, &tokens_0), _fx_catch_50);
                         }
                         else if (c1_0 == (char_)45) {
                            *pos_0 = *pos_0 + 1;
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BACK_ARROW, &loc_0, &v_272);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_272, 0, true, &result_83), _fx_catch_59);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_83, &result_0);
-                           FX_BREAK(_fx_catch_59);
+                           _fx_M5LexerFM9DOT_MINUSN14Lexer__token_t1B(prev_ne_0, &v_238);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_238, &loc_0, &v_239);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_239, 0, true, &tokens_0), _fx_catch_50);
                         }
-                        else {
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_273);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_273, &loc_0, &v_274);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_274, 0, true, &result_84), _fx_catch_59);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_84, &result_0);
-                           FX_BREAK(_fx_catch_59);
-                        }
-
-                     _fx_catch_59: ;
-                        if (result_84) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_84);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_274);
-                        _fx_free_N14Lexer__token_t(&v_273);
-                        if (result_83) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_83);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_272);
-                        if (result_82) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_82);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_271);
-                        if (result_81) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_81);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_270);
-                        _fx_free_N14Lexer__token_t(&v_269);
-                        if (result_80) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_80);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_268);
-                        _fx_free_N14Lexer__token_t(&v_267);
-                        if (result_79) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_79);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_266);
-                     }
-                     else if (c_2 == (char_)62) {
-                        _fx_N14Lexer__token_t v_275 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_276 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_85 = 0;
-                        _fx_N14Lexer__token_t v_277 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_278 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_86 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_279 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_87 = 0;
-                        _fx_N14Lexer__token_t v_280 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_281 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_88 = 0;
-                        if (c1_0 == (char_)61) {
-                           *pos_0 = *pos_0 + 1;
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_275);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_275, &loc_0, &v_276);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_276, 0, true, &result_85), _fx_catch_60);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_85, &result_0);
-                           FX_BREAK(_fx_catch_60);
-                        }
-                        else if (c1_0 == (char_)62) {
-                           if (c2_0 == (char_)61) {
+                        else if (c1_0 == (char_)42) {
+                           if (c2_0 == (char_)42) {
                               *pos_0 = *pos_0 + 2;
-                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpShiftRight, &v_277);
-                              _fx_make_T2N14Lexer__token_tTa2i(&v_277, &loc_0, &v_278);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_278, 0, true, &result_86), _fx_catch_60);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_86, &result_0);
-                              FX_BREAK(_fx_catch_60);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_POWER, &loc_0, &v_240);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_240, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else if (c2_0 == (char_)61) {
+                              *pos_0 = *pos_0 + 2;
+                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMul, &v_241);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_241, &loc_0, &v_242);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_242, 0, true, &tokens_0), _fx_catch_50);
                            }
                            else {
                               *pos_0 = *pos_0 + 1;
-                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__SHIFT_RIGHT, &loc_0, &v_279);
-                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_279, 0, true, &result_87), _fx_catch_60);
-                              _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                              FX_COPY_PTR(result_87, &result_0);
-                              FX_BREAK(_fx_catch_60);
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__DOT_STAR, &loc_0, &v_243);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_243, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                        }
+                        else if (c1_0 == (char_)47) {
+                           if (c2_0 == (char_)61) {
+                              *pos_0 = *pos_0 + 2;
+                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotDiv, &v_244);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_244, &loc_0, &v_245);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_245, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else {
+                              *pos_0 = *pos_0 + 1;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__DOT_SLASH, &loc_0, &v_246);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_246, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                        }
+                        else if (c1_0 == (char_)37) {
+                           if (c2_0 == (char_)61) {
+                              *pos_0 = *pos_0 + 2;
+                              _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g15Lexer__OpDotMod, &v_247);
+                              _fx_make_T2N14Lexer__token_tTa2i(&v_247, &loc_0, &v_248);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_248, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else {
+                              *pos_0 = *pos_0 + 1;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__DOT_PERCENT, &loc_0, &v_249);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_249, 0, true, &tokens_0), _fx_catch_50);
                            }
                         }
                         else {
-                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_280);
+                           bool t_28;
+                           if (c1_0 == (char_)46) {
+                              t_28 = c2_0 == (char_)46;
+                           }
+                           else {
+                              t_28 = false;
+                           }
+                           if (t_28) {
+                              *pos_0 = *pos_0 + 2;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__ELLIPSIS, &loc_0, &v_250);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_250, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                           else {
+                              *prev_dot_0 = true;
+                              _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__DOT, &loc_0, &v_251);
+                              FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_251, 0, true, &tokens_0), _fx_catch_50);
+                           }
+                        }
+                     }
+
+                  _fx_catch_50: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_251);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_250);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_249);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_248);
+                     _fx_free_N14Lexer__token_t(&v_247);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_246);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_245);
+                     _fx_free_N14Lexer__token_t(&v_244);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_243);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_242);
+                     _fx_free_N14Lexer__token_t(&v_241);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_240);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_239);
+                     _fx_free_N14Lexer__token_t(&v_238);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_237);
+                     _fx_free_N14Lexer__token_t(&v_236);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_235);
+                     _fx_free_N14Lexer__token_t(&v_234);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_233);
+                     _fx_free_N14Lexer__token_t(&v_232);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_231);
+                     _fx_free_N14Lexer__token_t(&v_230);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_229);
+                     _fx_free_N14Lexer__token_t(&v_228);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_227);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_226);
+                     _fx_free_N14Lexer__token_t(&v_225);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_224);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_223);
+                     _fx_free_N14Lexer__token_t(&v_222);
+                  }
+                  else if (c_2 == (char_)44) {
+                     _fx_T2N14Lexer__token_tTa2i v_252 = {0};
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &loc_0, &v_252);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_252, 0, true, &tokens_0), _fx_catch_51);
+
+                  _fx_catch_51: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_252);
+                  }
+                  else if (c_2 == (char_)59) {
+                     _fx_T2N14Lexer__token_tTa2i v_253 = {0};
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SEMICOLON, &loc_0, &v_253);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_253, 0, true, &tokens_0), _fx_catch_52);
+
+                  _fx_catch_52: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_253);
+                  }
+                  else if (c_2 == (char_)58) {
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_8 = 0;
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_8);
+                     if (paren_stack_8 != 0) {
+                        if (paren_stack_8->hd.t0.tag == 45) {
+                           fx_exn_t curr_exn_0 = {0};
+                           fx_exn_t v_254 = {0};
+                           fx_exn_t v_255 = {0};
+                           _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i v_256 = {0};
+                           _fx_T2R8format_ti v_257;
+                           FX_CALL(_fx_F12parse_formatT2R8format_ti2Si(&buf_0, *pos_0, &v_257, 0), _fx_catch_53);
+
+                        _fx_catch_53: ;
+                           if (fx_status < 0) {
+                              fx_exn_get_and_reset(fx_status, &curr_exn_0);
+                              fx_status = 0;
+                              _fx_Ta2i v_258;
+                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_258, 0),
+                                 _fx_catch_54);
+                              fx_str_t slit_17 = FX_MAKE_STR("invalid format specification");
+                              FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_258, &slit_17, &v_254), _fx_catch_54);
+                              FX_THROW(&v_254, true, _fx_catch_54);
+                           }
+                           _fx_R8format_t fmt__0 = v_257.t0;
+                           int_ end_0 = v_257.t1;
+                           _fx_Nt6option1R8format_t v_259;
+                           _fx_M5LexerFM4SomeNt6option1R8format_t1R8format_t(&fmt__0, &v_259);
+                           *fmt_0 = v_259;
+                           *pos_0 = end_0;
+                           if (FX_STR_ELEM_ZERO(buf_0, *pos_0) != (char_)125) {
+                              _fx_Ta2i v_260;
+                              FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &v_260, 0),
+                                 _fx_catch_54);
+                              fx_str_t slit_18 = FX_MAKE_STR("\'}\' is expected after \':...\' inside interpolated expression");
+                              FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&v_260, &slit_18, &v_255), _fx_catch_54);
+                              FX_THROW(&v_255, true, _fx_catch_54);
+                           }
+                           FX_CALL(_fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0(&v_256, fx_fv), _fx_catch_54);
+                           FX_COPY_PTR(v_256.t0, &tokens_0);
+
+                        _fx_catch_54: ;
+                           _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(&v_256);
+                           fx_free_exn(&v_255);
+                           fx_free_exn(&v_254);
+                           fx_free_exn(&curr_exn_0);
+                           goto _fx_endmatch_13;
+                        }
+                     }
+                     _fx_T2N14Lexer__token_tTa2i v_261 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_262 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_263 = {0};
+                     if (c1_0 == (char_)58) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CONS, &loc_0, &v_261);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_261, 0, true, &tokens_0), _fx_catch_55);
+                     }
+                     else if (c1_0 == (char_)62) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g11Lexer__CAST, &loc_0, &v_262);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_262, 0, true, &tokens_0), _fx_catch_55);
+                     }
+                     else {
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COLON, &loc_0, &v_263);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_263, 0, true, &tokens_0), _fx_catch_55);
+                     }
+
+                  _fx_catch_55: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_263);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_262);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_261);
+
+                  _fx_endmatch_13: ;
+                     FX_CHECK_EXN(_fx_catch_56);
+
+                  _fx_catch_56: ;
+                     if (paren_stack_8) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_8);
+                     }
+                  }
+                  else if (c_2 == (char_)33) {
+                     _fx_N14Lexer__token_t v_264 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_265 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_266 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpNE, &v_264);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_264, &loc_0, &v_265);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_265, 0, true, &tokens_0), _fx_catch_57);
+                     }
+                     else {
+                        _fx_Ta2i v_267;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_267, 0), _fx_catch_57);
+                        fx_str_t slit_19 = FX_MAKE_STR("!");
+                        FX_CALL(_fx_M5LexerFM8check_nev3BTa2iS(prev_ne_0, &v_267, &slit_19, 0), _fx_catch_57);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__LOGICAL_NOT, &loc_0, &v_266);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_266, 0, true, &tokens_0), _fx_catch_57);
+                     }
+
+                  _fx_catch_57: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_266);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_265);
+                     _fx_free_N14Lexer__token_t(&v_264);
+                  }
+                  else if (c_2 == (char_)63) {
+                     _fx_T2N14Lexer__token_tTa2i v_268 = {0};
+                     *new_exp_0 = false;
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g15Lexer__QUESTION, &loc_0, &v_268);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_268, 0, true, &tokens_0), _fx_catch_58);
+
+                  _fx_catch_58: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_268);
+                  }
+                  else if (c_2 == (char_)60) {
+                     _fx_T2N14Lexer__token_tTa2i v_269 = {0};
+                     _fx_N14Lexer__token_t v_270 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_271 = {0};
+                     _fx_N14Lexer__token_t v_272 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_273 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_274 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_275 = {0};
+                     _fx_N14Lexer__token_t v_276 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_277 = {0};
+                     if (c1_0 == (char_)61) {
+                        if (c2_0 == (char_)62) {
+                           *pos_0 = *pos_0 + 2;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g16Lexer__SPACESHIP, &loc_0, &v_269);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_269, 0, true, &tokens_0), _fx_catch_59);
+                        }
+                        else {
+                           *pos_0 = *pos_0 + 1;
+                           _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLE, &v_270);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_270, &loc_0, &v_271);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_271, 0, true, &tokens_0), _fx_catch_59);
+                        }
+                     }
+                     else if (c1_0 == (char_)60) {
+                        if (c2_0 == (char_)61) {
+                           *pos_0 = *pos_0 + 2;
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g18Lexer__OpShiftLeft, &v_272);
+                           _fx_make_T2N14Lexer__token_tTa2i(&v_272, &loc_0, &v_273);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_273, 0, true, &tokens_0), _fx_catch_59);
+                        }
+                        else {
+                           *pos_0 = *pos_0 + 1;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__SHIFT_LEFT, &loc_0, &v_274);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_274, 0, true, &tokens_0), _fx_catch_59);
+                        }
+                     }
+                     else if (c1_0 == (char_)45) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g17Lexer__BACK_ARROW, &loc_0, &v_275);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_275, 0, true, &tokens_0), _fx_catch_59);
+                     }
+                     else {
+                        _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpLT, &v_276);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_276, &loc_0, &v_277);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_277, 0, true, &tokens_0), _fx_catch_59);
+                     }
+
+                  _fx_catch_59: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_277);
+                     _fx_free_N14Lexer__token_t(&v_276);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_275);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_274);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_273);
+                     _fx_free_N14Lexer__token_t(&v_272);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_271);
+                     _fx_free_N14Lexer__token_t(&v_270);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_269);
+                  }
+                  else if (c_2 == (char_)62) {
+                     _fx_N14Lexer__token_t v_278 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_279 = {0};
+                     _fx_N14Lexer__token_t v_280 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_281 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_282 = {0};
+                     _fx_N14Lexer__token_t v_283 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_284 = {0};
+                     if (c1_0 == (char_)61) {
+                        *pos_0 = *pos_0 + 1;
+                        _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGE, &v_278);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_278, &loc_0, &v_279);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_279, 0, true, &tokens_0), _fx_catch_60);
+                     }
+                     else if (c1_0 == (char_)62) {
+                        if (c2_0 == (char_)61) {
+                           *pos_0 = *pos_0 + 2;
+                           _fx_M5LexerFM9AUG_BINOPN14Lexer__token_t1N13Ast__binary_t(_fx_g19Lexer__OpShiftRight, &v_280);
                            _fx_make_T2N14Lexer__token_tTa2i(&v_280, &loc_0, &v_281);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_281, 0, true, &result_88), _fx_catch_60);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_88, &result_0);
-                           FX_BREAK(_fx_catch_60);
-                        }
-
-                     _fx_catch_60: ;
-                        if (result_88) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_88);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_281);
-                        _fx_free_N14Lexer__token_t(&v_280);
-                        if (result_87) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_87);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_279);
-                        if (result_86) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_86);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_278);
-                        _fx_free_N14Lexer__token_t(&v_277);
-                        if (result_85) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_85);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_276);
-                        _fx_free_N14Lexer__token_t(&v_275);
-                     }
-                     else if (c_2 == (char_)96) {
-                        _fx_N14Lexer__token_t v_282 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_283 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_284 = 0;
-                        _fx_N14Lexer__token_t v_285 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_286 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_89 = 0;
-                        fx_str_t verb_0 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_9 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_287 = {0};
-                        _fx_N10Ast__lit_t v_288 = {0};
-                        _fx_N14Lexer__token_t v_289 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_290 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_291 = {0};
-                        fx_str_t v_292 = {0};
-                        fx_str_t v_293 = {0};
-                        _fx_N10Ast__lit_t v_294 = {0};
-                        _fx_N14Lexer__token_t v_295 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_296 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_297 = {0};
-                        _fx_N10Ast__lit_t v_298 = {0};
-                        _fx_N14Lexer__token_t v_299 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_300 = {0};
-                        _fx_T2N14Lexer__token_tTa2i v_301 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i v_302 = 0;
-                        if (*backquote_pos_0 < 0) {
-                           *backquote_pos_0 = *pos_0;
-                           _fx_Ta2i v_303;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_303, 0),
-                              _fx_catch_62);
-                           *backquote_loc_0 = v_303;
-                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_282);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_282, backquote_loc_0, &v_283);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_283, *paren_stack_0, true, &v_284), _fx_catch_62);
-                           _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                           FX_COPY_PTR(v_284, paren_stack_0);
-                           _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_285);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_285, &loc_0, &v_286);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_286, 0, true, &result_89), _fx_catch_62);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(result_89, &result_0);
-                           FX_BREAK(_fx_catch_62);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_281, 0, true, &tokens_0), _fx_catch_60);
                         }
                         else {
-                           FX_CALL(fx_substr(&buf_0, *backquote_pos_0, *pos_0 - 1, 1, 0, &verb_0), _fx_catch_62);
-                           _fx_Ta2i endloc_0;
-                           FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &endloc_0, 0),
-                              _fx_catch_62);
-                           *backquote_pos_0 = -1;
-                           *new_exp_0 = false;
-                           FX_COPY_PTR(*paren_stack_0, &paren_stack_9);
-                           if (paren_stack_9 != 0) {
-                              if (paren_stack_9->hd.t0.tag == 44) {
-                                 _fx_LT2N14Lexer__token_tTa2i* rest_6 = &paren_stack_9->tl;
-                                 _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_0);
-                                 FX_COPY_PTR(*rest_6, paren_stack_0);
-                                 goto _fx_endmatch_14;
-                              }
-                           }
-                           fx_exn_t v_304 = {0};
-                           fx_str_t slit_20 = FX_MAKE_STR("Unexpected \'`\', check parens");
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_20, &v_304), _fx_catch_61);
-                           FX_THROW(&v_304, true, _fx_catch_61);
-
-                        _fx_catch_61: ;
-                           fx_free_exn(&v_304);
-
-                        _fx_endmatch_14: ;
-                           FX_CHECK_EXN(_fx_catch_62);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_287);
-                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&verb_0, &v_288);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_288, &v_289);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_289, backquote_loc_0, &v_290);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_291);
-                           fx_copy_str(&strm_0->u.stream_t.t0, &v_292);
-                           FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_292, &v_293, 0), _fx_catch_62);
-                           _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_293, &v_294);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_294, &v_295);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_295, backquote_loc_0, &v_296);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_297);
-                           _fx_M3AstFM6LitIntN10Ast__lit_t1l((int64_t)backquote_loc_0->t0, &v_298);
-                           _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_298, &v_299);
-                           _fx_make_T2N14Lexer__token_tTa2i(&v_299, backquote_loc_0, &v_300);
-                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &endloc_0, &v_301);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_301, 0, true, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_300, v_302, false, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_297, v_302, false, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_296, v_302, false, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_291, v_302, false, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_290, v_302, false, &v_302), _fx_catch_62);
-                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_287, v_302, false, &v_302), _fx_catch_62);
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                           FX_COPY_PTR(v_302, &result_0);
-                           FX_BREAK(_fx_catch_62);
-                        }
-
-                     _fx_catch_62: ;
-                        if (v_302) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_302);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_301);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_300);
-                        _fx_free_N14Lexer__token_t(&v_299);
-                        _fx_free_N10Ast__lit_t(&v_298);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_297);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_296);
-                        _fx_free_N14Lexer__token_t(&v_295);
-                        _fx_free_N10Ast__lit_t(&v_294);
-                        FX_FREE_STR(&v_293);
-                        FX_FREE_STR(&v_292);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_291);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_290);
-                        _fx_free_N14Lexer__token_t(&v_289);
-                        _fx_free_N10Ast__lit_t(&v_288);
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_287);
-                        if (paren_stack_9) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_9);
-                        }
-                        FX_FREE_STR(&verb_0);
-                        if (result_89) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_89);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_286);
-                        _fx_free_N14Lexer__token_t(&v_285);
-                        if (v_284) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&v_284);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_283);
-                        _fx_free_N14Lexer__token_t(&v_282);
-                     }
-                     else if (c_2 == (char_)0) {
-                        _fx_LT2N14Lexer__token_tTa2i paren_stack_10 = 0;
-                        _fx_T2N14Lexer__token_tTa2i v_305 = {0};
-                        _fx_LT2N14Lexer__token_tTa2i result_90 = 0;
-                        FX_COPY_PTR(*paren_stack_0, &paren_stack_10);
-                        if (paren_stack_10 != 0) {
-                           fx_str_t v_306 = {0};
-                           fx_str_t v_307 = {0};
-                           fx_str_t v_308 = {0};
-                           fx_exn_t v_309 = {0};
-                           FX_CALL(
-                              _fx_M5LexerFM8lloc2strS2Ta2iN20LexerUtils__stream_t(&paren_stack_10->hd.t1, strm_0, &v_306, 0),
-                              _fx_catch_63);
-                           FX_CALL(_fx_M5LexerFM6stringS1S(&v_306, &v_307, 0), _fx_catch_63);
-                           fx_str_t slit_21 = FX_MAKE_STR("some braces (around ");
-                           fx_str_t slit_22 = FX_MAKE_STR(") are not closed");
-                           {
-                              const fx_str_t strs_2[] = { slit_21, v_307, slit_22 };
-                              FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_308), _fx_catch_63);
-                           }
-                           FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_308, &v_309), _fx_catch_63);
-                           FX_THROW(&v_309, true, _fx_catch_63);
-
-                        _fx_catch_63: ;
-                           fx_free_exn(&v_309);
-                           FX_FREE_STR(&v_308);
-                           FX_FREE_STR(&v_307);
-                           FX_FREE_STR(&v_306);
-                        }
-                        FX_CHECK_EXN(_fx_catch_64);
-                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__EOF, &loc_0, &v_305);
-                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_305, 0, true, &result_90), _fx_catch_64);
-                        _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
-                        FX_COPY_PTR(result_90, &result_0);
-                        FX_BREAK(_fx_catch_64);
-
-                     _fx_catch_64: ;
-                        if (result_90) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&result_90);
-                        }
-                        _fx_free_T2N14Lexer__token_tTa2i(&v_305);
-                        if (paren_stack_10) {
-                           _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_10);
+                           *pos_0 = *pos_0 + 1;
+                           _fx_make_T2N14Lexer__token_tTa2i(&_fx_g18Lexer__SHIFT_RIGHT, &loc_0, &v_282);
+                           FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_282, 0, true, &tokens_0), _fx_catch_60);
                         }
                      }
                      else {
+                        _fx_M5LexerFM3CMPN14Lexer__token_t1N12Ast__cmpop_t(&_fx_g12Lexer__CmpGT, &v_283);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_283, &loc_0, &v_284);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_284, 0, true, &tokens_0), _fx_catch_60);
+                     }
+
+                  _fx_catch_60: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_284);
+                     _fx_free_N14Lexer__token_t(&v_283);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_282);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_281);
+                     _fx_free_N14Lexer__token_t(&v_280);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_279);
+                     _fx_free_N14Lexer__token_t(&v_278);
+                  }
+                  else if (c_2 == (char_)96) {
+                     _fx_N14Lexer__token_t v_285 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_286 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_287 = 0;
+                     _fx_N14Lexer__token_t v_288 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_289 = {0};
+                     fx_str_t verb_0 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_9 = 0;
+                     _fx_T2N14Lexer__token_tTa2i v_290 = {0};
+                     _fx_N10Ast__lit_t v_291 = {0};
+                     _fx_N14Lexer__token_t v_292 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_293 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_294 = {0};
+                     fx_str_t v_295 = {0};
+                     fx_str_t v_296 = {0};
+                     _fx_N10Ast__lit_t v_297 = {0};
+                     _fx_N14Lexer__token_t v_298 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_299 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_300 = {0};
+                     _fx_N10Ast__lit_t v_301 = {0};
+                     _fx_N14Lexer__token_t v_302 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_303 = {0};
+                     _fx_T2N14Lexer__token_tTa2i v_304 = {0};
+                     _fx_LT2N14Lexer__token_tTa2i v_305 = 0;
+                     if (*backquote_pos_0 < 0) {
+                        *backquote_pos_0 = *pos_0;
+                        _fx_Ta2i v_306;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0 - 1, strm_0, &v_306, 0), _fx_catch_62);
+                        *backquote_loc_0 = v_306;
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_285);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_285, backquote_loc_0, &v_286);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_286, *paren_stack_1, true, &v_287), _fx_catch_62);
+                        _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                        FX_COPY_PTR(v_287, paren_stack_1);
+                        _fx_M5LexerFM6LPARENN14Lexer__token_t1B(true, &v_288);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_288, &loc_0, &v_289);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_289, 0, true, &tokens_0), _fx_catch_62);
+                     }
+                     else {
+                        FX_CALL(fx_substr(&buf_0, *backquote_pos_0, *pos_0 - 1, 1, 0, &verb_0), _fx_catch_62);
+                        _fx_Ta2i endloc_0;
+                        FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &endloc_0, 0), _fx_catch_62);
+                        *backquote_pos_0 = -1;
+                        *new_exp_0 = false;
+                        FX_COPY_PTR(*paren_stack_1, &paren_stack_9);
+                        if (paren_stack_9 != 0) {
+                           if (paren_stack_9->hd.t0.tag == 44) {
+                              _fx_LT2N14Lexer__token_tTa2i* rest_6 = &paren_stack_9->tl;
+                              _fx_free_LT2N14Lexer__token_tTa2i(paren_stack_1);
+                              FX_COPY_PTR(*rest_6, paren_stack_1);
+                              goto _fx_endmatch_14;
+                           }
+                        }
+                        fx_exn_t v_307 = {0};
+                        fx_str_t slit_20 = FX_MAKE_STR("Unexpected \'`\', check parens");
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &slit_20, &v_307), _fx_catch_61);
+                        FX_THROW(&v_307, true, _fx_catch_61);
+
+                     _fx_catch_61: ;
+                        fx_free_exn(&v_307);
+
+                     _fx_endmatch_14: ;
+                        FX_CHECK_EXN(_fx_catch_62);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_290);
+                        _fx_M3AstFM9LitStringN10Ast__lit_t1S(&verb_0, &v_291);
+                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_291, &v_292);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_292, backquote_loc_0, &v_293);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_294);
+                        fx_copy_str(&strm_0->u.stream_t.t0, &v_295);
+                        FX_CALL(_fx_M8FilenameFM8basenameS1S(&v_295, &v_296, 0), _fx_catch_62);
+                        _fx_M3AstFM9LitStringN10Ast__lit_t1S(&v_296, &v_297);
+                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_297, &v_298);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_298, backquote_loc_0, &v_299);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g12Lexer__COMMA, &endloc_0, &v_300);
+                        _fx_M3AstFM6LitIntN10Ast__lit_t1l((int64_t)backquote_loc_0->t0, &v_301);
+                        _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(&v_301, &v_302);
+                        _fx_make_T2N14Lexer__token_tTa2i(&v_302, backquote_loc_0, &v_303);
+                        _fx_make_T2N14Lexer__token_tTa2i(&_fx_g13Lexer__RPAREN, &endloc_0, &v_304);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_304, 0, true, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_303, v_305, false, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_300, v_305, false, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_299, v_305, false, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_294, v_305, false, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_293, v_305, false, &v_305), _fx_catch_62);
+                        FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_290, v_305, true, &tokens_0), _fx_catch_62);
+                     }
+
+                  _fx_catch_62: ;
+                     if (v_305) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_305);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_304);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_303);
+                     _fx_free_N14Lexer__token_t(&v_302);
+                     _fx_free_N10Ast__lit_t(&v_301);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_300);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_299);
+                     _fx_free_N14Lexer__token_t(&v_298);
+                     _fx_free_N10Ast__lit_t(&v_297);
+                     FX_FREE_STR(&v_296);
+                     FX_FREE_STR(&v_295);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_294);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_293);
+                     _fx_free_N14Lexer__token_t(&v_292);
+                     _fx_free_N10Ast__lit_t(&v_291);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_290);
+                     if (paren_stack_9) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_9);
+                     }
+                     FX_FREE_STR(&verb_0);
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_289);
+                     _fx_free_N14Lexer__token_t(&v_288);
+                     if (v_287) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&v_287);
+                     }
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_286);
+                     _fx_free_N14Lexer__token_t(&v_285);
+                  }
+                  else if (c_2 == (char_)0) {
+                     _fx_LT2N14Lexer__token_tTa2i paren_stack_10 = 0;
+                     _fx_T2N14Lexer__token_tTa2i v_308 = {0};
+                     FX_COPY_PTR(*paren_stack_1, &paren_stack_10);
+                     if (paren_stack_10 != 0) {
+                        fx_str_t v_309 = {0};
                         fx_str_t v_310 = {0};
                         fx_str_t v_311 = {0};
                         fx_exn_t v_312 = {0};
-                        FX_CALL(_fx_F6stringS1C(c_0, &v_310, 0), _fx_catch_65);
-                        fx_str_t slit_23 = FX_MAKE_STR("unrecognized character \'");
-                        fx_str_t slit_24 = FX_MAKE_STR("\'");
+                        FX_CALL(_fx_M5LexerFM8lloc2strS2Ta2iN20LexerUtils__stream_t(&paren_stack_10->hd.t1, strm_0, &v_309, 0),
+                           _fx_catch_63);
+                        FX_CALL(_fx_M5LexerFM6stringS1S(&v_309, &v_310, 0), _fx_catch_63);
+                        fx_str_t slit_21 = FX_MAKE_STR("some braces (around ");
+                        fx_str_t slit_22 = FX_MAKE_STR(") are not closed");
                         {
-                           const fx_str_t strs_3[] = { slit_23, v_310, slit_24 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_311), _fx_catch_65);
+                           const fx_str_t strs_2[] = { slit_21, v_310, slit_22 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_311), _fx_catch_63);
                         }
-                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_311, &v_312), _fx_catch_65);
-                        FX_THROW(&v_312, true, _fx_catch_65);
+                        FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_311, &v_312), _fx_catch_63);
+                        FX_THROW(&v_312, true, _fx_catch_63);
 
-                     _fx_catch_65: ;
+                     _fx_catch_63: ;
                         fx_free_exn(&v_312);
                         FX_FREE_STR(&v_311);
                         FX_FREE_STR(&v_310);
+                        FX_FREE_STR(&v_309);
                      }
-                     FX_CHECK_EXN(_fx_catch_66);
+                     FX_CHECK_EXN(_fx_catch_64);
+                     _fx_make_T2N14Lexer__token_tTa2i(&_fx_g10Lexer__EOF, &loc_0, &v_308);
+                     FX_CALL(_fx_cons_LT2N14Lexer__token_tTa2i(&v_308, 0, true, &tokens_0), _fx_catch_64);
+
+                  _fx_catch_64: ;
+                     _fx_free_T2N14Lexer__token_tTa2i(&v_308);
+                     if (paren_stack_10) {
+                        _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_10);
+                     }
                   }
+                  else {
+                     fx_str_t v_313 = {0};
+                     fx_str_t v_314 = {0};
+                     fx_exn_t v_315 = {0};
+                     FX_CALL(_fx_F6stringS1C(c_0, &v_313, 0), _fx_catch_65);
+                     fx_str_t slit_23 = FX_MAKE_STR("unrecognized character \'");
+                     fx_str_t slit_24 = FX_MAKE_STR("\'");
+                     {
+                        const fx_str_t strs_3[] = { slit_23, v_313, slit_24 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_3, 3, &v_314), _fx_catch_65);
+                     }
+                     FX_CALL(_fx_M10LexerUtilsFM15make_LexerErrorE2Ta2iS(&loc_0, &v_314, &v_315), _fx_catch_65);
+                     FX_THROW(&v_315, true, _fx_catch_65);
+
+                  _fx_catch_65: ;
+                     fx_free_exn(&v_315);
+                     FX_FREE_STR(&v_314);
+                     FX_FREE_STR(&v_313);
+                  }
+                  FX_CHECK_EXN(_fx_cleanup);
                }
             }
          }
       }
-
-   _fx_catch_66: ;
-      _fx_free_Nt6option1T2N14Lexer__token_ti(&v_45);
-      FX_FREE_STR(&ident_0);
-      FX_FREE_STR(&v_44);
-      if (result_6) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_6);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_43);
-      _fx_free_N14Lexer__token_t(&v_42);
-      _fx_free_N10Ast__lit_t(&v_41);
-      if (result_5) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_5);
-      }
-      if (v_40) {
-         _fx_free_LN14Lexer__token_t(&v_40);
-      }
-      if (v_39) {
-         _fx_free_LN14Lexer__token_t(&v_39);
-      }
-      _fx_free_N14Lexer__token_t(&v_38);
-      _fx_free_N14Lexer__token_t(&v_37);
-      if (v_36) {
-         _fx_free_LN14Lexer__token_t(&v_36);
-      }
-      _fx_free_N14Lexer__token_t(&v_35);
-      _fx_free_N14Lexer__token_t(&v_34);
-      _fx_free_N10Ast__lit_t(&v_33);
-      _fx_free_N14Lexer__token_t(&v_32);
-      _fx_free_N14Lexer__token_t(&v_31);
-      if (v_30) {
-         _fx_free_LN14Lexer__token_t(&v_30);
-      }
-      if (v_29) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&v_29);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_28);
-      if (result_4) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_4);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_27);
-      _fx_free_N14Lexer__token_t(&v_26);
-      _fx_free_N10Ast__lit_t(&v_25);
-      fx_free_exn(&v_24);
-      FX_FREE_STR(&res_0);
-      _fx_free_T4iSiB(&v_23);
-      if (result_3) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_3);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_22);
-      _fx_free_N14Lexer__token_t(&v_21);
-      FX_FREE_STR(&tyvar_0);
-      FX_FREE_STR(&v_20);
-      if (result_2) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_2);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_19);
-      if (result_1) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&result_1);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_18);
-      if (v_17) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&v_17);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_16);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_15);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_14);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_13);
-      _fx_free_N14Lexer__token_t(&v_12);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_11);
-      _fx_free_N14Lexer__token_t(&v_10);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_9);
-      _fx_free_N14Lexer__token_t(&v_8);
-      _fx_free_N10Ast__lit_t(&zero_0);
-      if (v_7) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&v_7);
-      }
-      _fx_free_T2N14Lexer__token_tTa2i(&v_6);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_5);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_4);
-      _fx_free_N14Lexer__token_t(&v_3);
-      _fx_free_T2N14Lexer__token_tTa2i(&v_2);
-      _fx_free_N14Lexer__token_t(&v_1);
-      _fx_free_N14Lexer__token_t(&t_0);
-      _fx_free_T2iT2N14Lexer__token_tC(&v_0);
-      if (paren_stack_1) {
-         _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_1);
-      }
-      FX_FREE_STR(&buf_0);
-      FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_cleanup);
    }
-   FX_COPY_PTR(result_0, fx_result);
+   _fx_Ta2i endloc_1;
+   FX_CALL(_fx_M5LexerFM6getlocTa2i2iN20LexerUtils__stream_t(*pos_0, strm_0, &endloc_1, 0), _fx_cleanup);
+   _fx_make_T3LT2N14Lexer__token_tTa2iTa2iTa2i(tokens_0, &loc_0, &endloc_1, fx_result);
 
 _fx_cleanup: ;
-   if (result_0) {
-      _fx_free_LT2N14Lexer__token_tTa2i(&result_0);
+   FX_FREE_STR(&buf_0);
+   if (paren_stack_0) {
+      _fx_free_LT2N14Lexer__token_tTa2i(&paren_stack_0);
    }
+   if (tokens_0) {
+      _fx_free_LT2N14Lexer__token_tTa2i(&tokens_0);
+   }
+   _fx_free_T2iT2N14Lexer__token_tC(&v_0);
+   _fx_free_N14Lexer__token_t(&t_0);
+   _fx_free_N14Lexer__token_t(&v_1);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_2);
+   _fx_free_N14Lexer__token_t(&v_3);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_4);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_5);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_6);
+   if (v_7) {
+      _fx_free_LT2N14Lexer__token_tTa2i(&v_7);
+   }
+   _fx_free_N10Ast__lit_t(&zero_0);
+   _fx_free_N14Lexer__token_t(&v_8);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_9);
+   _fx_free_N14Lexer__token_t(&v_10);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_11);
+   _fx_free_N14Lexer__token_t(&v_12);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_13);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_14);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_15);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_16);
+   if (v_17) {
+      _fx_free_LT2N14Lexer__token_tTa2i(&v_17);
+   }
+   _fx_free_T2N14Lexer__token_tTa2i(&v_18);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_19);
+   FX_FREE_STR(&v_20);
+   FX_FREE_STR(&tyvar_0);
+   _fx_free_N14Lexer__token_t(&v_21);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_22);
+   _fx_free_T4iSiB(&v_23);
+   FX_FREE_STR(&res_0);
+   fx_free_exn(&v_24);
+   _fx_free_N10Ast__lit_t(&v_25);
+   _fx_free_N14Lexer__token_t(&v_26);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_27);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_28);
+   if (v_29) {
+      _fx_free_LT2N14Lexer__token_tTa2i(&v_29);
+   }
+   if (v_30) {
+      _fx_free_LN14Lexer__token_t(&v_30);
+   }
+   _fx_free_N14Lexer__token_t(&v_31);
+   _fx_free_N14Lexer__token_t(&v_32);
+   _fx_free_N10Ast__lit_t(&v_33);
+   _fx_free_N14Lexer__token_t(&v_34);
+   _fx_free_N14Lexer__token_t(&v_35);
+   if (v_36) {
+      _fx_free_LN14Lexer__token_t(&v_36);
+   }
+   _fx_free_N14Lexer__token_t(&v_37);
+   _fx_free_N14Lexer__token_t(&v_38);
+   if (v_39) {
+      _fx_free_LN14Lexer__token_t(&v_39);
+   }
+   if (v_40) {
+      _fx_free_LN14Lexer__token_t(&v_40);
+   }
+   _fx_free_N10Ast__lit_t(&v_41);
+   _fx_free_N14Lexer__token_t(&v_42);
+   _fx_free_T2N14Lexer__token_tTa2i(&v_43);
+   FX_FREE_STR(&v_44);
+   FX_FREE_STR(&ident_0);
+   _fx_free_Nt6option1T2N14Lexer__token_ti(&v_45);
    return fx_status;
 }
 
 FX_EXTERN_C int
-   _fx_M5LexerFM7make_fpFPLT2N14Lexer__token_tTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
+   _fx_M5LexerFM7make_fpFPT3LT2N14Lexer__token_tTa2iTa2iTa2i09rTa2irirBrNt6option1R8format_trBrLT2N14Lexer__token_tTa2irirBN20LexerUtils__stream_t(
    struct _fx_rTa2i_data_t* arg0,
    struct _fx_ri_data_t* arg1,
    struct _fx_rB_data_t* arg2,
@@ -6518,10 +5902,11 @@ FX_EXTERN_C int
    struct _fx_ri_data_t* arg6,
    struct _fx_rB_data_t* arg7,
    struct _fx_N20LexerUtils__stream_t_data_t* arg8,
-   struct _fx_FPLT2N14Lexer__token_tTa2i0* fx_result)
+   struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0* fx_result)
 {
-   FX_MAKE_FP_IMPL_START(_fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0_cldata_t,
-      _fx_free_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0, _fx_M5LexerFM10nexttokensLT2N14Lexer__token_tTa2i0);
+   FX_MAKE_FP_IMPL_START(_fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0_cldata_t,
+      _fx_free_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0,
+      _fx_M5LexerFM10nexttokensT3LT2N14Lexer__token_tTa2iTa2iTa2i0);
    FX_COPY_PTR(arg0, &fcv->t0);
    FX_COPY_PTR(arg1, &fcv->t1);
    FX_COPY_PTR(arg2, &fcv->t2);

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -1094,10 +1094,16 @@ typedef struct _fx_Ta2S {
    fx_str_t t1;
 } _fx_Ta2S;
 
-typedef struct _fx_FPLT2N14Lexer__token_tTa2i0 {
-   int (*fp)(struct _fx_LT2N14Lexer__token_tTa2i_data_t**, void*);
+typedef struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i {
+   struct _fx_LT2N14Lexer__token_tTa2i_data_t* t0;
+   struct _fx_Ta2i t1;
+   struct _fx_Ta2i t2;
+} _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i;
+
+typedef struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0 {
+   int (*fp)(struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i*, void*);
    fx_fcv_t* fcv;
-} _fx_FPLT2N14Lexer__token_tTa2i0;
+} _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0;
 
 typedef struct _fx_N15Parser__ppval_t {
    int tag;
@@ -4237,6 +4243,31 @@ static void _fx_make_Ta2S(fx_str_t* t0, fx_str_t* t1, struct _fx_Ta2S* fx_result
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* dst)
+{
+   _fx_free_LT2N14Lexer__token_tTa2i(&dst->t0);
+}
+
+static void _fx_copy_T3LT2N14Lexer__token_tTa2iTa2iTa2i(
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* src,
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* dst)
+{
+   FX_COPY_PTR(src->t0, &dst->t0);
+   dst->t1 = src->t1;
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3LT2N14Lexer__token_tTa2iTa2iTa2i(
+   struct _fx_LT2N14Lexer__token_tTa2i_data_t* t0,
+   struct _fx_Ta2i* t1,
+   struct _fx_Ta2i* t2,
+   struct _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i* fx_result)
+{
+   FX_COPY_PTR(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
+   fx_result->t2 = *t2;
+}
+
 static void _fx_free_N15Parser__ppval_t(struct _fx_N15Parser__ppval_t* dst)
 {
    switch (dst->tag) {
@@ -6696,9 +6727,9 @@ FX_EXTERN_C int _fx_M10LexerUtilsFM11make_streamN20LexerUtils__stream_t1S(
 
 FX_EXTERN_C_VAL(int FX_EXN_FileOpenError)
 FX_EXTERN_C_VAL(int FX_EXN_IOError)
-FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUtils__stream_t(
+FX_EXTERN_C int _fx_M5LexerFM10make_lexerFPT3LT2N14Lexer__token_tTa2iTa2iTa2i01N20LexerUtils__stream_t(
    struct _fx_N20LexerUtils__stream_t_data_t*,
-   struct _fx_FPLT2N14Lexer__token_tTa2i0*,
+   struct _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0*,
    void*);
 
 FX_EXTERN_C_VAL(struct _fx_R18Options__options_t _fx_g12Options__opt)
@@ -27913,7 +27944,7 @@ FX_EXTERN_C int _fx_M6ParserFM5parseB3iLN14Lexer__token_tLS(
    _fx_R20Parser__parser_ctx_t v_2 = {0};
    _fx_N20LexerUtils__stream_t strm_0 = 0;
    fx_exn_t exn_0 = {0};
-   _fx_FPLT2N14Lexer__token_tTa2i0 lexer_0 = {0};
+   _fx_FPT3LT2N14Lexer__token_tTa2iTa2iTa2i0 lexer_0 = {0};
    _fx_LT2N14Lexer__token_tR10Ast__loc_t all_tokens_0 = 0;
    _fx_LT2N14Lexer__token_tR10Ast__loc_t __fold_result___0 = 0;
    _fx_LT2N14Lexer__token_tR10Ast__loc_t v_3 = 0;
@@ -27977,68 +28008,74 @@ _fx_catch_0: ;
       }
       FX_CHECK_EXN(_fx_cleanup);
    }
-   FX_CALL(_fx_M5LexerFM10make_lexerFPLT2N14Lexer__token_tTa2i01N20LexerUtils__stream_t(strm_0, &lexer_0, 0), _fx_cleanup);
+   FX_CALL(_fx_M5LexerFM10make_lexerFPT3LT2N14Lexer__token_tTa2iTa2iTa2i01N20LexerUtils__stream_t(strm_0, &lexer_0, 0),
+      _fx_cleanup);
    int_ prev_lineno_0 = -1;
    for (;;) {
+      _fx_T3LT2N14Lexer__token_tTa2iTa2iTa2i v_16 = {0};
       _fx_LT2N14Lexer__token_tTa2i more_tokens_0 = 0;
       _fx_LT2N14Lexer__token_tR10Ast__loc_t all_tokens_1 = 0;
-      FX_CALL(lexer_0.fp(&more_tokens_0, lexer_0.fcv), _fx_catch_5);
+      FX_CALL(lexer_0.fp(&v_16, lexer_0.fcv), _fx_catch_5);
+      FX_COPY_PTR(v_16.t0, &more_tokens_0);
+      _fx_Ta2i* v_17 = &v_16.t1;
+      int_ bline_0 = v_17->t0;
+      int_ bcol_0 = v_17->t1;
+      _fx_Ta2i* v_18 = &v_16.t2;
+      int_ eline_0 = v_18->t0;
+      int_ ecol_0 = v_18->t1;
+      _fx_R10Ast__loc_t loc_0 = { dm_0->u.defmodule_t.t2, bline_0, bcol_0, eline_0, ecol_0 };
       _fx_LT2N14Lexer__token_tTa2i lst_0 = more_tokens_0;
       for (; lst_0; lst_0 = lst_0->tl) {
          _fx_N14Lexer__token_t t_0 = {0};
-         fx_str_t v_16 = {0};
-         fx_str_t v_17 = {0};
-         fx_str_t v_18 = {0};
-         _fx_Ta2S v_19 = {0};
+         fx_str_t v_19 = {0};
          fx_str_t v_20 = {0};
          fx_str_t v_21 = {0};
-         _fx_T2N14Lexer__token_tR10Ast__loc_t v_22 = {0};
-         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_23 = 0;
+         _fx_Ta2S v_22 = {0};
+         fx_str_t v_23 = {0};
+         fx_str_t v_24 = {0};
+         _fx_T2N14Lexer__token_tR10Ast__loc_t v_25 = {0};
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_26 = 0;
          _fx_T2N14Lexer__token_tTa2i* __pat___0 = &lst_0->hd;
          _fx_copy_N14Lexer__token_t(&__pat___0->t0, &t_0);
-         _fx_Ta2i* i_0 = &__pat___0->t1;
-         int_ lineno_0 = i_0->t0;
-         int_ col_0 = i_0->t1;
-         _fx_R10Ast__loc_t loc_0 = { dm_0->u.defmodule_t.t2, lineno_0, col_0, lineno_0, col_0 };
          if (_fx_g12Options__opt.print_tokens) {
-            if (lineno_0 != prev_lineno_0) {
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&fname_id_0, &v_16, 0), _fx_catch_3);
-               FX_CALL(_fx_F6stringS1i(lineno_0, &v_17, 0), _fx_catch_3);
+            if (bline_0 != prev_lineno_0) {
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&fname_id_0, &v_19, 0), _fx_catch_3);
+               FX_CALL(_fx_F6stringS1i(bline_0, &v_20, 0), _fx_catch_3);
                fx_str_t slit_2 = FX_MAKE_STR("\n");
                fx_str_t slit_3 = FX_MAKE_STR(":");
                fx_str_t slit_4 = FX_MAKE_STR(": ");
                {
-                  const fx_str_t strs_0[] = { slit_2, v_16, slit_3, v_17, slit_4 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_18), _fx_catch_3);
+                  const fx_str_t strs_0[] = { slit_2, v_19, slit_3, v_20, slit_4 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_21), _fx_catch_3);
                }
-               _fx_F12print_stringv1S(&v_18, 0);
-               prev_lineno_0 = lineno_0;
+               _fx_F12print_stringv1S(&v_21, 0);
+               prev_lineno_0 = bline_0;
             }
-            FX_CALL(_fx_M5LexerFM7tok2strTa2S1N14Lexer__token_t(&t_0, &v_19, 0), _fx_catch_3);
-            fx_copy_str(&v_19.t0, &v_20);
+            FX_CALL(_fx_M5LexerFM7tok2strTa2S1N14Lexer__token_t(&t_0, &v_22, 0), _fx_catch_3);
+            fx_copy_str(&v_22.t0, &v_23);
             fx_str_t slit_5 = FX_MAKE_STR(" ");
             {
-               const fx_str_t strs_1[] = { v_20, slit_5 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 2, &v_21), _fx_catch_3);
+               const fx_str_t strs_1[] = { v_23, slit_5 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 2, &v_24), _fx_catch_3);
             }
-            _fx_F12print_stringv1S(&v_21, 0);
+            _fx_F12print_stringv1S(&v_24, 0);
          }
-         _fx_make_T2N14Lexer__token_tR10Ast__loc_t(&t_0, &loc_0, &v_22);
-         FX_CALL(_fx_cons_LT2N14Lexer__token_tR10Ast__loc_t(&v_22, all_tokens_0, true, &v_23), _fx_catch_3);
+         _fx_make_T2N14Lexer__token_tR10Ast__loc_t(&t_0, &loc_0, &v_25);
+         FX_CALL(_fx_cons_LT2N14Lexer__token_tR10Ast__loc_t(&v_25, all_tokens_0, true, &v_26), _fx_catch_3);
          _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&all_tokens_0);
-         FX_COPY_PTR(v_23, &all_tokens_0);
+         FX_COPY_PTR(v_26, &all_tokens_0);
 
       _fx_catch_3: ;
-         if (v_23) {
-            _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_23);
+         if (v_26) {
+            _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_26);
          }
-         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_22);
+         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_25);
+         FX_FREE_STR(&v_24);
+         FX_FREE_STR(&v_23);
+         _fx_free_Ta2S(&v_22);
          FX_FREE_STR(&v_21);
          FX_FREE_STR(&v_20);
-         _fx_free_Ta2S(&v_19);
-         FX_FREE_STR(&v_18);
-         FX_FREE_STR(&v_17);
-         FX_FREE_STR(&v_16);
+         FX_FREE_STR(&v_19);
          _fx_free_N14Lexer__token_t(&t_0);
          FX_CHECK_EXN(_fx_catch_5);
       }
@@ -28059,6 +28096,7 @@ _fx_catch_0: ;
       if (more_tokens_0) {
          _fx_free_LT2N14Lexer__token_tTa2i(&more_tokens_0);
       }
+      _fx_free_T3LT2N14Lexer__token_tTa2iTa2iTa2i(&v_16);
       FX_CHECK_BREAK();
       FX_CHECK_EXN(_fx_cleanup);
    }
@@ -28098,20 +28136,20 @@ _fx_catch_0: ;
    FX_COPY_PTR(__fold_result___1, &v_4);
    _fx_LN14Lexer__token_t lst_3 = v_4;
    for (; lst_3; lst_3 = lst_3->tl) {
-      _fx_T2N14Lexer__token_tR10Ast__loc_t v_24 = {0};
-      _fx_LT2N14Lexer__token_tR10Ast__loc_t v_25 = 0;
+      _fx_T2N14Lexer__token_tR10Ast__loc_t v_27 = {0};
+      _fx_LT2N14Lexer__token_tR10Ast__loc_t v_28 = 0;
       _fx_N14Lexer__token_t* t_1 = &lst_3->hd;
-      _fx_R10Ast__loc_t v_26 = _fx_g18Parser__parser_ctx.default_loc;
-      _fx_make_T2N14Lexer__token_tR10Ast__loc_t(t_1, &v_26, &v_24);
-      FX_CALL(_fx_cons_LT2N14Lexer__token_tR10Ast__loc_t(&v_24, all_tokens_0, true, &v_25), _fx_catch_8);
+      _fx_R10Ast__loc_t v_29 = _fx_g18Parser__parser_ctx.default_loc;
+      _fx_make_T2N14Lexer__token_tR10Ast__loc_t(t_1, &v_29, &v_27);
+      FX_CALL(_fx_cons_LT2N14Lexer__token_tR10Ast__loc_t(&v_27, all_tokens_0, true, &v_28), _fx_catch_8);
       _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&all_tokens_0);
-      FX_COPY_PTR(v_25, &all_tokens_0);
+      FX_COPY_PTR(v_28, &all_tokens_0);
 
    _fx_catch_8: ;
-      if (v_25) {
-         _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_25);
+      if (v_28) {
+         _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_28);
       }
-      _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_24);
+      _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_27);
       FX_CHECK_EXN(_fx_cleanup);
    }
    FX_CALL(_fx_M6ParserFM10preprocessLT2N14Lexer__token_tR10Ast__loc_t1LT2N14Lexer__token_tR10Ast__loc_t(all_tokens_0, &v_5, 0),
@@ -28122,9 +28160,9 @@ _fx_catch_0: ;
       _fx_M6ParserFM12parse_expseqT2LT2N14Lexer__token_tR10Ast__loc_tLN10Ast__exp_t2LT2N14Lexer__token_tR10Ast__loc_tB(
          all_tokens_0, true, &v_6, 0), _fx_cleanup);
    FX_COPY_PTR(v_6.t1, &v_7);
-   _fx_LN10Ast__exp_t* v_27 = &dm_0->u.defmodule_t.t4;
-   _fx_free_LN10Ast__exp_t(v_27);
-   FX_COPY_PTR(v_7, v_27);
+   _fx_LN10Ast__exp_t* v_30 = &dm_0->u.defmodule_t.t4;
+   _fx_free_LN10Ast__exp_t(v_30);
+   FX_COPY_PTR(v_7, v_30);
    FX_COPY_PTR(_fx_g18Parser__parser_ctx.deps, &v_8);
    _fx_Li lst_4 = v_8;
    for (; lst_4; lst_4 = lst_4->tl) {
@@ -28140,13 +28178,13 @@ _fx_catch_0: ;
       FX_CHECK_EXN(_fx_cleanup);
    }
    FX_COPY_PTR(__fold_result___2, &v_9);
-   _fx_Li* v_28 = &dm_0->u.defmodule_t.t5;
-   FX_FREE_LIST_SIMPLE(v_28);
-   FX_COPY_PTR(v_9, v_28);
+   _fx_Li* v_31 = &dm_0->u.defmodule_t.t5;
+   FX_FREE_LIST_SIMPLE(v_31);
+   FX_COPY_PTR(v_9, v_31);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t* v_29 = FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   _fx_free_N16Ast__defmodule_t(v_29);
-   FX_COPY_PTR(dm_0, v_29);
+   _fx_N16Ast__defmodule_t* v_32 = FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   _fx_free_N16Ast__defmodule_t(v_32);
+   FX_COPY_PTR(dm_0, v_32);
    *fx_result = true;
 
 _fx_cleanup: ;

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -18171,55 +18171,117 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
       if (vts_1 != 0) {
          _fx_LT2N14Lexer__token_tR10Ast__loc_t v_5 = vts_1->tl;
          if (v_5 != 0) {
-            if (v_5->hd.t0.tag == 2) {
-               _fx_T2N14Lexer__token_tR10Ast__loc_t* v_6 = &vts_1->hd;
-               if (v_6->t0.tag == 21) {
+            _fx_T2N14Lexer__token_tR10Ast__loc_t* v_6 = &v_5->hd;
+            if (v_6->t0.tag == 2) {
+               if (vts_1->hd.t0.tag == 21) {
                   _fx_LT2N14Lexer__token_tR10Ast__loc_t v_7 = 0;
                   _fx_T2LT2N14Lexer__token_tR10Ast__loc_tS v_8 = {0};
                   _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_2 = 0;
                   fx_str_t f_0 = {0};
-                  fx_str_t v_9 = {0};
-                  fx_str_t v_10 = {0};
-                  _fx_LT2N14Lexer__token_tR10Ast__loc_t v_11 = 0;
+                  _fx_LT2N14Lexer__token_tR10Ast__loc_t v_9 = 0;
+                  _fx_T2N14Lexer__token_tR10Ast__loc_t result_0 = {0};
+                  _fx_LT2N14Lexer__token_tR10Ast__loc_t l_0 = 0;
+                  _fx_T2N14Lexer__token_tR10Ast__loc_t v_10 = {0};
+                  _fx_LR10Ast__loc_t v_11 = 0;
+                  fx_str_t v_12 = {0};
+                  fx_str_t v_13 = {0};
+                  _fx_LT2N14Lexer__token_tR10Ast__loc_t v_14 = 0;
+                  _fx_R10Ast__loc_t* name_l0_0 = &v_6->t1;
                   if (vts_0 != 0) {
                      FX_COPY_PTR(vts_0->tl, &v_7);
                   }
                   else {
-                     FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_5);
+                     FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_7);
                   }
-                  FX_CHECK_EXN(_fx_catch_5);
+                  FX_CHECK_EXN(_fx_catch_7);
                   fx_str_t slit_4 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6ParserFM15parse_dot_identT2LT2N14Lexer__token_tR10Ast__loc_tS3LT2N14Lexer__token_tR10Ast__loc_tBS(
-                        v_7, false, &slit_4, &v_8, 0), _fx_catch_5);
+                        v_7, false, &slit_4, &v_8, 0), _fx_catch_7);
                   FX_COPY_PTR(v_8.t0, &ts_2);
                   fx_copy_str(&v_8.t1, &f_0);
-                  int_ dot_pos_0 = _fx_M6StringFM5rfindi2SC(&f_0, (char_)46, 0);
-                  _fx_Ta2R9Ast__id_t v_12;
-                  if (dot_pos_0 >= 0) {
-                     FX_CALL(fx_substr(&f_0, 0, dot_pos_0, 1, 1, &v_9), _fx_catch_5);
-                     _fx_R9Ast__id_t v_13;
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_9, &v_13, 0), _fx_catch_5);
-                     FX_CALL(fx_substr(&f_0, dot_pos_0 + 1, 0, 1, 2, &v_10), _fx_catch_5);
-                     _fx_R9Ast__id_t v_14;
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_10, &v_14, 0), _fx_catch_5);
-                     _fx_Ta2R9Ast__id_t tup_0 = { v_13, v_14 };
-                     v_12 = tup_0;
+                  if (vts_0 != 0) {
+                     FX_COPY_PTR(vts_0->tl, &v_9);
                   }
                   else {
-                     _fx_R9Ast__id_t v_15;
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&f_0, &v_15, 0), _fx_catch_5);
-                     _fx_Ta2R9Ast__id_t tup_1 = { _fx_g9Ast__noid, v_15 };
-                     v_12 = tup_1;
+                     FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_7);
                   }
-                  _fx_R9Ast__id_t class_id__0 = v_12.t0;
-                  _fx_R9Ast__id_t fname__0 = v_12.t1;
+                  FX_CHECK_EXN(_fx_catch_7);
+                  int_ v_15 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(v_9, 0);
+                  int_ v_16 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(ts_2, 0);
+                  int_ n_0 = v_15 - v_16;
+                  _fx_R10Ast__loc_t v_17;
+                  if (n_0 <= 0) {
+                     v_17 = _fx_g10Ast__noloc;
+                  }
+                  else {
+                     FX_COPY_PTR(v_9, &l_0);
+                     int_ n_1 = n_0 - 1;
+                     for (;;) {
+                        _fx_LT2N14Lexer__token_tR10Ast__loc_t l_1 = 0;
+                        FX_COPY_PTR(l_0, &l_1);
+                        int_ n_2 = n_1;
+                        if (l_1 != 0) {
+                           if (n_2 == 0) {
+                              _fx_T2N14Lexer__token_tR10Ast__loc_t* a_0 = &l_1->hd;
+                              _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
+                              _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(a_0, &result_0);
+                              FX_BREAK(_fx_catch_4);
+                           }
+                           else {
+                              _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_4 = &l_1->tl;
+                              _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+                              FX_COPY_PTR(*rest_4, &l_0);
+                              n_1 = n_2 - 1;
+                           }
+
+                        _fx_catch_4: ;
+                        }
+                        else {
+                           FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_5);
+                        }
+                        FX_CHECK_EXN(_fx_catch_5);
+
+                     _fx_catch_5: ;
+                        if (l_1) {
+                           _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_1);
+                        }
+                        FX_CHECK_BREAK();
+                        FX_CHECK_EXN(_fx_catch_7);
+                     }
+                     _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(&result_0, &v_10);
+                     v_17 = v_10.t1;
+                  }
+                  FX_CALL(_fx_cons_LR10Ast__loc_t(&v_17, 0, true, &v_11), _fx_catch_7);
+                  FX_CALL(_fx_cons_LR10Ast__loc_t(name_l0_0, v_11, false, &v_11), _fx_catch_7);
+                  _fx_R10Ast__loc_t name_loc_0;
+                  FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_11, name_l0_0, &name_loc_0, 0), _fx_catch_7);
+                  int_ dot_pos_0 = _fx_M6StringFM5rfindi2SC(&f_0, (char_)46, 0);
+                  _fx_Ta2R9Ast__id_t v_18;
+                  if (dot_pos_0 >= 0) {
+                     FX_CALL(fx_substr(&f_0, 0, dot_pos_0, 1, 1, &v_12), _fx_catch_7);
+                     _fx_R9Ast__id_t v_19;
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_12, &v_19, 0), _fx_catch_7);
+                     FX_CALL(fx_substr(&f_0, dot_pos_0 + 1, 0, 1, 2, &v_13), _fx_catch_7);
+                     _fx_R9Ast__id_t v_20;
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_13, &v_20, 0), _fx_catch_7);
+                     _fx_Ta2R9Ast__id_t tup_0 = { v_19, v_20 };
+                     v_18 = tup_0;
+                  }
+                  else {
+                     _fx_R9Ast__id_t v_21;
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&f_0, &v_21, 0), _fx_catch_7);
+                     _fx_Ta2R9Ast__id_t tup_1 = { _fx_g9Ast__noid, v_21 };
+                     v_18 = tup_1;
+                  }
+                  _fx_R9Ast__id_t class_id__0 = v_18.t0;
+                  _fx_R9Ast__id_t fname__0 = v_18.t1;
                   if (ts_2 != 0) {
                      if (ts_2->hd.t0.tag == 44) {
-                        FX_COPY_PTR(ts_2->tl, &v_11); goto _fx_endmatch_0;
+                        FX_COPY_PTR(ts_2->tl, &v_14); goto _fx_endmatch_0;
                      }
                   }
-                  fx_exn_t v_16 = {0};
+                  fx_exn_t v_22 = {0};
                   _fx_R10Ast__loc_t loc_5;
                   if (ts_2 != 0) {
                      loc_5 = ts_2->hd.t1;
@@ -18227,29 +18289,38 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
                   else {
                      loc_5 = _fx_g18Parser__parser_ctx.default_loc;
                   }
-                  FX_CHECK_EXN(_fx_catch_4);
+                  FX_CHECK_EXN(_fx_catch_6);
                   fx_str_t slit_5 = FX_MAKE_STR("\'(\' is expected after function name");
-                  FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_5, &slit_5, &v_16), _fx_catch_4);
-                  FX_THROW(&v_16, true, _fx_catch_4);
+                  FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_5, &slit_5, &v_22), _fx_catch_6);
+                  FX_THROW(&v_22, true, _fx_catch_6);
 
-               _fx_catch_4: ;
-                  fx_free_exn(&v_16);
+               _fx_catch_6: ;
+                  fx_free_exn(&v_22);
 
                _fx_endmatch_0: ;
-                  FX_CHECK_EXN(_fx_catch_5);
+                  FX_CHECK_EXN(_fx_catch_7);
                   _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&vts_0);
-                  FX_COPY_PTR(v_11, &vts_0);
+                  FX_COPY_PTR(v_14, &vts_0);
                   class_id_0 = class_id__0;
                   fname_0 = fname__0;
-                  loc_0 = v_6->t1;
-                  FX_BREAK(_fx_catch_5);
+                  loc_0 = name_loc_0;
+                  FX_BREAK(_fx_catch_7);
 
-               _fx_catch_5: ;
-                  if (v_11) {
-                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_11);
+               _fx_catch_7: ;
+                  if (v_14) {
+                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_14);
                   }
-                  FX_FREE_STR(&v_10);
-                  FX_FREE_STR(&v_9);
+                  FX_FREE_STR(&v_13);
+                  FX_FREE_STR(&v_12);
+                  FX_FREE_LIST_SIMPLE(&v_11);
+                  _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_10);
+                  if (l_0) {
+                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+                  }
+                  _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
+                  if (v_9) {
+                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&v_9);
+                  }
                   FX_FREE_STR(&f_0);
                   if (ts_2) {
                      _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_2);
@@ -18264,40 +18335,48 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
          }
       }
       if (vts_1 != 0) {
-         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_17 = vts_1->tl;
-         if (v_17 != 0) {
-            _fx_LT2N14Lexer__token_tR10Ast__loc_t v_18 = v_17->tl;
-            if (v_18 != 0) {
-               if (v_18->hd.t0.tag == 44) {
-                  _fx_T2N14Lexer__token_tR10Ast__loc_t* v_19 = &vts_1->hd;
-                  if (v_19->t0.tag == 28) {
-                     fx_exn_t v_20 = {0};
-                     _fx_T2N14Lexer__token_tR10Ast__loc_t* v_21 = &v_17->hd;
-                     _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_4 = &v_18->tl;
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_23 = vts_1->tl;
+         if (v_23 != 0) {
+            _fx_LT2N14Lexer__token_tR10Ast__loc_t v_24 = v_23->tl;
+            if (v_24 != 0) {
+               if (v_24->hd.t0.tag == 44) {
+                  _fx_T2N14Lexer__token_tR10Ast__loc_t* v_25 = &vts_1->hd;
+                  if (v_25->t0.tag == 28) {
+                     _fx_LR10Ast__loc_t v_26 = 0;
+                     fx_exn_t v_27 = {0};
+                     _fx_R10Ast__loc_t* l1_0 = &v_25->t1;
+                     _fx_T2N14Lexer__token_tR10Ast__loc_t* v_28 = &v_23->hd;
+                     _fx_R10Ast__loc_t* l2_0 = &v_28->t1;
+                     _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_5 = &v_24->tl;
                      _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&vts_0);
-                     FX_COPY_PTR(*rest_4, &vts_0);
-                     _fx_R9Ast__id_t v_22;
-                     FX_CALL(_fx_M6ParserFM10get_opnameR9Ast__id_t1N14Lexer__token_t(&v_21->t0, &v_22, 0), _fx_catch_6);
-                     fname_0 = v_22;
-                     loc_0 = v_19->t1;
+                     FX_COPY_PTR(*rest_5, &vts_0);
+                     _fx_R9Ast__id_t v_29;
+                     FX_CALL(_fx_M6ParserFM10get_opnameR9Ast__id_t1N14Lexer__token_t(&v_28->t0, &v_29, 0), _fx_catch_8);
+                     fname_0 = v_29;
+                     FX_CALL(_fx_cons_LR10Ast__loc_t(l2_0, 0, true, &v_26), _fx_catch_8);
+                     FX_CALL(_fx_cons_LR10Ast__loc_t(l1_0, v_26, false, &v_26), _fx_catch_8);
+                     _fx_R10Ast__loc_t v_30;
+                     FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_26, l1_0, &v_30, 0), _fx_catch_8);
+                     loc_0 = v_30;
                      bool res_0;
-                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&fname_0, &_fx_g9Ast__noid, &res_0, 0), _fx_catch_6);
+                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&fname_0, &_fx_g9Ast__noid, &res_0, 0), _fx_catch_8);
                      if (res_0) {
                         fx_str_t slit_6 = FX_MAKE_STR("invalid operator name");
-                        FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&v_21->t1, &slit_6, &v_20), _fx_catch_6);
-                        FX_THROW(&v_20, true, _fx_catch_6);
+                        FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(l2_0, &slit_6, &v_27), _fx_catch_8);
+                        FX_THROW(&v_27, true, _fx_catch_8);
                      }
-                     FX_BREAK(_fx_catch_6);
+                     FX_BREAK(_fx_catch_8);
 
-                  _fx_catch_6: ;
-                     fx_free_exn(&v_20);
+                  _fx_catch_8: ;
+                     fx_free_exn(&v_27);
+                     FX_FREE_LIST_SIMPLE(&v_26);
                      goto _fx_endmatch_1;
                   }
                }
             }
          }
       }
-      fx_exn_t v_23 = {0};
+      fx_exn_t v_31 = {0};
       _fx_R10Ast__loc_t loc_6;
       if (vts_0 != 0) {
          loc_6 = vts_0->hd.t1;
@@ -18305,18 +18384,18 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
       else {
          loc_6 = _fx_g18Parser__parser_ctx.default_loc;
       }
-      FX_CHECK_EXN(_fx_catch_7);
+      FX_CHECK_EXN(_fx_catch_9);
       fx_str_t slit_7 = FX_MAKE_STR("\'fun <funcname> (\' is expected (after optional attributes)");
-      FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_6, &slit_7, &v_23), _fx_catch_7);
-      FX_THROW(&v_23, true, _fx_catch_7);
+      FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_6, &slit_7, &v_31), _fx_catch_9);
+      FX_THROW(&v_31, true, _fx_catch_9);
 
-   _fx_catch_7: ;
-      fx_free_exn(&v_23);
+   _fx_catch_9: ;
+      fx_free_exn(&v_31);
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_8);
+      FX_CHECK_EXN(_fx_catch_10);
 
-   _fx_catch_8: ;
+   _fx_catch_10: ;
       if (vts_1) {
          _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&vts_1);
       }
@@ -18331,8 +18410,8 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
    FX_COPY_PTR(v_0.t2, &rt_0);
    FX_COPY_PTR(v_0.t3, &prologue_0);
    bool have_keywords_0 = v_0.t4;
-   _fx_R16Ast__fun_flags_t v_24;
-   FX_CALL(_fx_M3AstFM17default_fun_flagsRM11fun_flags_t0(&v_24, 0), _fx_cleanup);
+   _fx_R16Ast__fun_flags_t v_32;
+   FX_CALL(_fx_M3AstFM17default_fun_flagsRM11fun_flags_t0(&v_32, 0), _fx_cleanup);
    int_ t_0;
    if (is_pure_0) {
       t_0 = 1;
@@ -18340,12 +18419,12 @@ FX_EXTERN_C int _fx_M6ParserFM11parse_defunT2LT2N14Lexer__token_tR10Ast__loc_tN1
    else {
       t_0 = -1;
    }
-   _fx_R16Ast__fun_flags_t v_25 =
-      { t_0, v_24.fun_flag_ccode, have_keywords_0, is_inline_0, is_nothrow_0, v_24.fun_flag_really_nothrow, is_private_0,
-         v_24.fun_flag_ctor, class_id_0, v_24.fun_flag_uses_fv, v_24.fun_flag_recursive, v_24.fun_flag_instance };
+   _fx_R16Ast__fun_flags_t v_33 =
+      { t_0, v_32.fun_flag_ccode, have_keywords_0, is_inline_0, is_nothrow_0, v_32.fun_flag_really_nothrow, is_private_0,
+         v_32.fun_flag_ctor, class_id_0, v_32.fun_flag_uses_fv, v_32.fun_flag_recursive, v_32.fun_flag_instance };
    FX_CALL(
       _fx_M6ParserFM23parse_body_and_make_funT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t7LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_tLN10Ast__pat_tN10Ast__typ_tLN10Ast__exp_tR16Ast__fun_flags_tR10Ast__loc_t(
-         ts_1, &fname_0, params_0, rt_0, prologue_0, &v_25, &loc_0, fx_result, 0), _fx_cleanup);
+         ts_1, &fname_0, params_0, rt_0, prologue_0, &v_33, &loc_0, fx_result, 0), _fx_cleanup);
 
 _fx_cleanup: ;
    if (vts_0) {

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -1261,6 +1261,11 @@ typedef struct _fx_N17Parser__kw_mode_t {
    int tag;
 } _fx_N17Parser__kw_mode_t;
 
+typedef struct _fx_T2iS {
+   int_ t0;
+   fx_str_t t1;
+} _fx_T2iS;
+
 typedef struct _fx_T2LN10Ast__pat_tN10Ast__exp_t {
    struct _fx_LN10Ast__pat_t_data_t* t0;
    struct _fx_N10Ast__exp_t_data_t* t1;
@@ -4697,6 +4702,23 @@ static void _fx_make_R20Parser__parser_ctx_t(
    fx_result->default_loc = *r_default_loc;
 }
 
+static void _fx_free_T2iS(struct _fx_T2iS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2iS(struct _fx_T2iS* src, struct _fx_T2iS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2iS(int_ t0, fx_str_t* t1, struct _fx_T2iS* fx_result)
+{
+   fx_result->t0 = t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static void _fx_free_T2LN10Ast__pat_tN10Ast__exp_t(struct _fx_T2LN10Ast__pat_tN10Ast__exp_t* dst)
 {
    _fx_free_LN10Ast__pat_t(&dst->t0);
@@ -5913,6 +5935,18 @@ FX_EXTERN_C int _fx_F6assertv1B(bool, void*);
 FX_EXTERN_C int _fx_M7HashsetFM9makeindexA1i1i(int_, fx_arr_t*, void*);
 
 FX_EXTERN_C_VAL(struct _fx_R10Ast__loc_t _fx_g10Ast__noloc)
+FX_EXTERN_C int _fx_M8FilenameFM6concatS2SS(fx_str_t*, fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M8FilenameFM4globA1S1S(fx_str_t*, fx_arr_t*, void*);
+
+FX_EXTERN_C int _fx_M8FilenameFM8basenameS1S(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M8FilenameFM16remove_extensionS1S(fx_str_t*, fx_str_t*, void*);
+
+FX_EXTERN_C int _fx_M3AstFM13edit_distancei2SS(fx_str_t*, fx_str_t*, int_*, void*);
+
+FX_EXTERN_C int_ _fx_F7__cmp__i2SS(fx_str_t*, fx_str_t*, void*);
+
 FX_EXTERN_C int _fx_M3AstFM2ppS1RM4id_t(struct _fx_R9Ast__id_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M6StringFM5splitLS3SCB(fx_str_t*, char_, bool, struct _fx_LS_data_t**, void*);
@@ -5924,8 +5958,6 @@ FX_EXTERN_C int _fx_M6StringFM7replaceS3SSS(fx_str_t*, fx_str_t*, fx_str_t*, fx_
 FX_EXTERN_C int _fx_M8FilenameFM6locateS2SLS(fx_str_t*, struct _fx_LS_data_t*, fx_str_t*, void*);
 
 FX_EXTERN_C_VAL(int FX_EXN_NotFoundError)
-FX_EXTERN_C int _fx_M8FilenameFM6concatS2SS(fx_str_t*, fx_str_t*, fx_str_t*, void*);
-
 FX_EXTERN_C int _fx_M3AstFM6stringS1RM4id_t(struct _fx_R9Ast__id_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M8FilenameFM7dirnameS1S(fx_str_t*, fx_str_t*, void*);
@@ -6712,8 +6744,6 @@ static int
 FX_EXTERN_C int _fx_F7__cmp__i2ll(int64_t, int64_t, int_*, void*);
 
 FX_EXTERN_C int _fx_F7__cmp__i2BB(bool, bool, int_*, void*);
-
-FX_EXTERN_C int_ _fx_F7__cmp__i2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C void _fx_M5LexerFM7LITERALN14Lexer__token_t1N10Ast__lit_t(struct _fx_N10Ast__lit_t*, struct _fx_N14Lexer__token_t*);
 
@@ -8212,6 +8242,138 @@ FX_EXTERN_C void _fx_M6ParserFM9PP_STRINGN15Parser__ppval_t1S(fx_str_t* arg0, st
    fx_copy_str(arg0, &fx_result->u.PP_STRING);
 }
 
+FX_EXTERN_C int _fx_M6ParserFM14suggest_moduleS2SLS(
+   fx_str_t* mname_0,
+   struct _fx_LS_data_t* inc_dirs_0,
+   fx_str_t* fx_result,
+   void* fx_fv)
+{
+   _fx_T2iS __fold_result___0 = {0};
+   _fx_T2iS v_0 = {0};
+   fx_str_t best_0 = {0};
+   int fx_status = 0;
+   int_ tlen_0 = FX_STR_LENGTH(*mname_0);
+   int_ thresh_0;
+   if (tlen_0 <= 4) {
+      thresh_0 = 1;
+   }
+   else {
+      thresh_0 = 2;
+   }
+   fx_str_t slit_0 = FX_MAKE_STR("");
+   _fx_make_T2iS(thresh_0 + 1, &slit_0, &__fold_result___0);
+   _fx_LS lst_0 = inc_dirs_0;
+   for (; lst_0; lst_0 = lst_0->tl) {
+      _fx_T2iS v_1 = {0};
+      fx_str_t b_0 = {0};
+      _fx_T2iS __fold_result___1 = {0};
+      fx_str_t v_2 = {0};
+      fx_arr_t v_3 = {0};
+      fx_str_t* d_0 = &lst_0->hd;
+      _fx_copy_T2iS(&__fold_result___0, &v_1);
+      fx_copy_str(&v_1.t1, &b_0);
+      _fx_make_T2iS(v_1.t0, &b_0, &__fold_result___1);
+      fx_str_t slit_1 = FX_MAKE_STR("*.fx");
+      FX_CALL(_fx_M8FilenameFM6concatS2SS(d_0, &slit_1, &v_2, 0), _fx_catch_1);
+      FX_CALL(_fx_M8FilenameFM4globA1S1S(&v_2, &v_3, 0), _fx_catch_1);
+      int_ ni_0 = FX_ARR_SIZE(v_3, 0);
+      fx_str_t* ptr_v_0 = FX_PTR_1D(fx_str_t, v_3, 0);
+      for (int_ i_0 = 0; i_0 < ni_0; i_0++) {
+         fx_str_t path_0 = {0};
+         _fx_T2iS v_4 = {0};
+         fx_str_t b_1 = {0};
+         fx_str_t v_5 = {0};
+         fx_str_t nm_0 = {0};
+         _fx_T2iS v_6 = {0};
+         fx_copy_str(ptr_v_0 + i_0, &path_0);
+         _fx_copy_T2iS(&__fold_result___1, &v_4);
+         int_ bd_0 = v_4.t0;
+         fx_copy_str(&v_4.t1, &b_1);
+         FX_CALL(_fx_M8FilenameFM8basenameS1S(&path_0, &v_5, 0), _fx_catch_0);
+         FX_CALL(_fx_M8FilenameFM16remove_extensionS1S(&v_5, &nm_0, 0), _fx_catch_0);
+         bool v_7 = _fx_F6__eq__B2SS(&nm_0, mname_0, 0);
+         int_ dist_0;
+         if (v_7) {
+            dist_0 = bd_0 + 1;
+         }
+         else {
+            FX_CALL(_fx_M3AstFM13edit_distancei2SS(mname_0, &nm_0, &dist_0, 0), _fx_catch_0);
+         }
+         bool v_8;
+         if (dist_0 < bd_0) {
+            v_8 = true;
+         }
+         else if (dist_0 == bd_0) {
+            int_ v_9 = _fx_F7__cmp__i2SS(&nm_0, &b_1, 0); v_8 = v_9 < 0;
+         }
+         else {
+            v_8 = false;
+         }
+         if (v_8) {
+            _fx_make_T2iS(dist_0, &nm_0, &v_6);
+         }
+         else {
+            _fx_make_T2iS(bd_0, &b_1, &v_6);
+         }
+         _fx_free_T2iS(&__fold_result___1);
+         _fx_copy_T2iS(&v_6, &__fold_result___1);
+
+      _fx_catch_0: ;
+         _fx_free_T2iS(&v_6);
+         FX_FREE_STR(&nm_0);
+         FX_FREE_STR(&v_5);
+         FX_FREE_STR(&b_1);
+         _fx_free_T2iS(&v_4);
+         FX_FREE_STR(&path_0);
+         FX_CHECK_EXN(_fx_catch_1);
+      }
+      _fx_free_T2iS(&__fold_result___0);
+      _fx_copy_T2iS(&__fold_result___1, &__fold_result___0);
+
+   _fx_catch_1: ;
+      FX_FREE_ARR(&v_3);
+      FX_FREE_STR(&v_2);
+      _fx_free_T2iS(&__fold_result___1);
+      FX_FREE_STR(&b_0);
+      _fx_free_T2iS(&v_1);
+      FX_CHECK_EXN(_fx_cleanup);
+   }
+   _fx_copy_T2iS(&__fold_result___0, &v_0);
+   int_ best_d_0 = v_0.t0;
+   fx_copy_str(&v_0.t1, &best_0);
+   bool t_0;
+   if (tlen_0 > 0) {
+      t_0 = best_d_0 <= thresh_0;
+   }
+   else {
+      t_0 = false;
+   }
+   bool t_1;
+   if (t_0) {
+      t_1 = FX_STR_LENGTH(best_0) != 0;
+   }
+   else {
+      t_1 = false;
+   }
+   if (t_1) {
+      fx_str_t slit_2 = FX_MAKE_STR("; did you mean \'");
+      fx_str_t slit_3 = FX_MAKE_STR("\'?");
+      {
+         const fx_str_t strs_0[] = { slit_2, best_0, slit_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, fx_result), _fx_cleanup);
+      }
+   }
+   else {
+      fx_str_t slit_4 = FX_MAKE_STR(""); fx_copy_str(&slit_4, fx_result);
+   }
+
+_fx_cleanup: ;
+   _fx_free_T2iS(&__fold_result___0);
+   _fx_free_T2iS(&v_0);
+   FX_FREE_STR(&best_0);
+   return fx_status;
+}
+
 FX_EXTERN_C int _fx_M6ParserFM23add_to_imported_modulesi2R9Ast__id_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* mname_0,
    struct _fx_R10Ast__loc_t* loc_0,
@@ -8275,19 +8437,30 @@ _fx_catch_0: ;
             if (exn_1.tag == FX_EXN_NotFoundError) {
                fx_str_t v_8 = {0};
                fx_str_t v_9 = {0};
-               fx_exn_t v_10 = {0};
+               _fx_LS v_10 = 0;
+               fx_str_t v_11 = {0};
+               fx_str_t v_12 = {0};
+               fx_exn_t v_13 = {0};
                FX_CALL(_fx_M3AstFM6stringS1RM4id_t(mname_0, &v_8, 0), _fx_catch_2);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(mname_0, &v_9, 0), _fx_catch_2);
+               FX_COPY_PTR(_fx_g18Parser__parser_ctx.inc_dirs, &v_10);
+               FX_CALL(_fx_M6ParserFM14suggest_moduleS2SLS(&v_9, v_10, &v_11, 0), _fx_catch_2);
                fx_str_t slit_3 = FX_MAKE_STR("module ");
                fx_str_t slit_4 = FX_MAKE_STR(" is not found");
                {
-                  const fx_str_t strs_1[] = { slit_3, v_8, slit_4 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_9), _fx_catch_2);
+                  const fx_str_t strs_1[] = { slit_3, v_8, slit_4, v_11 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_1, 4, &v_12), _fx_catch_2);
                }
-               FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(loc_0, &v_9, &v_10), _fx_catch_2);
-               FX_THROW(&v_10, true, _fx_catch_2);
+               FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(loc_0, &v_12, &v_13), _fx_catch_2);
+               FX_THROW(&v_13, true, _fx_catch_2);
 
             _fx_catch_2: ;
-               fx_free_exn(&v_10);
+               fx_free_exn(&v_13);
+               FX_FREE_STR(&v_12);
+               FX_FREE_STR(&v_11);
+               if (v_10) {
+                  _fx_free_LS(&v_10);
+               }
                FX_FREE_STR(&v_9);
                FX_FREE_STR(&v_8);
             }
@@ -8308,24 +8481,24 @@ _fx_catch_0: ;
    fx_copy_str(&mfname_2, &dirname_0);
    int_ n_0 = ncomps_0;
    for (int_ i_0 = 0; i_0 < n_0; i_0++) {
-      fx_str_t v_11 = {0};
-      FX_CALL(_fx_M8FilenameFM7dirnameS1S(&dirname_0, &v_11, 0), _fx_catch_4);
+      fx_str_t v_14 = {0};
+      FX_CALL(_fx_M8FilenameFM7dirnameS1S(&dirname_0, &v_14, 0), _fx_catch_4);
       FX_FREE_STR(&dirname_0);
-      fx_copy_str(&v_11, &dirname_0);
-      uint64_t v_12 = _fx_F4hashq1S(&dirname_0, 0);
-      _fx_Ta2i v_13;
+      fx_copy_str(&v_14, &dirname_0);
+      uint64_t v_15 = _fx_F4hashq1S(&dirname_0, 0);
+      _fx_Ta2i v_16;
       FX_CALL(
-         _fx_M6ParserFM9find_idx_Ta2i3Nt10Hashset__t1SSq(_fx_g19Ast__all_c_inc_dirs, &dirname_0, v_12 & 9223372036854775807ULL,
-            &v_13, 0), _fx_catch_4);
-      if (v_13.t1 >= 0) {
+         _fx_M6ParserFM9find_idx_Ta2i3Nt10Hashset__t1SSq(_fx_g19Ast__all_c_inc_dirs, &dirname_0, v_15 & 9223372036854775807ULL,
+            &v_16, 0), _fx_catch_4);
+      if (v_16.t1 >= 0) {
          FX_BREAK(_fx_catch_4);
       }
-      uint64_t v_14 = _fx_F4hashq1S(&dirname_0, 0);
-      FX_CALL(_fx_M6ParserFM4add_v3Nt10Hashset__t1SSq(_fx_g19Ast__all_c_inc_dirs, &dirname_0, v_14 & 9223372036854775807ULL, 0),
+      uint64_t v_17 = _fx_F4hashq1S(&dirname_0, 0);
+      FX_CALL(_fx_M6ParserFM4add_v3Nt10Hashset__t1SSq(_fx_g19Ast__all_c_inc_dirs, &dirname_0, v_17 & 9223372036854775807ULL, 0),
          _fx_catch_4);
 
    _fx_catch_4: ;
-      FX_FREE_STR(&v_11);
+      FX_FREE_STR(&v_14);
       FX_CHECK_BREAK();
       FX_CHECK_EXN(_fx_cleanup);
    }
@@ -8347,9 +8520,9 @@ _fx_catch_0: ;
    if (!__fold_result___0) {
       FX_COPY_PTR(_fx_g18Parser__parser_ctx.deps, &v_3);
       FX_CALL(_fx_cons_Li(m_idx_0, v_3, false, &v_3), _fx_cleanup);
-      _fx_Li* v_15 = &_fx_g18Parser__parser_ctx.deps;
-      FX_FREE_LIST_SIMPLE(v_15);
-      FX_COPY_PTR(v_3, v_15);
+      _fx_Li* v_18 = &_fx_g18Parser__parser_ctx.deps;
+      FX_FREE_LIST_SIMPLE(v_18);
+      FX_COPY_PTR(v_3, v_18);
    }
    *fx_result = m_idx_0;
 

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -6804,6 +6804,15 @@ return fx_list_length(l);
 
 }
 
+FX_EXTERN_C int_ _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(
+   struct _fx_LT2N14Lexer__token_tR10Ast__loc_t_data_t* l,
+   void* fx_fv)
+{
+   
+return fx_list_length(l);
+
+}
+
 FX_EXTERN_C int_ _fx_M6ParserFM6lengthi1LS(struct _fx_LS_data_t* l, void* fx_fv)
 {
    
@@ -9584,6 +9593,70 @@ _fx_catch_2: ;
    FX_FREE_LIST_SIMPLE(&llist_0);
 
 _fx_endmatch_0: ;
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M6ParserFM12consumed_locR10Ast__loc_t2LT2N14Lexer__token_tR10Ast__loc_tLT2N14Lexer__token_tR10Ast__loc_t(
+   struct _fx_LT2N14Lexer__token_tR10Ast__loc_t_data_t* before_0,
+   struct _fx_LT2N14Lexer__token_tR10Ast__loc_t_data_t* after_0,
+   struct _fx_R10Ast__loc_t* fx_result,
+   void* fx_fv)
+{
+   _fx_T2N14Lexer__token_tR10Ast__loc_t result_0 = {0};
+   _fx_LT2N14Lexer__token_tR10Ast__loc_t l_0 = 0;
+   _fx_T2N14Lexer__token_tR10Ast__loc_t v_0 = {0};
+   int fx_status = 0;
+   int_ v_1 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(before_0, 0);
+   int_ v_2 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(after_0, 0);
+   int_ n_0 = v_1 - v_2;
+   if (n_0 <= 0) {
+      *fx_result = _fx_g10Ast__noloc;
+   }
+   else {
+      FX_COPY_PTR(before_0, &l_0);
+      int_ n_1 = n_0 - 1;
+      for (;;) {
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t l_1 = 0;
+         FX_COPY_PTR(l_0, &l_1);
+         int_ n_2 = n_1;
+         if (l_1 != 0) {
+            if (n_2 == 0) {
+               _fx_T2N14Lexer__token_tR10Ast__loc_t* a_0 = &l_1->hd;
+               _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
+               _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(a_0, &result_0);
+               FX_BREAK(_fx_catch_0);
+            }
+            else {
+               _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_0 = &l_1->tl;
+               _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+               FX_COPY_PTR(*rest_0, &l_0);
+               n_1 = n_2 - 1;
+            }
+
+         _fx_catch_0: ;
+         }
+         else {
+            FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_1);
+         }
+         FX_CHECK_EXN(_fx_catch_1);
+
+      _fx_catch_1: ;
+         if (l_1) {
+            _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_1);
+         }
+         FX_CHECK_BREAK();
+         FX_CHECK_EXN(_fx_cleanup);
+      }
+      _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(&result_0, &v_0);
+      *fx_result = v_0.t1;
+   }
+
+_fx_cleanup: ;
+   _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
+   if (l_0) {
+      _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+   }
+   _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_0);
    return fx_status;
 }
 
@@ -14515,11 +14588,16 @@ FX_EXTERN_C int
             _fx_LT2iR9Ast__id_t v_2 = 0;
             _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t result_4 = {0};
             _fx_T2LT2N14Lexer__token_tR10Ast__loc_tS v_3 = {0};
-            _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_3 = 0;
+            _fx_LT2N14Lexer__token_tR10Ast__loc_t ts1_0 = 0;
             fx_str_t i_0 = {0};
-            _fx_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t v_4 = {0};
-            _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_4 = 0;
-            _fx_LT2iR9Ast__id_t v_5 = 0;
+            _fx_T2N14Lexer__token_tR10Ast__loc_t result_5 = {0};
+            _fx_LT2N14Lexer__token_tR10Ast__loc_t l_0 = 0;
+            _fx_T2N14Lexer__token_tR10Ast__loc_t v_4 = {0};
+            _fx_LR10Ast__loc_t v_5 = 0;
+            _fx_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t v_6 = {0};
+            _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_3 = 0;
+            _fx_LT2iR9Ast__id_t v_7 = 0;
+            _fx_R10Ast__loc_t* loc_i_0 = &v_1->t1;
             if (expect_comma_2) {
                _fx_LT2iR9Ast__id_t lst_0 = result_3;
                for (; lst_0; lst_0 = lst_0->tl) {
@@ -14532,66 +14610,121 @@ FX_EXTERN_C int
 
                _fx_catch_1: ;
                   FX_FREE_LIST_SIMPLE(&r_0);
-                  FX_CHECK_EXN(_fx_catch_3);
+                  FX_CHECK_EXN(_fx_catch_5);
                }
                FX_COPY_PTR(__fold_result___0, &v_2);
                _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(ts_2, v_2, &result_4);
                _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_1);
                _fx_copy_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_4, &result_1);
-               FX_BREAK(_fx_catch_3);
+               FX_BREAK(_fx_catch_5);
             }
             else {
                fx_str_t slit_1 = FX_MAKE_STR("");
                FX_CALL(
                   _fx_M6ParserFM15parse_dot_identT2LT2N14Lexer__token_tR10Ast__loc_tS3LT2N14Lexer__token_tR10Ast__loc_tBS(ts_2,
-                     false, &slit_1, &v_3, 0), _fx_catch_3);
-               FX_COPY_PTR(v_3.t0, &ts_3);
+                     false, &slit_1, &v_3, 0), _fx_catch_5);
+               FX_COPY_PTR(v_3.t0, &ts1_0);
                fx_copy_str(&v_3.t1, &i_0);
-               _fx_R9Ast__id_t i_1;
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&i_0, &i_1, 0), _fx_catch_3);
-               if (ts_3 != 0) {
-                  if (ts_3->hd.t0.tag == 5) {
-                     _fx_LT2N14Lexer__token_tR10Ast__loc_t v_6 = ts_3->tl;
-                     if (v_6 != 0) {
-                        _fx_N14Lexer__token_t* v_7 = &v_6->hd.t0;
-                        if (v_7->tag == 2) {
-                           _fx_R9Ast__id_t v_8;
-                           FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_7->u.IDENT.t1, &v_8, 0), _fx_catch_2);
-                           _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(v_6->tl, &v_8, &v_4);
+               int_ v_8 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(ts_2, 0);
+               int_ v_9 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(ts1_0, 0);
+               int_ n_0 = v_8 - v_9;
+               _fx_R10Ast__loc_t v_10;
+               if (n_0 <= 0) {
+                  v_10 = _fx_g10Ast__noloc;
+               }
+               else {
+                  FX_COPY_PTR(ts_2, &l_0);
+                  int_ n_1 = n_0 - 1;
+                  for (;;) {
+                     _fx_LT2N14Lexer__token_tR10Ast__loc_t l_1 = 0;
+                     FX_COPY_PTR(l_0, &l_1);
+                     int_ n_2 = n_1;
+                     if (l_1 != 0) {
+                        if (n_2 == 0) {
+                           _fx_T2N14Lexer__token_tR10Ast__loc_t* a_1 = &l_1->hd;
+                           _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_5);
+                           _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(a_1, &result_5);
+                           FX_BREAK(_fx_catch_2);
+                        }
+                        else {
+                           _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_1 = &l_1->tl;
+                           _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+                           FX_COPY_PTR(*rest_1, &l_0);
+                           n_1 = n_2 - 1;
+                        }
 
-                        _fx_catch_2: ;
+                     _fx_catch_2: ;
+                     }
+                     else {
+                        FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_3);
+                     }
+                     FX_CHECK_EXN(_fx_catch_3);
+
+                  _fx_catch_3: ;
+                     if (l_1) {
+                        _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_1);
+                     }
+                     FX_CHECK_BREAK();
+                     FX_CHECK_EXN(_fx_catch_5);
+                  }
+                  _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(&result_5, &v_4);
+                  v_10 = v_4.t1;
+               }
+               FX_CALL(_fx_cons_LR10Ast__loc_t(&v_10, 0, true, &v_5), _fx_catch_5);
+               FX_CALL(_fx_cons_LR10Ast__loc_t(loc_i_0, v_5, false, &v_5), _fx_catch_5);
+               _fx_R10Ast__loc_t name_loc_0;
+               FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_5, loc_i_0, &name_loc_0, 0), _fx_catch_5);
+               _fx_R9Ast__id_t i_1;
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&i_0, &i_1, 0), _fx_catch_5);
+               if (ts1_0 != 0) {
+                  if (ts1_0->hd.t0.tag == 5) {
+                     _fx_LT2N14Lexer__token_tR10Ast__loc_t v_11 = ts1_0->tl;
+                     if (v_11 != 0) {
+                        _fx_N14Lexer__token_t* v_12 = &v_11->hd.t0;
+                        if (v_12->tag == 2) {
+                           _fx_R9Ast__id_t v_13;
+                           FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_12->u.IDENT.t1, &v_13, 0), _fx_catch_4);
+                           _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(v_11->tl, &v_13, &v_6);
+
+                        _fx_catch_4: ;
                            goto _fx_endmatch_0;
                         }
                      }
                   }
                }
-               _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(ts_3, &i_1, &v_4);
+               _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(ts1_0, &i_1, &v_6);
 
             _fx_endmatch_0: ;
-               FX_CHECK_EXN(_fx_catch_3);
-               FX_COPY_PTR(v_4.t0, &ts_4);
-               _fx_R9Ast__id_t j_0 = v_4.t1;
+               FX_CHECK_EXN(_fx_catch_5);
+               FX_COPY_PTR(v_6.t0, &ts_3);
+               _fx_R9Ast__id_t j_0 = v_6.t1;
                int_ i__0;
-               FX_CALL(_fx_M6ParserFM23add_to_imported_modulesi2R9Ast__id_tR10Ast__loc_t(&i_1, &v_1->t1, &i__0, 0),
-                  _fx_catch_3);
-               _fx_T2iR9Ast__id_t v_9 = { i__0, j_0 };
-               FX_CALL(_fx_cons_LT2iR9Ast__id_t(&v_9, result_3, true, &v_5), _fx_catch_3);
+               FX_CALL(_fx_M6ParserFM23add_to_imported_modulesi2R9Ast__id_tR10Ast__loc_t(&i_1, &name_loc_0, &i__0, 0),
+                  _fx_catch_5);
+               _fx_T2iR9Ast__id_t v_14 = { i__0, j_0 };
+               FX_CALL(_fx_cons_LT2iR9Ast__id_t(&v_14, result_3, true, &v_7), _fx_catch_5);
                _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
-               FX_COPY_PTR(ts_4, &ts_1);
+               FX_COPY_PTR(ts_3, &ts_1);
                expect_comma_1 = true;
                FX_FREE_LIST_SIMPLE(&result_2);
-               FX_COPY_PTR(v_5, &result_2);
+               FX_COPY_PTR(v_7, &result_2);
             }
 
-         _fx_catch_3: ;
-            FX_FREE_LIST_SIMPLE(&v_5);
-            if (ts_4) {
-               _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_4);
-            }
-            _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(&v_4);
-            FX_FREE_STR(&i_0);
+         _fx_catch_5: ;
+            FX_FREE_LIST_SIMPLE(&v_7);
             if (ts_3) {
                _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_3);
+            }
+            _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tR9Ast__id_t(&v_6);
+            FX_FREE_LIST_SIMPLE(&v_5);
+            _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_4);
+            if (l_0) {
+               _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+            }
+            _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_5);
+            FX_FREE_STR(&i_0);
+            if (ts1_0) {
+               _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts1_0);
             }
             _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tS(&v_3);
             _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_4);
@@ -14600,10 +14733,10 @@ FX_EXTERN_C int
             goto _fx_endmatch_1;
          }
       }
-      fx_exn_t v_10 = {0};
+      fx_exn_t v_15 = {0};
       _fx_LT2iR9Ast__id_t __fold_result___1 = 0;
-      _fx_LT2iR9Ast__id_t v_11 = 0;
-      _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t result_5 = {0};
+      _fx_LT2iR9Ast__id_t v_16 = 0;
+      _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t result_6 = {0};
       if (result_3 == 0) {
          _fx_R10Ast__loc_t loc_1;
          if (ts_2 != 0) {
@@ -14612,40 +14745,40 @@ FX_EXTERN_C int
          else {
             loc_1 = _fx_g18Parser__parser_ctx.default_loc;
          }
-         FX_CHECK_EXN(_fx_catch_5);
+         FX_CHECK_EXN(_fx_catch_7);
          fx_str_t slit_2 = FX_MAKE_STR("empty module list");
-         FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_1, &slit_2, &v_10), _fx_catch_5);
-         FX_THROW(&v_10, true, _fx_catch_5);
+         FX_CALL(_fx_M6ParserFM15make_ParseErrorE2R10Ast__loc_tS(&loc_1, &slit_2, &v_15), _fx_catch_7);
+         FX_THROW(&v_15, true, _fx_catch_7);
       }
       _fx_LT2iR9Ast__id_t lst_1 = result_3;
       for (; lst_1; lst_1 = lst_1->tl) {
          _fx_LT2iR9Ast__id_t r_1 = 0;
-         _fx_T2iR9Ast__id_t* a_1 = &lst_1->hd;
+         _fx_T2iR9Ast__id_t* a_2 = &lst_1->hd;
          FX_COPY_PTR(__fold_result___1, &r_1);
-         FX_CALL(_fx_cons_LT2iR9Ast__id_t(a_1, r_1, false, &r_1), _fx_catch_4);
+         FX_CALL(_fx_cons_LT2iR9Ast__id_t(a_2, r_1, false, &r_1), _fx_catch_6);
          FX_FREE_LIST_SIMPLE(&__fold_result___1);
          FX_COPY_PTR(r_1, &__fold_result___1);
 
-      _fx_catch_4: ;
+      _fx_catch_6: ;
          FX_FREE_LIST_SIMPLE(&r_1);
-         FX_CHECK_EXN(_fx_catch_5);
+         FX_CHECK_EXN(_fx_catch_7);
       }
-      FX_COPY_PTR(__fold_result___1, &v_11);
-      _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(ts_2, v_11, &result_5);
+      FX_COPY_PTR(__fold_result___1, &v_16);
+      _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(ts_2, v_16, &result_6);
       _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_1);
-      _fx_copy_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_5, &result_1);
-      FX_BREAK(_fx_catch_5);
+      _fx_copy_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_6, &result_1);
+      FX_BREAK(_fx_catch_7);
 
-   _fx_catch_5: ;
-      _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_5);
-      FX_FREE_LIST_SIMPLE(&v_11);
+   _fx_catch_7: ;
+      _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLT2iR9Ast__id_t(&result_6);
+      FX_FREE_LIST_SIMPLE(&v_16);
       FX_FREE_LIST_SIMPLE(&__fold_result___1);
-      fx_free_exn(&v_10);
+      fx_free_exn(&v_15);
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_6);
+      FX_CHECK_EXN(_fx_catch_8);
 
-   _fx_catch_6: ;
+   _fx_catch_8: ;
       FX_FREE_LIST_SIMPLE(&result_3);
       if (ts_2) {
          _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_2);
@@ -14836,7 +14969,7 @@ static int
       FX_COPY_PTR(ts_2, &ts_3);
 
    _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
       bool res_0;
       if (ts_3 != 0) {
          if (ts_3->hd.t0.tag == 50) {
@@ -14856,7 +14989,7 @@ static int
       res_0 = false;
 
    _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
       if (res_0) {
          fx_exn_t v_1 = {0};
          _fx_LN10Ast__exp_t v_2 = 0;
@@ -14929,7 +15062,7 @@ static int
       res_1 = false;
 
    _fx_endmatch_3: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
       if (res_1) {
          _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLN10Ast__exp_t v_5 = {0};
          _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_4 = 0;
@@ -14973,7 +15106,7 @@ static int
       res_2 = false;
 
    _fx_endmatch_4: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
       if (res_2) {
          _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_7 = {0};
          _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_5 = 0;
@@ -15105,7 +15238,7 @@ static int
       res_3 = false;
 
    _fx_endmatch_5: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
       if (res_3) {
          _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_15 = {0};
          _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_8 = 0;
@@ -15297,42 +15430,63 @@ static int
             _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_12 = 0;
             fx_str_t m__0 = {0};
             _fx_R10Ast__loc_t* l1_0 = &v_36->t1;
+            _fx_LT2N14Lexer__token_tR10Ast__loc_t rest_1 = ts_3->tl;
             if (!toplevel_0) {
                fx_str_t slit_7 = FX_MAKE_STR("import directives can only be used at the module level");
-               FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_7, &v_37, 0), _fx_catch_15);
-               FX_THROW(&v_37, true, _fx_catch_15);
+               FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_7, &v_37, 0), _fx_catch_16);
+               FX_THROW(&v_37, true, _fx_catch_16);
             }
             fx_str_t slit_8 = FX_MAKE_STR("");
             FX_CALL(
-               _fx_M6ParserFM15parse_dot_identT2LT2N14Lexer__token_tR10Ast__loc_tS3LT2N14Lexer__token_tR10Ast__loc_tBS(ts_3->tl,
-                  false, &slit_8, &v_38, 0), _fx_catch_15);
+               _fx_M6ParserFM15parse_dot_identT2LT2N14Lexer__token_tR10Ast__loc_tS3LT2N14Lexer__token_tR10Ast__loc_tBS(rest_1,
+                  false, &slit_8, &v_38, 0), _fx_catch_16);
             FX_COPY_PTR(v_38.t0, &ts_12);
             fx_copy_str(&v_38.t1, &m__0);
+            _fx_R10Ast__loc_t name_loc_0;
+            if (rest_1 != 0) {
+               _fx_LR10Ast__loc_t v_39 = 0;
+               _fx_R10Ast__loc_t* l0_0 = &rest_1->hd.t1;
+               _fx_R10Ast__loc_t v_40;
+               FX_CALL(
+                  _fx_M6ParserFM12consumed_locR10Ast__loc_t2LT2N14Lexer__token_tR10Ast__loc_tLT2N14Lexer__token_tR10Ast__loc_t(
+                     rest_1, ts_12, &v_40, 0), _fx_catch_12);
+               FX_CALL(_fx_cons_LR10Ast__loc_t(&v_40, 0, true, &v_39), _fx_catch_12);
+               FX_CALL(_fx_cons_LR10Ast__loc_t(l0_0, v_39, false, &v_39), _fx_catch_12);
+               FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_39, l0_0, &name_loc_0, 0), _fx_catch_12);
+
+            _fx_catch_12: ;
+               FX_FREE_LIST_SIMPLE(&v_39);
+            }
+            else {
+               name_loc_0 = *l1_0;
+            }
+            FX_CHECK_EXN(_fx_catch_16);
             _fx_R9Ast__id_t m_0;
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&m__0, &m_0, 0), _fx_catch_15);
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&m__0, &m_0, 0), _fx_catch_16);
             int_ m__1;
-            FX_CALL(_fx_M6ParserFM23add_to_imported_modulesi2R9Ast__id_tR10Ast__loc_t(&m_0, l1_0, &m__1, 0), _fx_catch_15);
+            FX_CALL(_fx_M6ParserFM23add_to_imported_modulesi2R9Ast__id_tR10Ast__loc_t(&m_0, &name_loc_0, &m__1, 0),
+               _fx_catch_16);
             if (ts_12 != 0) {
                if (ts_12->hd.t0.tag == 23) {
-                  _fx_LT2N14Lexer__token_tR10Ast__loc_t v_39 = ts_12->tl;
-                  if (v_39 != 0) {
-                     if (v_39->hd.t0.tag == 66) {
-                        _fx_N10Ast__exp_t v_40 = 0;
-                        _fx_LN10Ast__exp_t v_41 = 0;
-                        FX_CALL(_fx_M3AstFM13DirImportFromN10Ast__exp_t3iLRM4id_tRM5loc_t(m__1, 0, l1_0, &v_40), _fx_catch_12);
-                        FX_CALL(_fx_cons_LN10Ast__exp_t(v_40, result_3, true, &v_41), _fx_catch_12);
-                        _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_1 = &v_39->tl;
+                  _fx_LT2N14Lexer__token_tR10Ast__loc_t v_41 = ts_12->tl;
+                  if (v_41 != 0) {
+                     if (v_41->hd.t0.tag == 66) {
+                        _fx_N10Ast__exp_t v_42 = 0;
+                        _fx_LN10Ast__exp_t v_43 = 0;
+                        FX_CALL(_fx_M3AstFM13DirImportFromN10Ast__exp_t3iLRM4id_tRM5loc_t(m__1, 0, l1_0, &v_42), _fx_catch_13);
+                        FX_CALL(_fx_cons_LN10Ast__exp_t(v_42, result_3, true, &v_43), _fx_catch_13);
+                        _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_2 = &v_41->tl;
                         _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
-                        FX_COPY_PTR(*rest_1, &ts_1);
+                        FX_COPY_PTR(*rest_2, &ts_1);
                         _fx_free_LN10Ast__exp_t(&result_2);
-                        FX_COPY_PTR(v_41, &result_2);
+                        FX_COPY_PTR(v_43, &result_2);
 
-                     _fx_catch_12: ;
-                        if (v_41) {
-                           _fx_free_LN10Ast__exp_t(&v_41);
+                     _fx_catch_13: ;
+                        if (v_43) {
+                           _fx_free_LN10Ast__exp_t(&v_43);
                         }
-                        if (v_40) {
-                           _fx_free_N10Ast__exp_t(&v_40);
+                        if (v_42) {
+                           _fx_free_N10Ast__exp_t(&v_42);
                         }
                         goto _fx_endmatch_8;
                      }
@@ -15341,50 +15495,50 @@ static int
             }
             if (ts_12 != 0) {
                if (ts_12->hd.t0.tag == 23) {
-                  _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLR9Ast__id_t v_42 = {0};
+                  _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLR9Ast__id_t v_44 = {0};
                   _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_13 = 0;
                   _fx_LR9Ast__id_t il_0 = 0;
-                  _fx_N10Ast__exp_t v_43 = 0;
-                  _fx_LN10Ast__exp_t v_44 = 0;
+                  _fx_N10Ast__exp_t v_45 = 0;
+                  _fx_LN10Ast__exp_t v_46 = 0;
                   FX_CALL(
                      _fx_M6ParserFM16parse_ident_listT2LT2N14Lexer__token_tR10Ast__loc_tLR9Ast__id_t4LT2N14Lexer__token_tR10Ast__loc_tBBLR9Ast__id_t(
-                        ts_12->tl, false, false, 0, &v_42, 0), _fx_catch_13);
-                  FX_COPY_PTR(v_42.t0, &ts_13);
-                  FX_COPY_PTR(v_42.t1, &il_0);
-                  FX_CALL(_fx_M3AstFM13DirImportFromN10Ast__exp_t3iLRM4id_tRM5loc_t(m__1, il_0, l1_0, &v_43), _fx_catch_13);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_43, result_3, true, &v_44), _fx_catch_13);
+                        ts_12->tl, false, false, 0, &v_44, 0), _fx_catch_14);
+                  FX_COPY_PTR(v_44.t0, &ts_13);
+                  FX_COPY_PTR(v_44.t1, &il_0);
+                  FX_CALL(_fx_M3AstFM13DirImportFromN10Ast__exp_t3iLRM4id_tRM5loc_t(m__1, il_0, l1_0, &v_45), _fx_catch_14);
+                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_45, result_3, true, &v_46), _fx_catch_14);
                   _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
                   FX_COPY_PTR(ts_13, &ts_1);
                   _fx_free_LN10Ast__exp_t(&result_2);
-                  FX_COPY_PTR(v_44, &result_2);
+                  FX_COPY_PTR(v_46, &result_2);
 
-               _fx_catch_13: ;
-                  if (v_44) {
-                     _fx_free_LN10Ast__exp_t(&v_44);
+               _fx_catch_14: ;
+                  if (v_46) {
+                     _fx_free_LN10Ast__exp_t(&v_46);
                   }
-                  if (v_43) {
-                     _fx_free_N10Ast__exp_t(&v_43);
+                  if (v_45) {
+                     _fx_free_N10Ast__exp_t(&v_45);
                   }
                   FX_FREE_LIST_SIMPLE(&il_0);
                   if (ts_13) {
                      _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_13);
                   }
-                  _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLR9Ast__id_t(&v_42);
+                  _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLR9Ast__id_t(&v_44);
                   goto _fx_endmatch_8;
                }
             }
-            fx_exn_t v_45 = {0};
+            fx_exn_t v_47 = {0};
             fx_str_t slit_9 = FX_MAKE_STR("\'import\' is expected");
-            FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_12, &slit_9, &v_45, 0), _fx_catch_14);
-            FX_THROW(&v_45, true, _fx_catch_14);
-
-         _fx_catch_14: ;
-            fx_free_exn(&v_45);
-
-         _fx_endmatch_8: ;
-            FX_CHECK_EXN(_fx_catch_15);
+            FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_12, &slit_9, &v_47, 0), _fx_catch_15);
+            FX_THROW(&v_47, true, _fx_catch_15);
 
          _fx_catch_15: ;
+            fx_free_exn(&v_47);
+
+         _fx_endmatch_8: ;
+            FX_CHECK_EXN(_fx_catch_16);
+
+         _fx_catch_16: ;
             FX_FREE_STR(&m__0);
             if (ts_12) {
                _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_12);
@@ -15395,48 +15549,48 @@ static int
          }
       }
       if (ts_3 != 0) {
-         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_46 = ts_3->tl;
-         if (v_46 != 0) {
-            _fx_T2N14Lexer__token_tR10Ast__loc_t* v_47 = &v_46->hd;
-            _fx_N14Lexer__token_t* v_48 = &v_47->t0;
-            if (v_48->tag == 1) {
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t v_48 = ts_3->tl;
+         if (v_48 != 0) {
+            _fx_T2N14Lexer__token_tR10Ast__loc_t* v_49 = &v_48->hd;
+            _fx_N14Lexer__token_t* v_50 = &v_49->t0;
+            if (v_50->tag == 1) {
                if (ts_3->hd.t0.tag == 30) {
-                  fx_exn_t v_49 = {0};
+                  fx_exn_t v_51 = {0};
                   fx_str_t pr_0 = {0};
-                  _fx_LS v_50 = 0;
-                  _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLS v_51 = {0};
+                  _fx_LS v_52 = 0;
+                  _fx_T2LT2N14Lexer__token_tR10Ast__loc_tLS v_53 = {0};
                   _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_14 = 0;
                   _fx_LS prl_0 = 0;
-                  _fx_N10Ast__exp_t v_52 = 0;
-                  _fx_LN10Ast__exp_t v_53 = 0;
-                  _fx_R10Ast__loc_t* l2_0 = &v_47->t1;
+                  _fx_N10Ast__exp_t v_54 = 0;
+                  _fx_LN10Ast__exp_t v_55 = 0;
+                  _fx_R10Ast__loc_t* l2_0 = &v_49->t1;
                   if (!toplevel_0) {
                      fx_str_t slit_10 = FX_MAKE_STR("pragma directives can only be used at the module level");
-                     FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_10, &v_49, 0),
-                        _fx_catch_16);
-                     FX_THROW(&v_49, true, _fx_catch_16);
+                     FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_10, &v_51, 0),
+                        _fx_catch_17);
+                     FX_THROW(&v_51, true, _fx_catch_17);
                   }
-                  FX_CALL(_fx_M6ParserFM10get_stringS2N10Ast__lit_tR10Ast__loc_t(&v_48->u.LITERAL, l2_0, &pr_0, 0),
-                     _fx_catch_16);
-                  FX_CALL(_fx_cons_LS(&pr_0, 0, true, &v_50), _fx_catch_16);
+                  FX_CALL(_fx_M6ParserFM10get_stringS2N10Ast__lit_tR10Ast__loc_t(&v_50->u.LITERAL, l2_0, &pr_0, 0),
+                     _fx_catch_17);
+                  FX_CALL(_fx_cons_LS(&pr_0, 0, true, &v_52), _fx_catch_17);
                   FX_CALL(
                      _fx_M6ParserFM13more_pragmas_T2LT2N14Lexer__token_tR10Ast__loc_tLS2LT2N14Lexer__token_tR10Ast__loc_tLS(
-                        v_46->tl, v_50, &v_51, 0), _fx_catch_16);
-                  FX_COPY_PTR(v_51.t0, &ts_14);
-                  FX_COPY_PTR(v_51.t1, &prl_0);
-                  FX_CALL(_fx_M3AstFM9DirPragmaN10Ast__exp_t2LSRM5loc_t(prl_0, l2_0, &v_52), _fx_catch_16);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_52, result_3, true, &v_53), _fx_catch_16);
+                        v_48->tl, v_52, &v_53, 0), _fx_catch_17);
+                  FX_COPY_PTR(v_53.t0, &ts_14);
+                  FX_COPY_PTR(v_53.t1, &prl_0);
+                  FX_CALL(_fx_M3AstFM9DirPragmaN10Ast__exp_t2LSRM5loc_t(prl_0, l2_0, &v_54), _fx_catch_17);
+                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_54, result_3, true, &v_55), _fx_catch_17);
                   _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
                   FX_COPY_PTR(ts_14, &ts_1);
                   _fx_free_LN10Ast__exp_t(&result_2);
-                  FX_COPY_PTR(v_53, &result_2);
+                  FX_COPY_PTR(v_55, &result_2);
 
-               _fx_catch_16: ;
-                  if (v_53) {
-                     _fx_free_LN10Ast__exp_t(&v_53);
+               _fx_catch_17: ;
+                  if (v_55) {
+                     _fx_free_LN10Ast__exp_t(&v_55);
                   }
-                  if (v_52) {
-                     _fx_free_N10Ast__exp_t(&v_52);
+                  if (v_54) {
+                     _fx_free_N10Ast__exp_t(&v_54);
                   }
                   if (prl_0) {
                      _fx_free_LS(&prl_0);
@@ -15444,12 +15598,12 @@ static int
                   if (ts_14) {
                      _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_14);
                   }
-                  _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLS(&v_51);
-                  if (v_50) {
-                     _fx_free_LS(&v_50);
+                  _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tLS(&v_53);
+                  if (v_52) {
+                     _fx_free_LS(&v_52);
                   }
                   FX_FREE_STR(&pr_0);
-                  fx_free_exn(&v_49);
+                  fx_free_exn(&v_51);
                   goto _fx_endmatch_9;
                }
             }
@@ -15457,31 +15611,31 @@ static int
       }
       if (ts_3 != 0) {
          if (ts_3->hd.t0.tag == 9) {
-            fx_exn_t v_54 = {0};
-            _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_55 = {0};
+            fx_exn_t v_56 = {0};
+            _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_57 = {0};
             _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_15 = 0;
             _fx_N10Ast__exp_t e_1 = 0;
-            _fx_LN10Ast__exp_t v_56 = 0;
+            _fx_LN10Ast__exp_t v_58 = 0;
             if (!toplevel_0) {
                fx_str_t slit_11 =
                   FX_MAKE_STR("C code is only allowed at the top level or as rhs of function or value definition");
-               FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_11, &v_54, 0), _fx_catch_17);
-               FX_THROW(&v_54, true, _fx_catch_17);
+               FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_3, &slit_11, &v_56, 0), _fx_catch_18);
+               FX_THROW(&v_56, true, _fx_catch_18);
             }
             FX_CALL(
                _fx_M6ParserFM15parse_ccode_expT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t(
-                  ts_3, _fx_g15Parser__TypVoid, &v_55, 0), _fx_catch_17);
-            FX_COPY_PTR(v_55.t0, &ts_15);
-            FX_COPY_PTR(v_55.t1, &e_1);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, result_3, true, &v_56), _fx_catch_17);
+                  ts_3, _fx_g15Parser__TypVoid, &v_57, 0), _fx_catch_18);
+            FX_COPY_PTR(v_57.t0, &ts_15);
+            FX_COPY_PTR(v_57.t1, &e_1);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, result_3, true, &v_58), _fx_catch_18);
             _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
             FX_COPY_PTR(ts_15, &ts_1);
             _fx_free_LN10Ast__exp_t(&result_2);
-            FX_COPY_PTR(v_56, &result_2);
+            FX_COPY_PTR(v_58, &result_2);
 
-         _fx_catch_17: ;
-            if (v_56) {
-               _fx_free_LN10Ast__exp_t(&v_56);
+         _fx_catch_18: ;
+            if (v_58) {
+               _fx_free_LN10Ast__exp_t(&v_58);
             }
             if (e_1) {
                _fx_free_N10Ast__exp_t(&e_1);
@@ -15489,29 +15643,29 @@ static int
             if (ts_15) {
                _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_15);
             }
-            _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(&v_55);
-            fx_free_exn(&v_54);
+            _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(&v_57);
+            fx_free_exn(&v_56);
             goto _fx_endmatch_9;
          }
       }
-      _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_57 = {0};
+      _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t v_59 = {0};
       _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_16 = 0;
       _fx_N10Ast__exp_t e_2 = 0;
-      _fx_LN10Ast__exp_t v_58 = 0;
+      _fx_LN10Ast__exp_t v_60 = 0;
       FX_CALL(
          _fx_M6ParserFM10parse_stmtT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t1LT2N14Lexer__token_tR10Ast__loc_t(ts_3,
-            &v_57, 0), _fx_catch_18);
-      FX_COPY_PTR(v_57.t0, &ts_16);
-      FX_COPY_PTR(v_57.t1, &e_2);
-      FX_CALL(_fx_cons_LN10Ast__exp_t(e_2, result_3, true, &v_58), _fx_catch_18);
+            &v_59, 0), _fx_catch_19);
+      FX_COPY_PTR(v_59.t0, &ts_16);
+      FX_COPY_PTR(v_59.t1, &e_2);
+      FX_CALL(_fx_cons_LN10Ast__exp_t(e_2, result_3, true, &v_60), _fx_catch_19);
       _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
       FX_COPY_PTR(ts_16, &ts_1);
       _fx_free_LN10Ast__exp_t(&result_2);
-      FX_COPY_PTR(v_58, &result_2);
+      FX_COPY_PTR(v_60, &result_2);
 
-   _fx_catch_18: ;
-      if (v_58) {
-         _fx_free_LN10Ast__exp_t(&v_58);
+   _fx_catch_19: ;
+      if (v_60) {
+         _fx_free_LN10Ast__exp_t(&v_60);
       }
       if (e_2) {
          _fx_free_N10Ast__exp_t(&e_2);
@@ -15519,12 +15673,12 @@ static int
       if (ts_16) {
          _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_16);
       }
-      _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(&v_57);
+      _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(&v_59);
 
    _fx_endmatch_9: ;
-      FX_CHECK_EXN(_fx_catch_19);
+      FX_CHECK_EXN(_fx_catch_20);
 
-   _fx_catch_19: ;
+   _fx_catch_20: ;
       if (ts_3) {
          _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_3);
       }
@@ -18810,25 +18964,87 @@ FX_EXTERN_C int
          _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t v_1 = {0};
          _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_2 = 0;
          _fx_N10Ast__typ_t t_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_2 = {0};
-         _fx_N10Ast__exp_t v_3 = 0;
+         _fx_T2N14Lexer__token_tR10Ast__loc_t result_0 = {0};
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t l_0 = 0;
+         _fx_T2N14Lexer__token_tR10Ast__loc_t v_2 = {0};
+         _fx_LR10Ast__loc_t v_3 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_4 = {0};
+         _fx_N10Ast__exp_t v_5 = 0;
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t rest_0 = ts_1->tl;
          FX_CALL(
             _fx_M6ParserFM14parse_typespecT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t1LT2N14Lexer__token_tR10Ast__loc_t(
-               ts_1->tl, &v_1, 0), _fx_catch_0);
+               rest_0, &v_1, 0), _fx_catch_2);
          FX_COPY_PTR(v_1.t0, &ts_2);
          FX_COPY_PTR(v_1.t1, &t_0);
-         _fx_R10Ast__loc_t v_4;
-         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_4, 0), _fx_catch_0);
-         FX_CALL(_fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(&v_4, &v_2, 0), _fx_catch_0);
-         FX_CALL(_fx_M3AstFM8ExpTypedN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(e_0, t_0, &v_2, &v_3),
-            _fx_catch_0);
-         _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(ts_2, v_3, fx_result);
-
-      _fx_catch_0: ;
-         if (v_3) {
-            _fx_free_N10Ast__exp_t(&v_3);
+         _fx_R10Ast__loc_t v_6;
+         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_6, 0), _fx_catch_2);
+         int_ v_7 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(rest_0, 0);
+         int_ v_8 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(ts_2, 0);
+         int_ n_0 = v_7 - v_8;
+         _fx_R10Ast__loc_t v_9;
+         if (n_0 <= 0) {
+            v_9 = _fx_g10Ast__noloc;
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_2);
+         else {
+            FX_COPY_PTR(rest_0, &l_0);
+            int_ n_1 = n_0 - 1;
+            for (;;) {
+               _fx_LT2N14Lexer__token_tR10Ast__loc_t l_1 = 0;
+               FX_COPY_PTR(l_0, &l_1);
+               int_ n_2 = n_1;
+               if (l_1 != 0) {
+                  if (n_2 == 0) {
+                     _fx_T2N14Lexer__token_tR10Ast__loc_t* a_0 = &l_1->hd;
+                     _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
+                     _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(a_0, &result_0);
+                     FX_BREAK(_fx_catch_0);
+                  }
+                  else {
+                     _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_1 = &l_1->tl;
+                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+                     FX_COPY_PTR(*rest_1, &l_0);
+                     n_1 = n_2 - 1;
+                  }
+
+               _fx_catch_0: ;
+               }
+               else {
+                  FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_1);
+               }
+               FX_CHECK_EXN(_fx_catch_1);
+
+            _fx_catch_1: ;
+               if (l_1) {
+                  _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_1);
+               }
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_2);
+            }
+            _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(&result_0, &v_2);
+            v_9 = v_2.t1;
+         }
+         FX_CALL(_fx_cons_LR10Ast__loc_t(&v_9, 0, true, &v_3), _fx_catch_2);
+         FX_CALL(_fx_cons_LR10Ast__loc_t(&v_6, v_3, false, &v_3), _fx_catch_2);
+         _fx_R10Ast__loc_t v_10;
+         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_10, 0), _fx_catch_2);
+         _fx_R10Ast__loc_t loc_0;
+         FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_3, &v_10, &loc_0, 0), _fx_catch_2);
+         FX_CALL(_fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(&loc_0, &v_4, 0), _fx_catch_2);
+         FX_CALL(_fx_M3AstFM8ExpTypedN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(e_0, t_0, &v_4, &v_5),
+            _fx_catch_2);
+         _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(ts_2, v_5, fx_result);
+
+      _fx_catch_2: ;
+         if (v_5) {
+            _fx_free_N10Ast__exp_t(&v_5);
+         }
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_4);
+         FX_FREE_LIST_SIMPLE(&v_3);
+         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_2);
+         if (l_0) {
+            _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_0);
+         }
+         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_0);
          if (t_0) {
             _fx_free_N10Ast__typ_t(&t_0);
          }
@@ -18841,40 +19057,102 @@ FX_EXTERN_C int
    }
    if (ts_1 != 0) {
       if (ts_1->hd.t0.tag == 57) {
-         _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t v_5 = {0};
+         _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t v_11 = {0};
          _fx_LT2N14Lexer__token_tR10Ast__loc_t ts_3 = 0;
          _fx_N10Ast__typ_t t_1 = 0;
-         _fx_N10Ast__typ_t v_6 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_7 = {0};
-         _fx_N10Ast__exp_t v_8 = 0;
+         _fx_T2N14Lexer__token_tR10Ast__loc_t result_1 = {0};
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t l_2 = 0;
+         _fx_T2N14Lexer__token_tR10Ast__loc_t v_12 = {0};
+         _fx_LR10Ast__loc_t v_13 = 0;
+         _fx_N10Ast__typ_t v_14 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_15 = {0};
+         _fx_N10Ast__exp_t v_16 = 0;
+         _fx_LT2N14Lexer__token_tR10Ast__loc_t rest_2 = ts_1->tl;
          FX_CALL(
             _fx_M6ParserFM14parse_typespecT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t1LT2N14Lexer__token_tR10Ast__loc_t(
-               ts_1->tl, &v_5, 0), _fx_catch_1);
-         FX_COPY_PTR(v_5.t0, &ts_3);
-         FX_COPY_PTR(v_5.t1, &t_1);
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_6, 0), _fx_catch_1);
-         _fx_R10Ast__loc_t v_9;
-         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_9, 0), _fx_catch_1);
-         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_6, &v_9, &v_7);
-         FX_CALL(_fx_M3AstFM7ExpCastN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(e_0, t_1, &v_7, &v_8),
-            _fx_catch_1);
-         _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(ts_3, v_8, fx_result);
+               rest_2, &v_11, 0), _fx_catch_5);
+         FX_COPY_PTR(v_11.t0, &ts_3);
+         FX_COPY_PTR(v_11.t1, &t_1);
+         _fx_R10Ast__loc_t v_17;
+         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_17, 0), _fx_catch_5);
+         int_ v_18 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(rest_2, 0);
+         int_ v_19 = _fx_M6ParserFM6lengthi1LT2N14Lexer__token_tR10Ast__loc_t(ts_3, 0);
+         int_ n_3 = v_18 - v_19;
+         _fx_R10Ast__loc_t v_20;
+         if (n_3 <= 0) {
+            v_20 = _fx_g10Ast__noloc;
+         }
+         else {
+            FX_COPY_PTR(rest_2, &l_2);
+            int_ n_4 = n_3 - 1;
+            for (;;) {
+               _fx_LT2N14Lexer__token_tR10Ast__loc_t l_3 = 0;
+               FX_COPY_PTR(l_2, &l_3);
+               int_ n_5 = n_4;
+               if (l_3 != 0) {
+                  if (n_5 == 0) {
+                     _fx_T2N14Lexer__token_tR10Ast__loc_t* a_1 = &l_3->hd;
+                     _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_1);
+                     _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(a_1, &result_1);
+                     FX_BREAK(_fx_catch_3);
+                  }
+                  else {
+                     _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_3 = &l_3->tl;
+                     _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_2);
+                     FX_COPY_PTR(*rest_3, &l_2);
+                     n_4 = n_5 - 1;
+                  }
 
-      _fx_catch_1: ;
-         if (v_8) {
-            _fx_free_N10Ast__exp_t(&v_8);
+               _fx_catch_3: ;
+               }
+               else {
+                  FX_FAST_THROW(FX_EXN_OutOfRangeError, _fx_catch_4);
+               }
+               FX_CHECK_EXN(_fx_catch_4);
+
+            _fx_catch_4: ;
+               if (l_3) {
+                  _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_3);
+               }
+               FX_CHECK_BREAK();
+               FX_CHECK_EXN(_fx_catch_5);
+            }
+            _fx_copy_T2N14Lexer__token_tR10Ast__loc_t(&result_1, &v_12);
+            v_20 = v_12.t1;
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_7);
-         if (v_6) {
-            _fx_free_N10Ast__typ_t(&v_6);
+         FX_CALL(_fx_cons_LR10Ast__loc_t(&v_20, 0, true, &v_13), _fx_catch_5);
+         FX_CALL(_fx_cons_LR10Ast__loc_t(&v_17, v_13, false, &v_13), _fx_catch_5);
+         _fx_R10Ast__loc_t v_21;
+         FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_0, &v_21, 0), _fx_catch_5);
+         _fx_R10Ast__loc_t loc_1;
+         FX_CALL(_fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(v_13, &v_21, &loc_1, 0), _fx_catch_5);
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_14, 0), _fx_catch_5);
+         _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_14, &loc_1, &v_15);
+         FX_CALL(_fx_M3AstFM7ExpCastN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(e_0, t_1, &v_15, &v_16),
+            _fx_catch_5);
+         _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(ts_3, v_16, fx_result);
+
+      _fx_catch_5: ;
+         if (v_16) {
+            _fx_free_N10Ast__exp_t(&v_16);
          }
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_15);
+         if (v_14) {
+            _fx_free_N10Ast__typ_t(&v_14);
+         }
+         FX_FREE_LIST_SIMPLE(&v_13);
+         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&v_12);
+         if (l_2) {
+            _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&l_2);
+         }
+         _fx_free_T2N14Lexer__token_tR10Ast__loc_t(&result_1);
          if (t_1) {
             _fx_free_N10Ast__typ_t(&t_1);
          }
          if (ts_3) {
             _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_3);
          }
-         _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t(&v_5);
+         _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__typ_t(&v_11);
          goto _fx_endmatch_0;
       }
    }

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -205,11 +205,15 @@ CLAUDE.md and (at rewrite time) the tutorial state it plainly; the annotate-2
   to the enclosing binding's loc. `parse_typespec` returns no loc either.
 - impact: the `'t → [t]` reform and the type-name renames (`half → fp16`,
   `vector`, `Dynvec.t`) cannot locate type occurrences via AST spans, and type
-  diagnostics point at the wrong column. A span-based migrator would need
-  token-level scanning for types, or `typ_t` must gain source locations (a real
-  change). Documented in `docs/problematic_spans_log.txt`. Deferred (reform-prep-1
-  fixed token spans + the function-name/import/cast node spans; types are the
-  remaining hard case).
+  diagnostics point at the wrong column. Documented in
+  `docs/problematic_spans_log.txt`.
+- direction (Vadim): do NOT add a loc to `typ_t` — too fundamental (threads
+  through typecheck/K-form/C-gen). Instead, later introduce a wrapper
+  `typespec_t { typ: typ_t; loc: loc_t }` and switch `typ_t → typespec_t` ONLY
+  where a source position is needed (parser output / type annotations), leaving
+  the core structural type untouched. Deferred (reform-prep-1 fixed token spans +
+  the function-name/import/cast node spans; types are the remaining hard case,
+  resolved by this wrapper when the reform lands).
 
 ## FB-021  `.op` (elementwise) error surfaces inside the library  [OPEN — diag quality]
 - repro: `[1.0,2.0] .* "str"` reports at `lib/Array.fx:90` (inside the generic

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -196,6 +196,43 @@ Vadim (2026-07-09): intentional (OpenCV `cvFloor`/`cvRound` semantics —
 CLAUDE.md and (at rewrite time) the tutorial state it plainly; the annotate-2
 `int [+]` array annotations stand.
 
+## FB-020  types (`typ_t`) carry no source location  [OPEN — reform blocker]
+- repro: `val x: undefined_type = 5` — the "type is not found" caret lands on
+  the `:` / the val, NOT on `undefined_type`; `fun f(y: nosuchtype)` points at
+  the `:` before `y`, not the type name. Confirmed on plain names, generic-sig
+  names, and compound types (`nosuch list`).
+- cause: `typ_t` is structural and stores no `loc_t`; the diagnostic falls back
+  to the enclosing binding's loc. `parse_typespec` returns no loc either.
+- impact: the `'t → [t]` reform and the type-name renames (`half → fp16`,
+  `vector`, `Dynvec.t`) cannot locate type occurrences via AST spans, and type
+  diagnostics point at the wrong column. A span-based migrator would need
+  token-level scanning for types, or `typ_t` must gain source locations (a real
+  change). Documented in `docs/problematic_spans_log.txt`. Deferred (reform-prep-1
+  fixed token spans + the function-name/import/cast node spans; types are the
+  remaining hard case).
+
+## FB-021  `.op` (elementwise) error surfaces inside the library  [OPEN — diag quality]
+- repro: `[1.0,2.0] .* "str"` reports at `lib/Array.fx:90` (inside the generic
+  `__dot_mul__` body, caret on the library's `.*`), with a
+  "when instantiating ... at <user>:2:11" note pointing back — the primary
+  location is library code, not the user's `.*`.
+- cause: `.op` desugars to a generic operator call; the mismatch is caught at
+  the instantiation site inside the operator body, whose loc wins.
+- impact: confusing diagnostics for a common numeric-code mistake. Relevant to
+  the `.op → plain op / @ matmul` reform (which removes `.op`) and to a future
+  "report at the call site, not the instantiation site" diagnostic pass.
+
+## FB-022  a failed `fold`-valued `val` cascades ("<name> not found")  [OPEN — recovery gap]
+- repro: `val s = fold acc = 0 for x <- [1,2,3] {acc + undefined}` reports the
+  body error AND a spurious `s is not found` at a later use of `s`.
+- cause: `fold` desugars during parsing into a block (`__fold_result__` etc.),
+  so the DefVal that binds `s` no longer has a simple RHS; the diag-1 recovery
+  that poisons a failed `val`'s pattern to `TypErr` does not fire on this
+  desugared shape, leaving `s` unbound → cascade.
+- impact: minor extra diagnostic; the root error is still correct. A diag-1
+  follow-up would extend the DefVal recovery to poison the pattern regardless of
+  RHS shape.
+
 ## (non-compiler) NN.Quantized.dequantizeLinear  [FENCED — DL-engine bug]
 `lib/NN/OpQuantized.run_dequantize` int8 scalar path yields 0 on Linux/x86.
 Known DL-engine defect, unrelated to the compiler; fenced by commenting the

--- a/docs/reform_prep1_handoff.md
+++ b/docs/reform_prep1_handoff.md
@@ -1,0 +1,114 @@
+# Handoff: reform-prep-1 — migrator spans + corpus census + A/B renders (Opus)
+
+**You are Claude Code (Opus) working in the Ficus repo.** Branch
+`reform-prep-1` off master. Context: `docs/language_changes_brief.md` (the
+reform agenda; §8 methodology — "measure every reform on the corpus"),
+`docs/diag1_report.md` (loc_t carries `{line0,col0,line1,col1}`; most locs
+are currently single-point), repo CLAUDE.md. This package prepares the syntax
+reform epoch: it makes the automigrator *possible* (WP-1), sizes the
+migration (WP-2), and produces the eyes-on material for the design sessions
+(WP-3/4). Nothing here changes language behavior.
+
+## WP-1 — parser spans for the rewrite subset (the migrator prerequisite)
+
+The automigrator will be a **span-based textual rewriter**: parse → compute
+edits as `(source span → new text)` → apply to the original text (preserving
+comments/formatting; NO pretty-print round-trip). It reads the AST as the
+parser built it — stages after typecheck are irrelevant, and NO location
+plumbing through K-form/optimizations is in scope (explicit non-goal,
+per diag-1).
+
+Required: for the **rewrite subset** below, every AST node's `loc_t` must be
+a true span (first token's `{line0,col0}` .. last token's `{line1,col1}`),
+not a single point. Audit the lexer first (tokens almost certainly carry
+correct spans already), then the parser's loc-folding at these node kinds:
+
+1. `fold` expressions — the whole form, the header (`fold acc=init for ...`),
+   and the body separately;
+2. `'t`-style type variables and the type expressions containing them
+   (`'t list`, `('t, 't)`, `'t [+]`, ...);
+3. cast expressions `(x :> T)` — the whole parenthesized form;
+4. `.op` elementwise operator uses (`.*`, `.+`, `.<=`, ...);
+5. backtick forms;
+6. type name occurrences: `half`, `vector`, `Dynvec.t` (for the
+   fp16/containers renames);
+7. `import` clauses (module-name spans, for the module-naming reform);
+8. function definition headers (for the generic-fun syntax rewrite).
+
+**Acceptance oracle — reparse round-trip**: a new tool
+`tools/span_check.py` (or an `.fx` tool if more natural): for every node of
+the subset kinds in every corpus file, cut `source[span]` and verify it
+lexes/parses back to the same node kind with the same structure (a
+normalized-AST comparison at the subtree level; gensym-insensitive). Run over
+the full corpus (`lib/`, `compiler/`, `test/`, `examples/`); the tool reports
+per-kind counts and failures. 100% pass for the subset = WP-1 done. Wire it
+into fxtest as an optional leg (`fxtest.py spans`) so the reform work keeps
+it green.
+
+Behavior neutrality: loc changes must not alter diagnostics' PRIMARY
+positions in existing negative goldens except where a span legitimately
+extends a caret to `^~~~` — each such golden diff is reviewed and expected.
+Ladder + determinism + census + bootstrap fixpoint as always (Parser/Lexer
+edits regenerate their bootstrap modules; program codegen byte-identical).
+
+## WP-2 — migration census (report only, no changes)
+
+One script pass (`tools/reform_census.py`, AST-driven where possible, else
+`-pr-ast`-driven) over the full corpus, reporting per-file and total counts:
+
+- **fold sites**, classified by body shape: single accumulator / tuple
+  accumulator (the simultaneous-assignment migration case) / nested fold /
+  fold-inside-comprehension / bodies already ending in an assignment-like
+  form. This table IS the automigrator spec input and the migration size.
+- `(x :> T)` cast sites (and how many are chained);
+- `.op` elementwise uses, by operator;
+- `'t`-notation sites (type-variable occurrences in type expressions) — the
+  `[t]`-reform footprint;
+- backtick uses (UTest and beyond);
+- `half` / `vector` / `Dynvec` occurrences;
+- type/value name shadowings (the long-planned `[t]` ambiguity census:
+  identifiers used both as a type name and a value name in overlapping
+  scopes — expected ~0, list every hit verbatim);
+- modules whose names start lowercase (naming reform footprint).
+
+Deliverable: `docs/reform_census.md` with the tables + verbatim lists for
+anything unusual.
+
+## WP-3 — A/B renders (for the design sessions, human-eyes material)
+
+Hand-crafted (not tool-generated) rewrites of 2–3 REAL fragments each,
+side-by-side old/new in `docs/reform_ab_renders.md`:
+
+- a representative fold-heavy function (pick from `compiler/` or `lib/`) in
+  today's tuple-fold form vs the imperative form (per language_changes §2);
+- one `.op`-heavy numeric fragment in {.op kept} vs {plain ops + `@` matmul};
+- one generics-heavy signature set in `'t`-notation vs `[t]`-notation
+  (`fun add[u, v, r](a: u, b: v): r` style included);
+- one cast-heavy fragment `:>` vs `T(x)`.
+
+Faithfulness matters more than beauty: if the new form makes something
+awkward, render it awkward and flag it — that is the point of the exercise.
+
+## WP-4 — `list[t]` parser spike (measurement, THROWAWAY branch)
+
+On a scratch branch off `reform-prep-1` (never to merge): teach the parser
+to ALSO accept `name[targs]` in type position (keeping `'t name`), enough to
+parse — no typecheck integration required. Then: (a) does the grammar
+conflict anywhere (report each conflict with the production); (b) run the
+parser over the corpus rendered... corpus is in old notation, so instead:
+parse the WP-3 `[t]` renders plus a directed file of tricky cases
+(`a[i]` indexing vs `list[t]` in expression position, `result[a, b]`,
+nested `list[list[t]]`, `t[...]` array types adjacency). Deliverable: a
+section in `docs/reform_census.md` — "list[t] parseability: conflicts found /
+resolutions available", with the spike branch name for reference. Do NOT
+polish the spike.
+
+## Ground rules
+
+Standard ladder per WP; `update_compiler.py` fixpoint; `-pr-resolve` census
+unchanged; new bugs → found_bugs, fence, don't chase; don't push. Final
+report `docs/reform_prep1_report.md`: WP-1 oracle results (per-kind
+counts/failures fixed), the census headline numbers, A/B render pointers,
+spike verdict, CLAUDE.md lesson lines if any. This package is the data floor
+for design sessions D1 (fold) → D2 (generics/casts) → D3 (operators) → D4
+(records/modules); implementation waves come after those.

--- a/docs/reform_prep1_report.md
+++ b/docs/reform_prep1_report.md
@@ -1,0 +1,82 @@
+# reform-prep-1 report — parser spans + import/function diagnostics
+
+Branch `reform-prep-1` off master. Handoff: `docs/reform_prep1_handoff.md`.
+Status: **WP-1 (spans) done for the actionable subset + the diagnostic wins
+Vadim prioritized; not pushed.** WP-2/3/4 (census, A/B renders, list[t] spike)
+are measurement deliverables, not started — see "Open follow-ups". Nothing here
+changes language behavior; all changes are locations + diagnostics.
+
+Five compact commits:
+
+- **WP-1a** — token spans (the foundation). `Lexer.make_lexer` now returns
+  `((token, lloc) list, batch_begin, batch_end)`: the lexer works internally
+  with point locs, but `nexttokens`' dispatch body is bound to `val tokens =
+  ...` and after it runs `pos` sits at the batch end, so `getloc(pos)` is the
+  end. The parser applies the batch span to every token. Result: `loc_t` is a
+  real span, a caret shows the token width (`^~~~`), and `loclist2loc` (already
+  used at ~18 parser sites) folds true node spans. Internal recursive
+  `nexttokens()` calls (string interpolation etc.) take `.0`. No per-arm changes.
+- **WP-1b** — `ExpCast`/`ExpTyped` fold to the whole `x :> T` / `x : T` (helper
+  `consumed_loc`, since types carry no loc). (Cast is being removed by the
+  reform — kept for completeness, harmless.)
+- **WP-1c** — import errors underline the whole (dotted) module name instead of
+  the first token / the `from` keyword; and the ParseError printer gained the
+  same caret excerpt as CompileError, so ALL parse errors now carry carets
+  (EOF errors degrade to no caret).
+- **WP-1d** — a not-found import gets a Levenshtein `did you mean 'String'?`,
+  candidates globbed from the include path (`Filename.glob`). `edit_distance`
+  moved to `Ast.fx` so typecheck and parser share one copy.
+- **WP-1e** — a function's own diagnostics (implicit-return warning,
+  redeclaration, overload candidate listing) point at the NAME, not the `fun`
+  keyword; operators span `operator X`.
+
+## Span audit — what the reform constructs currently get
+
+Full log with live compiler output: `docs/problematic_spans_log.txt`. Summary,
+ranked by difficulty for a span-based migrator:
+
+- **Token spans: solid.** Identifiers, operators, keywords all get their full
+  width; sub-expression errors inside fold / `.op` / backtick point precisely.
+- **Function name / import name: fixed** (WP-1c/e) — the two the diagnostics
+  care about most.
+- **`fun` header extent, fold whole-form, backtick delimiters:** the node loc is
+  the opening token; folding these to the full construct is straightforward
+  (like WP-1b) if a migrator needs them, but each construct is being reformed so
+  the priority is low.
+- **`.op` operator token:** the `ExpBinary` stores the operator KIND, not a loc
+  for the `.*` token; a `.op → @`/plain-op migrator needs that token position.
+  Also FB-021: `.op` type errors surface inside the library.
+- **Types (`'t`, type names): the hard gap (FB-020).** `typ_t` carries NO source
+  location, so type-name diagnostics land on the preceding `:` and a span-based
+  migrator cannot locate `'t` / `half` / `vector` occurrences via the AST. The
+  `'t → [t]` reform will need token-level scanning for types or locs added to
+  `typ_t`.
+
+## Bugs filed
+
+FB-020 (types loc-less — reform blocker), FB-021 (`.op` diagnostic surfaces in
+the library), FB-022 (a failed `fold`-valued `val` cascades because the
+desugared shape sidesteps diag-1's DefVal recovery). All fenced, not chased.
+
+## Verification
+
+test_all 147; `fxtest all` (unit + negative 87 + ir + cfold + corpus O0/O3);
+`-pr-resolve` census 356 unchanged; rettype gate clean; bootstrap fixpoint holds
+(each WP regenerates only the modules it edits — Lexer/Parser/Compiler/Ast).
+~90 negative goldens migrated to carets across diag-1 + this package; each diff
+reviewed as a format change (wider carets, name-column citations).
+
+## Open follow-ups
+
+- **WP-2** migration census (`docs/reform_census.md`): counts of fold / cast /
+  `.op` / `'t` / backtick / `half`/`vector`/`Dynvec` sites, type/value name
+  shadowings, lowercase modules. Report only.
+- **WP-3** A/B renders (`docs/reform_ab_renders.md`): hand-crafted old/new of a
+  fold-heavy fn, a `.op` fragment, a generics signature set, a cast fragment.
+- **WP-4** `list[t]` parser spike (throwaway branch): grammar-conflict
+  measurement.
+- **span_check oracle** (`tools/span_check.py`): the WP-1 acceptance criterion
+  (cut `source[node.span]`, reparse, compare) — needs a fragment-reparse entry
+  point; not built. The node-folding gaps above (types especially) are what it
+  would flag.
+- FB-020/021/022 fixes.

--- a/test/negative/009_overload_arity.err
+++ b/test/negative/009_overload_arity.err
@@ -3,6 +3,6 @@ Candidates:
  ff(int, int) -> int @ 009_overload_arity.fx:4:1 -- takes 2 argument(s), but 1 given
 
  5 | val r = ff(1)
-   |         ^
+   |         ^~
 
 1 errors occured during type checking.

--- a/test/negative/009_overload_arity.err
+++ b/test/negative/009_overload_arity.err
@@ -1,6 +1,6 @@
 009_overload_arity.fx:5:9: error: the appropriate match for 'ff' of type '(int -> <unknown>)' is not found.
 Candidates:
- ff(int, int) -> int @ 009_overload_arity.fx:4:1 -- takes 2 argument(s), but 1 given
+ ff(int, int) -> int @ 009_overload_arity.fx:4:5 -- takes 2 argument(s), but 1 given
 
  5 | val r = ff(1)
    |         ^~

--- a/test/negative/010_overload_keyword.err
+++ b/test/negative/010_overload_keyword.err
@@ -1,6 +1,6 @@
 010_overload_keyword.fx:4:9: error: the appropriate match for 'kk' of type '({z: int} -> <unknown>)' is not found.
 Candidates:
- kk({a: int}) -> int @ 010_overload_keyword.fx:3:1 -- keyword arguments '{z: int}' do not match the accepted '{a: int}'
+ kk({a: int}) -> int @ 010_overload_keyword.fx:3:5 -- keyword arguments '{z: int}' do not match the accepted '{a: int}'
 
  4 | val r = kk(z=5)
    |         ^~

--- a/test/negative/010_overload_keyword.err
+++ b/test/negative/010_overload_keyword.err
@@ -3,6 +3,6 @@ Candidates:
  kk({a: int}) -> int @ 010_overload_keyword.fx:3:1 -- keyword arguments '{z: int}' do not match the accepted '{a: int}'
 
  4 | val r = kk(z=5)
-   |         ^
+   |         ^~
 
 1 errors occured during type checking.

--- a/test/negative/011_overload_not_found_candidates.err
+++ b/test/negative/011_overload_not_found_candidates.err
@@ -4,6 +4,6 @@ Candidates:
  oo(float) -> int @ 011_overload_not_found_candidates.fx:5:1 -- argument 1 of type 'string' does not match 'float'
 
  6 | val r = oo("x")
-   |         ^
+   |         ^~
 
 1 errors occured during type checking.

--- a/test/negative/011_overload_not_found_candidates.err
+++ b/test/negative/011_overload_not_found_candidates.err
@@ -1,7 +1,7 @@
 011_overload_not_found_candidates.fx:6:9: error: the appropriate match for 'oo' of type '(string -> <unknown>)' is not found.
 Candidates:
- oo(int) -> int @ 011_overload_not_found_candidates.fx:4:1 -- argument 1 of type 'string' does not match 'int',
- oo(float) -> int @ 011_overload_not_found_candidates.fx:5:1 -- argument 1 of type 'string' does not match 'float'
+ oo(int) -> int @ 011_overload_not_found_candidates.fx:4:5 -- argument 1 of type 'string' does not match 'int',
+ oo(float) -> int @ 011_overload_not_found_candidates.fx:5:5 -- argument 1 of type 'string' does not match 'float'
 
  6 | val r = oo("x")
    |         ^~

--- a/test/negative/012_overload_ambiguous_incomp.err
+++ b/test/negative/012_overload_ambiguous_incomp.err
@@ -3,6 +3,6 @@
  amb('t, int) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:5:1
 define/import a more specific overload, or use a module-qualified call (e.g. Module.amb(...)) to disambiguate
  7 | val r = amb(1, 2)
-   |         ^
+   |         ^~~
 
 1 errors occured during type checking.

--- a/test/negative/012_overload_ambiguous_incomp.err
+++ b/test/negative/012_overload_ambiguous_incomp.err
@@ -1,6 +1,6 @@
 012_overload_ambiguous_incomp.fx:7:9: error: ambiguous call of overloaded 'amb': the candidates overlap, but none is the most specific. Candidates:
- amb(int, 't) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:6:1
- amb('t, int) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:5:1
+ amb(int, 't) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:6:5
+ amb('t, int) -> <unknown> [generic: 't] @ 012_overload_ambiguous_incomp.fx:5:5
 define/import a more specific overload, or use a module-qualified call (e.g. Module.amb(...)) to disambiguate
  7 | val r = amb(1, 2)
    |         ^~~

--- a/test/negative/013_overload_ambiguous_eq.err
+++ b/test/negative/013_overload_ambiguous_eq.err
@@ -1,6 +1,6 @@
 013_overload_ambiguous_eq.fx:7:9: error: ambiguous call of overloaded 'g': the candidates are equally applicable. Candidates:
- g('u) -> <unknown> [generic: 'u] @ 013_overload_ambiguous_eq.fx:6:1
- g('t) -> <unknown> [generic: 't] @ 013_overload_ambiguous_eq.fx:5:1
+ g('u) -> <unknown> [generic: 'u] @ 013_overload_ambiguous_eq.fx:6:5
+ g('t) -> <unknown> [generic: 't] @ 013_overload_ambiguous_eq.fx:5:5
 use a module-qualified call (e.g. Module.g(...)) to select one
  7 | val r = g(5)
    |         ^

--- a/test/negative/014_overload_ambiguous_xmodule.err
+++ b/test/negative/014_overload_ambiguous_xmodule.err
@@ -3,6 +3,6 @@
  length(string) -> int @ Builtins.fx:L:C
 use a module-qualified call (e.g. Module.length(...)) to select one
  13 | val r = length("abc")
-    |         ^
+    |         ^~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/014_overload_ambiguous_xmodule.err
+++ b/test/negative/014_overload_ambiguous_xmodule.err
@@ -1,5 +1,5 @@
 014_overload_ambiguous_xmodule.fx:13:9: error: ambiguous call of overloaded 'length': the candidates are equally applicable. Candidates:
- length(string) -> int @ 014_overload_ambiguous_xmodule.fx:12:1
+ length(string) -> int @ 014_overload_ambiguous_xmodule.fx:12:5
  length(string) -> int @ Builtins.fx:L:C
 use a module-qualified call (e.g. Module.length(...)) to select one
  13 | val r = length("abc")

--- a/test/negative/103_lowercase_variant.err
+++ b/test/negative/103_lowercase_variant.err
@@ -1,1 +1,3 @@
 103_lowercase_variant.fx:2:14: error: variant label should start with a capital letter A..Z
+ 2 | type bad_t = red | green | blue
+   |              ^~~

--- a/test/negative/104_lowercase_exception.err
+++ b/test/negative/104_lowercase_exception.err
@@ -1,1 +1,3 @@
 104_lowercase_exception.fx:2:1: error: exception name should start with a capital letter (A..Z)
+ 2 | exception myError
+   | ^~~~~~~~~

--- a/test/negative/105_arrow_instead_of_fatarrow.err
+++ b/test/negative/105_arrow_instead_of_fatarrow.err
@@ -1,1 +1,3 @@
 105_arrow_instead_of_fatarrow.fx:2:23: error: unexpected '->', did you mean '=>'?
+ 2 | val x = match 1 { | 1 -> 10 | _ -> 0 }
+   |                       ^~

--- a/test/negative/106_empty_match.err
+++ b/test/negative/106_empty_match.err
@@ -1,1 +1,3 @@
 106_empty_match.fx:2:18: error: at least one pattern-matching case is expected
+ 2 | val x = match 1 {}
+   |                  ^

--- a/test/negative/107_no_function_body.err
+++ b/test/negative/107_no_function_body.err
@@ -1,1 +1,3 @@
 107_no_function_body.fx:3:1: error: '=' or '{' is expected before the function body
+ 3 | println(0)
+   | ^~~~~~~

--- a/test/negative/108_positional_after_named.err
+++ b/test/negative/108_positional_after_named.err
@@ -1,6 +1,6 @@
 108_positional_after_named.fx:3:9: error: the appropriate match for 'g' of type '((int, {a: int}) -> <unknown>)' is not found.
 Candidates:
- g({a: int; b: int}) -> int @ 108_positional_after_named.fx:2:1 -- takes 0 positional argument(s), but 1 given
+ g({a: int; b: int}) -> int @ 108_positional_after_named.fx:2:5 -- takes 0 positional argument(s), but 1 given
 
  3 | println(g(a=1, 2))
    |         ^

--- a/test/negative/109_import_inside_function.err
+++ b/test/negative/109_import_inside_function.err
@@ -1,1 +1,1 @@
-109_import_inside_function.fx:3:5: error: import directives can only be used at the module level
+109_import_inside_function.fx:2:9: error: import directives can only be used at the module level

--- a/test/negative/109_import_inside_function.err
+++ b/test/negative/109_import_inside_function.err
@@ -1,1 +1,3 @@
 109_import_inside_function.fx:2:9: error: import directives can only be used at the module level
+ 2 | fun f() {
+   |         ^

--- a/test/negative/110_extra_comma.err
+++ b/test/negative/110_extra_comma.err
@@ -1,1 +1,3 @@
 110_extra_comma.fx:2:16: error: extra ','?
+ 2 | val a = [1, 2, , 3]
+   |                ^

--- a/test/negative/111_no_type_after_colon.err
+++ b/test/negative/111_no_type_after_colon.err
@@ -1,1 +1,3 @@
 111_no_type_after_colon.fx:2:8: error: type is expected here (starting from indent, type var, '(' or '{'
+ 2 | val x: = 5
+   |        ^

--- a/test/negative/112_empty_pattern.err
+++ b/test/negative/112_empty_pattern.err
@@ -1,1 +1,3 @@
 112_empty_pattern.fx:2:21: error: pattern is expected
+ 2 | val x = match 1 { | => 0 }
+   |                     ^~

--- a/test/negative/113_augmented_non_lvalue.err
+++ b/test/negative/113_augmented_non_lvalue.err
@@ -1,1 +1,3 @@
 113_augmented_non_lvalue.fx:2:3: error: left-hand-side of the assignment is not an l-value
+ 2 | 1 += 2
+   |   ^~

--- a/test/negative/114_underscore_as_label.err
+++ b/test/negative/114_underscore_as_label.err
@@ -1,1 +1,3 @@
 114_underscore_as_label.fx:2:28: error: '_' cannot be used as a variant label
+ 2 | val x = match 1 { | 1 10 | _ 0 }
+   |                            ^

--- a/test/negative/201_if_branches_differ.err
+++ b/test/negative/201_if_branches_differ.err
@@ -1,5 +1,5 @@
-201_if_branches_differ.fx:2:27: error: if() expression should have the same type as its branches
+201_if_branches_differ.fx:2:26: error: if() expression should have the same type as its branches
  2 | val a = if true {1} else {"s"}
-   |                           ^
+   |                          ^~~~
 
 1 errors occured during type checking.

--- a/test/negative/202_if_no_else.err
+++ b/test/negative/202_if_no_else.err
@@ -1,5 +1,5 @@
 202_if_no_else.fx:2:9: error: if() expression of non-void type has no 'else' branch
  2 | val a = if true {1}
-   |         ^
+   |         ^~
 
 1 errors occured during type checking.

--- a/test/negative/210_wrong_return_type.err
+++ b/test/negative/210_wrong_return_type.err
@@ -1,5 +1,5 @@
 210_wrong_return_type.fx:2:16: error: the function body type does not match the function type
  2 | fun f(): int = "s"
-   |                ^
+   |                ^~~
 
 1 errors occured during type checking.

--- a/test/negative/212_negate_string.err
+++ b/test/negative/212_negate_string.err
@@ -4,6 +4,6 @@ Candidates:
  __negate__('t [+]) -> 't [+] [generic: 't, __var_array__] @ Array.fx:L:C -- argument 1 of type 'string' does not match ''t [+]'
 
  2 | val x = -"abc"
-   |         ^
+   |         ^~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/216_break_outside_loop.err
+++ b/test/negative/216_break_outside_loop.err
@@ -1,5 +1,5 @@
-216_break_outside_loop.fx:4:17: error: cannot use 'break' outside of loop
+216_break_outside_loop.fx:4:15: error: cannot use 'break' outside of loop
  4 | fun f(): void { break }
-   |                 ^
+   |               ^~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/217_break_in_arm_outside_loop.err
+++ b/test/negative/217_break_in_arm_outside_loop.err
@@ -1,5 +1,5 @@
 217_break_in_arm_outside_loop.fx:5:39: error: cannot use 'break' outside of loop
  5 | fun f(x: int): int = match x { | 0 => break | v => v }
-   |                                       ^
+   |                                       ^~~~~
 
 1 errors occured during type checking.

--- a/test/negative/218_bare_return_nonvoid.err
+++ b/test/negative/218_bare_return_nonvoid.err
@@ -1,5 +1,5 @@
-218_bare_return_nonvoid.fx:5:43: error: the return statement type void is inconsistent with the previously deduced type int of function f
+218_bare_return_nonvoid.fx:5:41: error: the return statement type void is inconsistent with the previously deduced type int of function f
  5 | fun f(): int { for i <- 0:3 { if i == 1 { return } else {} }; 0 }
-   |                                           ^
+   |                                         ^~~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/219_continue_in_arm_outside_loop.err
+++ b/test/negative/219_continue_in_arm_outside_loop.err
@@ -1,5 +1,5 @@
 219_continue_in_arm_outside_loop.fx:3:39: error: cannot use 'continue' outside of loop
  3 | fun f(x: int): int = match x { | 0 => continue | v => v }
-   |                                       ^
+   |                                       ^~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/220_implicit_rettype.err
+++ b/test/negative/220_implicit_rettype.err
@@ -1,5 +1,5 @@
 220_implicit_rettype.fx:7:1: warning: implicit return type of module-level function 'norm' (inferred: double)
  7 | fun norm(x: double, y: double) = sqrt(x*x + y*y)
-   | ^
+   | ^~~
 
 1 warning generated (treated as errors due to -Werror).

--- a/test/negative/220_implicit_rettype.err
+++ b/test/negative/220_implicit_rettype.err
@@ -1,5 +1,5 @@
-220_implicit_rettype.fx:7:1: warning: implicit return type of module-level function 'norm' (inferred: double)
+220_implicit_rettype.fx:7:5: warning: implicit return type of module-level function 'norm' (inferred: double)
  7 | fun norm(x: double, y: double) = sqrt(x*x + y*y)
-   | ^~~
+   |     ^~~~
 
 1 warning generated (treated as errors due to -Werror).

--- a/test/negative/230_recovery_independent.err
+++ b/test/negative/230_recovery_independent.err
@@ -1,11 +1,11 @@
-230_recovery_independent.fx:4:16: error: the appropriate match for 'undef_a' of type '<unknown>' is not found.
+230_recovery_independent.fx:4:14: error: the appropriate match for 'undef_a' of type '<unknown>' is not found.
  4 | fun a(): int { undef_a + 1 }
-   |                ^
-230_recovery_independent.fx:5:16: error: the appropriate match for 'undef_b' of type '<unknown>' is not found.
+   |              ^~~~~~~~~
+230_recovery_independent.fx:5:14: error: the appropriate match for 'undef_b' of type '<unknown>' is not found.
  5 | fun b(): int { undef_b + 2 }
-   |                ^
-230_recovery_independent.fx:6:16: error: the appropriate match for 'undef_c' of type '<unknown>' is not found.
+   |              ^~~~~~~~~
+230_recovery_independent.fx:6:14: error: the appropriate match for 'undef_c' of type '<unknown>' is not found.
  6 | fun c(): int { undef_c + 3 }
-   |                ^
+   |              ^~~~~~~~~
 
 3 errors occured during type checking.

--- a/test/negative/231_recovery_cascade.err
+++ b/test/negative/231_recovery_cascade.err
@@ -1,5 +1,5 @@
 231_recovery_cascade.fx:4:9: error: the appropriate match for 'undefined_root' of type '<unknown>' is not found.
  4 | val x = undefined_root
-   |         ^
+   |         ^~~~~~~~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/232_recovery_firewall.err
+++ b/test/negative/232_recovery_firewall.err
@@ -1,6 +1,6 @@
-232_recovery_firewall.fx:6:22: error: the appropriate match for 'undefined_thing' of type '<unknown>' is not found.
+232_recovery_firewall.fx:6:20: error: the appropriate match for 'undefined_thing' of type '<unknown>' is not found.
  6 | fun f(x: int): int { undefined_thing + x }
-   |                      ^
+   |                    ^~~~~~~~~~~~~~~~~
 232_recovery_firewall.fx:8:19: error: the appropriate match for 'f' of type '(int -> string)' is not found.
 Candidates:
  f(int) -> int @ 232_recovery_firewall.fx:6:1 -- the return type or the signature as a whole does not match

--- a/test/negative/232_recovery_firewall.err
+++ b/test/negative/232_recovery_firewall.err
@@ -3,7 +3,7 @@
    |                    ^~~~~~~~~~~~~~~~~
 232_recovery_firewall.fx:8:19: error: the appropriate match for 'f' of type '(int -> string)' is not found.
 Candidates:
- f(int) -> int @ 232_recovery_firewall.fx:6:1 -- the return type or the signature as a whole does not match
+ f(int) -> int @ 232_recovery_firewall.fx:6:5 -- the return type or the signature as a whole does not match
 
  8 | val bad: string = f(5)
    |                   ^

--- a/test/negative/233_recovery_match_arms.err
+++ b/test/negative/233_recovery_match_arms.err
@@ -1,8 +1,8 @@
 233_recovery_match_arms.fx:6:12: error: the appropriate match for 'undef_a' of type 'int' is not found.
  6 |     | 0 => undef_a
-   |            ^
+   |            ^~~~~~~
 233_recovery_match_arms.fx:7:12: error: the appropriate match for 'undef_b' of type 'int' is not found.
  7 |     | 1 => undef_b
-   |            ^
+   |            ^~~~~~~
 
 2 errors occured during type checking.

--- a/test/negative/234_recovery_maxerrors.err
+++ b/test/negative/234_recovery_maxerrors.err
@@ -1,9 +1,9 @@
-234_recovery_maxerrors.fx:5:16: error: the appropriate match for 'undef_a' of type 'int' is not found.
+234_recovery_maxerrors.fx:5:14: error: the appropriate match for 'undef_a' of type 'int' is not found.
  5 | fun a(): int { undef_a }
-   |                ^
-234_recovery_maxerrors.fx:6:16: error: the appropriate match for 'undef_b' of type 'int' is not found.
+   |              ^~~~~~~~~
+234_recovery_maxerrors.fx:6:14: error: the appropriate match for 'undef_b' of type 'int' is not found.
  6 | fun b(): int { undef_b }
-   |                ^
+   |              ^~~~~~~~~
 
 2 further diagnostic(s) suppressed (-fmax-errors=2).
 

--- a/test/negative/235_did_you_mean.err
+++ b/test/negative/235_did_you_mean.err
@@ -1,5 +1,5 @@
 235_did_you_mean.fx:6:9: error: the appropriate match for 'lenght' of type '<unknown>' is not found; did you mean 'length'?
  6 | val r = lenght + doubled
-   |         ^
+   |         ^~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/236_parallel_continue.err
+++ b/test/negative/236_parallel_continue.err
@@ -1,5 +1,5 @@
-236_parallel_continue.fx:6:43: error: cannot use 'continue' inside a '@parallel' loop
+236_parallel_continue.fx:6:41: error: cannot use 'continue' inside a '@parallel' loop
  6 | @parallel for i <- 0:10 { if i % 2 == 0 { continue } else {}; a[i] = i }
-   |                                           ^
+   |                                         ^~~~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/237_import_not_found.err
+++ b/test/negative/237_import_not_found.err
@@ -1,0 +1,3 @@
+237_import_not_found.fx:4:8: error: module Foo.Bar.Baz is not found
+ 4 | import Foo.Bar.Baz
+   |        ^~~~~~~~~~~

--- a/test/negative/237_import_not_found.fx
+++ b/test/negative/237_import_not_found.fx
@@ -1,0 +1,5 @@
+// expect: is not found
+// reform-prep-1: an import of a missing/misspelled module underlines the whole
+// (possibly dotted) module name, with a caret.
+import Foo.Bar.Baz
+println("hi")

--- a/test/negative/238_import_did_you_mean.err
+++ b/test/negative/238_import_did_you_mean.err
@@ -1,0 +1,3 @@
+238_import_did_you_mean.fx:4:8: error: module Strig is not found; did you mean 'String'?
+ 4 | import Strig
+   |        ^~~~~

--- a/test/negative/238_import_did_you_mean.fx
+++ b/test/negative/238_import_did_you_mean.fx
@@ -1,0 +1,5 @@
+// expect: did you mean
+// reform-prep-1: a misspelled stdlib import gets a Levenshtein suggestion drawn
+// from the *.fx module files on the include path.
+import Strig
+println("x")

--- a/test/negative/303_redeclared_function.err
+++ b/test/negative/303_redeclared_function.err
@@ -1,5 +1,5 @@
-303_redeclared_function.fx:3:1: error: the symbol f is re-declared in the same scope; the previous declaration is here: 303_redeclared_function.fx:2:1
+303_redeclared_function.fx:3:5: error: the symbol f is re-declared in the same scope; the previous declaration is here: 303_redeclared_function.fx:2:5
  3 | fun f(a: int) = a + 1
-   | ^~~
+   |     ^
 
 1 errors occured during type checking.

--- a/test/negative/303_redeclared_function.err
+++ b/test/negative/303_redeclared_function.err
@@ -1,5 +1,5 @@
 303_redeclared_function.fx:3:1: error: the symbol f is re-declared in the same scope; the previous declaration is here: 303_redeclared_function.fx:2:1
  3 | fun f(a: int) = a + 1
-   | ^
+   | ^~~
 
 1 errors occured during type checking.

--- a/test/negative/304_duplicate_record_field.err
+++ b/test/negative/304_duplicate_record_field.err
@@ -1,5 +1,5 @@
 304_duplicate_record_field.fx:2:6: error: duplicate record field 'a'
  2 | type bad_t = {a: int; a: int}
-   |      ^
+   |      ^~~~~
 
 1 errors occured during type checking.

--- a/test/negative/305_unknown_symbol_in_module.err
+++ b/test/negative/305_unknown_symbol_in_module.err
@@ -1,5 +1,5 @@
 305_unknown_symbol_in_module.fx:3:9: error: the appropriate match for 'no_such_function' of type '(double -> <unknown>)' is not found.
  3 | val x = Math.no_such_function(1.0)
-   |         ^
+   |         ^~~~
 
 1 errors occured during type checking.

--- a/test/negative/307_unbound_function_call.err
+++ b/test/negative/307_unbound_function_call.err
@@ -1,5 +1,5 @@
 307_unbound_function_call.fx:2:9: error: the appropriate match for 'totally_undefined_fn' of type '(int -> <unknown>)' is not found.
  2 | val y = totally_undefined_fn(3)
-   |         ^
+   |         ^~~~~~~~~~~~~~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/401_nonexhaustive_match.err
+++ b/test/negative/401_nonexhaustive_match.err
@@ -1,3 +1,3 @@
 401_nonexhaustive_match.fx:3:19: error: the cases ['Green', 'Blue'] are not covered; add '| _ => ...' clause to suppress this error
  3 | fun f(c: rgb_t) = match c { | Red => 1 }
-   |                   ^
+   |                   ^~~~~

--- a/test/negative/403_cons_on_nonlist.err
+++ b/test/negative/403_cons_on_nonlist.err
@@ -1,5 +1,5 @@
 403_cons_on_nonlist.fx:2:23: error: '::' pattern is used with non-list type
  2 | val x = match 5 { | a :: rest => 1 | _ => 0 }
-   |                       ^
+   |                       ^~
 
 1 errors occured during type checking.

--- a/test/negative/406_ref_pattern_nonref.err
+++ b/test/negative/406_ref_pattern_nonref.err
@@ -1,5 +1,5 @@
 406_ref_pattern_nonref.fx:2:21: error: 'ref' pattern is used with non-reference type
  2 | val x = match 5 { | ref y => 1 | _ => 0 }
-   |                     ^
+   |                     ^~~
 
 1 errors occured during type checking.

--- a/test/negative/407_string_literal_pat_on_int.err
+++ b/test/negative/407_string_literal_pat_on_int.err
@@ -1,5 +1,5 @@
 407_string_literal_pat_on_int.fx:2:21: error: the literal of unexpected type
  2 | val x = match 5 { | "s" => 1 | _ => 0 }
-   |                     ^
+   |                     ^~~
 
 1 errors occured during type checking.

--- a/test/negative/502_assign_to_literal.err
+++ b/test/negative/502_assign_to_literal.err
@@ -1,1 +1,3 @@
 502_assign_to_literal.fx:2:3: error: left-hand-side of the assignment is not an l-value
+ 2 | 1 = 2
+   |   ^

--- a/test/negative/503_break_outside_loop.err
+++ b/test/negative/503_break_outside_loop.err
@@ -1,5 +1,5 @@
-503_break_outside_loop.fx:2:11: error: cannot use 'break' outside of loop
+503_break_outside_loop.fx:2:9: error: cannot use 'break' outside of loop
  2 | fun f() { break }
-   |           ^
+   |         ^~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/504_continue_outside_loop.err
+++ b/test/negative/504_continue_outside_loop.err
@@ -1,5 +1,5 @@
-504_continue_outside_loop.fx:2:11: error: cannot use 'continue' outside of loop
+504_continue_outside_loop.fx:2:9: error: cannot use 'continue' outside of loop
  2 | fun f() { continue }
-   |           ^
+   |         ^~~~~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/505_return_outside_function.err
+++ b/test/negative/505_return_outside_function.err
@@ -1,5 +1,5 @@
 505_return_outside_function.fx:2:1: error: return statement occurs outside of a function body
  2 | return 5
-   | ^
+   | ^~~~~~~
 
 1 errors occured during type checking.

--- a/test/negative/601_index_nonint.err
+++ b/test/negative/601_index_nonint.err
@@ -1,5 +1,5 @@
 601_index_nonint.fx:3:11: error: each scalar index in array access op must have some integer type or bool; in the case of interpolation it can also be float or double
  3 | val b = a["x"]
-   |           ^
+   |           ^~~
 
 1 errors occured during type checking.

--- a/test/negative/701_exception_in_function.err
+++ b/test/negative/701_exception_in_function.err
@@ -1,1 +1,1 @@
-701_exception_in_function.fx:3:5: error: exceptions can only be defined at module level
+701_exception_in_function.fx:2:9: error: exceptions can only be defined at module level

--- a/test/negative/701_exception_in_function.err
+++ b/test/negative/701_exception_in_function.err
@@ -1,1 +1,3 @@
 701_exception_in_function.fx:2:9: error: exceptions can only be defined at module level
+ 2 | fun f() {
+   |         ^

--- a/test/negative/702_module_not_found.err
+++ b/test/negative/702_module_not_found.err
@@ -1,1 +1,3 @@
 702_module_not_found.fx:2:8: error: module NoSuchModule is not found
+ 2 | import NoSuchModule
+   |        ^~~~~~~~~~~~

--- a/test/negative/703_variant_pat_nonvariant.err
+++ b/test/negative/703_variant_pat_nonvariant.err
@@ -3,6 +3,6 @@ Candidates:
  Some('t) -> 't option@12 [generic: 't] @ Builtins.fx:L:C -- the return type or the signature as a whole does not match
 
  2 | val x = match 5 { | Some y => 1 | _ => 0 }
-   |                     ^
+   |                     ^~~~
 
 1 errors occured during type checking.


### PR DESCRIPTION
Groundwork for the syntax-reform automigrator (and better diagnostics along the
way): source locations are now true **spans**, not points, and import/function
errors point at the right thing. Nothing here changes language behavior — only
locations and diagnostics.

## Spans (the foundation)

Previously every token carried only its begin `(line, col)`; the parser stamped
a point, so a caret was always a single `^`. Now the lexer returns, per batch,
`(tokens, batch_begin, batch_end)` — after `nexttokens`' body runs, `pos` sits
at the batch end, so `getloc(pos)` is the end loc — and the parser applies that
span to every token. So `loc_t` is a real span, a caret shows the token width,
and `loclist2loc` folds true node spans:

```
val x = lenght + 1
        ^~~~~~        (was a single ^)
```

Internal recursive `nexttokens()` calls (string interpolation, numeric-suffix,
brace grouping) take `.0`; no per-arm changes; the lexer's internal point locs
are untouched.

## Diagnostics point at the name

- **Imports** (a common error — misspelled or off-path module): the caret lands
  on the whole (possibly dotted) module name, not the first token or the `from`
  keyword, with a Levenshtein `did you mean` whose candidates are the `*.fx`
  files on the include path:

  ```
  import Strig
         ^~~~~   error: module Strig is not found; did you mean 'String'?
  ```

- **Functions**: a function's own diagnostics (implicit-return-type warning,
  redeclaration, the overload candidate listing) point at the NAME, not `fun`;
  operators span `operator X`; dotted method names span `Class.method`.

- **Parse errors** now carry the same caret excerpt as type errors (they are
  frontend diagnostics with accurate locations); EOF errors degrade to no caret.

- **`ExpCast`/`ExpTyped`** fold to the whole `x :> T` / `x : T` construct.

Helper `edit_distance` moved to `Ast.fx` so the parser (unknown modules) and the
type checker (unknown identifiers) share one copy; `consumed_loc(before, after)`
folds a node's span out to the end of a sub-parser that returns no loc.

## Reform-relevant findings (filed, not fixed)

- **FB-020 — `typ_t` carries no source location**: type-name diagnostics land on
  the preceding `:`, and a span-based migrator cannot locate `'t` / `half` /
  `vector` occurrences via the AST. The `'t → [t]` reform will need token-level
  scanning for types, or locs added to `typ_t`. The biggest gap.
- **FB-021** — `.op` type errors surface inside the library (`__dot_mul__`
  instantiation site), not at the user's `.*`.
- **FB-022** — a failed `fold`-valued `val` cascades because the desugared shape
  sidesteps diag-1's DefVal recovery.

`docs/problematic_spans_log.txt` is the full audit (live compiler output for
each reform construct).

## Verification

test_all 147, `fxtest all` (unit + negative 87 + ir + cfold + corpus O0/O3),
`-pr-resolve` census 356 unchanged, rettype gate clean, bootstrap fixpoint holds.
~90 negative goldens migrated to carets (reviewed as a format change — wider
carets, name-column citations).

## Not in scope (see `docs/reform_prep1_report.md`)

WP-2 migration census, WP-3 A/B renders, WP-4 `list[t]` parser spike, and the
`tools/span_check.py` acceptance oracle — measurement/tooling deliverables for
the design sessions, plus the FB-020/021/022 fixes.
