### PR TITLE
newvec-2: vector performance & ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,12 @@ intuition — read `doc/ficustut.md` and existing code. Verified traps:
   Lists: `[:: 1, 2, 3]`, cons `::`, list-comp `[:: for x <- l {..}]`.
 - **fold (fold-1 reform)** is now imperative: `fold acc=init for x <- a {acc +=
   x}` desugars to `{ var acc=init; for x <- a {..}; acc }`. The accumulator is a
-  real mutable **var**, ASSIGNED in the body (`acc = f(acc,x)` / `acc += x`), not
-  yielded as the tail value (that was the OLD form — it now warns "accumulator
-  never assigned"). Multiple accumulators: `fold a=0, b=1 for ..` (each its own
+  real mutable **var**, updated in the body — either ASSIGNED (`acc = f(acc,x)` /
+  `acc += x`) or, for a reference-mutable accumulator, mutated in place
+  (`fold r=vector() for v <- vs {r.append(v)}`). Yielding the accumulator as the
+  tail value (the OLD form, `fold s=0 for x {s+x}`) is now a **type error** (the
+  void body has nowhere to put the value) — there is no separate "never assigned"
+  warning. Multiple accumulators: `fold a=0, b=1 for ..` (each its own
   var; a tuple pattern also works). `break`/`continue`/`return` are legal in the
   body (it is a plain `for`). Simultaneous tuple assignment `(a,b)=(b,a+b)` is a
   language feature (parse-time desugar via a temp; the Fibonacci/swap idiom).

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -488,7 +488,7 @@ fun default_module() =
         dm_defs=[], dm_idx=-1,
         dm_deps=[], dm_env=empty_env,
         dm_parsed=false, dm_real=false,
-        dm_table=Vector.make(0, IdNone),
+        dm_table=vector(0, IdNone),
         dm_block_idx=-1
     }
 
@@ -507,7 +507,7 @@ fun is_compiler_frontend(): bool = compiler_stage == CompilerFrontend
 
 var freeze_ids = false
 var lock_all_names = 0
-var all_names = Vector.make(0, "")
+var all_names = vector(0, "")
 var all_strhash: (string, int) Hashmap.t = Hashmap.empty(1024, "", -1)
 var all_modules_hash: (string, int) Hashmap.t = Hashmap.empty(1024, "", -1)
 var all_modules: defmodule_t [] = []
@@ -828,7 +828,7 @@ fun find_module(mname: id_t, mfname: string) =
             dm_name=mname, dm_filename=mfname,
             dm_idx=m_idx, dm_defs=[], dm_deps=[],
             dm_env=empty_env, dm_parsed=false, dm_real=true,
-            dm_table=Vector.make(0, IdNone),
+            dm_table=vector(0, IdNone),
             dm_block_idx=-1
         }
         val saved_modules = all_modules

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -188,6 +188,7 @@ type intrin_t =
     | IntrinAccessSlice
     | IntrinVecPushBack
     | IntrinVecPopBack
+    | IntrinVecSplice
     | IntrinMath: id_t
     | IntrinSaturate: sctyp_t
 
@@ -1125,6 +1126,7 @@ fun string(iop: intrin_t): string
     | IntrinAccessSlice => "__intrin_access_slice__"
     | IntrinVecPushBack => "__intrin_push__"
     | IntrinVecPopBack => "__intrin_pop__"
+    | IntrinVecSplice => "__intrin_splice__"
 }
 
 fun border2str(border: border_t, f: bool) {

--- a/compiler/Ast.fx
+++ b/compiler/Ast.fx
@@ -186,6 +186,8 @@ type intrin_t =
     | IntrinGEMM
     | IntrinGetSlice
     | IntrinAccessSlice
+    | IntrinVecPushBack
+    | IntrinVecPopBack
     | IntrinMath: id_t
     | IntrinSaturate: sctyp_t
 
@@ -1121,6 +1123,8 @@ fun string(iop: intrin_t): string
     | IntrinSaturate(sct) => f"__intrin_sat_{sct}__"
     | IntrinGetSlice => "__intrin_get_slice__"
     | IntrinAccessSlice => "__intrin_access_slice__"
+    | IntrinVecPushBack => "__intrin_push__"
+    | IntrinVecPopBack => "__intrin_pop__"
 }
 
 fun border2str(border: border_t, f: bool) {

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -2368,6 +2368,33 @@ fun check_exp(e: exp_t, env: env_t, sc: scope_t list) {
                                      a rrbvec or an array")
             }
             ExpIntrin(iop, a::(if idx > 0 {args.tl()} else {[]}), ctx)
+        | IntrinVecPushBack =>
+            val (v, elem) = match args {
+                | [:: v, elem] => (v, elem)
+                | _ => throw compile_err(eloc,
+                    "__intrin_push__ intrinsic expects exactly two arguments (vector, element)")
+                }
+            val v = check_exp(v, env, sc)
+            val et = make_new_typ()
+            unify(get_exp_typ(v), TypVector(et), get_exp_loc(v),
+                "the first argument of __intrin_push__ must be a vector")
+            val elem = check_exp(elem, env, sc)
+            unify(get_exp_typ(elem), et, get_exp_loc(elem),
+                "the element type must match the vector element type in __intrin_push__")
+            unify(etyp, TypVoid, eloc, "the result of __intrin_push__ must be void")
+            ExpIntrin(iop, [:: v, elem], ctx)
+        | IntrinVecPopBack =>
+            val v = match args {
+                | [:: v] => v
+                | _ => throw compile_err(eloc,
+                    "__intrin_pop__ intrinsic expects exactly one argument (vector)")
+                }
+            val v = check_exp(v, env, sc)
+            val et = make_new_typ()
+            unify(get_exp_typ(v), TypVector(et), get_exp_loc(v),
+                "the argument of __intrin_pop__ must be a vector")
+            unify(etyp, TypVoid, eloc, "the result of __intrin_pop__ must be void")
+            ExpIntrin(iop, [:: v], ctx)
         | _ => throw compile_err(eloc, f"the intrinsic '{iop}' is not supported by the type checker")
         }
     | ExpSeq(eseq, _) =>

--- a/compiler/C_form.fx
+++ b/compiler/C_form.fx
@@ -340,7 +340,7 @@ fun init_all_idcs()
     freeze_ids = true
     freeze_idks = true
     freeze_idcs = false
-    all_idcs = [for k <- all_idks {Vector.make(size(k), CNone)}]
+    all_idcs = [for k <- all_idks {vector(size(k), CNone)}]
 }
 
 fun get_cexp_ctx(e: cexp_t): cctx_t

--- a/compiler/C_gen_code.fx
+++ b/compiler/C_gen_code.fx
@@ -2014,6 +2014,35 @@ fun gen_ccode(cmods: cmodule_t list, kmod: kmodule_t, c_fdecls: ccode_t, mod_ini
                 val (i_exp, ccode) = atom2cexp(idx, ccode, kloc)
                 val get_elem_exp = CExpBinary(COpArrayElem, ptr_exp, i_exp, (ctyp, kloc))
                 (true, get_elem_exp, ccode)
+            | (IntrinVecPushBack, [:: vec, elem]) =>
+                val lbl = curr_block_label(kloc)
+                val (vec_exp, ccode) = atom2cexp(vec, ccode, kloc)
+                val (elem_exp, ccode) = atom2cexp(elem, ccode, kloc)
+                val et = match get_atom_ktyp(vec, kloc) {
+                    | KTypVector et => et
+                    | t => throw compile_err(kloc,
+                        f"cgen: __intrin_push__ applied to a non-vector type {t}")
+                    }
+                val elem_ctyp = C_gen_types.ktyp2ctyp(et, kloc)
+                val {ktp_complex} = K_annotate.get_ktprops(et, kloc)
+                val macro = if ktp_complex {get_id("FX_VEC_PUSH_BACK")}
+                            else {get_id("FX_VEC_PUSH_BACK_FAST")}
+                val push = make_call(macro, [:: CExpTyp(elem_ctyp, kloc), vec_exp, elem_exp, lbl],
+                                     CTypVoid, kloc)
+                (false, dummy_exp, CExp(push) :: ccode)
+            | (IntrinVecPopBack, [:: vec]) =>
+                val lbl = curr_block_label(kloc)
+                val (vec_exp, ccode) = atom2cexp(vec, ccode, kloc)
+                val et = match get_atom_ktyp(vec, kloc) {
+                    | KTypVector et => et
+                    | t => throw compile_err(kloc,
+                        f"cgen: __intrin_pop__ applied to a non-vector type {t}")
+                    }
+                val {ktp_complex} = K_annotate.get_ktprops(et, kloc)
+                val macro = if ktp_complex {get_id("FX_VEC_POP_BACK")}
+                            else {get_id("FX_VEC_POP_BACK_FAST")}
+                val pop = make_call(macro, [:: vec_exp, lbl], CTypVoid, kloc)
+                (false, dummy_exp, CExp(pop) :: ccode)
             | _ => throw compile_err(kloc,
                 f"cgen: unsupported KExpIntrin({intr}, ...) or the wrong number of arguments ({args.length()})")
             }

--- a/compiler/C_gen_code.fx
+++ b/compiler/C_gen_code.fx
@@ -2043,6 +2043,30 @@ fun gen_ccode(cmods: cmodule_t list, kmod: kmodule_t, c_fdecls: ccode_t, mod_ini
                             else {get_id("FX_VEC_POP_BACK_FAST")}
                 val pop = make_call(macro, [:: vec_exp, lbl], CTypVoid, kloc)
                 (false, dummy_exp, CExp(pop) :: ccode)
+            | (IntrinVecSplice, [:: vec, a, b, delta, rhs]) =>
+                // vec[a:b:delta] = rhs (rhs NULL/empty => deletion). The mask
+                // (missing-bound bits) is computed exactly as for a slice read.
+                val (vec_exp, ccode) = atom2cexp(vec, ccode, kloc)
+                val (mask, (a_exp, ccode)) =
+                    match a {
+                    | AtomLit(KLitNil _) => (1, (make_int_exp(0, kloc), ccode))
+                    | _ => (0, atom2cexp(a, ccode, kloc))
+                    }
+                val (mask, (b_exp, ccode)) =
+                    match b {
+                    | AtomLit(KLitNil _) => (2 + mask, (make_int_exp(0, kloc), ccode))
+                    | _ => (mask, atom2cexp(b, ccode, kloc))
+                    }
+                val (delta_exp, ccode) =
+                    match delta {
+                    | AtomLit(KLitNil _) => (make_int_exp(1, kloc), ccode)
+                    | _ => atom2cexp(delta, ccode, kloc)
+                    }
+                val (rhs_exp, ccode) = atom2cexp(rhs, ccode, kloc)
+                val call_splice = make_call(get_id("fx_vec_splice"),
+                    [:: vec_exp, a_exp, b_exp, delta_exp, make_int_exp(mask, kloc), rhs_exp],
+                    CTypCInt, kloc)
+                (false, dummy_exp, add_fx_call(call_splice, ccode, kloc))
             | _ => throw compile_err(kloc,
                 f"cgen: unsupported KExpIntrin({intr}, ...) or the wrong number of arguments ({args.length()})")
             }

--- a/compiler/K_form.fx
+++ b/compiler/K_form.fx
@@ -307,7 +307,7 @@ fun init_all_idks(): void
     freeze_idks = false
     all_idks = [for dm <- all_modules {
         val sz = size(dm.dm_table)
-        Vector.make(sz, KNone)
+        vector(sz, KNone)
     }]
 }
 

--- a/compiler/K_normalize.fx
+++ b/compiler/K_normalize.fx
@@ -615,6 +615,41 @@ fun exp2kexp(e: exp_t, code: kcode_t, tref: bool, sc: scope_t list)
                 f"unsupported '(some_struct : {typ2str(get_exp_typ(e1))}).{pp(n)}' access operation")
         | (_, _) => throw compile_err(e1loc, "unsupported access operation")
         }
+    | ExpAssign(ExpAt(arr, BorderNone, InterpNone, [:: idx], _), e2, _)
+        when is_range(idx) &&
+            (match typ2ktyp(get_exp_typ(arr), get_exp_loc(arr)) {
+             | KTypVector _ => true | _ => false }) =>
+        // in-place vector slice assignment `vec[a:b:delta] = rhs`:
+        //   rhs == [] deletes the selected elements (any step);
+        //   rhs a vector replaces a CONTIGUOUS (step 1) range, growing/shrinking.
+        // A strided replace with a non-empty vector is rejected here.
+        val vec_ktyp = typ2ktyp(get_exp_typ(arr), get_exp_loc(arr))
+        val delta_is_one = match idx {
+            | ExpRange(_, _, None, _) => true
+            | ExpRange(_, _, Some(ExpLit(LitInt(1i64), _)), _) => true
+            | _ => false
+            }
+        val rhs_is_empty = match e2 {
+            | ExpLit(LitEmpty, _) => true
+            | ExpMkArray([], _) | ExpMkArray([:: []], _) | ExpMkVector([], _) => true
+            | _ => false
+            }
+        if !delta_is_one && !rhs_is_empty {
+            throw compile_err(eloc,
+                "a strided vector slice (step != 1) can only be deleted by assigning '[]'; \
+                 replacing strided elements with a non-empty vector is not supported")
+        }
+        val (arr_a, code) = exp2atom(arr, code, false, sc)
+        val (dom, code) = exp2dom(idx, code, sc)
+        val (a_at, b_at, d_at) = match dom {
+            | DomainRange(a, b, d) => (a, b, d)
+            | _ => throw compile_err(eloc, "k-norm: vector slice-assign index is not a range")
+            }
+        val (rhs_a, code) =
+            if rhs_is_empty { (AtomLit(KLitNil(vec_ktyp)), code) }
+            else { exp2atom(e2, code, false, sc) }
+        (KExpIntrin(IntrinVecSplice, [:: arr_a, a_at, b_at, d_at, rhs_a],
+                    (KTypVoid, eloc)), code)
     | ExpAssign(e1, e2, _) =>
         val (a2, code) = exp2atom(e2, code, false, sc)
         val (a_id, code) = exp2id(e1, code, true, sc, "a literal cannot be assigned")

--- a/compiler/K_remove_unused.fx
+++ b/compiler/K_remove_unused.fx
@@ -51,7 +51,7 @@ fun pure_kexp(e: kexp_t): bool
         | KExpIntrin (intr, _, _) =>
             match intr {
             | IntrinPopExn | IntrinCheckIdx | IntrinCheckIdxRange => ispure = false
-            | IntrinVecPushBack | IntrinVecPopBack => ispure = false
+            | IntrinVecPushBack | IntrinVecPopBack | IntrinVecSplice => ispure = false
             | _ => {}
             }
         | KExpCall (f, _, (_, loc)) =>

--- a/compiler/K_remove_unused.fx
+++ b/compiler/K_remove_unused.fx
@@ -51,6 +51,7 @@ fun pure_kexp(e: kexp_t): bool
         | KExpIntrin (intr, _, _) =>
             match intr {
             | IntrinPopExn | IntrinCheckIdx | IntrinCheckIdxRange => ispure = false
+            | IntrinVecPushBack | IntrinVecPopBack => ispure = false
             | _ => {}
             }
         | KExpCall (f, _, (_, loc)) =>

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -266,39 +266,12 @@ fun transform_new_fold_exp(fold_pat: pat_t, fold_init_exp: exp_t,
                            for_exp: exp_t, fold_loc: loc_t): exp_t
 {
     val acc_loc = get_pat_loc(fold_pat)
-    val acc_ids = fold_acc_ids(fold_pat)
-
-    // Scan the body for updates to each accumulator, so we can warn about an
-    // accumulator that is never assigned (a likely mistake — the fold does
-    // nothing). `acc = _` is the deliberate no-op suppression: it counts as a
-    // mention and lowers to nothing. One walk_exp pass both records the
-    // assigned/suppressed accumulators and strips the `acc = _` markers.
-    var assigned: id_t list = [], suppressed: id_t list = []
-    fun scan_cb(e: exp_t, callb: ast_callb_t): exp_t =
-        match e {
-        | ExpAssign(ExpIdent(id, _), ExpIdent(rid, _), aloc)
-            when acc_ids.mem(id) && rid == dummyid =>
-            // `acc = _`: deliberate no-op suppression -> lowers to nothing.
-            if !suppressed.mem(id) { suppressed = id :: suppressed }
-            ExpNop(aloc)
-        | ExpAssign((ExpIdent(id, _) as lhs), rhs, aloc) when acc_ids.mem(id) =>
-            if !assigned.mem(id) { assigned = id :: assigned }
-            ExpAssign(lhs, check_n_walk_exp(rhs, callb), aloc)
-        | ExpBinary((OpAugBinary _) as bop, (ExpIdent(id, _) as lhs), rhs, ctx)
-            when acc_ids.mem(id) =>
-            if !assigned.mem(id) { assigned = id :: assigned }
-            ExpBinary(bop, lhs, check_n_walk_exp(rhs, callb), ctx)
-        | _ => walk_exp(e, callb)
-        }
-    val callb = ast_callb_t {ast_cb_typ=None, ast_cb_exp=Some(scan_cb), ast_cb_pat=None}
-    val for_exp = check_n_walk_exp(for_exp, callb)
-    for id <- acc_ids {
-        if !assigned.mem(id) && !suppressed.mem(id) {
-            compile_warning(acc_loc, f"'fold' accumulator '{pp(id)}' is never assigned \
-in the body, so the fold has no effect. The body must UPDATE the accumulator \
-(e.g. '{pp(id)} = <expr>' or '{pp(id)} += ...'); write '{pp(id)} = _' to silence")
-        }
-    }
+    // No "accumulator never assigned" check: the fold body is now void, so the
+    // old-style body that yields a value instead of updating the accumulator
+    // (`fold s=0 for x <- a {s + x}`) is already a type error. The imperative
+    // accumulator may also be a reference-mutable type updated *in place*
+    // (`fold r=vector() for v <- vs {r.append(v)}`), which no syntactic
+    // "assigned?" scan can recognize — so no warning is emitted.
 
     // Emit SEPARATE `var a = e0, b = e1, …` rather than a destructuring
     // `var (a,…) = (e0,…)`: the destructuring form leaves an unused local

--- a/compiler/Parser.fx
+++ b/compiler/Parser.fx
@@ -567,6 +567,8 @@ fun parse_simple_exp(ts: tklist_t, allow_mkrecord: bool): (tklist_t, exp_t)
                             | "__intrin_sat_uint16__" => IntrinSaturate(ScUInt16)
                             | "__intrin_sat_int16__" => IntrinSaturate(ScInt16)
                             | "__intrin_size__" => IntrinGetSize
+                            | "__intrin_push__" => IntrinVecPushBack
+                            | "__intrin_pop__" => IntrinVecPopBack
 
                             | "__intrin_gemm__" => IntrinGEMM
 

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -7023,7 +7023,7 @@ FX_EXTERN_C void _fx_M3AstFM10IntrinMathN13Ast__intrin_t1RM4id_t(
    struct _fx_R9Ast__id_t* arg0,
    struct _fx_N13Ast__intrin_t* fx_result)
 {
-   fx_result->tag = 18;
+   fx_result->tag = 19;
    fx_result->u.IntrinMath = *arg0;
 }
 
@@ -7031,7 +7031,7 @@ FX_EXTERN_C void _fx_M3AstFM14IntrinSaturateN13Ast__intrin_t1N12Ast__sctyp_t(
    struct _fx_N12Ast__sctyp_t* arg0,
    struct _fx_N13Ast__intrin_t* fx_result)
 {
-   fx_result->tag = 19;
+   fx_result->tag = 20;
    fx_result->u.IntrinSaturate = *arg0;
 }
 
@@ -11968,7 +11968,7 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    else if (tag_0 == 13) {
       fx_str_t slit_12 = FX_MAKE_STR("__intrin_gemm__"); fx_copy_str(&slit_12, fx_result);
    }
-   else if (tag_0 == 18) {
+   else if (tag_0 == 19) {
       fx_str_t v_0 = {0};
       _fx_R9Ast__id_t* f_0 = &iop_0->u.IntrinMath;
       bool t_0;
@@ -11996,7 +11996,7 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    _fx_catch_0: ;
       FX_FREE_STR(&v_0);
    }
-   else if (tag_0 == 19) {
+   else if (tag_0 == 20) {
       fx_str_t v_2 = {0};
       int tag_1 = iop_0->u.IntrinSaturate.tag;
       if (tag_1 == 2) {
@@ -12036,6 +12036,9 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    }
    else if (tag_0 == 17) {
       fx_str_t slit_25 = FX_MAKE_STR("__intrin_pop__"); fx_copy_str(&slit_25, fx_result);
+   }
+   else if (tag_0 == 18) {
+      fx_str_t slit_26 = FX_MAKE_STR("__intrin_splice__"); fx_copy_str(&slit_26, fx_result);
    }
    else {
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -255,273 +255,6 @@ typedef struct _fx_Nt6option1i {
    } u;
 } _fx_Nt6option1i;
 
-typedef struct _fx_T2SB {
-   fx_str_t t0;
-   bool t1;
-} _fx_T2SB;
-
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
-typedef struct _fx_T2N14Ast__id_info_tB {
-   struct _fx_N14Ast__id_info_t t0;
-   bool t1;
-} _fx_T2N14Ast__id_info_tB;
-
 typedef struct _fx_FPi2SS {
    int (*fp)(fx_str_t*, fx_str_t*, int_*, void*);
    fx_fcv_t* fcv;
@@ -678,10 +411,20 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* root;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
 typedef struct _fx_N12Set__color_t {
    int tag;
@@ -742,6 +485,36 @@ typedef struct _fx_T2Nt11Set__tree_t1SB {
    bool t1;
 } _fx_T2Nt11Set__tree_t1SB;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
@@ -795,6 +568,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -876,6 +673,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -895,6 +716,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -1091,6 +922,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -1263,6 +1232,14 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
 
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
    struct _fx_R10Ast__loc_t t1;
@@ -1278,6 +1255,19 @@ typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
    struct _fx_LT2SR10Ast__loc_t_data_t* pragma_clibs;
 } _fx_R14Ast__pragmas_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1707,595 +1697,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
       _fx_free_N10Ast__exp_t(&(*dst)->u.Some); fx_free(*dst);
    }
    *dst = 0;
-}
-
-static void _fx_free_T2SB(struct _fx_T2SB* dst)
-{
-   fx_free_str(&dst->t0);
-}
-
-static void _fx_copy_T2SB(struct _fx_T2SB* src, struct _fx_T2SB* dst)
-{
-   fx_copy_str(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2SB(fx_str_t* t0, bool t1, struct _fx_T2SB* fx_result)
-{
-   fx_copy_str(t0, &fx_result->t0);
-   fx_result->t1 = t1;
-}
-
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_free_N14Ast__id_info_t(&dst->t0);
-}
-
-static void _fx_copy_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* src, struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_copy_N14Ast__id_info_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N14Ast__id_info_tB(struct _fx_N14Ast__id_info_t* t0, bool t1, struct _fx_T2N14Ast__id_info_tB* fx_result)
-{
-   _fx_copy_N14Ast__id_info_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
 }
 
 static void _fx_free_Rt20Hashmap__hashentry_t2iLS(struct _fx_Rt20Hashmap__hashentry_t2iLS* dst)
@@ -2770,6 +2171,29 @@ static void _fx_make_Rt6Map__t2R9Ast__id_tR9Ast__id_t(
    FX_COPY_FP(r_cmp, &fx_result->cmp);
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T4N12Set__color_tNt11Set__tree_t1SSNt11Set__tree_t1S(
    struct _fx_T4N12Set__color_tNt11Set__tree_t1SSNt11Set__tree_t1S* dst)
 {
@@ -3039,6 +2463,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3996,6 +3473,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4465,6 +4348,37 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
    fx_free_str(&dst->t0);
@@ -4514,6 +4428,48 @@ static void _fx_make_R14Ast__pragmas_t(
 {
    fx_result->pragma_cpp = r_pragma_cpp;
    FX_COPY_PTR(r_pragma_clibs, &fx_result->pragma_clibs);
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -5139,27 +5095,6 @@ FX_EXTERN_C int _fx_M3AstFM5clearv1VS(fx_vec_t v, void* fx_fv)
 
 if (v) return fx_vec_resize(v, 0, 0);
     return FX_OK;
-
-}
-
-FX_EXTERN_C int _fx_M3AstFM10push_back_v2VST2SB(fx_vec_t v, struct _fx_T2SB* elem_, void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
-}
-
-FX_EXTERN_C int _fx_M3AstFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(
-   fx_vec_t v,
-   struct _fx_T2N14Ast__id_info_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
 
 }
 
@@ -7088,7 +7023,7 @@ FX_EXTERN_C void _fx_M3AstFM10IntrinMathN13Ast__intrin_t1RM4id_t(
    struct _fx_R9Ast__id_t* arg0,
    struct _fx_N13Ast__intrin_t* fx_result)
 {
-   fx_result->tag = 16;
+   fx_result->tag = 18;
    fx_result->u.IntrinMath = *arg0;
 }
 
@@ -7096,7 +7031,7 @@ FX_EXTERN_C void _fx_M3AstFM14IntrinSaturateN13Ast__intrin_t1N12Ast__sctyp_t(
    struct _fx_N12Ast__sctyp_t* arg0,
    struct _fx_N13Ast__intrin_t* fx_result)
 {
-   fx_result->tag = 17;
+   fx_result->tag = 19;
    fx_result->u.IntrinSaturate = *arg0;
 }
 
@@ -9233,33 +9168,116 @@ FX_EXTERN_C int _fx_M3AstFM12is_unique_idB1RM4id_t(struct _fx_R9Ast__id_t* i_0, 
 
 FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t* s_0, int_* fx_result, void* fx_fv)
 {
-   _fx_T2SB v_0 = {0};
    fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
-   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_4 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
    int_ h_idx_0;
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
-   _fx_Rt20Hashmap__hashentry_t2Si* v_5 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
-   int_ idx_0 = v_5->data;
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
    if (idx_0 >= 0) {
       *fx_result = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
-      _fx_make_T2SB(s_0, true, &v_0);
-      FX_CALL(_fx_M3AstFM10push_back_v2VST2SB(_fx_g14Ast__all_names, &v_0, 0), _fx_cleanup);
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, *s_0, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_5 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_5->data = idx_1;
+      *fx_result = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_6 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_6), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_7 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_6);
+         fx_copy_str(&v_7->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_1 = FX_MAKE_STR(":");
+      fx_str_t slit_2 = FX_MAKE_STR(":");
+      fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_8 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_8), _fx_catch_0);
+         fx_str_t slit_4 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_8, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_8) {
+            _fx_free_LS(&v_8);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t* s_0, struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, *s_0, _fx_cleanup);
       int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
       _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
       v_6->data = idx_1;
-      *fx_result = idx_1;
+      v_5 = idx_1;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
@@ -9271,14 +9289,14 @@ FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t* s_0, int_* fx_result, vo
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
-      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, v_2 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
@@ -9299,167 +9317,75 @@ FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t* s_0, int_* fx_result, vo
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
-      FX_THROW(&v_4, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
    }
-
-_fx_cleanup: ;
-   _fx_free_T2SB(&v_0);
-   FX_FREE_STR(&fname_0);
-   FX_FREE_STR(&v_1);
-   FX_FREE_STR(&v_2);
-   FX_FREE_STR(&v_3);
-   FX_FREE_STR(&whole_msg_0);
-   if (all_compile_err_ctx_0) {
-      _fx_free_LS(&all_compile_err_ctx_0);
-   }
-   FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_4);
-   return fx_status;
-}
-
-FX_EXTERN_C int _fx_M3AstFM6get_idRM4id_t1S(fx_str_t* s_0, struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
-{
-   _fx_T2SB v_0 = {0};
-   fx_str_t fname_0 = {0};
-   fx_str_t v_1 = {0};
-   fx_str_t v_2 = {0};
-   fx_str_t v_3 = {0};
-   fx_str_t whole_msg_0 = {0};
-   _fx_LS all_compile_err_ctx_0 = 0;
-   fx_str_t whole_msg_1 = {0};
-   fx_exn_t v_4 = {0};
-   int fx_status = 0;
-   int_ h_idx_0;
-   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
-   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
-   _fx_Rt20Hashmap__hashentry_t2Si* v_5 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
-   int_ idx_0 = v_5->data;
-   int_ v_6;
-   if (idx_0 >= 0) {
-      v_6 = idx_0;
-   }
-   else if (_fx_g19Ast__lock_all_names == 0) {
-      _fx_make_T2SB(s_0, true, &v_0);
-      FX_CALL(_fx_M3AstFM10push_back_v2VST2SB(_fx_g14Ast__all_names, &v_0, 0), _fx_cleanup);
-      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
-      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
-      _fx_Rt20Hashmap__hashentry_t2Si* v_7 =
-         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
-      v_7->data = idx_1;
-      v_6 = idx_1;
-   }
-   else {
-      if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_8 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_8), _fx_cleanup);
-         _fx_N16Ast__defmodule_t v_9 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_8);
-         fx_copy_str(&v_9->u.defmodule_t.t1, &fname_0);
-      }
-      else {
-         fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
-      }
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
-      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
-      fx_str_t slit_1 = FX_MAKE_STR(":");
-      fx_str_t slit_2 = FX_MAKE_STR(":");
-      fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
-      {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
-      }
-      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
-      if (all_compile_err_ctx_0 == 0) {
-         fx_copy_str(&whole_msg_0, &whole_msg_1);
-      }
-      else {
-         _fx_LS v_10 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_10), _fx_catch_0);
-         fx_str_t slit_4 =
-            FX_MAKE_STR("\n"
-               U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_10, &whole_msg_1, 0), _fx_catch_0);
-
-      _fx_catch_0: ;
-         if (v_10) {
-            _fx_free_LS(&v_10);
-         }
-      }
-      FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
-      FX_THROW(&v_4, true, _fx_cleanup);
-   }
-   _fx_R9Ast__id_t rec_0 = { 0, v_6, 0 };
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
-   _fx_free_T2SB(&v_0);
    FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
-   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
-   fx_free_exn(&v_4);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM6gen_idRM4id_t2iS(int_ m_idx_0, fx_str_t* s_0, struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
-   _fx_T2SB v_0 = {0};
    fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
    fx_str_t v_1 = {0};
    fx_str_t v_2 = {0};
-   fx_str_t v_3 = {0};
    fx_str_t whole_msg_0 = {0};
    _fx_LS all_compile_err_ctx_0 = 0;
    fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    fx_exn_t v_4 = {0};
-   fx_exn_t v_5 = {0};
-   fx_vec_t v_6 = 0;
-   _fx_T2N14Ast__id_info_tB v_7 = {0};
+   fx_vec_t v_5 = 0;
    int fx_status = 0;
    int_ h_idx_0;
    FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, s_0, &h_idx_0, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
-   _fx_Rt20Hashmap__hashentry_t2Si* v_8 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
-   int_ idx_0 = v_8->data;
-   int_ v_9;
+   _fx_Rt20Hashmap__hashentry_t2Si* v_6 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_6->data;
+   int_ v_7;
    if (idx_0 >= 0) {
-      v_9 = idx_0;
+      v_7 = idx_0;
    }
    else if (_fx_g19Ast__lock_all_names == 0) {
-      _fx_make_T2SB(s_0, true, &v_0);
-      FX_CALL(_fx_M3AstFM10push_back_v2VST2SB(_fx_g14Ast__all_names, &v_0, 0), _fx_cleanup);
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, *s_0, _fx_cleanup);
       int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
-      _fx_Rt20Hashmap__hashentry_t2Si* v_10 =
+      _fx_Rt20Hashmap__hashentry_t2Si* v_8 =
          FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
-      v_10->data = idx_1;
-      v_9 = idx_1;
+      v_8->data = idx_1;
+      v_7 = idx_1;
    }
    else {
       if (_fx_g10Ast__noloc.m_idx >= 0) {
-         int_ v_11 = _fx_g10Ast__noloc.m_idx;
-         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_11), _fx_cleanup);
-         _fx_N16Ast__defmodule_t v_12 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_11);
-         fx_copy_str(&v_12->u.defmodule_t.t1, &fname_0);
+         int_ v_9 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_9), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_10 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_9);
+         fx_copy_str(&v_10->u.defmodule_t.t1, &fname_0);
       }
       else {
          fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
-      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
-      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
       fx_str_t slit_1 = FX_MAKE_STR(":");
       fx_str_t slit_2 = FX_MAKE_STR(":");
       fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_3 };
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_0, slit_2, v_1, slit_3, v_2 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
@@ -9467,50 +9393,47 @@ FX_EXTERN_C int _fx_M3AstFM6gen_idRM4id_t2iS(int_ m_idx_0, fx_str_t* s_0, struct
          fx_copy_str(&whole_msg_0, &whole_msg_1);
       }
       else {
-         _fx_LS v_13 = 0;
-         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_13), _fx_catch_0);
+         _fx_LS v_11 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_11), _fx_catch_0);
          fx_str_t slit_4 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_13, &whole_msg_1, 0), _fx_catch_0);
+         FX_CALL(_fx_F4joinS2SLS(&slit_4, v_11, &whole_msg_1, 0), _fx_catch_0);
 
       _fx_catch_0: ;
-         if (v_13) {
-            _fx_free_LS(&v_13);
+         if (v_11) {
+            _fx_free_LS(&v_11);
          }
       }
       FX_CHECK_EXN(_fx_cleanup);
-      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
-      FX_THROW(&v_4, true, _fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
    }
    if (_fx_g15Ast__freeze_ids) {
       fx_str_t slit_5 = FX_MAKE_STR("internal error: attempt to add new AST id during K-phase or C code generation phase");
-      FX_CALL(_fx_F9make_FailE1S(&slit_5, &v_5), _fx_cleanup);
-      FX_THROW(&v_5, true, _fx_cleanup);
+      FX_CALL(_fx_F9make_FailE1S(&slit_5, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
    }
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_14 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   FX_COPY_PTR(v_14->u.defmodule_t.t9, &v_6);
-   _fx_make_T2N14Ast__id_info_tB(&_fx_g11Ast__IdNone, true, &v_7);
-   FX_CALL(_fx_M3AstFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_6, &v_7, 0), _fx_cleanup);
-   _fx_R9Ast__id_t rec_0 = { m_idx_0, v_9, FX_VEC_SIZE(v_6) - 1 };
+   _fx_N16Ast__defmodule_t v_12 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_12->u.defmodule_t.t9, &v_5);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_5, _fx_g11Ast__IdNone, _fx_cleanup);
+   _fx_R9Ast__id_t rec_0 = { m_idx_0, v_7, FX_VEC_SIZE(v_5) - 1 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
-   _fx_free_T2SB(&v_0);
    FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
    FX_FREE_STR(&v_1);
    FX_FREE_STR(&v_2);
-   FX_FREE_STR(&v_3);
    FX_FREE_STR(&whole_msg_0);
    if (all_compile_err_ctx_0) {
       _fx_free_LS(&all_compile_err_ctx_0);
    }
    FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    fx_free_exn(&v_4);
-   fx_free_exn(&v_5);
-   FX_FREE_VEC(&v_6);
-   _fx_free_T2N14Ast__id_info_tB(&v_7);
+   FX_FREE_VEC(&v_5);
    return fx_status;
 }
 
@@ -9522,7 +9445,6 @@ FX_EXTERN_C int _fx_M3AstFM6dup_idRM4id_t2iRM4id_t(
 {
    fx_exn_t v_0 = {0};
    fx_vec_t v_1 = 0;
-   _fx_T2N14Ast__id_info_tB v_2 = {0};
    int fx_status = 0;
    if (_fx_g15Ast__freeze_ids) {
       fx_str_t slit_0 = FX_MAKE_STR("internal error: attempt to add new AST id during K-phase or C code generation phase");
@@ -9530,10 +9452,9 @@ FX_EXTERN_C int _fx_M3AstFM6dup_idRM4id_t2iRM4id_t(
       FX_THROW(&v_0, true, _fx_cleanup);
    }
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_3 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   FX_COPY_PTR(v_3->u.defmodule_t.t9, &v_1);
-   _fx_make_T2N14Ast__id_info_tB(&_fx_g11Ast__IdNone, true, &v_2);
-   FX_CALL(_fx_M3AstFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_1, &v_2, 0), _fx_cleanup);
+   _fx_N16Ast__defmodule_t v_2 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_2->u.defmodule_t.t9, &v_1);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g11Ast__IdNone, _fx_cleanup);
    int_ j_0 = FX_VEC_SIZE(v_1) - 1;
    _fx_R9Ast__id_t rec_0 = { m_idx_0, old_id_0->i, j_0 };
    *fx_result = rec_0;
@@ -9541,7 +9462,6 @@ FX_EXTERN_C int _fx_M3AstFM6dup_idRM4id_t2iRM4id_t(
 _fx_cleanup: ;
    fx_free_exn(&v_0);
    FX_FREE_VEC(&v_1);
-   _fx_free_T2N14Ast__id_info_tB(&v_2);
    return fx_status;
 }
 
@@ -10810,6 +10730,14 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
 {
    fx_str_t n_str_0 = {0};
    fx_str_t v_0 = {0};
+   fx_str_t fname_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t v_3 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    bool t_0;
    if ((bool)((n_0->m == _fx_g9Ast__noid.m) & (n_0->i == _fx_g9Ast__noid.i))) {
@@ -10822,9 +10750,9 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
       fx_str_t slit_0 = FX_MAKE_STR("<noid>"); fx_copy_str(&slit_0, &n_str_0);
    }
    else {
-      int_ v_1 = n_0->i;
-      FX_VEC_CHKIDX(_fx_g14Ast__all_names, v_1, _fx_cleanup);
-      fx_copy_str(&FX_VEC_ELEM(fx_str_t, _fx_g14Ast__all_names, v_1), &n_str_0);
+      int_ v_5 = n_0->i;
+      FX_VEC_CHKIDX(_fx_g14Ast__all_names, v_5, _fx_cleanup);
+      fx_copy_str(&FX_VEC_ELEM(fx_str_t, _fx_g14Ast__all_names, v_5), &n_str_0);
    }
    int_ dot_pos_0 = _fx_M6StringFM5rfindi2SC(&n_str_0, (char_)46, 0);
    if (dot_pos_0 < 0) {
@@ -10833,11 +10761,81 @@ FX_EXTERN_C int _fx_M3AstFM13get_bare_nameRM4id_t1RM4id_t(
    else {
       FX_CALL(fx_substr(&n_str_0, dot_pos_0 + 1, 0, 1, 2, &v_0), _fx_cleanup);
    }
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_0, fx_result, 0), _fx_cleanup);
+   int_ h_idx_0;
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &v_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_6 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_6->data;
+   int_ v_7;
+   if (idx_0 >= 0) {
+      v_7 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, v_0, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_8 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_8->data = idx_1;
+      v_7 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_9 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_9), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_10 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_9);
+         fx_copy_str(&v_10->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_1 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_1, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_2, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_3, 0), _fx_cleanup);
+      fx_str_t slit_2 = FX_MAKE_STR(":");
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_2, v_1, slit_3, v_2, slit_4, v_3 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_11 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_11), _fx_catch_0);
+         fx_str_t slit_5 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_5, v_11, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_11) {
+            _fx_free_LS(&v_11);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_7, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
    FX_FREE_STR(&n_str_0);
    FX_FREE_STR(&v_0);
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&v_3);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -11970,7 +11968,7 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    else if (tag_0 == 13) {
       fx_str_t slit_12 = FX_MAKE_STR("__intrin_gemm__"); fx_copy_str(&slit_12, fx_result);
    }
-   else if (tag_0 == 16) {
+   else if (tag_0 == 18) {
       fx_str_t v_0 = {0};
       _fx_R9Ast__id_t* f_0 = &iop_0->u.IntrinMath;
       bool t_0;
@@ -11998,7 +11996,7 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    _fx_catch_0: ;
       FX_FREE_STR(&v_0);
    }
-   else if (tag_0 == 17) {
+   else if (tag_0 == 19) {
       fx_str_t v_2 = {0};
       int tag_1 = iop_0->u.IntrinSaturate.tag;
       if (tag_1 == 2) {
@@ -12032,6 +12030,12 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t
    }
    else if (tag_0 == 15) {
       fx_str_t slit_23 = FX_MAKE_STR("__intrin_access_slice__"); fx_copy_str(&slit_23, fx_result);
+   }
+   else if (tag_0 == 16) {
+      fx_str_t slit_24 = FX_MAKE_STR("__intrin_push__"); fx_copy_str(&slit_24, fx_result);
+   }
+   else if (tag_0 == 17) {
+      fx_str_t slit_25 = FX_MAKE_STR("__intrin_pop__"); fx_copy_str(&slit_25, fx_result);
    }
    else {
       FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
@@ -12133,481 +12137,6053 @@ _fx_cleanup: ;
 
 FX_EXTERN_C int _fx_M3AstFM13fname_op_aposRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__apos__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__apos__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_addRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__add__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_subRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__sub__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__mul__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_divRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__div__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM13fname_op_rdivRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__rdiv__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__rdiv__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_modRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__mod__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_powRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__pow__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__pow__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_addRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_add__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_subRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_sub__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_mul__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_divRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_div__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_modRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_mod__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_powRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_pow__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_pow__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_shlRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__shl__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__shl__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_shrRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__shr__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__shr__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_andRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_and__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__bit_and__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_bit_orRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_or__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__bit_or__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_xorRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_xor__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__bit_xor__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM12fname_op_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__cmp__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__cmp__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__eq__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__eq__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_neRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__ne__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__ne__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__lt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__lt__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__gt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__gt__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_leRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__le__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__le__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM11fname_op_geRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__ge__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__ge__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_dot_cmpRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_cmp__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_cmp__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_eqRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_eq__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_eq__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_neRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_ne__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_ne__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_ltRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_lt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_lt__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_gtRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_gt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_gt__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_leRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_le__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_le__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM15fname_op_dot_geRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__dot_ge__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_ge__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM13fname_op_sameRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__same__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__same__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM13fname_op_plusRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("__plus__");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__plus__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15fname_op_negateRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("__negate__");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__negate__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM18fname_op_dot_minusRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("__dot_minus__");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__dot_minus__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_bit_notRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__bit_not__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__bit_not__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_addRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_add__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_subRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_sub__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_mul__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_divRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_div__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_modRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_mod__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_andRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_and__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_and__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM19fname_op_aug_bit_orRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_or__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_or__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_bit_xorRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_bit_xor__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_bit_xor__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_mulRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_mul__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_divRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_div__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM20fname_op_aug_dot_modRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_dot_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_dot_mod__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shlRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_shl__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_shl__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
 FX_EXTERN_C int _fx_M3AstFM16fname_op_aug_shrRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
 {
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
+   int_ h_idx_0;
    fx_str_t slit_0 = FX_MAKE_STR("__aug_shr__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("__aug_shr__");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
 
 _fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM12fname_to_intRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("int");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("int");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM13fname_to_longRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("long");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("long");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM14fname_to_uint8RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("uint8");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("uint8");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM13fname_to_int8RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("int8");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("int8");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15fname_to_uint16RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("uint16");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("uint16");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM14fname_to_int16RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("int16");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("int16");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15fname_to_uint32RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("uint32");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("uint32");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM14fname_to_int32RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("int32");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("int32");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15fname_to_uint64RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("uint64");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("uint64");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM14fname_to_int64RM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("int64");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("int64");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM14fname_to_floatRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("float");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("float");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM15fname_to_doubleRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("double");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("double");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM13fname_to_boolRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("bool");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("bool");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM12fname_stringRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("string");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("string");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM11fname_printRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("print");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("print");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM10fname_reprRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("repr");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("repr");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
+   return fx_status;
+}
+
+FX_EXTERN_C int _fx_M3AstFM10fname_hashRM4id_t0(struct _fx_R9Ast__id_t* fx_result, void* fx_fv)
+{
+   fx_str_t fname_0 = {0};
+   fx_str_t v_0 = {0};
+   fx_str_t v_1 = {0};
+   fx_str_t v_2 = {0};
+   fx_str_t whole_msg_0 = {0};
+   _fx_LS all_compile_err_ctx_0 = 0;
+   fx_str_t whole_msg_1 = {0};
+   fx_exn_t v_3 = {0};
+   int fx_status = 0;
+   int_ h_idx_0;
+   fx_str_t slit_0 = FX_MAKE_STR("hash");
+   FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, &slit_0, &h_idx_0, 0), _fx_cleanup);
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+   _fx_Rt20Hashmap__hashentry_t2Si* v_4 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+   int_ idx_0 = v_4->data;
+   int_ v_5;
+   if (idx_0 >= 0) {
+      v_5 = idx_0;
+   }
+   else if (_fx_g19Ast__lock_all_names == 0) {
+      fx_str_t slit_1 = FX_MAKE_STR("hash");
+      FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, slit_1, _fx_cleanup);
+      int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_cleanup);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_6 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      v_6->data = idx_1;
+      v_5 = idx_1;
+   }
+   else {
+      if (_fx_g10Ast__noloc.m_idx >= 0) {
+         int_ v_7 = _fx_g10Ast__noloc.m_idx;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_7), _fx_cleanup);
+         _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_7);
+         fx_copy_str(&v_8->u.defmodule_t.t1, &fname_0);
+      }
+      else {
+         fx_str_t slit_2 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_2, &fname_0);
+      }
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_0, 0), _fx_cleanup);
+      FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_1, 0), _fx_cleanup);
+      FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_2, 0), _fx_cleanup);
+      fx_str_t slit_3 = FX_MAKE_STR(":");
+      fx_str_t slit_4 = FX_MAKE_STR(":");
+      fx_str_t slit_5 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+      {
+         const fx_str_t strs_0[] = { fname_0, slit_3, v_0, slit_4, v_1, slit_5, v_2 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_cleanup);
+      }
+      FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+      if (all_compile_err_ctx_0 == 0) {
+         fx_copy_str(&whole_msg_0, &whole_msg_1);
+      }
+      else {
+         _fx_LS v_9 = 0;
+         FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_9), _fx_catch_0);
+         fx_str_t slit_6 =
+            FX_MAKE_STR("\n"
+               U"\t");
+         FX_CALL(_fx_F4joinS2SLS(&slit_6, v_9, &whole_msg_1, 0), _fx_catch_0);
+
+      _fx_catch_0: ;
+         if (v_9) {
+            _fx_free_LS(&v_9);
+         }
+      }
+      FX_CHECK_EXN(_fx_cleanup);
+      FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { 0, v_5, 0 };
+   *fx_result = rec_0;
+
+_fx_cleanup: ;
+   FX_FREE_STR(&fname_0);
+   FX_FREE_STR(&v_0);
+   FX_FREE_STR(&v_1);
+   FX_FREE_STR(&v_2);
+   FX_FREE_STR(&whole_msg_0);
+   if (all_compile_err_ctx_0) {
+      _fx_free_LS(&all_compile_err_ctx_0);
+   }
+   FX_FREE_STR(&whole_msg_1);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
@@ -12651,375 +18227,191 @@ FX_EXTERN_C int _fx_M3AstFM16get_binary_fnameRM4id_t2N13Ast__binary_tRM5loc_t(
    int fx_status = 0;
    int tag_0 = FX_REC_VARIANT_TAG(bop_0);
    if (tag_0 == 1) {
-      fx_str_t slit_0 = FX_MAKE_STR("__add__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_catch_0);
-
-   _fx_catch_0: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_addRM4id_t0(fx_result, 0), _fx_catch_0);  _fx_catch_0: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 2) {
-      fx_str_t slit_1 = FX_MAKE_STR("__sub__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, fx_result, 0), _fx_catch_1);
-
-   _fx_catch_1: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_subRM4id_t0(fx_result, 0), _fx_catch_1);  _fx_catch_1: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 3) {
-      fx_str_t slit_2 = FX_MAKE_STR("__mul__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, fx_result, 0), _fx_catch_2);
-
-   _fx_catch_2: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_mulRM4id_t0(fx_result, 0), _fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 4) {
-      fx_str_t slit_3 = FX_MAKE_STR("__div__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_3, fx_result, 0), _fx_catch_3);
-
-   _fx_catch_3: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_divRM4id_t0(fx_result, 0), _fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 5) {
-      fx_str_t slit_4 = FX_MAKE_STR("__rdiv__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_4, fx_result, 0), _fx_catch_4);
-
-   _fx_catch_4: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM13fname_op_rdivRM4id_t0(fx_result, 0), _fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 6) {
-      fx_str_t slit_5 = FX_MAKE_STR("__mod__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_5, fx_result, 0), _fx_catch_5);
-
-   _fx_catch_5: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_modRM4id_t0(fx_result, 0), _fx_catch_5);  _fx_catch_5: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 7) {
-      fx_str_t slit_6 = FX_MAKE_STR("__pow__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_6, fx_result, 0), _fx_catch_6);
-
-   _fx_catch_6: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_powRM4id_t0(fx_result, 0), _fx_catch_6);  _fx_catch_6: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 10) {
-      fx_str_t slit_7 = FX_MAKE_STR("__dot_add__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_7, fx_result, 0), _fx_catch_7);
-
-   _fx_catch_7: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_addRM4id_t0(fx_result, 0), _fx_catch_7);  _fx_catch_7: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 11) {
-      fx_str_t slit_8 = FX_MAKE_STR("__dot_sub__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_8, fx_result, 0), _fx_catch_8);
-
-   _fx_catch_8: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_subRM4id_t0(fx_result, 0), _fx_catch_8);  _fx_catch_8: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 12) {
-      fx_str_t slit_9 = FX_MAKE_STR("__dot_mul__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_9, fx_result, 0), _fx_catch_9);
-
-   _fx_catch_9: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_mulRM4id_t0(fx_result, 0), _fx_catch_9);  _fx_catch_9: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 13) {
-      fx_str_t slit_10 = FX_MAKE_STR("__dot_div__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_10, fx_result, 0), _fx_catch_10);
-
-   _fx_catch_10: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_divRM4id_t0(fx_result, 0), _fx_catch_10);  _fx_catch_10: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 14) {
-      fx_str_t slit_11 = FX_MAKE_STR("__dot_mod__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_11, fx_result, 0), _fx_catch_11);
-
-   _fx_catch_11: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_modRM4id_t0(fx_result, 0), _fx_catch_11);  _fx_catch_11: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 15) {
-      fx_str_t slit_12 = FX_MAKE_STR("__dot_pow__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_12, fx_result, 0), _fx_catch_12);
-
-   _fx_catch_12: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_powRM4id_t0(fx_result, 0), _fx_catch_12);  _fx_catch_12: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 8) {
-      fx_str_t slit_13 = FX_MAKE_STR("__shl__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_13, fx_result, 0), _fx_catch_13);
-
-   _fx_catch_13: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_shlRM4id_t0(fx_result, 0), _fx_catch_13);  _fx_catch_13: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 9) {
-      fx_str_t slit_14 = FX_MAKE_STR("__shr__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_14, fx_result, 0), _fx_catch_14);
-
-   _fx_catch_14: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_shrRM4id_t0(fx_result, 0), _fx_catch_14);  _fx_catch_14: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 16) {
-      fx_str_t slit_15 = FX_MAKE_STR("__bit_and__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_15, fx_result, 0), _fx_catch_15);
-
-   _fx_catch_15: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_bit_andRM4id_t0(fx_result, 0), _fx_catch_15);  _fx_catch_15: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 18) {
-      fx_str_t slit_16 = FX_MAKE_STR("__bit_or__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_16, fx_result, 0), _fx_catch_16);
-
-   _fx_catch_16: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM15fname_op_bit_orRM4id_t0(fx_result, 0), _fx_catch_16);  _fx_catch_16: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 20) {
-      fx_str_t slit_17 = FX_MAKE_STR("__bit_xor__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_17, fx_result, 0), _fx_catch_17);
-
-   _fx_catch_17: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_bit_xorRM4id_t0(fx_result, 0), _fx_catch_17);  _fx_catch_17: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 23) {
-      fx_str_t slit_18 = FX_MAKE_STR("__cmp__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_18, fx_result, 0), _fx_catch_18);
-
-   _fx_catch_18: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM12fname_op_cmpRM4id_t0(fx_result, 0), _fx_catch_18);  _fx_catch_18: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 25) {
-      fx_str_t slit_19 = FX_MAKE_STR("__same__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_19, fx_result, 0), _fx_catch_19);
-
-   _fx_catch_19: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM13fname_op_sameRM4id_t0(fx_result, 0), _fx_catch_19);  _fx_catch_19: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 1) {
-         fx_str_t slit_20 = FX_MAKE_STR("__eq__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_20, fx_result, 0), _fx_catch_20);
-
-      _fx_catch_20: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_eqRM4id_t0(fx_result, 0), _fx_catch_20);  _fx_catch_20: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 2) {
-         fx_str_t slit_21 = FX_MAKE_STR("__ne__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_21, fx_result, 0), _fx_catch_21);
-
-      _fx_catch_21: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_neRM4id_t0(fx_result, 0), _fx_catch_21);  _fx_catch_21: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 3) {
-         fx_str_t slit_22 = FX_MAKE_STR("__lt__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_22, fx_result, 0), _fx_catch_22);
-
-      _fx_catch_22: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_ltRM4id_t0(fx_result, 0), _fx_catch_22);  _fx_catch_22: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 4) {
-         fx_str_t slit_23 = FX_MAKE_STR("__le__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_23, fx_result, 0), _fx_catch_23);
-
-      _fx_catch_23: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_leRM4id_t0(fx_result, 0), _fx_catch_23);  _fx_catch_23: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 5) {
-         fx_str_t slit_24 = FX_MAKE_STR("__ge__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_24, fx_result, 0), _fx_catch_24);
-
-      _fx_catch_24: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_geRM4id_t0(fx_result, 0), _fx_catch_24);  _fx_catch_24: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 21) {
       if (bop_0->u.OpCmp.tag == 6) {
-         fx_str_t slit_25 = FX_MAKE_STR("__gt__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_25, fx_result, 0), _fx_catch_25);
-
-      _fx_catch_25: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM11fname_op_gtRM4id_t0(fx_result, 0), _fx_catch_25);  _fx_catch_25: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 24) {
-      fx_str_t slit_26 = FX_MAKE_STR("__dot_cmp__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_26, fx_result, 0), _fx_catch_26);
-
-   _fx_catch_26: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_dot_cmpRM4id_t0(fx_result, 0), _fx_catch_26);  _fx_catch_26: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 1) {
-         fx_str_t slit_27 = FX_MAKE_STR("__dot_eq__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_27, fx_result, 0), _fx_catch_27);
-
-      _fx_catch_27: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_eqRM4id_t0(fx_result, 0), _fx_catch_27);  _fx_catch_27: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 2) {
-         fx_str_t slit_28 = FX_MAKE_STR("__dot_ne__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_28, fx_result, 0), _fx_catch_28);
-
-      _fx_catch_28: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_neRM4id_t0(fx_result, 0), _fx_catch_28);  _fx_catch_28: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 3) {
-         fx_str_t slit_29 = FX_MAKE_STR("__dot_lt__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_29, fx_result, 0), _fx_catch_29);
-
-      _fx_catch_29: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_ltRM4id_t0(fx_result, 0), _fx_catch_29);  _fx_catch_29: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 4) {
-         fx_str_t slit_30 = FX_MAKE_STR("__dot_le__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_30, fx_result, 0), _fx_catch_30);
-
-      _fx_catch_30: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_leRM4id_t0(fx_result, 0), _fx_catch_30);  _fx_catch_30: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 5) {
-         fx_str_t slit_31 = FX_MAKE_STR("__dot_ge__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_31, fx_result, 0), _fx_catch_31);
-
-      _fx_catch_31: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_geRM4id_t0(fx_result, 0), _fx_catch_31);  _fx_catch_31: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 22) {
       if (bop_0->u.OpDotCmp.tag == 6) {
-         fx_str_t slit_32 = FX_MAKE_STR("__dot_gt__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_32, fx_result, 0), _fx_catch_32);
-
-      _fx_catch_32: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM15fname_op_dot_gtRM4id_t0(fx_result, 0), _fx_catch_32);  _fx_catch_32: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 1) {
-         fx_str_t slit_33 = FX_MAKE_STR("__aug_add__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_33, fx_result, 0), _fx_catch_33);
-
-      _fx_catch_33: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_addRM4id_t0(fx_result, 0), _fx_catch_33);  _fx_catch_33: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 2) {
-         fx_str_t slit_34 = FX_MAKE_STR("__aug_sub__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_34, fx_result, 0), _fx_catch_34);
-
-      _fx_catch_34: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_subRM4id_t0(fx_result, 0), _fx_catch_34);  _fx_catch_34: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 3) {
-         fx_str_t slit_35 = FX_MAKE_STR("__aug_mul__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_35, fx_result, 0), _fx_catch_35);
-
-      _fx_catch_35: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_mulRM4id_t0(fx_result, 0), _fx_catch_35);  _fx_catch_35: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 4) {
-         fx_str_t slit_36 = FX_MAKE_STR("__aug_div__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_36, fx_result, 0), _fx_catch_36);
-
-      _fx_catch_36: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_divRM4id_t0(fx_result, 0), _fx_catch_36);  _fx_catch_36: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 6) {
-         fx_str_t slit_37 = FX_MAKE_STR("__aug_mod__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_37, fx_result, 0), _fx_catch_37);
-
-      _fx_catch_37: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_modRM4id_t0(fx_result, 0), _fx_catch_37);  _fx_catch_37: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 16) {
-         fx_str_t slit_38 = FX_MAKE_STR("__aug_bit_and__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_38, fx_result, 0), _fx_catch_38);
-
-      _fx_catch_38: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM20fname_op_aug_bit_andRM4id_t0(fx_result, 0), _fx_catch_38);  _fx_catch_38: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 18) {
-         fx_str_t slit_39 = FX_MAKE_STR("__aug_bit_or__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_39, fx_result, 0), _fx_catch_39);
-
-      _fx_catch_39: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM19fname_op_aug_bit_orRM4id_t0(fx_result, 0), _fx_catch_39);  _fx_catch_39: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 20) {
-         fx_str_t slit_40 = FX_MAKE_STR("__aug_bit_xor__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_40, fx_result, 0), _fx_catch_40);
-
-      _fx_catch_40: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM20fname_op_aug_bit_xorRM4id_t0(fx_result, 0), _fx_catch_40);  _fx_catch_40: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 12) {
-         fx_str_t slit_41 = FX_MAKE_STR("__aug_dot_mul__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_41, fx_result, 0), _fx_catch_41);
-
-      _fx_catch_41: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM20fname_op_aug_dot_mulRM4id_t0(fx_result, 0), _fx_catch_41);  _fx_catch_41: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 13) {
-         fx_str_t slit_42 = FX_MAKE_STR("__aug_dot_div__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_42, fx_result, 0), _fx_catch_42);
-
-      _fx_catch_42: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM20fname_op_aug_dot_divRM4id_t0(fx_result, 0), _fx_catch_42);  _fx_catch_42: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 14) {
-         fx_str_t slit_43 = FX_MAKE_STR("__aug_dot_mod__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_43, fx_result, 0), _fx_catch_43);
-
-      _fx_catch_43: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM20fname_op_aug_dot_modRM4id_t0(fx_result, 0), _fx_catch_43);  _fx_catch_43: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 8) {
-         fx_str_t slit_44 = FX_MAKE_STR("__aug_shl__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_44, fx_result, 0), _fx_catch_44);
-
-      _fx_catch_44: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_shlRM4id_t0(fx_result, 0), _fx_catch_44);  _fx_catch_44: ; goto _fx_endmatch_0;
       }
    }
    if (tag_0 == 27) {
       if (FX_REC_VARIANT_TAG(bop_0->u.OpAugBinary) == 9) {
-         fx_str_t slit_45 = FX_MAKE_STR("__aug_shr__");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_45, fx_result, 0), _fx_catch_45);
-
-      _fx_catch_45: ;
-         goto _fx_endmatch_0;
+         FX_CALL(_fx_M3AstFM16fname_op_aug_shrRM4id_t0(fx_result, 0), _fx_catch_45);  _fx_catch_45: ; goto _fx_endmatch_0;
       }
    }
    bool res_0;
@@ -13057,17 +18449,17 @@ FX_EXTERN_C int _fx_M3AstFM16get_binary_fnameRM4id_t2N13Ast__binary_tRM5loc_t(
          fx_copy_str(&v_6->u.defmodule_t.t1, &fname_0);
       }
       else {
-         fx_str_t slit_46 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_46, &fname_0);
+         fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_1, 0), _fx_catch_47);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_2, 0), _fx_catch_47);
       FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_3, 0), _fx_catch_47);
-      fx_str_t slit_47 = FX_MAKE_STR(":");
-      fx_str_t slit_48 = FX_MAKE_STR(":");
-      fx_str_t slit_49 = FX_MAKE_STR(": error: for binary operation \"");
-      fx_str_t slit_50 = FX_MAKE_STR("\" there is no corresponding function");
+      fx_str_t slit_1 = FX_MAKE_STR(":");
+      fx_str_t slit_2 = FX_MAKE_STR(":");
+      fx_str_t slit_3 = FX_MAKE_STR(": error: for binary operation \"");
+      fx_str_t slit_4 = FX_MAKE_STR("\" there is no corresponding function");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_47, v_1, slit_48, v_2, slit_49, v_0, slit_50, v_3 };
+         const fx_str_t strs_0[] = { fname_0, slit_1, v_1, slit_2, v_2, slit_3, v_0, slit_4, v_3 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_47);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
@@ -13077,10 +18469,10 @@ FX_EXTERN_C int _fx_M3AstFM16get_binary_fnameRM4id_t2N13Ast__binary_tRM5loc_t(
       else {
          _fx_LS v_7 = 0;
          FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_7), _fx_catch_46);
-         fx_str_t slit_51 =
+         fx_str_t slit_5 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_51, v_7, &whole_msg_1, 0), _fx_catch_46);
+         FX_CALL(_fx_F4joinS2SLS(&slit_5, v_7, &whole_msg_1, 0), _fx_catch_46);
 
       _fx_catch_46: ;
          if (v_7) {
@@ -13122,39 +18514,19 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
    int fx_status = 0;
    int tag_0 = uop_0->tag;
    if (tag_0 == 9) {
-      fx_str_t slit_0 = FX_MAKE_STR("__apos__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_catch_0);
-
-   _fx_catch_0: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM13fname_op_aposRM4id_t0(fx_result, 0), _fx_catch_0);  _fx_catch_0: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 1) {
-      fx_str_t slit_1 = FX_MAKE_STR("__plus__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, fx_result, 0), _fx_catch_1);
-
-   _fx_catch_1: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM13fname_op_plusRM4id_t0(fx_result, 0), _fx_catch_1);  _fx_catch_1: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 2) {
-      fx_str_t slit_2 = FX_MAKE_STR("__negate__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, fx_result, 0), _fx_catch_2);
-
-   _fx_catch_2: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM15fname_op_negateRM4id_t0(fx_result, 0), _fx_catch_2);  _fx_catch_2: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 3) {
-      fx_str_t slit_3 = FX_MAKE_STR("__dot_minus__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_3, fx_result, 0), _fx_catch_3);
-
-   _fx_catch_3: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM18fname_op_dot_minusRM4id_t0(fx_result, 0), _fx_catch_3);  _fx_catch_3: ; goto _fx_endmatch_0;
    }
    if (tag_0 == 4) {
-      fx_str_t slit_4 = FX_MAKE_STR("__bit_not__");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_4, fx_result, 0), _fx_catch_4);
-
-   _fx_catch_4: ;
-      goto _fx_endmatch_0;
+      FX_CALL(_fx_M3AstFM16fname_op_bit_notRM4id_t0(fx_result, 0), _fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_0;
    }
    bool res_0;
    if (tag_0 == 5) {
@@ -13185,31 +18557,31 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
       fx_exn_t v_4 = {0};
       int tag_1 = uop_0->tag;
       if (tag_1 == 1) {
-         fx_str_t slit_5 = FX_MAKE_STR("+"); fx_copy_str(&slit_5, &v_0);
+         fx_str_t slit_0 = FX_MAKE_STR("+"); fx_copy_str(&slit_0, &v_0);
       }
       else if (tag_1 == 2) {
-         fx_str_t slit_6 = FX_MAKE_STR("-"); fx_copy_str(&slit_6, &v_0);
+         fx_str_t slit_1 = FX_MAKE_STR("-"); fx_copy_str(&slit_1, &v_0);
       }
       else if (tag_1 == 3) {
-         fx_str_t slit_7 = FX_MAKE_STR(".-"); fx_copy_str(&slit_7, &v_0);
+         fx_str_t slit_2 = FX_MAKE_STR(".-"); fx_copy_str(&slit_2, &v_0);
       }
       else if (tag_1 == 4) {
-         fx_str_t slit_8 = FX_MAKE_STR("~"); fx_copy_str(&slit_8, &v_0);
+         fx_str_t slit_3 = FX_MAKE_STR("~"); fx_copy_str(&slit_3, &v_0);
       }
       else if (tag_1 == 5) {
-         fx_str_t slit_9 = FX_MAKE_STR("!"); fx_copy_str(&slit_9, &v_0);
+         fx_str_t slit_4 = FX_MAKE_STR("!"); fx_copy_str(&slit_4, &v_0);
       }
       else if (tag_1 == 8) {
-         fx_str_t slit_10 = FX_MAKE_STR("\\"); fx_copy_str(&slit_10, &v_0);
+         fx_str_t slit_5 = FX_MAKE_STR("\\"); fx_copy_str(&slit_5, &v_0);
       }
       else if (tag_1 == 6) {
-         fx_str_t slit_11 = FX_MAKE_STR("REF"); fx_copy_str(&slit_11, &v_0);
+         fx_str_t slit_6 = FX_MAKE_STR("REF"); fx_copy_str(&slit_6, &v_0);
       }
       else if (tag_1 == 7) {
-         fx_str_t slit_12 = FX_MAKE_STR("*"); fx_copy_str(&slit_12, &v_0);
+         fx_str_t slit_7 = FX_MAKE_STR("*"); fx_copy_str(&slit_7, &v_0);
       }
       else if (tag_1 == 9) {
-         fx_str_t slit_13 = FX_MAKE_STR("\'"); fx_copy_str(&slit_13, &v_0);
+         fx_str_t slit_8 = FX_MAKE_STR("\'"); fx_copy_str(&slit_8, &v_0);
       }
       else {
          FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_6);
@@ -13222,17 +18594,17 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
          fx_copy_str(&v_6->u.defmodule_t.t1, &fname_0);
       }
       else {
-         fx_str_t slit_14 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_14, &fname_0);
+         fx_str_t slit_9 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_9, &fname_0);
       }
       FX_CALL(_fx_F6stringS1i(loc_0->line0, &v_1, 0), _fx_catch_6);
       FX_CALL(_fx_F6stringS1i(loc_0->col0, &v_2, 0), _fx_catch_6);
       FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(loc_0, &v_3, 0), _fx_catch_6);
-      fx_str_t slit_15 = FX_MAKE_STR(":");
-      fx_str_t slit_16 = FX_MAKE_STR(":");
-      fx_str_t slit_17 = FX_MAKE_STR(": error: for unary operation \"");
-      fx_str_t slit_18 = FX_MAKE_STR("\" there is no corresponding function");
+      fx_str_t slit_10 = FX_MAKE_STR(":");
+      fx_str_t slit_11 = FX_MAKE_STR(":");
+      fx_str_t slit_12 = FX_MAKE_STR(": error: for unary operation \"");
+      fx_str_t slit_13 = FX_MAKE_STR("\" there is no corresponding function");
       {
-         const fx_str_t strs_0[] = { fname_0, slit_15, v_1, slit_16, v_2, slit_17, v_0, slit_18, v_3 };
+         const fx_str_t strs_0[] = { fname_0, slit_10, v_1, slit_11, v_2, slit_12, v_0, slit_13, v_3 };
          FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &whole_msg_0), _fx_catch_6);
       }
       FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
@@ -13242,10 +18614,10 @@ FX_EXTERN_C int _fx_M3AstFM15get_unary_fnameRM4id_t2N12Ast__unary_tRM5loc_t(
       else {
          _fx_LS v_7 = 0;
          FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_7), _fx_catch_5);
-         fx_str_t slit_19 =
+         fx_str_t slit_14 =
             FX_MAKE_STR("\n"
                U"\t");
-         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_7, &whole_msg_1, 0), _fx_catch_5);
+         FX_CALL(_fx_F4joinS2SLS(&slit_14, v_7, &whole_msg_1, 0), _fx_catch_5);
 
       _fx_catch_5: ;
          if (v_7) {
@@ -13283,209 +18655,141 @@ FX_EXTERN_C int _fx_M3AstFM19fname_always_importLRM4id_t0(struct _fx_LR9Ast__id_
    _fx_LR9Ast__id_t v_0 = 0;
    int fx_status = 0;
    _fx_R9Ast__id_t v_1;
-   fx_str_t slit_0 = FX_MAKE_STR("__add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, &v_1, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_addRM4id_t0(&v_1, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_2;
-   fx_str_t slit_1 = FX_MAKE_STR("__sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, &v_2, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_subRM4id_t0(&v_2, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_3;
-   fx_str_t slit_2 = FX_MAKE_STR("__mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, &v_3, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_mulRM4id_t0(&v_3, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_4;
-   fx_str_t slit_3 = FX_MAKE_STR("__div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_3, &v_4, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_divRM4id_t0(&v_4, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_5;
-   fx_str_t slit_4 = FX_MAKE_STR("__rdiv__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_4, &v_5, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_op_rdivRM4id_t0(&v_5, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_6;
-   fx_str_t slit_5 = FX_MAKE_STR("__mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_5, &v_6, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_modRM4id_t0(&v_6, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_7;
-   fx_str_t slit_6 = FX_MAKE_STR("__pow__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_6, &v_7, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_powRM4id_t0(&v_7, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_8;
-   fx_str_t slit_7 = FX_MAKE_STR("__dot_add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_7, &v_8, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_addRM4id_t0(&v_8, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_9;
-   fx_str_t slit_8 = FX_MAKE_STR("__dot_sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_8, &v_9, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_subRM4id_t0(&v_9, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_10;
-   fx_str_t slit_9 = FX_MAKE_STR("__dot_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_9, &v_10, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_mulRM4id_t0(&v_10, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_11;
-   fx_str_t slit_10 = FX_MAKE_STR("__dot_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_10, &v_11, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_divRM4id_t0(&v_11, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_12;
-   fx_str_t slit_11 = FX_MAKE_STR("__dot_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_11, &v_12, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_modRM4id_t0(&v_12, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_13;
-   fx_str_t slit_12 = FX_MAKE_STR("__dot_pow__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_12, &v_13, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_powRM4id_t0(&v_13, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_14;
-   fx_str_t slit_13 = FX_MAKE_STR("__shl__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_13, &v_14, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_shlRM4id_t0(&v_14, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_15;
-   fx_str_t slit_14 = FX_MAKE_STR("__shr__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_14, &v_15, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_shrRM4id_t0(&v_15, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_16;
-   fx_str_t slit_15 = FX_MAKE_STR("__bit_and__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_15, &v_16, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_bit_andRM4id_t0(&v_16, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_17;
-   fx_str_t slit_16 = FX_MAKE_STR("__bit_or__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_16, &v_17, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_bit_orRM4id_t0(&v_17, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_18;
-   fx_str_t slit_17 = FX_MAKE_STR("__bit_xor__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_17, &v_18, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_bit_xorRM4id_t0(&v_18, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_19;
-   fx_str_t slit_18 = FX_MAKE_STR("__cmp__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_18, &v_19, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_op_cmpRM4id_t0(&v_19, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_20;
-   fx_str_t slit_19 = FX_MAKE_STR("__dot_cmp__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_19, &v_20, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_dot_cmpRM4id_t0(&v_20, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_21;
-   fx_str_t slit_20 = FX_MAKE_STR("__same__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_20, &v_21, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_op_sameRM4id_t0(&v_21, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_22;
-   fx_str_t slit_21 = FX_MAKE_STR("__eq__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_21, &v_22, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_eqRM4id_t0(&v_22, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_23;
-   fx_str_t slit_22 = FX_MAKE_STR("__ne__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_22, &v_23, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_neRM4id_t0(&v_23, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_24;
-   fx_str_t slit_23 = FX_MAKE_STR("__le__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_23, &v_24, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_leRM4id_t0(&v_24, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_25;
-   fx_str_t slit_24 = FX_MAKE_STR("__ge__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_24, &v_25, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_geRM4id_t0(&v_25, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_26;
-   fx_str_t slit_25 = FX_MAKE_STR("__lt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_25, &v_26, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_ltRM4id_t0(&v_26, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_27;
-   fx_str_t slit_26 = FX_MAKE_STR("__gt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_26, &v_27, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_op_gtRM4id_t0(&v_27, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_28;
-   fx_str_t slit_27 = FX_MAKE_STR("__dot_eq__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_27, &v_28, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_eqRM4id_t0(&v_28, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_29;
-   fx_str_t slit_28 = FX_MAKE_STR("__dot_ne__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_28, &v_29, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_neRM4id_t0(&v_29, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_30;
-   fx_str_t slit_29 = FX_MAKE_STR("__dot_le__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_29, &v_30, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_leRM4id_t0(&v_30, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_31;
-   fx_str_t slit_30 = FX_MAKE_STR("__dot_ge__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_30, &v_31, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_geRM4id_t0(&v_31, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_32;
-   fx_str_t slit_31 = FX_MAKE_STR("__dot_lt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_31, &v_32, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_ltRM4id_t0(&v_32, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_33;
-   fx_str_t slit_32 = FX_MAKE_STR("__dot_gt__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_32, &v_33, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_dot_gtRM4id_t0(&v_33, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_34;
-   fx_str_t slit_33 = FX_MAKE_STR("__plus__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_33, &v_34, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_op_plusRM4id_t0(&v_34, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_35;
-   fx_str_t slit_34 = FX_MAKE_STR("__negate__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_34, &v_35, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_op_negateRM4id_t0(&v_35, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_36;
-   fx_str_t slit_35 = FX_MAKE_STR("__dot_minus__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_35, &v_36, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM18fname_op_dot_minusRM4id_t0(&v_36, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_37;
-   fx_str_t slit_36 = FX_MAKE_STR("__bit_not__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_36, &v_37, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_bit_notRM4id_t0(&v_37, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_38;
-   fx_str_t slit_37 = FX_MAKE_STR("__aug_add__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_37, &v_38, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_addRM4id_t0(&v_38, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_39;
-   fx_str_t slit_38 = FX_MAKE_STR("__aug_sub__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_38, &v_39, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_subRM4id_t0(&v_39, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_40;
-   fx_str_t slit_39 = FX_MAKE_STR("__aug_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_39, &v_40, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_mulRM4id_t0(&v_40, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_41;
-   fx_str_t slit_40 = FX_MAKE_STR("__aug_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_40, &v_41, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_divRM4id_t0(&v_41, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_42;
-   fx_str_t slit_41 = FX_MAKE_STR("__aug_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_41, &v_42, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_modRM4id_t0(&v_42, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_43;
-   fx_str_t slit_42 = FX_MAKE_STR("__aug_bit_and__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_42, &v_43, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM20fname_op_aug_bit_andRM4id_t0(&v_43, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_44;
-   fx_str_t slit_43 = FX_MAKE_STR("__aug_bit_or__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_43, &v_44, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM19fname_op_aug_bit_orRM4id_t0(&v_44, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_45;
-   fx_str_t slit_44 = FX_MAKE_STR("__aug_bit_xor__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_44, &v_45, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM20fname_op_aug_bit_xorRM4id_t0(&v_45, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_46;
-   fx_str_t slit_45 = FX_MAKE_STR("__aug_dot_mul__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_45, &v_46, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM20fname_op_aug_dot_mulRM4id_t0(&v_46, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_47;
-   fx_str_t slit_46 = FX_MAKE_STR("__aug_dot_div__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_46, &v_47, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM20fname_op_aug_dot_divRM4id_t0(&v_47, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_48;
-   fx_str_t slit_47 = FX_MAKE_STR("__aug_dot_mod__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_47, &v_48, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM20fname_op_aug_dot_modRM4id_t0(&v_48, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_49;
-   fx_str_t slit_48 = FX_MAKE_STR("__aug_shl__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_48, &v_49, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_shlRM4id_t0(&v_49, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_50;
-   fx_str_t slit_49 = FX_MAKE_STR("__aug_shr__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_49, &v_50, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM16fname_op_aug_shrRM4id_t0(&v_50, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_51;
-   fx_str_t slit_50 = FX_MAKE_STR("__apos__");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_50, &v_51, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_op_aposRM4id_t0(&v_51, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_52;
-   fx_str_t slit_51 = FX_MAKE_STR("int");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_51, &v_52, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_to_intRM4id_t0(&v_52, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_53;
-   fx_str_t slit_52 = FX_MAKE_STR("long");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_52, &v_53, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_to_longRM4id_t0(&v_53, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_54;
-   fx_str_t slit_53 = FX_MAKE_STR("uint8");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_53, &v_54, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM14fname_to_uint8RM4id_t0(&v_54, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_55;
-   fx_str_t slit_54 = FX_MAKE_STR("int8");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_54, &v_55, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_to_int8RM4id_t0(&v_55, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_56;
-   fx_str_t slit_55 = FX_MAKE_STR("uint16");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_55, &v_56, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_to_uint16RM4id_t0(&v_56, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_57;
-   fx_str_t slit_56 = FX_MAKE_STR("int16");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_56, &v_57, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM14fname_to_int16RM4id_t0(&v_57, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_58;
-   fx_str_t slit_57 = FX_MAKE_STR("uint32");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_57, &v_58, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_to_uint32RM4id_t0(&v_58, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_59;
-   fx_str_t slit_58 = FX_MAKE_STR("int32");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_58, &v_59, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM14fname_to_int32RM4id_t0(&v_59, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_60;
-   fx_str_t slit_59 = FX_MAKE_STR("uint64");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_59, &v_60, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_to_uint64RM4id_t0(&v_60, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_61;
-   fx_str_t slit_60 = FX_MAKE_STR("int64");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_60, &v_61, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM14fname_to_int64RM4id_t0(&v_61, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_62;
-   fx_str_t slit_61 = FX_MAKE_STR("float");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_61, &v_62, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM14fname_to_floatRM4id_t0(&v_62, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_63;
-   fx_str_t slit_62 = FX_MAKE_STR("double");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_62, &v_63, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM15fname_to_doubleRM4id_t0(&v_63, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_64;
-   fx_str_t slit_63 = FX_MAKE_STR("bool");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_63, &v_64, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM13fname_to_boolRM4id_t0(&v_64, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_65;
-   fx_str_t slit_64 = FX_MAKE_STR("string");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_64, &v_65, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12fname_stringRM4id_t0(&v_65, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_66;
-   fx_str_t slit_65 = FX_MAKE_STR("print");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_65, &v_66, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11fname_printRM4id_t0(&v_66, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_67;
-   fx_str_t slit_66 = FX_MAKE_STR("repr");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_66, &v_67, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM10fname_reprRM4id_t0(&v_67, 0), _fx_cleanup);
    _fx_R9Ast__id_t v_68;
-   fx_str_t slit_67 = FX_MAKE_STR("hash");
-   FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_67, &v_68, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM10fname_hashRM4id_t0(&v_68, 0), _fx_cleanup);
    FX_CALL(_fx_cons_LR9Ast__id_t(&v_68, 0, true, &v_0), _fx_cleanup);
    FX_CALL(_fx_cons_LR9Ast__id_t(&v_67, v_0, false, &v_0), _fx_cleanup);
    FX_CALL(_fx_cons_LR9Ast__id_t(&v_66, v_0, false, &v_0), _fx_cleanup);
@@ -13657,124 +18961,72 @@ FX_EXTERN_C int _fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(
    FX_CHECK_EXN(_fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(v_0);
    if (tag_0 == 6) {
-      fx_str_t slit_0 = FX_MAKE_STR("int");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_0, fx_result, 0), _fx_catch_4);
-
-   _fx_catch_4: ;
-      goto _fx_endmatch_1;
+      FX_CALL(_fx_M3AstFM12fname_to_intRM4id_t0(fx_result, 0), _fx_catch_4);  _fx_catch_4: ; goto _fx_endmatch_1;
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 8) {
-         fx_str_t slit_1 = FX_MAKE_STR("int8");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_1, fx_result, 0), _fx_catch_5);
-
-      _fx_catch_5: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM13fname_to_int8RM4id_t0(fx_result, 0), _fx_catch_5);  _fx_catch_5: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 16) {
-         fx_str_t slit_2 = FX_MAKE_STR("int16");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_2, fx_result, 0), _fx_catch_6);
-
-      _fx_catch_6: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM14fname_to_int16RM4id_t0(fx_result, 0), _fx_catch_6);  _fx_catch_6: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 32) {
-         fx_str_t slit_3 = FX_MAKE_STR("int32");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_3, fx_result, 0), _fx_catch_7);
-
-      _fx_catch_7: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM14fname_to_int32RM4id_t0(fx_result, 0), _fx_catch_7);  _fx_catch_7: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 7) {
       if (v_0->u.TypSInt == 64) {
-         fx_str_t slit_4 = FX_MAKE_STR("int64");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_4, fx_result, 0), _fx_catch_8);
-
-      _fx_catch_8: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM14fname_to_int64RM4id_t0(fx_result, 0), _fx_catch_8);  _fx_catch_8: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 8) {
-         fx_str_t slit_5 = FX_MAKE_STR("uint8");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_5, fx_result, 0), _fx_catch_9);
-
-      _fx_catch_9: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM14fname_to_uint8RM4id_t0(fx_result, 0), _fx_catch_9);  _fx_catch_9: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 16) {
-         fx_str_t slit_6 = FX_MAKE_STR("uint16");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_6, fx_result, 0), _fx_catch_10);
-
-      _fx_catch_10: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM15fname_to_uint16RM4id_t0(fx_result, 0), _fx_catch_10);  _fx_catch_10: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 32) {
-         fx_str_t slit_7 = FX_MAKE_STR("uint32");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_7, fx_result, 0), _fx_catch_11);
-
-      _fx_catch_11: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM15fname_to_uint32RM4id_t0(fx_result, 0), _fx_catch_11);  _fx_catch_11: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 8) {
       if (v_0->u.TypUInt == 64) {
-         fx_str_t slit_8 = FX_MAKE_STR("uint64");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_8, fx_result, 0), _fx_catch_12);
-
-      _fx_catch_12: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM15fname_to_uint64RM4id_t0(fx_result, 0), _fx_catch_12);  _fx_catch_12: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 10) {
       if (v_0->u.TypFloat == 32) {
-         fx_str_t slit_9 = FX_MAKE_STR("float");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_9, fx_result, 0), _fx_catch_13);
-
-      _fx_catch_13: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM14fname_to_floatRM4id_t0(fx_result, 0), _fx_catch_13);  _fx_catch_13: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 10) {
       if (v_0->u.TypFloat == 64) {
-         fx_str_t slit_10 = FX_MAKE_STR("double");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_10, fx_result, 0), _fx_catch_14);
-
-      _fx_catch_14: ;
-         goto _fx_endmatch_1;
+         FX_CALL(_fx_M3AstFM15fname_to_doubleRM4id_t0(fx_result, 0), _fx_catch_14);  _fx_catch_14: ; goto _fx_endmatch_1;
       }
    }
    if (tag_0 == 13) {
-      fx_str_t slit_11 = FX_MAKE_STR("bool");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_11, fx_result, 0), _fx_catch_15);
-
-   _fx_catch_15: ;
-      goto _fx_endmatch_1;
+      FX_CALL(_fx_M3AstFM13fname_to_boolRM4id_t0(fx_result, 0), _fx_catch_15);  _fx_catch_15: ; goto _fx_endmatch_1;
    }
    if (tag_0 == 11) {
-      fx_str_t slit_12 = FX_MAKE_STR("string");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_12, fx_result, 0), _fx_catch_16);
-
-   _fx_catch_16: ;
-      goto _fx_endmatch_1;
+      FX_CALL(_fx_M3AstFM12fname_stringRM4id_t0(fx_result, 0), _fx_catch_16);  _fx_catch_16: ; goto _fx_endmatch_1;
    }
    fx_str_t v_6 = {0};
    fx_str_t v_7 = {0};
    fx_exn_t v_8 = {0};
    FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_17);
-   fx_str_t slit_13 = FX_MAKE_STR("for type \'");
-   fx_str_t slit_14 = FX_MAKE_STR("\' there is no corresponding cast function");
+   fx_str_t slit_0 = FX_MAKE_STR("for type \'");
+   fx_str_t slit_1 = FX_MAKE_STR("\' there is no corresponding cast function");
    {
-      const fx_str_t strs_0[] = { slit_13, v_6, slit_14 };
+      const fx_str_t strs_0[] = { slit_0, v_6, slit_1 };
       FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_7), _fx_catch_17);
    }
    FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(loc_0, &v_7, &v_8), _fx_catch_17);
@@ -18190,45 +23442,121 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
    FX_COPY_PTR(res_0, &v_4);
    _fx_LS lst_1 = v_4;
    for (; lst_1; lst_1 = lst_1->tl) {
+      fx_str_t fname_0 = {0};
+      fx_str_t v_17 = {0};
+      fx_str_t v_18 = {0};
+      fx_str_t v_19 = {0};
+      fx_str_t whole_msg_0 = {0};
+      _fx_LS all_compile_err_ctx_0 = 0;
+      fx_str_t whole_msg_1 = {0};
+      fx_exn_t v_20 = {0};
       fx_str_t* i_3 = &lst_1->hd;
-      _fx_R9Ast__id_t res_2;
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(i_3, &res_2, 0), _fx_catch_1);
+      int_ h_idx_0;
+      FX_CALL(_fx_M3AstFM18find_idx_or_inserti2Nt10Hashmap__t2SiS(_fx_g16Ast__all_strhash, i_3, &h_idx_0, 0), _fx_catch_2);
+      FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_2);
+      _fx_Rt20Hashmap__hashentry_t2Si* v_21 =
+         FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+      int_ idx_0 = v_21->data;
+      int_ t_0;
+      if (idx_0 >= 0) {
+         t_0 = idx_0;
+      }
+      else if (_fx_g19Ast__lock_all_names == 0) {
+         FX_VEC_PUSH_BACK(fx_str_t, _fx_g14Ast__all_names, *i_3, _fx_catch_2);
+         int_ idx_1 = FX_VEC_SIZE(_fx_g14Ast__all_names) - 1;
+         FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_strhash->u.t.t5, 0, h_idx_0), _fx_catch_2);
+         _fx_Rt20Hashmap__hashentry_t2Si* v_22 =
+            FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, _fx_g16Ast__all_strhash->u.t.t5, h_idx_0);
+         v_22->data = idx_1;
+         t_0 = idx_1;
+      }
+      else {
+         if (_fx_g10Ast__noloc.m_idx >= 0) {
+            int_ v_23 = _fx_g10Ast__noloc.m_idx;
+            FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, v_23), _fx_catch_2);
+            _fx_N16Ast__defmodule_t v_24 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, v_23);
+            fx_copy_str(&v_24->u.defmodule_t.t1, &fname_0);
+         }
+         else {
+            fx_str_t slit_0 = FX_MAKE_STR("unknown"); fx_copy_str(&slit_0, &fname_0);
+         }
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.line0, &v_17, 0), _fx_catch_2);
+         FX_CALL(_fx_F6stringS1i(_fx_g10Ast__noloc.col0, &v_18, 0), _fx_catch_2);
+         FX_CALL(_fx_M3AstFM11loc_excerptS1RM5loc_t(&_fx_g10Ast__noloc, &v_19, 0), _fx_catch_2);
+         fx_str_t slit_1 = FX_MAKE_STR(":");
+         fx_str_t slit_2 = FX_MAKE_STR(":");
+         fx_str_t slit_3 = FX_MAKE_STR(": error: \'all_names\' are locked. Attempt to call get_id()");
+         {
+            const fx_str_t strs_0[] = { fname_0, slit_1, v_17, slit_2, v_18, slit_3, v_19 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 7, &whole_msg_0), _fx_catch_2);
+         }
+         FX_COPY_PTR(_fx_g24Ast__all_compile_err_ctx, &all_compile_err_ctx_0);
+         if (all_compile_err_ctx_0 == 0) {
+            fx_copy_str(&whole_msg_0, &whole_msg_1);
+         }
+         else {
+            _fx_LS v_25 = 0;
+            FX_CALL(_fx_cons_LS(&whole_msg_0, all_compile_err_ctx_0, true, &v_25), _fx_catch_1);
+            fx_str_t slit_4 =
+               FX_MAKE_STR("\n"
+                  U"\t");
+            FX_CALL(_fx_F4joinS2SLS(&slit_4, v_25, &whole_msg_1, 0), _fx_catch_1);
 
-   _fx_catch_1: ;
+         _fx_catch_1: ;
+            if (v_25) {
+               _fx_free_LS(&v_25);
+            }
+         }
+         FX_CHECK_EXN(_fx_catch_2);
+         FX_CALL(_fx_M3AstFM17make_CompileErrorE2RM5loc_tS(&_fx_g10Ast__noloc, &whole_msg_1, &v_20), _fx_catch_2);
+         FX_THROW(&v_20, true, _fx_catch_2);
+      }
+
+   _fx_catch_2: ;
+      fx_free_exn(&v_20);
+      FX_FREE_STR(&whole_msg_1);
+      if (all_compile_err_ctx_0) {
+         _fx_free_LS(&all_compile_err_ctx_0);
+      }
+      FX_FREE_STR(&whole_msg_0);
+      FX_FREE_STR(&v_19);
+      FX_FREE_STR(&v_18);
+      FX_FREE_STR(&v_17);
+      FX_FREE_STR(&fname_0);
       FX_CHECK_EXN(_fx_cleanup);
    }
    FX_CALL(_fx_M3AstFM19fname_always_importLRM4id_t0(&res_1, 0), _fx_cleanup);
    _fx_copy_Rt20Hashmap__hashentry_t2Si(&_fx_g21Ast__all_modules_hash->u.t.t0, &entry0_3);
    fx_copy_arr(&_fx_g21Ast__all_modules_hash->u.t.t5, &table_3);
-   int_ v_17 = FX_ARR_SIZE(table_3, 0);
-   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_3, 0), 0, v_17, 1, 1, 0, _fx_cleanup);
+   int_ v_26 = FX_ARR_SIZE(table_3, 0);
+   FX_CHKIDX_RANGE(FX_ARR_SIZE(table_3, 0), 0, v_26, 1, 1, 0, _fx_cleanup);
    _fx_Rt20Hashmap__hashentry_t2Si* ptr_3 = FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2Si, table_3, 0);
-   for (int_ i_4 = 0; i_4 < v_17; i_4++) {
-      _fx_Rt20Hashmap__hashentry_t2Si* v_18 = ptr_3 + i_4;
-      _fx_free_Rt20Hashmap__hashentry_t2Si(v_18);
-      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_3, v_18);
+   for (int_ i_4 = 0; i_4 < v_26; i_4++) {
+      _fx_Rt20Hashmap__hashentry_t2Si* v_27 = ptr_3 + i_4;
+      _fx_free_Rt20Hashmap__hashentry_t2Si(v_27);
+      _fx_copy_Rt20Hashmap__hashentry_t2Si(&entry0_3, v_27);
    }
    _fx_g21Ast__all_modules_hash->u.t.t1 = 0;
    _fx_g21Ast__all_modules_hash->u.t.t2 = 0;
    _fx_g21Ast__all_modules_hash->u.t.t3 = 0;
    FX_CALL(_fx_M7HashmapFM9makeindexA1i1i(FX_ARR_SIZE(table_3, 0) * 2, &v_5, 0), _fx_cleanup);
-   fx_arr_t* v_19 = &_fx_g21Ast__all_modules_hash->u.t.t4;
-   FX_FREE_ARR(v_19);
-   fx_copy_arr(&v_5, v_19);
+   fx_arr_t* v_28 = &_fx_g21Ast__all_modules_hash->u.t.t4;
+   FX_FREE_ARR(v_28);
+   fx_copy_arr(&v_5, v_28);
    FX_FREE_ARR(&_fx_g16Ast__all_modules);
    fx_copy_arr(&z_0, &_fx_g16Ast__all_modules);
-   fx_str_t slit_0 = FX_MAKE_STR("<Names>");
+   fx_str_t slit_5 = FX_MAKE_STR("<Names>");
+   int_ res_2;
+   FX_CALL(_fx_M3AstFM11find_modulei2RM4id_tS(&_fx_g17Ast__std__Names__, &slit_5, &res_2, 0), _fx_cleanup);
+   fx_str_t slit_6 = FX_MAKE_STR("<Runtime>");
    int_ res_3;
-   FX_CALL(_fx_M3AstFM11find_modulei2RM4id_tS(&_fx_g17Ast__std__Names__, &slit_0, &res_3, 0), _fx_cleanup);
-   fx_str_t slit_1 = FX_MAKE_STR("<Runtime>");
-   int_ res_4;
-   FX_CALL(_fx_M3AstFM11find_modulei2RM4id_tS(&_fx_g19Ast__std__Runtime__, &slit_1, &res_4, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM11find_modulei2RM4id_tS(&_fx_g19Ast__std__Runtime__, &slit_6, &res_3, 0), _fx_cleanup);
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, 0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_20 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, 0);
-   v_20->u.defmodule_t.t3 = false;
+   _fx_N16Ast__defmodule_t v_29 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, 0);
+   v_29->u.defmodule_t.t3 = false;
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, 1), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_21 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, 1);
-   v_21->u.defmodule_t.t3 = false;
+   _fx_N16Ast__defmodule_t v_30 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, 1);
+   v_30->u.defmodule_t.t3 = false;
    FX_FREE_LIST_SIMPLE(&_fx_g23Ast__all_modules_sorted);
    _fx_g23Ast__all_modules_sorted = 0;
    _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_id_fp_0 = { _fx_M3AstFM6cmp_idi2RM4id_tRM4id_t, 0 };
@@ -18241,9 +23569,9 @@ FX_EXTERN_C int _fx_M3AstFM8init_allv0(void* fx_fv)
    _fx_g22Ast__all_compile_warns = 0;
    _fx_free_LS(&_fx_g24Ast__all_compile_err_ctx);
    _fx_g24Ast__all_compile_err_ctx = 0;
-   fx_str_t slit_2 = FX_MAKE_STR("");
+   fx_str_t slit_7 = FX_MAKE_STR("");
    FX_FREE_STR(&_fx_g19Ast__ficus_std_path);
-   fx_copy_str(&slit_2, &_fx_g19Ast__ficus_std_path);
+   fx_copy_str(&slit_7, &_fx_g19Ast__ficus_std_path);
 
 _fx_cleanup: ;
    _fx_free_Rt20Hashmap__hashentry_t2iLS(&entry0_0);

--- a/compiler/bootstrap/Ast.c
+++ b/compiler/bootstrap/Ast.c
@@ -4808,8 +4808,6 @@ _fx_T2LSi _fx_g19Ast__builtin_ids16_ = {0};
 _fx_T2LSi _fx_g19Ast__builtin_ids17_ = {0};
 _fx_T2LSi _fx_g19Ast__builtin_ids18_ = {0};
 _fx_T2LSi _fx_g19Ast__builtin_ids19_ = {0};
-FX_EXTERN_C int _fx_M3AstFM7resize_v3VSiT2SB(fx_vec_t, int_, struct _fx_T2SB*, void*);
-
 FX_EXTERN_C int_ _fx_F7__cmp__i2SS(fx_str_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int _fx_M7HashmapFM9makeindexA1i1i(int_, fx_arr_t*, void*);
@@ -5121,19 +5119,18 @@ return fx_list_length(l);
 
 }
 
-FX_EXTERN_C int _fx_M3AstFM4makeVS2iS(int_ n_0, fx_str_t* val0_0, fx_vec_t* fx_result, void* fx_fv)
+FX_EXTERN_C int _fx_M3AstFM6vectorVS2iS(int_ n_0, fx_str_t* x_0, fx_vec_t* fx_result, void* fx_fv)
 {
-   fx_vec_t z_0 = 0;
-   _fx_T2SB v_0 = {0};
    int fx_status = 0;
-   fx_make_vec(0, 0, sizeof(fx_str_t), (fx_free_t)fx_free_str, (fx_copy_t)fx_copy_str, 0, &z_0);
-   _fx_make_T2SB(val0_0, true, &v_0);
-   FX_CALL(_fx_M3AstFM7resize_v3VSiT2SB(z_0, n_0, &v_0, 0), _fx_cleanup);
-   FX_COPY_PTR(z_0, fx_result);
+   fx_str_t* dstptr_0 = 0;
+   FX_CALL(fx_make_vec(n_0, n_0, sizeof(fx_str_t), (fx_free_t)fx_free_str, (fx_copy_t)fx_copy_str, 0, fx_result), _fx_cleanup);
+   dstptr_0 = (fx_str_t*)(*fx_result)->data;
+   for (int_ i_0 = 0; i_0 < n_0; i_0++) {
+      fx_copy_str(x_0, dstptr_0); dstptr_0++;
+   }
+   (*fx_result)->size = dstptr_0 - (fx_str_t*)(*fx_result)->data;
 
 _fx_cleanup: ;
-   FX_FREE_VEC(&z_0);
-   _fx_free_T2SB(&v_0);
    return fx_status;
 }
 
@@ -5142,28 +5139,6 @@ FX_EXTERN_C int _fx_M3AstFM5clearv1VS(fx_vec_t v, void* fx_fv)
 
 if (v) return fx_vec_resize(v, 0, 0);
     return FX_OK;
-
-}
-
-FX_EXTERN_C int _fx_M3AstFM7resize_v3VSiT2SB(fx_vec_t v, int_ size, struct _fx_T2SB* val0_, void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_resize(v, size, val0_);
-
-}
-
-FX_EXTERN_C int _fx_M3AstFM7resize_v3VN14Ast__id_info_tiT2N14Ast__id_info_tB(
-   fx_vec_t v,
-   int_ size,
-   struct _fx_T2N14Ast__id_info_tB* val0_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_resize(v, size, val0_);
 
 }
 
@@ -10430,21 +10405,25 @@ FX_EXTERN_C int _fx_M3AstFM11find_modulei2RM4id_tS(
       *fx_result = v_1.u.Some;
    }
    else {
-      fx_vec_t z_0 = 0;
-      _fx_T2N14Ast__id_info_tB v_3 = {0};
+      fx_vec_t v_3 = 0;
       _fx_N16Ast__defmodule_t newmodule_0 = 0;
       fx_arr_t saved_modules_0 = {0};
       fx_arr_t v_4 = {0};
       int_ m_idx_0 = FX_ARR_SIZE(_fx_g16Ast__all_modules, 0);
-      fx_make_vec(0, 0, sizeof(_fx_N14Ast__id_info_t), (fx_free_t)_fx_free_N14Ast__id_info_t,
-         (fx_copy_t)_fx_copy_N14Ast__id_info_t, 0, &z_0);
-      _fx_make_T2N14Ast__id_info_tB(&_fx_g11Ast__IdNone, true, &v_3);
-      FX_CALL(_fx_M3AstFM7resize_v3VN14Ast__id_info_tiT2N14Ast__id_info_tB(z_0, 0, &v_3, 0), _fx_catch_1);
+      _fx_N14Ast__id_info_t* dstptr_0 = 0;
+      FX_CALL(
+         fx_make_vec(0, 0, sizeof(_fx_N14Ast__id_info_t), (fx_free_t)_fx_free_N14Ast__id_info_t,
+            (fx_copy_t)_fx_copy_N14Ast__id_info_t, 0, &v_3), _fx_catch_1);
+      dstptr_0 = (_fx_N14Ast__id_info_t*)v_3->data;
+      for (int_ i_0 = 0; i_0 < 0; i_0++) {
+         _fx_copy_N14Ast__id_info_t(&_fx_g11Ast__IdNone, dstptr_0); dstptr_0++;
+      }
+      v_3->size = dstptr_0 - (_fx_N14Ast__id_info_t*)v_3->data;
       FX_CALL(
          _fx_M3AstFM11defmodule_tN16Ast__defmodule_t10RM4id_tSiBLN10Ast__exp_tLiRt6Map__t2RM4id_tLN16Ast__env_entry_tBiVN14Ast__id_info_t(
-            mname_0, mfname_0, m_idx_0, true, 0, 0, &_fx_g14Ast__empty_env, false, -1, z_0, &newmodule_0), _fx_catch_1);
+            mname_0, mfname_0, m_idx_0, true, 0, 0, &_fx_g14Ast__empty_env, false, -1, v_3, &newmodule_0), _fx_catch_1);
       fx_copy_arr(&_fx_g16Ast__all_modules, &saved_modules_0);
-      _fx_N16Ast__defmodule_t* dstptr_0 = 0;
+      _fx_N16Ast__defmodule_t* dstptr_1 = 0;
       int_ v_5 = m_idx_0 + 1;
       {
          const int_ shape_0[] = { v_5 };
@@ -10452,17 +10431,17 @@ FX_EXTERN_C int _fx_M3AstFM11find_modulei2RM4id_tS(
             fx_make_arr(1, shape_0, sizeof(_fx_N16Ast__defmodule_t), (fx_free_t)_fx_free_N16Ast__defmodule_t,
                (fx_copy_t)fx_copy_ptr, 0, &v_4), _fx_catch_1);
       }
-      dstptr_0 = (_fx_N16Ast__defmodule_t*)v_4.data;
-      for (int_ i_0 = 0; i_0 < v_5; i_0++, dstptr_0++) {
+      dstptr_1 = (_fx_N16Ast__defmodule_t*)v_4.data;
+      for (int_ i_1 = 0; i_1 < v_5; i_1++, dstptr_1++) {
          _fx_N16Ast__defmodule_t t_0 = 0;
-         if (i_0 < m_idx_0) {
-            FX_CHKIDX(FX_CHKIDX1(saved_modules_0, 0, i_0), _fx_catch_0);
-            FX_COPY_PTR(*FX_PTR_1D(_fx_N16Ast__defmodule_t, saved_modules_0, i_0), &t_0);
+         if (i_1 < m_idx_0) {
+            FX_CHKIDX(FX_CHKIDX1(saved_modules_0, 0, i_1), _fx_catch_0);
+            FX_COPY_PTR(*FX_PTR_1D(_fx_N16Ast__defmodule_t, saved_modules_0, i_1), &t_0);
          }
          else {
             FX_COPY_PTR(newmodule_0, &t_0);
          }
-         FX_COPY_PTR(t_0, dstptr_0);
+         FX_COPY_PTR(t_0, dstptr_1);
 
       _fx_catch_0: ;
          if (t_0) {
@@ -10487,8 +10466,7 @@ FX_EXTERN_C int _fx_M3AstFM11find_modulei2RM4id_tS(
       if (newmodule_0) {
          _fx_free_N16Ast__defmodule_t(&newmodule_0);
       }
-      _fx_free_T2N14Ast__id_info_tB(&v_3);
-      FX_FREE_VEC(&z_0);
+      FX_FREE_VEC(&v_3);
    }
 
 _fx_cleanup: ;
@@ -18348,7 +18326,7 @@ FX_EXTERN_C int fx_init_Ast(void)
       _fx_cleanup);
    _fx_g19Ast__compiler_stage = _fx_g17Ast__CompilerInit;
    fx_str_t slit_1 = FX_MAKE_STR("");
-   FX_CALL(_fx_M3AstFM4makeVS2iS(0, &slit_1, &_fx_g14Ast__all_names, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM6vectorVS2iS(0, &slit_1, &_fx_g14Ast__all_names, 0), _fx_cleanup);
    fx_str_t slit_2 = FX_MAKE_STR("");
    FX_CALL(_fx_M3AstFM5emptyNt10Hashmap__t2Si3iSi(1024, &slit_2, -1, &_fx_g16Ast__all_strhash, 0), _fx_cleanup);
    fx_str_t slit_3 = FX_MAKE_STR("");

--- a/compiler/bootstrap/Ast_pp.c
+++ b/compiler/bootstrap/Ast_pp.c
@@ -86,263 +86,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_N12Map__color_t {
    int tag;
 } _fx_N12Map__color_t;
@@ -368,6 +111,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
          Node;
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -422,6 +205,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -503,6 +310,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -522,6 +353,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -718,6 +559,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -889,6 +868,27 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
       struct _fx_N10Ast__typ_t_data_t* EnvTyp;
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
+
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1070,561 +1070,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_LN16Ast__env_entry_t(struct _fx_LN16Ast__env_entry_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN16Ast__env_entry_t, _fx_free_N16Ast__env_entry_t);
@@ -1689,6 +1134,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
 }
 
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
@@ -1794,6 +1262,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -2751,6 +2272,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -3218,6 +3145,79 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
       switch ((*dst)->tag) { case 2:     _fx_free_N10Ast__typ_t(&(*dst)->u.EnvTyp); break; default:    ; } fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -23226,7 +23226,7 @@ FX_EXTERN_C int
       if (tag_0 == 10) {
          _fx_T3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_13 = &e_2->u.ExpIntrin;
          _fx_N13Ast__intrin_t* v_158 = &vcase_13->t0;
-         if (v_158->tag == 18) {
+         if (v_158->tag == 19) {
             _fx_LN10Ast__typ_t argtyps_0 = 0;
             _fx_LN10Ast__exp_t args_0 = 0;
             fx_str_t fstr_0 = {0};

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -209,263 +209,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -529,10 +272,20 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* root;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
 
 typedef struct _fx_N12Set__color_t {
    int tag;
@@ -557,6 +310,36 @@ typedef struct _fx_Rt6Set__t1R9Ast__id_t {
    int_ size;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Set__t1R9Ast__id_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -611,6 +394,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -692,6 +499,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -711,6 +542,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -907,6 +748,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -1078,6 +1057,27 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
       struct _fx_N10Ast__typ_t_data_t* EnvTyp;
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
+
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1918,561 +1918,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -2657,6 +2102,29 @@ static void _fx_make_Rt6Map__t2R9Ast__id_tR9Ast__id_t(
    FX_COPY_FP(r_cmp, &fx_result->cmp);
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t(
    struct _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t* dst)
 {
@@ -2823,6 +2291,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3780,6 +3301,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4247,6 +4174,79 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
       switch ((*dst)->tag) { case 2:     _fx_free_N10Ast__typ_t(&(*dst)->u.EnvTyp); break; default:    ; } fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -6577,6 +6577,10 @@ FX_EXTERN_C int _fx_M3AstFM6stringS1N12Ast__unary_t(struct _fx_N12Ast__unary_t*,
 
 FX_EXTERN_C void _fx_M3AstFM10IntrinMathN13Ast__intrin_t1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_N13Ast__intrin_t*);
 
+FX_EXTERN_C int _fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(
+   struct _fx_N10Ast__typ_t_data_t*,
+   struct _fx_N10Ast__typ_t_data_t**);
+
 FX_EXTERN_C int _fx_M3AstFM6stringS1N13Ast__intrin_t(struct _fx_N13Ast__intrin_t*, fx_str_t*, void*);
 
 FX_EXTERN_C int
@@ -6653,10 +6657,6 @@ FX_EXTERN_C int
    struct _fx_N10Ast__exp_t_data_t**);
 
 FX_EXTERN_C int _fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(
-   struct _fx_N10Ast__typ_t_data_t*,
-   struct _fx_N10Ast__typ_t_data_t**);
-
-FX_EXTERN_C int _fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(
    struct _fx_N10Ast__typ_t_data_t*,
    struct _fx_N10Ast__typ_t_data_t**);
 
@@ -20775,11 +20775,11 @@ FX_EXTERN_C int
       FX_COPY_PTR(e_1, &e_2);
       _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_1, &env_2);
       FX_COPY_PTR(sc_1, &sc_2);
-      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_2, &ctx_0, 0), _fx_catch_217);
+      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_2, &ctx_0, 0), _fx_catch_221);
       FX_COPY_PTR(ctx_0.t0, &etyp_0);
       _fx_R10Ast__loc_t eloc_0 = ctx_0.t1;
       int_ curr_m_idx_0;
-      FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_2, &curr_m_idx_0, 0), _fx_catch_217);
+      FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_2, &curr_m_idx_0, 0), _fx_catch_221);
       int tag_0 = FX_REC_VARIANT_TAG(e_2);
       if (tag_0 == 1) {
          _fx_free_N10Ast__exp_t(&result_0);
@@ -20787,7 +20787,7 @@ FX_EXTERN_C int
          FX_BREAK(_fx_catch_0);
 
       _fx_catch_0: ;
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 5) {
          _fx_Nt6option1N10Ast__exp_t new_e1_opt_0 = 0;
@@ -20862,7 +20862,7 @@ FX_EXTERN_C int
          if (new_e1_opt_0) {
             _fx_free_Nt6option1N10Ast__exp_t(&new_e1_opt_0);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 6) {
          _fx_N10Ast__typ_t v_5 = 0;
@@ -20878,7 +20878,7 @@ FX_EXTERN_C int
          if (v_5) {
             _fx_free_N10Ast__typ_t(&v_5);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 7) {
          _fx_T2R9Ast__id_tN10Ast__typ_t v_6 = {0};
@@ -20905,7 +20905,7 @@ FX_EXTERN_C int
             _fx_free_N10Ast__typ_t(&t_0);
          }
          _fx_free_T2R9Ast__id_tN10Ast__typ_t(&v_6);
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 21) {
          _fx_N10Ast__exp_t new_e1_0 = 0;
@@ -21345,7 +21345,7 @@ FX_EXTERN_C int
          if (new_e1_0) {
             _fx_free_N10Ast__exp_t(&new_e1_0);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 20) {
          _fx_N10Ast__exp_t new_e1_1 = 0;
@@ -21415,7 +21415,7 @@ FX_EXTERN_C int
          if (new_e1_1) {
             _fx_free_N10Ast__exp_t(&new_e1_1);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 8) {
          _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_5 = &e_2->u.ExpBinary;
@@ -21598,7 +21598,7 @@ FX_EXTERN_C int
             if (new_e1_2) {
                _fx_free_N10Ast__exp_t(&new_e1_2);
             }
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 8) {
@@ -21987,7 +21987,7 @@ FX_EXTERN_C int
             if (new_e1_3) {
                _fx_free_N10Ast__exp_t(&new_e1_3);
             }
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 8) {
@@ -22240,7 +22240,7 @@ FX_EXTERN_C int
             FX_CHECK_EXN(_fx_catch_43);
 
          _fx_catch_43: ;
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 8) {
@@ -22883,7 +22883,7 @@ FX_EXTERN_C int
          if (new_e1_6) {
             _fx_free_N10Ast__exp_t(&new_e1_6);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 22) {
          _fx_T2N10Ast__typ_tR10Ast__loc_t v_145 = {0};
@@ -22917,7 +22917,7 @@ FX_EXTERN_C int
             _fx_free_N10Ast__typ_t(&etyp1_7);
          }
          _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_145);
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 9) {
          _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_10 = &e_2->u.ExpUnary;
@@ -22958,7 +22958,7 @@ FX_EXTERN_C int
                _fx_free_N10Ast__typ_t(&etyp1_8);
             }
             _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_146);
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 9) {
@@ -23001,7 +23001,7 @@ FX_EXTERN_C int
                _fx_free_N10Ast__typ_t(&etyp1_9);
             }
             _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_148);
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 9) {
@@ -23221,12 +23221,12 @@ FX_EXTERN_C int
          if (new_e1_10) {
             _fx_free_N10Ast__exp_t(&new_e1_10);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 10) {
          _fx_T3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_13 = &e_2->u.ExpIntrin;
          _fx_N13Ast__intrin_t* v_158 = &vcase_13->t0;
-         if (v_158->tag == 16) {
+         if (v_158->tag == 18) {
             _fx_LN10Ast__typ_t argtyps_0 = 0;
             _fx_LN10Ast__exp_t args_0 = 0;
             fx_str_t fstr_0 = {0};
@@ -23603,7 +23603,7 @@ FX_EXTERN_C int
             if (argtyps_0) {
                _fx_free_LN10Ast__typ_t(&argtyps_0);
             }
-            goto _fx_endmatch_41;
+            goto _fx_endmatch_43;
          }
       }
       if (tag_0 == 10) {
@@ -24077,7 +24077,7 @@ FX_EXTERN_C int
                                                                if (v_196) {
                                                                   _fx_free_N10Ast__exp_t(&v_196);
                                                                }
-                                                               goto _fx_endmatch_41;
+                                                               goto _fx_endmatch_43;
                                                             }
                                                          }
                                                       }
@@ -24101,7 +24101,8 @@ FX_EXTERN_C int
          _fx_T3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_15 = &e_2->u.ExpIntrin;
          _fx_LN10Ast__exp_t args_4 = vcase_15->t1;
          _fx_N13Ast__intrin_t* iop_0 = &vcase_15->t0;
-         if (iop_0->tag == 9) {
+         int tag_9 = iop_0->tag;
+         if (tag_9 == 9) {
             _fx_T2N10Ast__exp_ti v_233 = {0};
             _fx_N10Ast__exp_t a_2 = 0;
             _fx_N10Ast__exp_t a_3 = 0;
@@ -24236,78 +24237,245 @@ FX_EXTERN_C int
             }
             _fx_free_T2N10Ast__exp_ti(&v_233);
          }
-         else {
-            fx_str_t v_243 = {0};
-            fx_str_t v_244 = {0};
-            fx_exn_t v_245 = {0};
-            FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(iop_0, &v_243, 0), _fx_catch_92);
-            fx_str_t slit_106 = FX_MAKE_STR("the intrinsic \'");
-            fx_str_t slit_107 = FX_MAKE_STR("\' is not supported by the type checker");
-            {
-               const fx_str_t strs_13[] = { slit_106, v_243, slit_107 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_13, 3, &v_244), _fx_catch_92);
+         else if (tag_9 == 16) {
+            _fx_Ta2N10Ast__exp_t v_243 = {0};
+            _fx_N10Ast__exp_t v_244 = 0;
+            _fx_N10Ast__exp_t elem_0 = 0;
+            _fx_N10Ast__exp_t v_245 = 0;
+            _fx_N10Ast__typ_t et_1 = 0;
+            _fx_N10Ast__typ_t v_246 = 0;
+            _fx_N10Ast__typ_t v_247 = 0;
+            _fx_N10Ast__exp_t elem_1 = 0;
+            _fx_N10Ast__typ_t v_248 = 0;
+            _fx_LN10Ast__exp_t v_249 = 0;
+            _fx_N10Ast__exp_t result_31 = 0;
+            if (args_4 != 0) {
+               _fx_LN10Ast__exp_t v_250 = args_4->tl;
+               if (v_250 != 0) {
+                  if (v_250->tl == 0) {
+                     _fx_make_Ta2N10Ast__exp_t(args_4->hd, v_250->hd, &v_243); goto _fx_endmatch_21;
+                  }
+               }
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_244, &v_245, 0), _fx_catch_92);
-            FX_THROW(&v_245, false, _fx_catch_92);
+            fx_exn_t v_251 = {0};
+            fx_str_t slit_106 = FX_MAKE_STR("__intrin_push__ intrinsic expects exactly two arguments (vector, element)");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_106, &v_251, 0), _fx_catch_92);
+            FX_THROW(&v_251, false, _fx_catch_92);
 
          _fx_catch_92: ;
-            fx_free_exn(&v_245);
-            FX_FREE_STR(&v_244);
-            FX_FREE_STR(&v_243);
-         }
-         FX_CHECK_EXN(_fx_catch_93);
+            fx_free_exn(&v_251);
 
-      _fx_catch_93: ;
-         goto _fx_endmatch_41;
+         _fx_endmatch_21: ;
+            FX_CHECK_EXN(_fx_catch_93);
+            FX_COPY_PTR(v_243.t0, &v_244);
+            FX_COPY_PTR(v_243.t1, &elem_0);
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+                  v_244, &env_2, sc_2, &v_245, 0), _fx_catch_93);
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&et_1, 0), _fx_catch_93);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(v_245, &v_246, 0), _fx_catch_93);
+            FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(et_1, &v_247), _fx_catch_93);
+            _fx_R10Ast__loc_t v_252;
+            FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_245, &v_252, 0), _fx_catch_93);
+            fx_str_t slit_107 = FX_MAKE_STR("the first argument of __intrin_push__ must be a vector");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_246, v_247, &v_252, &slit_107, 0),
+               _fx_catch_93);
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+                  elem_0, &env_2, sc_2, &elem_1, 0), _fx_catch_93);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(elem_1, &v_248, 0), _fx_catch_93);
+            _fx_R10Ast__loc_t v_253;
+            FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(elem_1, &v_253, 0), _fx_catch_93);
+            fx_str_t slit_108 = FX_MAKE_STR("the element type must match the vector element type in __intrin_push__");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_248, et_1, &v_253, &slit_108, 0),
+               _fx_catch_93);
+            fx_str_t slit_109 = FX_MAKE_STR("the result of __intrin_push__ must be void");
+            FX_CALL(
+               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypVoid,
+                  &eloc_0, &slit_109, 0), _fx_catch_93);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(elem_1, 0, true, &v_249), _fx_catch_93);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_245, v_249, false, &v_249), _fx_catch_93);
+            FX_CALL(
+               _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(iop_0, v_249, &ctx_0,
+                  &result_31), _fx_catch_93);
+            _fx_free_N10Ast__exp_t(&result_0);
+            FX_COPY_PTR(result_31, &result_0);
+            FX_BREAK(_fx_catch_93);
+
+         _fx_catch_93: ;
+            if (result_31) {
+               _fx_free_N10Ast__exp_t(&result_31);
+            }
+            if (v_249) {
+               _fx_free_LN10Ast__exp_t(&v_249);
+            }
+            if (v_248) {
+               _fx_free_N10Ast__typ_t(&v_248);
+            }
+            if (elem_1) {
+               _fx_free_N10Ast__exp_t(&elem_1);
+            }
+            if (v_247) {
+               _fx_free_N10Ast__typ_t(&v_247);
+            }
+            if (v_246) {
+               _fx_free_N10Ast__typ_t(&v_246);
+            }
+            if (et_1) {
+               _fx_free_N10Ast__typ_t(&et_1);
+            }
+            if (v_245) {
+               _fx_free_N10Ast__exp_t(&v_245);
+            }
+            if (elem_0) {
+               _fx_free_N10Ast__exp_t(&elem_0);
+            }
+            if (v_244) {
+               _fx_free_N10Ast__exp_t(&v_244);
+            }
+            _fx_free_Ta2N10Ast__exp_t(&v_243);
+         }
+         else if (tag_9 == 17) {
+            _fx_N10Ast__exp_t v_254 = 0;
+            _fx_N10Ast__exp_t v_255 = 0;
+            _fx_N10Ast__typ_t et_2 = 0;
+            _fx_N10Ast__typ_t v_256 = 0;
+            _fx_N10Ast__typ_t v_257 = 0;
+            _fx_LN10Ast__exp_t v_258 = 0;
+            _fx_N10Ast__exp_t result_32 = 0;
+            if (args_4 != 0) {
+               if (args_4->tl == 0) {
+                  FX_COPY_PTR(args_4->hd, &v_254); goto _fx_endmatch_22;
+               }
+            }
+            fx_exn_t v_259 = {0};
+            fx_str_t slit_110 = FX_MAKE_STR("__intrin_pop__ intrinsic expects exactly one argument (vector)");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_110, &v_259, 0), _fx_catch_94);
+            FX_THROW(&v_259, false, _fx_catch_94);
+
+         _fx_catch_94: ;
+            fx_free_exn(&v_259);
+
+         _fx_endmatch_22: ;
+            FX_CHECK_EXN(_fx_catch_95);
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+                  v_254, &env_2, sc_2, &v_255, 0), _fx_catch_95);
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&et_2, 0), _fx_catch_95);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(v_255, &v_256, 0), _fx_catch_95);
+            FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(et_2, &v_257), _fx_catch_95);
+            _fx_R10Ast__loc_t v_260;
+            FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_255, &v_260, 0), _fx_catch_95);
+            fx_str_t slit_111 = FX_MAKE_STR("the argument of __intrin_pop__ must be a vector");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_256, v_257, &v_260, &slit_111, 0),
+               _fx_catch_95);
+            fx_str_t slit_112 = FX_MAKE_STR("the result of __intrin_pop__ must be void");
+            FX_CALL(
+               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypVoid,
+                  &eloc_0, &slit_112, 0), _fx_catch_95);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_255, 0, true, &v_258), _fx_catch_95);
+            FX_CALL(
+               _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(iop_0, v_258, &ctx_0,
+                  &result_32), _fx_catch_95);
+            _fx_free_N10Ast__exp_t(&result_0);
+            FX_COPY_PTR(result_32, &result_0);
+            FX_BREAK(_fx_catch_95);
+
+         _fx_catch_95: ;
+            if (result_32) {
+               _fx_free_N10Ast__exp_t(&result_32);
+            }
+            if (v_258) {
+               _fx_free_LN10Ast__exp_t(&v_258);
+            }
+            if (v_257) {
+               _fx_free_N10Ast__typ_t(&v_257);
+            }
+            if (v_256) {
+               _fx_free_N10Ast__typ_t(&v_256);
+            }
+            if (et_2) {
+               _fx_free_N10Ast__typ_t(&et_2);
+            }
+            if (v_255) {
+               _fx_free_N10Ast__exp_t(&v_255);
+            }
+            if (v_254) {
+               _fx_free_N10Ast__exp_t(&v_254);
+            }
+         }
+         else {
+            fx_str_t v_261 = {0};
+            fx_str_t v_262 = {0};
+            fx_exn_t v_263 = {0};
+            FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(iop_0, &v_261, 0), _fx_catch_96);
+            fx_str_t slit_113 = FX_MAKE_STR("the intrinsic \'");
+            fx_str_t slit_114 = FX_MAKE_STR("\' is not supported by the type checker");
+            {
+               const fx_str_t strs_13[] = { slit_113, v_261, slit_114 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_13, 3, &v_262), _fx_catch_96);
+            }
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_262, &v_263, 0), _fx_catch_96);
+            FX_THROW(&v_263, false, _fx_catch_96);
+
+         _fx_catch_96: ;
+            fx_free_exn(&v_263);
+            FX_FREE_STR(&v_262);
+            FX_FREE_STR(&v_261);
+         }
+         FX_CHECK_EXN(_fx_catch_97);
+
+      _fx_catch_97: ;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 12) {
          _fx_N10Ast__typ_t eseq_typ_0 = 0;
-         _fx_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_246 = {0};
+         _fx_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t v_264 = {0};
          _fx_LN10Ast__exp_t eseq_0 = 0;
-         _fx_N10Ast__exp_t result_31 = 0;
+         _fx_N10Ast__exp_t result_33 = 0;
          _fx_LN10Ast__exp_t eseq_1 = e_2->u.ExpSeq.t0;
          bool is_func_body_0;
          if (sc_2 != 0) {
             if (sc_2->hd.tag == 7) {
-               is_func_body_0 = true; goto _fx_endmatch_21;
+               is_func_body_0 = true; goto _fx_endmatch_23;
             }
          }
          if (sc_2 != 0) {
             if (sc_2->hd.tag == 1) {
-               _fx_LN12Ast__scope_t v_247 = sc_2->tl;
-               if (v_247 != 0) {
-                  if (v_247->hd.tag == 7) {
-                     is_func_body_0 = true; goto _fx_endmatch_21;
+               _fx_LN12Ast__scope_t v_265 = sc_2->tl;
+               if (v_265 != 0) {
+                  if (v_265->hd.tag == 7) {
+                     is_func_body_0 = true; goto _fx_endmatch_23;
                   }
                }
             }
          }
          is_func_body_0 = false;
 
-      _fx_endmatch_21: ;
-         FX_CHECK_EXN(_fx_catch_95);
+      _fx_endmatch_23: ;
+         FX_CHECK_EXN(_fx_catch_99);
          if (eseq_1 == 0) {
             FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &eseq_typ_0);
          }
          else {
             _fx_N10Ast__exp_t last_exp_0 = 0;
             _fx_N10Ast__exp_t last_exp_1 = 0;
-            FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(eseq_1, &last_exp_0, 0), _fx_catch_94);
+            FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(eseq_1, &last_exp_0, 0), _fx_catch_98);
             if (FX_REC_VARIANT_TAG(last_exp_0) == 4) {
-               _fx_Nt6option1N10Ast__exp_t v_248 = last_exp_0->u.ExpReturn.t0;
-               if ((v_248 != 0) + 1 == 2) {
+               _fx_Nt6option1N10Ast__exp_t v_266 = last_exp_0->u.ExpReturn.t0;
+               if ((v_266 != 0) + 1 == 2) {
                   if (is_func_body_0) {
-                     FX_COPY_PTR(v_248->u.Some, &last_exp_1); goto _fx_endmatch_22;
+                     FX_COPY_PTR(v_266->u.Some, &last_exp_1); goto _fx_endmatch_24;
                   }
                }
             }
             FX_COPY_PTR(last_exp_0, &last_exp_1);
 
-         _fx_endmatch_22: ;
-            FX_CHECK_EXN(_fx_catch_94);
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(last_exp_1, &eseq_typ_0, 0), _fx_catch_94);
+         _fx_endmatch_24: ;
+            FX_CHECK_EXN(_fx_catch_98);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(last_exp_1, &eseq_typ_0, 0), _fx_catch_98);
 
-         _fx_catch_94: ;
+         _fx_catch_98: ;
             if (last_exp_1) {
                _fx_free_N10Ast__exp_t(&last_exp_1);
             }
@@ -24315,107 +24483,16 @@ FX_EXTERN_C int
                _fx_free_N10Ast__exp_t(&last_exp_0);
             }
          }
-         FX_CHECK_EXN(_fx_catch_95);
-         fx_str_t slit_108 = FX_MAKE_STR("the expected type of block expression does not match its actual type");
+         FX_CHECK_EXN(_fx_catch_99);
+         fx_str_t slit_115 = FX_MAKE_STR("the expected type of block expression does not match its actual type");
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, eseq_typ_0, &eloc_0, &slit_108, 0),
-            _fx_catch_95);
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, eseq_typ_0, &eloc_0, &slit_115, 0),
+            _fx_catch_99);
          FX_CALL(
             _fx_M13Ast_typecheckFM10check_eseqT2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t4LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tB(
-               eseq_1, &env_2, sc_2, true, &v_246, 0), _fx_catch_95);
-         FX_COPY_PTR(v_246.t0, &eseq_0);
-         FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(eseq_0, &ctx_0, &result_31),
-            _fx_catch_95);
-         _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_31, &result_0);
-         FX_BREAK(_fx_catch_95);
-
-      _fx_catch_95: ;
-         if (result_31) {
-            _fx_free_N10Ast__exp_t(&result_31);
-         }
-         if (eseq_0) {
-            _fx_free_LN10Ast__exp_t(&eseq_0);
-         }
-         _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_246);
-         if (eseq_typ_0) {
-            _fx_free_N10Ast__typ_t(&eseq_typ_0);
-         }
-         goto _fx_endmatch_41;
-      }
-      if (tag_0 == 11) {
-         _fx_N10Ast__exp_t e_3 = 0;
-         _fx_N10Ast__exp_t result_32 = 0;
-         _fx_T2R9Ast__id_tN10Ast__exp_t* vcase_16 = &e_2->u.ExpSync;
-         FX_CALL(
-            _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(false, false, true, sc_2, &eloc_0, 0),
-            _fx_catch_96);
-         FX_CALL(
-            _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               vcase_16->t1, &env_2, sc_2, &e_3, 0), _fx_catch_96);
-         FX_CALL(_fx_M3AstFM7ExpSyncN10Ast__exp_t2RM4id_tN10Ast__exp_t(&vcase_16->t0, e_3, &result_32), _fx_catch_96);
-         _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_32, &result_0);
-         FX_BREAK(_fx_catch_96);
-
-      _fx_catch_96: ;
-         if (result_32) {
-            _fx_free_N10Ast__exp_t(&result_32);
-         }
-         if (e_3) {
-            _fx_free_N10Ast__exp_t(&e_3);
-         }
-         goto _fx_endmatch_41;
-      }
-      if (tag_0 == 13) {
-         _fx_LN10Ast__typ_t tl_0 = 0;
-         _fx_LN10Ast__exp_t el_0 = 0;
-         _fx_N10Ast__typ_t v_249 = 0;
-         _fx_LN10Ast__exp_t v_250 = 0;
-         _fx_LN10Ast__exp_t el_1 = 0;
-         _fx_N10Ast__exp_t result_33 = 0;
-         _fx_LN10Ast__exp_t el_2 = e_2->u.ExpMkTuple.t0;
-         _fx_LN10Ast__typ_t lstend_2 = 0;
-         FX_COPY_PTR(el_2, &el_0);
-         _fx_LN10Ast__exp_t lst_3 = el_0;
-         for (; lst_3; lst_3 = lst_3->tl) {
-            _fx_N10Ast__typ_t res_28 = 0;
-            _fx_N10Ast__exp_t e_4 = lst_3->hd;
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_4, &res_28, 0), _fx_catch_97);
-            _fx_LN10Ast__typ_t node_2 = 0;
-            FX_CALL(_fx_cons_LN10Ast__typ_t(res_28, 0, false, &node_2), _fx_catch_97);
-            FX_LIST_APPEND(tl_0, lstend_2, node_2);
-
-         _fx_catch_97: ;
-            if (res_28) {
-               _fx_free_N10Ast__typ_t(&res_28);
-            }
-            FX_CHECK_EXN(_fx_catch_99);
-         }
-         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_0, &v_249), _fx_catch_99);
-         fx_str_t slit_109 = FX_MAKE_STR("improper type of tuple elements or the number of elements");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_249, &eloc_0, &slit_109, 0),
-            _fx_catch_99);
-         _fx_LN10Ast__exp_t lstend_3 = 0;
-         FX_COPY_PTR(el_2, &el_1);
-         _fx_LN10Ast__exp_t lst_4 = el_1;
-         for (; lst_4; lst_4 = lst_4->tl) {
-            _fx_N10Ast__exp_t res_29 = 0;
-            _fx_N10Ast__exp_t e_5 = lst_4->hd;
-            FX_CALL(
-               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  e_5, &env_2, sc_2, &res_29, 0), _fx_catch_98);
-            _fx_LN10Ast__exp_t node_3 = 0;
-            FX_CALL(_fx_cons_LN10Ast__exp_t(res_29, 0, false, &node_3), _fx_catch_98);
-            FX_LIST_APPEND(v_250, lstend_3, node_3);
-
-         _fx_catch_98: ;
-            if (res_29) {
-               _fx_free_N10Ast__exp_t(&res_29);
-            }
-            FX_CHECK_EXN(_fx_catch_99);
-         }
-         FX_CALL(_fx_M3AstFM10ExpMkTupleN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_250, &ctx_0, &result_33),
+               eseq_1, &env_2, sc_2, true, &v_264, 0), _fx_catch_99);
+         FX_COPY_PTR(v_264.t0, &eseq_0);
+         FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(eseq_0, &ctx_0, &result_33),
             _fx_catch_99);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(result_33, &result_0);
@@ -24425,14 +24502,105 @@ FX_EXTERN_C int
          if (result_33) {
             _fx_free_N10Ast__exp_t(&result_33);
          }
+         if (eseq_0) {
+            _fx_free_LN10Ast__exp_t(&eseq_0);
+         }
+         _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_264);
+         if (eseq_typ_0) {
+            _fx_free_N10Ast__typ_t(&eseq_typ_0);
+         }
+         goto _fx_endmatch_43;
+      }
+      if (tag_0 == 11) {
+         _fx_N10Ast__exp_t e_3 = 0;
+         _fx_N10Ast__exp_t result_34 = 0;
+         _fx_T2R9Ast__id_tN10Ast__exp_t* vcase_16 = &e_2->u.ExpSync;
+         FX_CALL(
+            _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(false, false, true, sc_2, &eloc_0, 0),
+            _fx_catch_100);
+         FX_CALL(
+            _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+               vcase_16->t1, &env_2, sc_2, &e_3, 0), _fx_catch_100);
+         FX_CALL(_fx_M3AstFM7ExpSyncN10Ast__exp_t2RM4id_tN10Ast__exp_t(&vcase_16->t0, e_3, &result_34), _fx_catch_100);
+         _fx_free_N10Ast__exp_t(&result_0);
+         FX_COPY_PTR(result_34, &result_0);
+         FX_BREAK(_fx_catch_100);
+
+      _fx_catch_100: ;
+         if (result_34) {
+            _fx_free_N10Ast__exp_t(&result_34);
+         }
+         if (e_3) {
+            _fx_free_N10Ast__exp_t(&e_3);
+         }
+         goto _fx_endmatch_43;
+      }
+      if (tag_0 == 13) {
+         _fx_LN10Ast__typ_t tl_0 = 0;
+         _fx_LN10Ast__exp_t el_0 = 0;
+         _fx_N10Ast__typ_t v_267 = 0;
+         _fx_LN10Ast__exp_t v_268 = 0;
+         _fx_LN10Ast__exp_t el_1 = 0;
+         _fx_N10Ast__exp_t result_35 = 0;
+         _fx_LN10Ast__exp_t el_2 = e_2->u.ExpMkTuple.t0;
+         _fx_LN10Ast__typ_t lstend_2 = 0;
+         FX_COPY_PTR(el_2, &el_0);
+         _fx_LN10Ast__exp_t lst_3 = el_0;
+         for (; lst_3; lst_3 = lst_3->tl) {
+            _fx_N10Ast__typ_t res_28 = 0;
+            _fx_N10Ast__exp_t e_4 = lst_3->hd;
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_4, &res_28, 0), _fx_catch_101);
+            _fx_LN10Ast__typ_t node_2 = 0;
+            FX_CALL(_fx_cons_LN10Ast__typ_t(res_28, 0, false, &node_2), _fx_catch_101);
+            FX_LIST_APPEND(tl_0, lstend_2, node_2);
+
+         _fx_catch_101: ;
+            if (res_28) {
+               _fx_free_N10Ast__typ_t(&res_28);
+            }
+            FX_CHECK_EXN(_fx_catch_103);
+         }
+         FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_0, &v_267), _fx_catch_103);
+         fx_str_t slit_116 = FX_MAKE_STR("improper type of tuple elements or the number of elements");
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_267, &eloc_0, &slit_116, 0),
+            _fx_catch_103);
+         _fx_LN10Ast__exp_t lstend_3 = 0;
+         FX_COPY_PTR(el_2, &el_1);
+         _fx_LN10Ast__exp_t lst_4 = el_1;
+         for (; lst_4; lst_4 = lst_4->tl) {
+            _fx_N10Ast__exp_t res_29 = 0;
+            _fx_N10Ast__exp_t e_5 = lst_4->hd;
+            FX_CALL(
+               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
+                  e_5, &env_2, sc_2, &res_29, 0), _fx_catch_102);
+            _fx_LN10Ast__exp_t node_3 = 0;
+            FX_CALL(_fx_cons_LN10Ast__exp_t(res_29, 0, false, &node_3), _fx_catch_102);
+            FX_LIST_APPEND(v_268, lstend_3, node_3);
+
+         _fx_catch_102: ;
+            if (res_29) {
+               _fx_free_N10Ast__exp_t(&res_29);
+            }
+            FX_CHECK_EXN(_fx_catch_103);
+         }
+         FX_CALL(_fx_M3AstFM10ExpMkTupleN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_268, &ctx_0, &result_35),
+            _fx_catch_103);
+         _fx_free_N10Ast__exp_t(&result_0);
+         FX_COPY_PTR(result_35, &result_0);
+         FX_BREAK(_fx_catch_103);
+
+      _fx_catch_103: ;
+         if (result_35) {
+            _fx_free_N10Ast__exp_t(&result_35);
+         }
          if (el_1) {
             _fx_free_LN10Ast__exp_t(&el_1);
          }
-         if (v_250) {
-            _fx_free_LN10Ast__exp_t(&v_250);
+         if (v_268) {
+            _fx_free_LN10Ast__exp_t(&v_268);
          }
-         if (v_249) {
-            _fx_free_N10Ast__typ_t(&v_249);
+         if (v_267) {
+            _fx_free_N10Ast__typ_t(&v_267);
          }
          if (el_0) {
             _fx_free_LN10Ast__exp_t(&el_0);
@@ -24440,7 +24608,7 @@ FX_EXTERN_C int
          if (tl_0) {
             _fx_free_LN10Ast__typ_t(&tl_0);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 18) {
          _fx_N10Ast__exp_t f_2 = 0;
@@ -24448,130 +24616,130 @@ FX_EXTERN_C int
          _fx_LN10Ast__exp_t args_5 = 0;
          _fx_LN10Ast__typ_t arg_typs_0 = 0;
          _fx_N10Ast__typ_t f_expected_typ_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_251 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_269 = {0};
          _fx_N10Ast__typ_t f_real_typ_0 = 0;
-         fx_str_t v_252 = {0};
-         fx_str_t v_253 = {0};
-         fx_str_t v_254 = {0};
-         fx_str_t v_255 = {0};
-         fx_str_t v_256 = {0};
+         fx_str_t v_270 = {0};
+         fx_str_t v_271 = {0};
+         fx_str_t v_272 = {0};
+         fx_str_t v_273 = {0};
+         fx_str_t v_274 = {0};
          _fx_LT2N10Ast__exp_tB new_args_0 = 0;
-         _fx_N10Ast__exp_t result_34 = 0;
+         _fx_N10Ast__exp_t result_36 = 0;
          fx_exn_t exn_2 = {0};
          _fx_T3N10Ast__exp_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_17 = &e_2->u.ExpCall;
          _fx_LN10Ast__exp_t args0_0 = vcase_17->t1;
          _fx_N10Ast__exp_t f0_0 = vcase_17->t0;
-         FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(f0_0, &f_2, 0), _fx_catch_117);
+         FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(f0_0, &f_2, 0), _fx_catch_121);
          _fx_FPN10Ast__exp_t1N10Ast__exp_t dup_exp_fp_0 = { _fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t, 0 };
          FX_COPY_FP(&dup_exp_fp_0, &dup_exp_0);
          FX_CALL(
             _fx_M13Ast_typecheckFM3mapLN10Ast__exp_t2LN10Ast__exp_tFPN10Ast__exp_t1N10Ast__exp_t(args0_0, &dup_exp_0, &args_5,
-               0), _fx_catch_117);
+               0), _fx_catch_121);
          _fx_LN10Ast__typ_t lstend_4 = 0;
          _fx_LN10Ast__exp_t lst_5 = args_5;
          for (; lst_5; lst_5 = lst_5->tl) {
             _fx_N10Ast__typ_t res_30 = 0;
             _fx_N10Ast__exp_t a_4 = lst_5->hd;
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(a_4, &res_30, 0), _fx_catch_100);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(a_4, &res_30, 0), _fx_catch_104);
             _fx_LN10Ast__typ_t node_4 = 0;
-            FX_CALL(_fx_cons_LN10Ast__typ_t(res_30, 0, false, &node_4), _fx_catch_100);
+            FX_CALL(_fx_cons_LN10Ast__typ_t(res_30, 0, false, &node_4), _fx_catch_104);
             FX_LIST_APPEND(arg_typs_0, lstend_4, node_4);
 
-         _fx_catch_100: ;
+         _fx_catch_104: ;
             if (res_30) {
                _fx_free_N10Ast__typ_t(&res_30);
             }
-            FX_CHECK_EXN(_fx_catch_117);
+            FX_CHECK_EXN(_fx_catch_121);
          }
          FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(arg_typs_0, etyp_0, &f_expected_typ_0),
-            _fx_catch_117);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(f_2, &v_251, 0), _fx_catch_117);
-         FX_COPY_PTR(v_251.t0, &f_real_typ_0);
-         _fx_R10Ast__loc_t floc_0 = v_251.t1;
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(f_real_typ_0, &v_252, 0), _fx_catch_117);
-         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_252, &v_253, 0), _fx_catch_117);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(f_expected_typ_0, &v_254, 0), _fx_catch_117);
-         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_254, &v_255, 0), _fx_catch_117);
-         fx_str_t slit_110 = FX_MAKE_STR("the real \'");
-         fx_str_t slit_111 = FX_MAKE_STR("\' and expected \'");
-         fx_str_t slit_112 = FX_MAKE_STR("\' function type do not match");
+            _fx_catch_121);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(f_2, &v_269, 0), _fx_catch_121);
+         FX_COPY_PTR(v_269.t0, &f_real_typ_0);
+         _fx_R10Ast__loc_t floc_0 = v_269.t1;
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(f_real_typ_0, &v_270, 0), _fx_catch_121);
+         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_270, &v_271, 0), _fx_catch_121);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(f_expected_typ_0, &v_272, 0), _fx_catch_121);
+         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_272, &v_273, 0), _fx_catch_121);
+         fx_str_t slit_117 = FX_MAKE_STR("the real \'");
+         fx_str_t slit_118 = FX_MAKE_STR("\' and expected \'");
+         fx_str_t slit_119 = FX_MAKE_STR("\' function type do not match");
          {
-            const fx_str_t strs_14[] = { slit_110, v_253, slit_111, v_255, slit_112 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_14, 5, &v_256), _fx_catch_117);
+            const fx_str_t strs_14[] = { slit_117, v_271, slit_118, v_273, slit_119 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_14, 5, &v_274), _fx_catch_121);
          }
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(f_real_typ_0, f_expected_typ_0, &floc_0,
-               &v_256, 0), _fx_catch_117);
+               &v_274, 0), _fx_catch_121);
          _fx_LT2N10Ast__exp_tB lstend_5 = 0;
          _fx_LN10Ast__exp_t lst_6 = args_5;
          for (; lst_6; lst_6 = lst_6->tl) {
-            _fx_R13Ast__deffun_t v_257 = {0};
+            _fx_R13Ast__deffun_t v_275 = {0};
             _fx_T2N10Ast__exp_tB t_8 = {0};
-            _fx_N10Ast__exp_t v_258 = 0;
+            _fx_N10Ast__exp_t v_276 = 0;
             _fx_N10Ast__exp_t a_5 = lst_6->hd;
-            int tag_9 = FX_REC_VARIANT_TAG(a_5);
+            int tag_10 = FX_REC_VARIANT_TAG(a_5);
             bool need_to_check_0;
-            if (tag_9 == 12) {
-               _fx_LN10Ast__exp_t v_259 = a_5->u.ExpSeq.t0;
-               if (v_259 != 0) {
-                  _fx_LN10Ast__exp_t v_260 = v_259->tl;
-                  if (v_260 != 0) {
-                     if (v_260->tl == 0) {
-                        _fx_N10Ast__exp_t v_261 = v_260->hd;
-                        if (FX_REC_VARIANT_TAG(v_261) == 7) {
-                           _fx_R9Ast__id_t* f_3 = &v_261->u.ExpIdent.t0;
-                           _fx_N10Ast__exp_t exp_df_0 = v_259->hd;
+            if (tag_10 == 12) {
+               _fx_LN10Ast__exp_t v_277 = a_5->u.ExpSeq.t0;
+               if (v_277 != 0) {
+                  _fx_LN10Ast__exp_t v_278 = v_277->tl;
+                  if (v_278 != 0) {
+                     if (v_278->tl == 0) {
+                        _fx_N10Ast__exp_t v_279 = v_278->hd;
+                        if (FX_REC_VARIANT_TAG(v_279) == 7) {
+                           _fx_R9Ast__id_t* f_3 = &v_279->u.ExpIdent.t0;
+                           _fx_N10Ast__exp_t exp_df_0 = v_277->hd;
                            if (FX_REC_VARIANT_TAG(exp_df_0) == 35) {
-                              _fx_copy_R13Ast__deffun_t(&exp_df_0->u.DefFun->data, &v_257);
-                              _fx_R9Ast__id_t v_262;
-                              FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(f_3, &v_262, 0), _fx_catch_108);
+                              _fx_copy_R13Ast__deffun_t(&exp_df_0->u.DefFun->data, &v_275);
+                              _fx_R9Ast__id_t v_280;
+                              FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(f_3, &v_280, 0), _fx_catch_112);
                               bool res_31;
-                              FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_262, &_fx_g18Ast__std__lambda__, &res_31, 0),
-                                 _fx_catch_108);
+                              FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_280, &_fx_g18Ast__std__lambda__, &res_31, 0),
+                                 _fx_catch_112);
                               bool t_9;
                               if (res_31) {
-                                 FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(f_3, &v_257.df_name, &t_9, 0), _fx_catch_108);
+                                 FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(f_3, &v_275.df_name, &t_9, 0), _fx_catch_112);
                               }
                               else {
                                  t_9 = false;
                               }
                               if (t_9) {
-                                 _fx_N10Ast__exp_t v_263 = 0;
+                                 _fx_N10Ast__exp_t v_281 = 0;
                                  _fx_rR13Ast__deffun_t df_0 = 0;
                                  _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t res_32 = {0};
-                                 _fx_LR9Ast__id_t v_264 = 0;
-                                 FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(exp_df_0, &v_263, 0), _fx_catch_102);
-                                 if (FX_REC_VARIANT_TAG(v_263) == 35) {
-                                    FX_COPY_PTR(v_263->u.DefFun, &df_0);
+                                 _fx_LR9Ast__id_t v_282 = 0;
+                                 FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(exp_df_0, &v_281, 0), _fx_catch_106);
+                                 if (FX_REC_VARIANT_TAG(v_281) == 35) {
+                                    FX_COPY_PTR(v_281->u.DefFun, &df_0);
                                  }
                                  else {
-                                    fx_exn_t v_265 = {0};
-                                    fx_str_t slit_113 = FX_MAKE_STR("after duplication function is not a function anymore!");
-                                    FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_257.df_loc, &slit_113, &v_265, 0),
-                                       _fx_catch_101);
-                                    FX_THROW(&v_265, false, _fx_catch_101);
+                                    fx_exn_t v_283 = {0};
+                                    fx_str_t slit_120 = FX_MAKE_STR("after duplication function is not a function anymore!");
+                                    FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_275.df_loc, &slit_120, &v_283, 0),
+                                       _fx_catch_105);
+                                    FX_THROW(&v_283, false, _fx_catch_105);
 
-                                 _fx_catch_101: ;
-                                    fx_free_exn(&v_265);
+                                 _fx_catch_105: ;
+                                    fx_free_exn(&v_283);
                                  }
-                                 FX_CHECK_EXN(_fx_catch_102);
+                                 FX_CHECK_EXN(_fx_catch_106);
                                  FX_CALL(
                                     _fx_M13Ast_typecheckFM10reg_deffunRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t3rR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                                       df_0, &env_2, sc_2, &res_32, 0), _fx_catch_102);
-                                 _fx_R13Ast__deffun_t* v_266 = &df_0->data;
-                                 FX_COPY_PTR(v_266->df_templ_args, &v_264);
-                                 need_to_check_0 = v_264 == 0;
+                                       df_0, &env_2, sc_2, &res_32, 0), _fx_catch_106);
+                                 _fx_R13Ast__deffun_t* v_284 = &df_0->data;
+                                 FX_COPY_PTR(v_284->df_templ_args, &v_282);
+                                 need_to_check_0 = v_282 == 0;
 
-                              _fx_catch_102: ;
-                                 FX_FREE_LIST_SIMPLE(&v_264);
+                              _fx_catch_106: ;
+                                 FX_FREE_LIST_SIMPLE(&v_282);
                                  _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&res_32);
                                  if (df_0) {
                                     _fx_free_rR13Ast__deffun_t(&df_0);
                                  }
-                                 if (v_263) {
-                                    _fx_free_N10Ast__exp_t(&v_263);
+                                 if (v_281) {
+                                    _fx_free_N10Ast__exp_t(&v_281);
                                  }
-                                 goto _fx_endmatch_25;
+                                 goto _fx_endmatch_27;
                               }
                            }
                         }
@@ -24580,203 +24748,203 @@ FX_EXTERN_C int
                }
             }
             bool res_33;
-            if (tag_9 == 7) {
-               res_33 = true; goto _fx_endmatch_23;
+            if (tag_10 == 7) {
+               res_33 = true; goto _fx_endmatch_25;
             }
-            if (tag_9 == 21) {
+            if (tag_10 == 21) {
                if (FX_REC_VARIANT_TAG(a_5->u.ExpMem.t1) == 7) {
-                  res_33 = true; goto _fx_endmatch_23;
+                  res_33 = true; goto _fx_endmatch_25;
                }
             }
             res_33 = false;
 
-         _fx_endmatch_23: ;
-            FX_CHECK_EXN(_fx_catch_108);
+         _fx_endmatch_25: ;
+            FX_CHECK_EXN(_fx_catch_112);
             if (res_33) {
-               _fx_N10Ast__exp_t v_267 = 0;
-               _fx_N10Ast__exp_t v_268 = 0;
-               _fx_N10Ast__typ_t v_269 = 0;
-               FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(a_5, &v_267, 0), _fx_catch_107);
+               _fx_N10Ast__exp_t v_285 = 0;
+               _fx_N10Ast__exp_t v_286 = 0;
+               _fx_N10Ast__typ_t v_287 = 0;
+               FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(a_5, &v_285, 0), _fx_catch_111);
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     v_267, &env_2, sc_2, &v_268, 0), _fx_catch_107);
-               if (FX_REC_VARIANT_TAG(v_268) == 7) {
-                  _fx_T2R9Ast__id_tT2N10Ast__typ_tR10Ast__loc_t* vcase_18 = &v_268->u.ExpIdent;
+                     v_285, &env_2, sc_2, &v_286, 0), _fx_catch_111);
+               if (FX_REC_VARIANT_TAG(v_286) == 7) {
+                  _fx_T2R9Ast__id_tT2N10Ast__typ_tR10Ast__loc_t* vcase_18 = &v_286->u.ExpIdent;
                   _fx_R9Ast__id_t* f_4 = &vcase_18->t0;
-                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(vcase_18->t1.t0, &v_269, 0), _fx_catch_107);
+                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(vcase_18->t1.t0, &v_287, 0), _fx_catch_111);
                   bool res_34;
-                  if (FX_REC_VARIANT_TAG(v_269) == 15) {
+                  if (FX_REC_VARIANT_TAG(v_287) == 15) {
                      res_34 = true;
                   }
                   else {
                      res_34 = false;
                   }
-                  FX_CHECK_EXN(_fx_catch_107);
+                  FX_CHECK_EXN(_fx_catch_111);
                   if (res_34) {
-                     _fx_N14Ast__id_info_t v_270 = {0};
-                     FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(f_4, &eloc_0, &v_270, 0), _fx_catch_106);
-                     if (v_270.tag == 3) {
-                        _fx_R13Ast__deffun_t v_271 = {0};
+                     _fx_N14Ast__id_info_t v_288 = {0};
+                     FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(f_4, &eloc_0, &v_288, 0), _fx_catch_110);
+                     if (v_288.tag == 3) {
+                        _fx_R13Ast__deffun_t v_289 = {0};
                         _fx_LN16Ast__env_entry_t all_entries_0 = 0;
-                        _fx_copy_R13Ast__deffun_t(&v_270.u.IdFun->data, &v_271);
-                        _fx_R9Ast__id_t v_272;
-                        FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(f_4, &v_272, 0), _fx_catch_105);
+                        _fx_copy_R13Ast__deffun_t(&v_288.u.IdFun->data, &v_289);
+                        _fx_R9Ast__id_t v_290;
+                        FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(f_4, &v_290, 0), _fx_catch_109);
                         FX_CALL(
                            _fx_M13Ast_typecheckFM8find_allLN16Ast__env_entry_t2R9Ast__id_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                              &v_272, &v_271.df_env, &all_entries_0, 0), _fx_catch_105);
+                              &v_290, &v_289.df_env, &all_entries_0, 0), _fx_catch_109);
                         int_ possible_matches_0 = 0;
                         _fx_LN16Ast__env_entry_t lst_7 = all_entries_0;
                         for (; lst_7; lst_7 = lst_7->tl) {
                            _fx_N16Ast__env_entry_t entry_0 = lst_7->hd;
                            int_ new_matches_0;
                            if (FX_REC_VARIANT_TAG(entry_0) == 1) {
-                              _fx_N14Ast__id_info_t v_273 = {0};
+                              _fx_N14Ast__id_info_t v_291 = {0};
                               FX_CALL(
-                                 _fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&entry_0->u.EnvId, &eloc_0, &v_273, 0),
-                                 _fx_catch_103);
-                              if (v_273.tag == 3) {
-                                 _fx_R13Ast__deffun_t v_274 = {0};
-                                 _fx_copy_R13Ast__deffun_t(&v_273.u.IdFun->data, &v_274);
-                                 if (v_274.df_templ_args != 0) {
+                                 _fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&entry_0->u.EnvId, &eloc_0, &v_291, 0),
+                                 _fx_catch_107);
+                              if (v_291.tag == 3) {
+                                 _fx_R13Ast__deffun_t v_292 = {0};
+                                 _fx_copy_R13Ast__deffun_t(&v_291.u.IdFun->data, &v_292);
+                                 if (v_292.df_templ_args != 0) {
                                     new_matches_0 = 100;
                                  }
                                  else {
                                     new_matches_0 = 1;
                                  }
-                                 _fx_free_R13Ast__deffun_t(&v_274);
+                                 _fx_free_R13Ast__deffun_t(&v_292);
                               }
                               else {
                                  new_matches_0 = 0;
                               }
-                              FX_CHECK_EXN(_fx_catch_103);
+                              FX_CHECK_EXN(_fx_catch_107);
 
-                           _fx_catch_103: ;
-                              _fx_free_N14Ast__id_info_t(&v_273);
+                           _fx_catch_107: ;
+                              _fx_free_N14Ast__id_info_t(&v_291);
                            }
                            else {
                               new_matches_0 = 0;
                            }
-                           FX_CHECK_EXN(_fx_catch_104);
+                           FX_CHECK_EXN(_fx_catch_108);
                            possible_matches_0 = possible_matches_0 + new_matches_0;
 
-                        _fx_catch_104: ;
-                           FX_CHECK_EXN(_fx_catch_105);
+                        _fx_catch_108: ;
+                           FX_CHECK_EXN(_fx_catch_109);
                         }
                         need_to_check_0 = possible_matches_0 <= 1;
 
-                     _fx_catch_105: ;
+                     _fx_catch_109: ;
                         if (all_entries_0) {
                            _fx_free_LN16Ast__env_entry_t(&all_entries_0);
                         }
-                        _fx_free_R13Ast__deffun_t(&v_271);
+                        _fx_free_R13Ast__deffun_t(&v_289);
                      }
                      else {
                         need_to_check_0 = true;
                      }
-                     FX_CHECK_EXN(_fx_catch_106);
+                     FX_CHECK_EXN(_fx_catch_110);
 
-                  _fx_catch_106: ;
-                     _fx_free_N14Ast__id_info_t(&v_270);
-                     goto _fx_endmatch_24;
+                  _fx_catch_110: ;
+                     _fx_free_N14Ast__id_info_t(&v_288);
+                     goto _fx_endmatch_26;
                   }
                }
                need_to_check_0 = true;
 
-            _fx_endmatch_24: ;
-               FX_CHECK_EXN(_fx_catch_107);
+            _fx_endmatch_26: ;
+               FX_CHECK_EXN(_fx_catch_111);
 
-            _fx_catch_107: ;
-               if (v_269) {
-                  _fx_free_N10Ast__typ_t(&v_269);
+            _fx_catch_111: ;
+               if (v_287) {
+                  _fx_free_N10Ast__typ_t(&v_287);
                }
-               if (v_268) {
-                  _fx_free_N10Ast__exp_t(&v_268);
+               if (v_286) {
+                  _fx_free_N10Ast__exp_t(&v_286);
                }
-               if (v_267) {
-                  _fx_free_N10Ast__exp_t(&v_267);
+               if (v_285) {
+                  _fx_free_N10Ast__exp_t(&v_285);
                }
-               goto _fx_endmatch_25;
+               goto _fx_endmatch_27;
             }
             need_to_check_0 = true;
 
-         _fx_endmatch_25: ;
-            FX_CHECK_EXN(_fx_catch_108);
+         _fx_endmatch_27: ;
+            FX_CHECK_EXN(_fx_catch_112);
             if (need_to_check_0) {
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     a_5, &env_2, sc_2, &v_258, 0), _fx_catch_108);
-               _fx_make_T2N10Ast__exp_tB(v_258, true, &t_8);
+                     a_5, &env_2, sc_2, &v_276, 0), _fx_catch_112);
+               _fx_make_T2N10Ast__exp_tB(v_276, true, &t_8);
             }
             else {
                _fx_make_T2N10Ast__exp_tB(a_5, false, &t_8);
             }
             _fx_LT2N10Ast__exp_tB node_5 = 0;
-            FX_CALL(_fx_cons_LT2N10Ast__exp_tB(&t_8, 0, false, &node_5), _fx_catch_108);
+            FX_CALL(_fx_cons_LT2N10Ast__exp_tB(&t_8, 0, false, &node_5), _fx_catch_112);
             FX_LIST_APPEND(new_args_0, lstend_5, node_5);
 
-         _fx_catch_108: ;
-            if (v_258) {
-               _fx_free_N10Ast__exp_t(&v_258);
+         _fx_catch_112: ;
+            if (v_276) {
+               _fx_free_N10Ast__exp_t(&v_276);
             }
             _fx_free_T2N10Ast__exp_tB(&t_8);
-            _fx_free_R13Ast__deffun_t(&v_257);
-            FX_CHECK_EXN(_fx_catch_117);
+            _fx_free_R13Ast__deffun_t(&v_275);
+            FX_CHECK_EXN(_fx_catch_121);
          }
          _fx_N10Ast__exp_t new_f_0 = 0;
-         _fx_N10Ast__typ_t v_275 = 0;
-         _fx_N10Ast__typ_t v_276 = 0;
+         _fx_N10Ast__typ_t v_293 = 0;
+         _fx_N10Ast__typ_t v_294 = 0;
          _fx_LT2N10Ast__exp_tB new_args_1 = 0;
          _fx_LN10Ast__exp_t new_args_2 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               f_2, &env_2, sc_2, &new_f_0, 0), _fx_catch_112);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_f_0, &v_275, 0), _fx_catch_112);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_275, &v_276, 0), _fx_catch_112);
-         if (FX_REC_VARIANT_TAG(v_276) == 15) {
+               f_2, &env_2, sc_2, &new_f_0, 0), _fx_catch_116);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_f_0, &v_293, 0), _fx_catch_116);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_293, &v_294, 0), _fx_catch_116);
+         if (FX_REC_VARIANT_TAG(v_294) == 15) {
             _fx_N10Ast__typ_t last_typ_0 = 0;
-            _fx_N10Ast__exp_t v_277 = 0;
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_278 = {0};
+            _fx_N10Ast__exp_t v_295 = 0;
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_296 = {0};
             _fx_N10Ast__exp_t mkrec_0 = 0;
-            _fx_T2N10Ast__exp_tB v_279 = {0};
-            _fx_LT2N10Ast__exp_tB v_280 = 0;
-            _fx_LN10Ast__typ_t argtyps_1 = v_276->u.TypFun.t0;
-            int_ v_281;
-            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(argtyps_1, &v_281, 0), _fx_catch_109);
-            int_ v_282;
-            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LT2N10Ast__exp_tB(new_args_0, &v_282, 0), _fx_catch_109);
-            if (v_281 == v_282) {
+            _fx_T2N10Ast__exp_tB v_297 = {0};
+            _fx_LT2N10Ast__exp_tB v_298 = 0;
+            _fx_LN10Ast__typ_t argtyps_1 = v_294->u.TypFun.t0;
+            int_ v_299;
+            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(argtyps_1, &v_299, 0), _fx_catch_113);
+            int_ v_300;
+            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LT2N10Ast__exp_tB(new_args_0, &v_300, 0), _fx_catch_113);
+            if (v_299 == v_300) {
                FX_COPY_PTR(new_args_0, &new_args_1);
             }
             else {
-               int_ v_283;
-               FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(argtyps_1, &v_283, 0), _fx_catch_109);
-               int_ v_284;
-               FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LT2N10Ast__exp_tB(new_args_0, &v_284, 0), _fx_catch_109);
-               FX_CALL(_fx_F6assertv1B(v_283 == v_284 + 1, 0), _fx_catch_109);
-               FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__typ_t1LN10Ast__typ_t(argtyps_1, &last_typ_0, 0), _fx_catch_109);
-               FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloc_0, &v_277), _fx_catch_109);
-               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(last_typ_0, &eloc_0, &v_278);
+               int_ v_301;
+               FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(argtyps_1, &v_301, 0), _fx_catch_113);
+               int_ v_302;
+               FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LT2N10Ast__exp_tB(new_args_0, &v_302, 0), _fx_catch_113);
+               FX_CALL(_fx_F6assertv1B(v_301 == v_302 + 1, 0), _fx_catch_113);
+               FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__typ_t1LN10Ast__typ_t(argtyps_1, &last_typ_0, 0), _fx_catch_113);
+               FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloc_0, &v_295), _fx_catch_113);
+               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(last_typ_0, &eloc_0, &v_296);
                FX_CALL(
-                  _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_277, 0,
-                     &v_278, &mkrec_0), _fx_catch_109);
-               _fx_make_T2N10Ast__exp_tB(mkrec_0, true, &v_279);
-               FX_CALL(_fx_cons_LT2N10Ast__exp_tB(&v_279, 0, true, &v_280), _fx_catch_109);
+                  _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_295, 0,
+                     &v_296, &mkrec_0), _fx_catch_113);
+               _fx_make_T2N10Ast__exp_tB(mkrec_0, true, &v_297);
+               FX_CALL(_fx_cons_LT2N10Ast__exp_tB(&v_297, 0, true, &v_298), _fx_catch_113);
                FX_CALL(
-                  _fx_M13Ast_typecheckFM7__add__LT2N10Ast__exp_tB2LT2N10Ast__exp_tBLT2N10Ast__exp_tB(new_args_0, v_280,
-                     &new_args_1, 0), _fx_catch_109);
+                  _fx_M13Ast_typecheckFM7__add__LT2N10Ast__exp_tB2LT2N10Ast__exp_tBLT2N10Ast__exp_tB(new_args_0, v_298,
+                     &new_args_1, 0), _fx_catch_113);
             }
 
-         _fx_catch_109: ;
-            if (v_280) {
-               _fx_free_LT2N10Ast__exp_tB(&v_280);
+         _fx_catch_113: ;
+            if (v_298) {
+               _fx_free_LT2N10Ast__exp_tB(&v_298);
             }
-            _fx_free_T2N10Ast__exp_tB(&v_279);
+            _fx_free_T2N10Ast__exp_tB(&v_297);
             if (mkrec_0) {
                _fx_free_N10Ast__exp_t(&mkrec_0);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_278);
-            if (v_277) {
-               _fx_free_N10Ast__exp_t(&v_277);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_296);
+            if (v_295) {
+               _fx_free_N10Ast__exp_t(&v_295);
             }
             if (last_typ_0) {
                _fx_free_N10Ast__typ_t(&last_typ_0);
@@ -24785,7 +24953,7 @@ FX_EXTERN_C int
          else {
             FX_COPY_PTR(new_args_0, &new_args_1);
          }
-         FX_CHECK_EXN(_fx_catch_112);
+         FX_CHECK_EXN(_fx_catch_116);
          _fx_LN10Ast__exp_t lstend_6 = 0;
          _fx_LT2N10Ast__exp_tB lst_8 = new_args_1;
          for (; lst_8; lst_8 = lst_8->tl) {
@@ -24799,37 +24967,37 @@ FX_EXTERN_C int
             else {
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     e_6, &env_2, sc_2, &res_35, 0), _fx_catch_110);
+                     e_6, &env_2, sc_2, &res_35, 0), _fx_catch_114);
 
-            _fx_catch_110: ;
+            _fx_catch_114: ;
             }
-            FX_CHECK_EXN(_fx_catch_111);
+            FX_CHECK_EXN(_fx_catch_115);
             _fx_LN10Ast__exp_t node_6 = 0;
-            FX_CALL(_fx_cons_LN10Ast__exp_t(res_35, 0, false, &node_6), _fx_catch_111);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(res_35, 0, false, &node_6), _fx_catch_115);
             FX_LIST_APPEND(new_args_2, lstend_6, node_6);
 
-         _fx_catch_111: ;
+         _fx_catch_115: ;
             if (res_35) {
                _fx_free_N10Ast__exp_t(&res_35);
             }
             if (e_6) {
                _fx_free_N10Ast__exp_t(&e_6);
             }
-            FX_CHECK_EXN(_fx_catch_112);
+            FX_CHECK_EXN(_fx_catch_116);
          }
          FX_CALL(
             _fx_M3AstFM7ExpCallN10Ast__exp_t3N10Ast__exp_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_f_0, new_args_2, &ctx_0,
-               &result_34), _fx_catch_112);
+               &result_36), _fx_catch_116);
 
-      _fx_catch_112: ;
+      _fx_catch_116: ;
          if (new_f_0) {
             _fx_free_N10Ast__exp_t(&new_f_0);
          }
-         if (v_275) {
-            _fx_free_N10Ast__typ_t(&v_275);
+         if (v_293) {
+            _fx_free_N10Ast__typ_t(&v_293);
          }
-         if (v_276) {
-            _fx_free_N10Ast__typ_t(&v_276);
+         if (v_294) {
+            _fx_free_N10Ast__typ_t(&v_294);
          }
          if (new_args_1) {
             _fx_free_LT2N10Ast__exp_tB(&new_args_1);
@@ -24840,8 +25008,8 @@ FX_EXTERN_C int
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_2);
             fx_status = 0;
-            if (result_34) {
-               _fx_free_N10Ast__exp_t(&result_34);
+            if (result_36) {
+               _fx_free_N10Ast__exp_t(&result_36);
             }
             if (exn_2.tag == _FX_EXN_E17Ast__CompileError) {
                if (FX_REC_VARIANT_TAG(f0_0) == 21) {
@@ -24849,125 +25017,125 @@ FX_EXTERN_C int
                   _fx_T2N10Ast__typ_tR10Ast__loc_t* mem_ctx_0 = &vcase_19->t2;
                   _fx_N10Ast__exp_t mem_f_exp_0 = vcase_19->t1;
                   if (FX_REC_VARIANT_TAG(mem_f_exp_0) == 7) {
-                     _fx_N10Ast__exp_t v_285 = 0;
+                     _fx_N10Ast__exp_t v_303 = 0;
                      _fx_N10Ast__exp_t r_0 = 0;
                      _fx_N10Ast__typ_t r_t_0 = 0;
-                     _fx_N10Ast__typ_t v_286 = 0;
+                     _fx_N10Ast__typ_t v_304 = 0;
                      fx_str_t mstr_0 = {0};
                      _fx_N10Ast__exp_t new_f_1 = 0;
-                     _fx_N10Ast__typ_t v_287 = 0;
-                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_288 = {0};
-                     _fx_N10Ast__exp_t v_289 = 0;
-                     _fx_LN10Ast__exp_t v_290 = 0;
+                     _fx_N10Ast__typ_t v_305 = 0;
+                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_306 = {0};
+                     _fx_N10Ast__exp_t v_307 = 0;
+                     _fx_LN10Ast__exp_t v_308 = 0;
                      _fx_N10Ast__exp_t new_exp_0 = 0;
                      _fx_N10Ast__exp_t r0_0 = vcase_19->t0;
-                     FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(r0_0, &v_285, 0), _fx_catch_115);
+                     FX_CALL(_fx_M3AstFM7dup_expN10Ast__exp_t1N10Ast__exp_t(r0_0, &v_303, 0), _fx_catch_119);
                      FX_CALL(
                         _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                           v_285, &env_2, sc_2, &r_0, 0), _fx_catch_115);
-                     FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(r_0, &r_t_0, 0), _fx_catch_115);
-                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(r_t_0, &v_286, 0), _fx_catch_115);
-                     int tag_10 = FX_REC_VARIANT_TAG(v_286);
-                     if (tag_10 == 16) {
-                        fx_str_t slit_114 = FX_MAKE_STR("List"); fx_copy_str(&slit_114, &mstr_0);
+                           v_303, &env_2, sc_2, &r_0, 0), _fx_catch_119);
+                     FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(r_0, &r_t_0, 0), _fx_catch_119);
+                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(r_t_0, &v_304, 0), _fx_catch_119);
+                     int tag_11 = FX_REC_VARIANT_TAG(v_304);
+                     if (tag_11 == 16) {
+                        fx_str_t slit_121 = FX_MAKE_STR("List"); fx_copy_str(&slit_121, &mstr_0);
                      }
-                     else if (tag_10 == 17) {
-                        fx_str_t slit_115 = FX_MAKE_STR("Rrbvec"); fx_copy_str(&slit_115, &mstr_0);
+                     else if (tag_11 == 17) {
+                        fx_str_t slit_122 = FX_MAKE_STR("Rrbvec"); fx_copy_str(&slit_122, &mstr_0);
                      }
-                     else if (tag_10 == 18) {
-                        fx_str_t slit_116 = FX_MAKE_STR("Vector"); fx_copy_str(&slit_116, &mstr_0);
+                     else if (tag_11 == 18) {
+                        fx_str_t slit_123 = FX_MAKE_STR("Vector"); fx_copy_str(&slit_123, &mstr_0);
                      }
-                     else if (tag_10 == 11) {
-                        fx_str_t slit_117 = FX_MAKE_STR("String"); fx_copy_str(&slit_117, &mstr_0);
+                     else if (tag_11 == 11) {
+                        fx_str_t slit_124 = FX_MAKE_STR("String"); fx_copy_str(&slit_124, &mstr_0);
                      }
-                     else if (tag_10 == 12) {
-                        fx_str_t slit_118 = FX_MAKE_STR("Char"); fx_copy_str(&slit_118, &mstr_0);
+                     else if (tag_11 == 12) {
+                        fx_str_t slit_125 = FX_MAKE_STR("Char"); fx_copy_str(&slit_125, &mstr_0);
                      }
-                     else if (tag_10 == 21) {
-                        fx_str_t slit_119 = FX_MAKE_STR("Array"); fx_copy_str(&slit_119, &mstr_0);
+                     else if (tag_11 == 21) {
+                        fx_str_t slit_126 = FX_MAKE_STR("Array"); fx_copy_str(&slit_126, &mstr_0);
                      }
-                     else if (tag_10 == 26) {
-                        _fx_N14Ast__id_info_t v_291 = {0};
-                        _fx_R17Ast__defvariant_t v_292 = {0};
-                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_286->u.TypApp.t1, &eloc_0, &v_291, 0),
-                           _fx_catch_114);
-                        if (v_291.tag == 6) {
-                           _fx_copy_R17Ast__defvariant_t(&v_291.u.IdVariant->data, &v_292);
-                           int_ m_0 = v_292.dvar_flags.var_flag_class_from;
+                     else if (tag_11 == 26) {
+                        _fx_N14Ast__id_info_t v_309 = {0};
+                        _fx_R17Ast__defvariant_t v_310 = {0};
+                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(&v_304->u.TypApp.t1, &eloc_0, &v_309, 0),
+                           _fx_catch_118);
+                        if (v_309.tag == 6) {
+                           _fx_copy_R17Ast__defvariant_t(&v_309.u.IdVariant->data, &v_310);
+                           int_ m_0 = v_310.dvar_flags.var_flag_class_from;
                            if (m_0 > 0) {
-                              _fx_R9Ast__id_t v_293;
-                              FX_CALL(_fx_M3AstFM15get_module_nameRM4id_t1i(m_0, &v_293, 0), _fx_catch_113);
-                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_293, &mstr_0, 0), _fx_catch_113);
+                              _fx_R9Ast__id_t v_311;
+                              FX_CALL(_fx_M3AstFM15get_module_nameRM4id_t1i(m_0, &v_311, 0), _fx_catch_117);
+                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_311, &mstr_0, 0), _fx_catch_117);
 
-                           _fx_catch_113: ;
-                              goto _fx_endmatch_26;
+                           _fx_catch_117: ;
+                              goto _fx_endmatch_28;
                            }
                         }
-                        fx_str_t slit_120 = FX_MAKE_STR("");
-                        fx_copy_str(&slit_120, &mstr_0);
+                        fx_str_t slit_127 = FX_MAKE_STR("");
+                        fx_copy_str(&slit_127, &mstr_0);
 
-                     _fx_endmatch_26: ;
-                        FX_CHECK_EXN(_fx_catch_114);
+                     _fx_endmatch_28: ;
+                        FX_CHECK_EXN(_fx_catch_118);
 
-                     _fx_catch_114: ;
-                        _fx_free_R17Ast__defvariant_t(&v_292);
-                        _fx_free_N14Ast__id_info_t(&v_291);
+                     _fx_catch_118: ;
+                        _fx_free_R17Ast__defvariant_t(&v_310);
+                        _fx_free_N14Ast__id_info_t(&v_309);
                      }
                      else {
-                        fx_str_t slit_121 = FX_MAKE_STR(""); fx_copy_str(&slit_121, &mstr_0);
+                        fx_str_t slit_128 = FX_MAKE_STR(""); fx_copy_str(&slit_128, &mstr_0);
                      }
-                     FX_CHECK_EXN(_fx_catch_115);
-                     bool v_294;
-                     fx_str_t slit_122 = FX_MAKE_STR("Builtins");
-                     v_294 = _fx_F6__eq__B2SS(&mstr_0, &slit_122, 0);
-                     if (v_294) {
+                     FX_CHECK_EXN(_fx_catch_119);
+                     bool v_312;
+                     fx_str_t slit_129 = FX_MAKE_STR("Builtins");
+                     v_312 = _fx_F6__eq__B2SS(&mstr_0, &slit_129, 0);
+                     if (v_312) {
                         FX_COPY_PTR(mem_f_exp_0, &new_f_1);
                      }
                      else {
                         _fx_R9Ast__id_t m_id_0;
                         if (FX_STR_LENGTH(mstr_0) != 0) {
-                           FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&mstr_0, &m_id_0, 0), _fx_catch_115);
+                           FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&mstr_0, &m_id_0, 0), _fx_catch_119);
                         }
                         else {
-                           FX_THROW(&exn_2, false, _fx_catch_115);
+                           FX_THROW(&exn_2, false, _fx_catch_119);
                         }
                         _fx_R10Ast__loc_t floc_1 = mem_ctx_0->t1;
-                        FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_287, 0), _fx_catch_115);
-                        _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_287, &floc_1, &v_288);
-                        FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&m_id_0, &v_288, &v_289),
-                           _fx_catch_115);
+                        FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_305, 0), _fx_catch_119);
+                        _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_305, &floc_1, &v_306);
+                        FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&m_id_0, &v_306, &v_307),
+                           _fx_catch_119);
                         FX_CALL(
-                           _fx_M3AstFM6ExpMemN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_289, mem_f_exp_0,
-                              mem_ctx_0, &new_f_1), _fx_catch_115);
+                           _fx_M3AstFM6ExpMemN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_307, mem_f_exp_0,
+                              mem_ctx_0, &new_f_1), _fx_catch_119);
                      }
-                     FX_CALL(_fx_cons_LN10Ast__exp_t(r0_0, args0_0, true, &v_290), _fx_catch_115);
+                     FX_CALL(_fx_cons_LN10Ast__exp_t(r0_0, args0_0, true, &v_308), _fx_catch_119);
                      FX_CALL(
-                        _fx_M3AstFM7ExpCallN10Ast__exp_t3N10Ast__exp_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_f_1, v_290,
-                           &ctx_0, &new_exp_0), _fx_catch_115);
+                        _fx_M3AstFM7ExpCallN10Ast__exp_t3N10Ast__exp_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_f_1, v_308,
+                           &ctx_0, &new_exp_0), _fx_catch_119);
                      FX_CALL(
                         _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                           new_exp_0, &env_2, sc_2, &result_34, 0), _fx_catch_115);
+                           new_exp_0, &env_2, sc_2, &result_36, 0), _fx_catch_119);
 
-                  _fx_catch_115: ;
+                  _fx_catch_119: ;
                      if (new_exp_0) {
                         _fx_free_N10Ast__exp_t(&new_exp_0);
                      }
-                     if (v_290) {
-                        _fx_free_LN10Ast__exp_t(&v_290);
+                     if (v_308) {
+                        _fx_free_LN10Ast__exp_t(&v_308);
                      }
-                     if (v_289) {
-                        _fx_free_N10Ast__exp_t(&v_289);
+                     if (v_307) {
+                        _fx_free_N10Ast__exp_t(&v_307);
                      }
-                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_288);
-                     if (v_287) {
-                        _fx_free_N10Ast__typ_t(&v_287);
+                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_306);
+                     if (v_305) {
+                        _fx_free_N10Ast__typ_t(&v_305);
                      }
                      if (new_f_1) {
                         _fx_free_N10Ast__exp_t(&new_f_1);
                      }
                      FX_FREE_STR(&mstr_0);
-                     if (v_286) {
-                        _fx_free_N10Ast__typ_t(&v_286);
+                     if (v_304) {
+                        _fx_free_N10Ast__typ_t(&v_304);
                      }
                      if (r_t_0) {
                         _fx_free_N10Ast__typ_t(&r_t_0);
@@ -24975,45 +25143,45 @@ FX_EXTERN_C int
                      if (r_0) {
                         _fx_free_N10Ast__exp_t(&r_0);
                      }
-                     if (v_285) {
-                        _fx_free_N10Ast__exp_t(&v_285);
+                     if (v_303) {
+                        _fx_free_N10Ast__exp_t(&v_303);
                      }
-                     goto _fx_endmatch_27;
+                     goto _fx_endmatch_29;
                   }
                }
-               FX_THROW(&exn_2, false, _fx_catch_116);
+               FX_THROW(&exn_2, false, _fx_catch_120);
 
-            _fx_endmatch_27: ;
-               FX_CHECK_EXN(_fx_catch_116);
+            _fx_endmatch_29: ;
+               FX_CHECK_EXN(_fx_catch_120);
 
-            _fx_catch_116: ;
+            _fx_catch_120: ;
             }
             else {
-               FX_RETHROW(&exn_2, _fx_catch_117);
+               FX_RETHROW(&exn_2, _fx_catch_121);
             }
-            FX_CHECK_EXN(_fx_catch_117);
+            FX_CHECK_EXN(_fx_catch_121);
          }
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_34, &result_0);
-         FX_BREAK(_fx_catch_117);
+         FX_COPY_PTR(result_36, &result_0);
+         FX_BREAK(_fx_catch_121);
 
-      _fx_catch_117: ;
+      _fx_catch_121: ;
          fx_free_exn(&exn_2);
-         if (result_34) {
-            _fx_free_N10Ast__exp_t(&result_34);
+         if (result_36) {
+            _fx_free_N10Ast__exp_t(&result_36);
          }
          if (new_args_0) {
             _fx_free_LT2N10Ast__exp_tB(&new_args_0);
          }
-         FX_FREE_STR(&v_256);
-         FX_FREE_STR(&v_255);
-         FX_FREE_STR(&v_254);
-         FX_FREE_STR(&v_253);
-         FX_FREE_STR(&v_252);
+         FX_FREE_STR(&v_274);
+         FX_FREE_STR(&v_273);
+         FX_FREE_STR(&v_272);
+         FX_FREE_STR(&v_271);
+         FX_FREE_STR(&v_270);
          if (f_real_typ_0) {
             _fx_free_N10Ast__typ_t(&f_real_typ_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_251);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_269);
          if (f_expected_typ_0) {
             _fx_free_N10Ast__typ_t(&f_expected_typ_0);
          }
@@ -25027,183 +25195,183 @@ FX_EXTERN_C int
          if (f_2) {
             _fx_free_N10Ast__exp_t(&f_2);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 19) {
-         _fx_T3N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_t v_295 = {0};
+         _fx_T3N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_t v_313 = {0};
          _fx_N10Ast__exp_t arr_0 = 0;
          _fx_N10Ast__exp_t new_arr_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_296 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_314 = {0};
          _fx_N10Ast__typ_t new_atyp_0 = 0;
-         fx_exn_t v_297 = {0};
+         fx_exn_t v_315 = {0};
          _fx_T5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_20 =
             &e_2->u.ExpAt;
          _fx_LN10Ast__exp_t idxs_0 = vcase_20->t3;
          FX_CALL(
             _fx_M13Ast_typecheckFM10check_attrT3N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_t4N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tR10Ast__loc_t(
-               vcase_20->t0, &vcase_20->t1, &vcase_20->t2, &eloc_0, &v_295, 0), _fx_catch_137);
-         FX_COPY_PTR(v_295.t0, &arr_0);
-         _fx_N13Ast__border_t border_0 = v_295.t1;
-         _fx_N18Ast__interpolate_t interp_0 = v_295.t2;
+               vcase_20->t0, &vcase_20->t1, &vcase_20->t2, &eloc_0, &v_313, 0), _fx_catch_141);
+         FX_COPY_PTR(v_313.t0, &arr_0);
+         _fx_N13Ast__border_t border_0 = v_313.t1;
+         _fx_N18Ast__interpolate_t interp_0 = v_313.t2;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               arr_0, &env_2, sc_2, &new_arr_0, 0), _fx_catch_137);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(new_arr_0, &v_296, 0), _fx_catch_137);
-         FX_COPY_PTR(v_296.t0, &new_atyp_0);
-         _fx_R10Ast__loc_t new_aloc_0 = v_296.t1;
+               arr_0, &env_2, sc_2, &new_arr_0, 0), _fx_catch_141);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(new_arr_0, &v_314, 0), _fx_catch_141);
+         FX_COPY_PTR(v_314.t0, &new_atyp_0);
+         _fx_R10Ast__loc_t new_aloc_0 = v_314.t1;
          if (interp_0.tag != 1) {
-            fx_str_t slit_123 = FX_MAKE_STR("inter-element interpolation is not supported yet");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_123, &v_297, 0), _fx_catch_137);
-            FX_THROW(&v_297, false, _fx_catch_137);
+            fx_str_t slit_130 = FX_MAKE_STR("inter-element interpolation is not supported yet");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_130, &v_315, 0), _fx_catch_141);
+            FX_THROW(&v_315, false, _fx_catch_141);
          }
          if (idxs_0 != 0) {
             if (idxs_0->tl == 0) {
-               _fx_N10Ast__exp_t v_298 = idxs_0->hd;
-               if (FX_REC_VARIANT_TAG(v_298) == 5) {
+               _fx_N10Ast__exp_t v_316 = idxs_0->hd;
+               if (FX_REC_VARIANT_TAG(v_316) == 5) {
                   _fx_T4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t*
-                     vcase_21 = &v_298->u.ExpRange;
+                     vcase_21 = &v_316->u.ExpRange;
                   if ((vcase_21->t0 != 0) + 1 == 1) {
                      if ((vcase_21->t1 != 0) + 1 == 1) {
                         if ((vcase_21->t2 != 0) + 1 == 1) {
-                           _fx_N10Ast__exp_t v_299 = 0;
+                           _fx_N10Ast__exp_t v_317 = 0;
                            _fx_N10Ast__exp_t new_idx_0 = 0;
-                           _fx_N10Ast__typ_t v_300 = 0;
-                           FX_CALL(_fx_M13Ast_typecheckFM2hdN10Ast__exp_t1LN10Ast__exp_t(idxs_0, &v_299, 0), _fx_catch_123);
+                           _fx_N10Ast__typ_t v_318 = 0;
+                           FX_CALL(_fx_M13Ast_typecheckFM2hdN10Ast__exp_t1LN10Ast__exp_t(idxs_0, &v_317, 0), _fx_catch_127);
                            FX_CALL(
                               _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                                 v_299, &env_2, sc_2, &new_idx_0, 0), _fx_catch_123);
-                           FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_300, 0), _fx_catch_123);
-                           int tag_11 = FX_REC_VARIANT_TAG(v_300);
-                           if (tag_11 == 21) {
-                              _fx_N10Ast__typ_t v_301 = 0;
-                              _fx_LN10Ast__exp_t v_302 = 0;
-                              _fx_N10Ast__exp_t result_35 = 0;
-                              FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_300->u.TypArray.t1, &v_301),
-                                 _fx_catch_118);
-                              fx_str_t slit_124 =
+                                 v_317, &env_2, sc_2, &new_idx_0, 0), _fx_catch_127);
+                           FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_318, 0), _fx_catch_127);
+                           int tag_12 = FX_REC_VARIANT_TAG(v_318);
+                           if (tag_12 == 21) {
+                              _fx_N10Ast__typ_t v_319 = 0;
+                              _fx_LN10Ast__exp_t v_320 = 0;
+                              _fx_N10Ast__exp_t result_37 = 0;
+                              FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_318->u.TypArray.t1, &v_319),
+                                 _fx_catch_122);
+                              fx_str_t slit_131 =
                                  FX_MAKE_STR(
                                     "the result of flatten operation ([:]) applied to N-D array must be 1D array with elements of the same type as input array");
                               FX_CALL(
-                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_301, &eloc_0,
-                                    &slit_124, 0), _fx_catch_118);
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_302), _fx_catch_118);
+                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_319, &eloc_0,
+                                    &slit_131, 0), _fx_catch_122);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_320), _fx_catch_122);
                               FX_CALL(
                                  _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_302,
-                                    &ctx_0, &result_35), _fx_catch_118);
-                              _fx_free_N10Ast__exp_t(&result_0);
-                              FX_COPY_PTR(result_35, &result_0);
-                              FX_BREAK(_fx_catch_118);
-
-                           _fx_catch_118: ;
-                              if (result_35) {
-                                 _fx_free_N10Ast__exp_t(&result_35);
-                              }
-                              if (v_302) {
-                                 _fx_free_LN10Ast__exp_t(&v_302);
-                              }
-                              if (v_301) {
-                                 _fx_free_N10Ast__typ_t(&v_301);
-                              }
-                           }
-                           else if (tag_11 == 17) {
-                              _fx_N10Ast__typ_t v_303 = 0;
-                              _fx_LN10Ast__exp_t v_304 = 0;
-                              _fx_N10Ast__exp_t result_36 = 0;
-                              FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(v_300->u.TypRRBVec, &v_303),
-                                 _fx_catch_119);
-                              fx_str_t slit_125 =
-                                 FX_MAKE_STR(
-                                    "the result of flatten operation ([:]) applied to rrbvec must be a rrbvec of the same type");
-                              FX_CALL(
-                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_303, &eloc_0,
-                                    &slit_125, 0), _fx_catch_119);
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_304), _fx_catch_119);
-                              FX_CALL(
-                                 _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_304,
-                                    &ctx_0, &result_36), _fx_catch_119);
-                              _fx_free_N10Ast__exp_t(&result_0);
-                              FX_COPY_PTR(result_36, &result_0);
-                              FX_BREAK(_fx_catch_119);
-
-                           _fx_catch_119: ;
-                              if (result_36) {
-                                 _fx_free_N10Ast__exp_t(&result_36);
-                              }
-                              if (v_304) {
-                                 _fx_free_LN10Ast__exp_t(&v_304);
-                              }
-                              if (v_303) {
-                                 _fx_free_N10Ast__typ_t(&v_303);
-                              }
-                           }
-                           else if (tag_11 == 18) {
-                              _fx_N10Ast__typ_t v_305 = 0;
-                              _fx_LN10Ast__exp_t v_306 = 0;
-                              _fx_N10Ast__exp_t result_37 = 0;
-                              FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(v_300->u.TypVector, &v_305),
-                                 _fx_catch_120);
-                              fx_str_t slit_126 =
-                                 FX_MAKE_STR(
-                                    "the result of flatten operation ([:]) applied to a vector must be a vector of the same type");
-                              FX_CALL(
-                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_305, &eloc_0,
-                                    &slit_126, 0), _fx_catch_120);
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_306), _fx_catch_120);
-                              FX_CALL(
-                                 _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_306,
-                                    &ctx_0, &result_37), _fx_catch_120);
+                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_320,
+                                    &ctx_0, &result_37), _fx_catch_122);
                               _fx_free_N10Ast__exp_t(&result_0);
                               FX_COPY_PTR(result_37, &result_0);
-                              FX_BREAK(_fx_catch_120);
+                              FX_BREAK(_fx_catch_122);
 
-                           _fx_catch_120: ;
+                           _fx_catch_122: ;
                               if (result_37) {
                                  _fx_free_N10Ast__exp_t(&result_37);
                               }
-                              if (v_306) {
-                                 _fx_free_LN10Ast__exp_t(&v_306);
+                              if (v_320) {
+                                 _fx_free_LN10Ast__exp_t(&v_320);
                               }
-                              if (v_305) {
-                                 _fx_free_N10Ast__typ_t(&v_305);
+                              if (v_319) {
+                                 _fx_free_N10Ast__typ_t(&v_319);
                               }
                            }
-                           else if (tag_11 == 11) {
-                              fx_str_t slit_127 =
+                           else if (tag_12 == 17) {
+                              _fx_N10Ast__typ_t v_321 = 0;
+                              _fx_LN10Ast__exp_t v_322 = 0;
+                              _fx_N10Ast__exp_t result_38 = 0;
+                              FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(v_318->u.TypRRBVec, &v_321),
+                                 _fx_catch_123);
+                              fx_str_t slit_132 =
+                                 FX_MAKE_STR(
+                                    "the result of flatten operation ([:]) applied to rrbvec must be a rrbvec of the same type");
+                              FX_CALL(
+                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_321, &eloc_0,
+                                    &slit_132, 0), _fx_catch_123);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_322), _fx_catch_123);
+                              FX_CALL(
+                                 _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
+                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_322,
+                                    &ctx_0, &result_38), _fx_catch_123);
+                              _fx_free_N10Ast__exp_t(&result_0);
+                              FX_COPY_PTR(result_38, &result_0);
+                              FX_BREAK(_fx_catch_123);
+
+                           _fx_catch_123: ;
+                              if (result_38) {
+                                 _fx_free_N10Ast__exp_t(&result_38);
+                              }
+                              if (v_322) {
+                                 _fx_free_LN10Ast__exp_t(&v_322);
+                              }
+                              if (v_321) {
+                                 _fx_free_N10Ast__typ_t(&v_321);
+                              }
+                           }
+                           else if (tag_12 == 18) {
+                              _fx_N10Ast__typ_t v_323 = 0;
+                              _fx_LN10Ast__exp_t v_324 = 0;
+                              _fx_N10Ast__exp_t result_39 = 0;
+                              FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(v_318->u.TypVector, &v_323),
+                                 _fx_catch_124);
+                              fx_str_t slit_133 =
+                                 FX_MAKE_STR(
+                                    "the result of flatten operation ([:]) applied to a vector must be a vector of the same type");
+                              FX_CALL(
+                                 _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_323, &eloc_0,
+                                    &slit_133, 0), _fx_catch_124);
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_0, 0, true, &v_324), _fx_catch_124);
+                              FX_CALL(
+                                 _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
+                                    new_arr_0, &_fx_g25Ast_typecheck__BorderNone, &_fx_g25Ast_typecheck__InterpNone, v_324,
+                                    &ctx_0, &result_39), _fx_catch_124);
+                              _fx_free_N10Ast__exp_t(&result_0);
+                              FX_COPY_PTR(result_39, &result_0);
+                              FX_BREAK(_fx_catch_124);
+
+                           _fx_catch_124: ;
+                              if (result_39) {
+                                 _fx_free_N10Ast__exp_t(&result_39);
+                              }
+                              if (v_324) {
+                                 _fx_free_LN10Ast__exp_t(&v_324);
+                              }
+                              if (v_323) {
+                                 _fx_free_N10Ast__typ_t(&v_323);
+                              }
+                           }
+                           else if (tag_12 == 11) {
+                              fx_str_t slit_134 =
                                  FX_MAKE_STR("the result of flatten operation ([:]) applied to a string must be string");
                               FX_CALL(
                                  _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0,
-                                    _fx_g24Ast_typecheck__TypString, &eloc_0, &slit_127, 0), _fx_catch_121);
+                                    _fx_g24Ast_typecheck__TypString, &eloc_0, &slit_134, 0), _fx_catch_125);
                               _fx_free_N10Ast__exp_t(&result_0);
                               FX_COPY_PTR(new_arr_0, &result_0);
-                              FX_BREAK(_fx_catch_121);
+                              FX_BREAK(_fx_catch_125);
 
-                           _fx_catch_121: ;
+                           _fx_catch_125: ;
                            }
                            else {
-                              fx_exn_t v_307 = {0};
-                              fx_str_t slit_128 = FX_MAKE_STR("the argument of the flatten operation must be an array");
-                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_128, &v_307, 0), _fx_catch_122);
-                              FX_THROW(&v_307, false, _fx_catch_122);
+                              fx_exn_t v_325 = {0};
+                              fx_str_t slit_135 = FX_MAKE_STR("the argument of the flatten operation must be an array");
+                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_135, &v_325, 0), _fx_catch_126);
+                              FX_THROW(&v_325, false, _fx_catch_126);
 
-                           _fx_catch_122: ;
-                              fx_free_exn(&v_307);
+                           _fx_catch_126: ;
+                              fx_free_exn(&v_325);
                            }
-                           FX_CHECK_EXN(_fx_catch_123);
+                           FX_CHECK_EXN(_fx_catch_127);
 
-                        _fx_catch_123: ;
-                           if (v_300) {
-                              _fx_free_N10Ast__typ_t(&v_300);
+                        _fx_catch_127: ;
+                           if (v_318) {
+                              _fx_free_N10Ast__typ_t(&v_318);
                            }
                            if (new_idx_0) {
                               _fx_free_N10Ast__exp_t(&new_idx_0);
                            }
-                           if (v_299) {
-                              _fx_free_N10Ast__exp_t(&v_299);
+                           if (v_317) {
+                              _fx_free_N10Ast__exp_t(&v_317);
                            }
-                           goto _fx_endmatch_29;
+                           goto _fx_endmatch_31;
                         }
                      }
                   }
@@ -25212,10 +25380,10 @@ FX_EXTERN_C int
          }
          _fx_LN10Ast__exp_t new_idxs_0 = 0;
          _fx_LN10Ast__exp_t idxs_1 = 0;
-         _fx_N10Ast__typ_t v_308 = 0;
-         _fx_T3iiN10Ast__typ_t v_309 = {0};
-         _fx_LN10Ast__exp_t v_310 = 0;
-         _fx_N10Ast__exp_t result_38 = 0;
+         _fx_N10Ast__typ_t v_326 = 0;
+         _fx_T3iiN10Ast__typ_t v_327 = {0};
+         _fx_LN10Ast__exp_t v_328 = 0;
+         _fx_N10Ast__exp_t result_40 = 0;
          int_ ndims_0 = 0;
          int_ nfirst_scalars_acc_0 = 0;
          int_ nranges_0 = 0;
@@ -25226,80 +25394,80 @@ FX_EXTERN_C int
             _fx_N10Ast__exp_t idx_1 = lst_9->hd;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  idx_1, &env_2, sc_2, &new_idx_1, 0), _fx_catch_126);
+                  idx_1, &env_2, sc_2, &new_idx_1, 0), _fx_catch_130);
             if (FX_REC_VARIANT_TAG(new_idx_1) == 5) {
-               _fx_LN10Ast__exp_t v_311 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_1, new_idxs_0, true, &v_311), _fx_catch_124);
+               _fx_LN10Ast__exp_t v_329 = 0;
+               FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_1, new_idxs_0, true, &v_329), _fx_catch_128);
                _fx_free_LN10Ast__exp_t(&new_idxs_0);
-               FX_COPY_PTR(v_311, &new_idxs_0);
+               FX_COPY_PTR(v_329, &new_idxs_0);
                ndims_0 = ndims_0 + 1;
                nranges_0 = nranges_0 + 1;
 
-            _fx_catch_124: ;
-               if (v_311) {
-                  _fx_free_LN10Ast__exp_t(&v_311);
+            _fx_catch_128: ;
+               if (v_329) {
+                  _fx_free_LN10Ast__exp_t(&v_329);
                }
             }
             else {
-               _fx_N10Ast__typ_t v_312 = 0;
-               _fx_N10Ast__typ_t v_313 = 0;
-               _fx_N10Ast__typ_t v_314 = 0;
-               _fx_N10Ast__typ_t v_315 = 0;
-               _fx_N10Ast__typ_t v_316 = 0;
-               _fx_N10Ast__typ_t v_317 = 0;
-               _fx_N10Ast__typ_t v_318 = 0;
-               _fx_N10Ast__typ_t v_319 = 0;
-               _fx_LN10Ast__typ_t v_320 = 0;
+               _fx_N10Ast__typ_t v_330 = 0;
+               _fx_N10Ast__typ_t v_331 = 0;
+               _fx_N10Ast__typ_t v_332 = 0;
+               _fx_N10Ast__typ_t v_333 = 0;
+               _fx_N10Ast__typ_t v_334 = 0;
+               _fx_N10Ast__typ_t v_335 = 0;
+               _fx_N10Ast__typ_t v_336 = 0;
+               _fx_N10Ast__typ_t v_337 = 0;
+               _fx_LN10Ast__typ_t v_338 = 0;
                _fx_LN10Ast__typ_t possible_idx_typs_0 = 0;
-               _fx_T2N10Ast__typ_tR10Ast__loc_t v_321 = {0};
+               _fx_T2N10Ast__typ_tR10Ast__loc_t v_339 = {0};
                _fx_N10Ast__typ_t new_ityp_0 = 0;
-               fx_exn_t v_322 = {0};
-               _fx_LN10Ast__exp_t v_323 = 0;
-               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_312), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(8, &v_313), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(16, &v_314), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(16, &v_315), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(32, &v_316), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(32, &v_317), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(64, &v_318), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(64, &v_319), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_319, 0, true, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_318, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_317, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_316, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_315, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_314, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_313, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(v_312, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(_fx_g22Ast_typecheck__TypBool, v_320, false, &v_320), _fx_catch_125);
-               FX_CALL(_fx_cons_LN10Ast__typ_t(_fx_g21Ast_typecheck__TypInt, v_320, true, &possible_idx_typs_0), _fx_catch_125);
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(new_idx_1, &v_321, 0), _fx_catch_125);
-               FX_COPY_PTR(v_321.t0, &new_ityp_0);
-               _fx_R10Ast__loc_t new_iloc_0 = v_321.t1;
-               bool v_324;
+               fx_exn_t v_340 = {0};
+               _fx_LN10Ast__exp_t v_341 = 0;
+               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_330), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(8, &v_331), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(16, &v_332), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(16, &v_333), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(32, &v_334), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(32, &v_335), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(64, &v_336), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM7TypSIntN10Ast__typ_t1i(64, &v_337), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_337, 0, true, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_336, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_335, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_334, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_333, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_332, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_331, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(v_330, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(_fx_g22Ast_typecheck__TypBool, v_338, false, &v_338), _fx_catch_129);
+               FX_CALL(_fx_cons_LN10Ast__typ_t(_fx_g21Ast_typecheck__TypInt, v_338, true, &possible_idx_typs_0), _fx_catch_129);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(new_idx_1, &v_339, 0), _fx_catch_129);
+               FX_COPY_PTR(v_339.t0, &new_ityp_0);
+               _fx_R10Ast__loc_t new_iloc_0 = v_339.t1;
+               bool v_342;
                FX_CALL(
                   _fx_M13Ast_typecheckFM26idx_type_is_correct_scalarB4N10Ast__typ_tR10Ast__loc_tN18Ast__interpolate_tLN10Ast__typ_t(
-                     new_ityp_0, &new_iloc_0, &interp_0, possible_idx_typs_0, &v_324, 0), _fx_catch_125);
+                     new_ityp_0, &new_iloc_0, &interp_0, possible_idx_typs_0, &v_342, 0), _fx_catch_129);
                int_ dim_inc_0;
-               if (v_324) {
+               if (v_342) {
                   dim_inc_0 = 1;
                }
                else {
-                  _fx_T2Bi v_325;
+                  _fx_T2Bi v_343;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM25idx_type_is_correct_tupleT2Bi5N10Ast__typ_tR10Ast__loc_tLN10Ast__exp_tN18Ast__interpolate_tLN10Ast__typ_t(
-                        new_ityp_0, &new_iloc_0, idxs_0, &interp_0, possible_idx_typs_0, &v_325, 0), _fx_catch_125);
-                  bool is_correct_tuple_0 = v_325.t0;
-                  int_ dim_inc_1 = v_325.t1;
+                        new_ityp_0, &new_iloc_0, idxs_0, &interp_0, possible_idx_typs_0, &v_343, 0), _fx_catch_129);
+                  bool is_correct_tuple_0 = v_343.t0;
+                  int_ dim_inc_1 = v_343.t1;
                   if (is_correct_tuple_0) {
                      dim_inc_0 = dim_inc_1;
                   }
                   else {
-                     fx_str_t slit_129 =
+                     fx_str_t slit_136 =
                         FX_MAKE_STR(
                            "each scalar index in array access op must have some integer type or bool; in the case of interpolation it can also be float or double");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&new_iloc_0, &slit_129, &v_322, 0), _fx_catch_125);
-                     FX_THROW(&v_322, false, _fx_catch_125);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&new_iloc_0, &slit_136, &v_340, 0), _fx_catch_129);
+                     FX_THROW(&v_340, false, _fx_catch_129);
                   }
                }
                int_ nfirst_scalars_0;
@@ -25309,269 +25477,269 @@ FX_EXTERN_C int
                else {
                   nfirst_scalars_0 = nfirst_scalars_acc_0;
                }
-               FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_1, new_idxs_0, true, &v_323), _fx_catch_125);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(new_idx_1, new_idxs_0, true, &v_341), _fx_catch_129);
                _fx_free_LN10Ast__exp_t(&new_idxs_0);
-               FX_COPY_PTR(v_323, &new_idxs_0);
+               FX_COPY_PTR(v_341, &new_idxs_0);
                ndims_0 = ndims_0 + dim_inc_0;
                nfirst_scalars_acc_0 = nfirst_scalars_0;
 
-            _fx_catch_125: ;
-               if (v_323) {
-                  _fx_free_LN10Ast__exp_t(&v_323);
+            _fx_catch_129: ;
+               if (v_341) {
+                  _fx_free_LN10Ast__exp_t(&v_341);
                }
-               fx_free_exn(&v_322);
+               fx_free_exn(&v_340);
                if (new_ityp_0) {
                   _fx_free_N10Ast__typ_t(&new_ityp_0);
                }
-               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_321);
+               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_339);
                if (possible_idx_typs_0) {
                   _fx_free_LN10Ast__typ_t(&possible_idx_typs_0);
                }
-               if (v_320) {
-                  _fx_free_LN10Ast__typ_t(&v_320);
+               if (v_338) {
+                  _fx_free_LN10Ast__typ_t(&v_338);
                }
-               if (v_319) {
-                  _fx_free_N10Ast__typ_t(&v_319);
+               if (v_337) {
+                  _fx_free_N10Ast__typ_t(&v_337);
                }
-               if (v_318) {
-                  _fx_free_N10Ast__typ_t(&v_318);
+               if (v_336) {
+                  _fx_free_N10Ast__typ_t(&v_336);
                }
-               if (v_317) {
-                  _fx_free_N10Ast__typ_t(&v_317);
+               if (v_335) {
+                  _fx_free_N10Ast__typ_t(&v_335);
                }
-               if (v_316) {
-                  _fx_free_N10Ast__typ_t(&v_316);
+               if (v_334) {
+                  _fx_free_N10Ast__typ_t(&v_334);
                }
-               if (v_315) {
-                  _fx_free_N10Ast__typ_t(&v_315);
+               if (v_333) {
+                  _fx_free_N10Ast__typ_t(&v_333);
                }
-               if (v_314) {
-                  _fx_free_N10Ast__typ_t(&v_314);
+               if (v_332) {
+                  _fx_free_N10Ast__typ_t(&v_332);
                }
-               if (v_313) {
-                  _fx_free_N10Ast__typ_t(&v_313);
+               if (v_331) {
+                  _fx_free_N10Ast__typ_t(&v_331);
                }
-               if (v_312) {
-                  _fx_free_N10Ast__typ_t(&v_312);
+               if (v_330) {
+                  _fx_free_N10Ast__typ_t(&v_330);
                }
             }
-            FX_CHECK_EXN(_fx_catch_126);
+            FX_CHECK_EXN(_fx_catch_130);
 
-         _fx_catch_126: ;
+         _fx_catch_130: ;
             if (new_idx_1) {
                _fx_free_N10Ast__exp_t(&new_idx_1);
             }
-            FX_CHECK_EXN(_fx_catch_136);
+            FX_CHECK_EXN(_fx_catch_140);
          }
          int_ nfirst_scalars_1 = nfirst_scalars_acc_0;
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_308, 0), _fx_catch_136);
-         _fx_make_T3iiN10Ast__typ_t(ndims_0, nranges_0, v_308, &v_309);
-         if (v_309.t1 == 0) {
-            if (v_309.t0 == 1) {
-               if (FX_REC_VARIANT_TAG(v_309.t2) == 11) {
-                  fx_str_t slit_130 = FX_MAKE_STR("indexing string should give a char");
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(new_atyp_0, &v_326, 0), _fx_catch_140);
+         _fx_make_T3iiN10Ast__typ_t(ndims_0, nranges_0, v_326, &v_327);
+         if (v_327.t1 == 0) {
+            if (v_327.t0 == 1) {
+               if (FX_REC_VARIANT_TAG(v_327.t2) == 11) {
+                  fx_str_t slit_137 = FX_MAKE_STR("indexing string should give a char");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0,
-                        _fx_g22Ast_typecheck__TypChar, &new_aloc_0, &slit_130, 0), _fx_catch_127);
+                        _fx_g22Ast_typecheck__TypChar, &new_aloc_0, &slit_137, 0), _fx_catch_131);
 
-               _fx_catch_127: ;
-                  goto _fx_endmatch_28;
+               _fx_catch_131: ;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         if (v_309.t1 == 1) {
-            if (v_309.t0 == 1) {
-               if (FX_REC_VARIANT_TAG(v_309.t2) == 11) {
-                  fx_str_t slit_131 = FX_MAKE_STR("indexing string with a range should give a string");
+         if (v_327.t1 == 1) {
+            if (v_327.t0 == 1) {
+               if (FX_REC_VARIANT_TAG(v_327.t2) == 11) {
+                  fx_str_t slit_138 = FX_MAKE_STR("indexing string with a range should give a string");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0,
-                        _fx_g24Ast_typecheck__TypString, &new_aloc_0, &slit_131, 0), _fx_catch_128);
+                        _fx_g24Ast_typecheck__TypString, &new_aloc_0, &slit_138, 0), _fx_catch_132);
 
-               _fx_catch_128: ;
-                  goto _fx_endmatch_28;
+               _fx_catch_132: ;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         if (v_309.t1 == 0) {
-            if (v_309.t0 == 1) {
-               _fx_N10Ast__typ_t v_326 = v_309.t2;
-               if (FX_REC_VARIANT_TAG(v_326) == 17) {
-                  fx_str_t slit_132 =
+         if (v_327.t1 == 0) {
+            if (v_327.t0 == 1) {
+               _fx_N10Ast__typ_t v_344 = v_327.t2;
+               if (FX_REC_VARIANT_TAG(v_344) == 17) {
+                  fx_str_t slit_139 =
                      FX_MAKE_STR(
                         "incorrect type of the rrbvec element access operation; it gives \'{typ2str(et)}\', but \'{typ2str(etyp)}\' is expected");
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_326->u.TypRRBVec,
-                        &new_aloc_0, &slit_132, 0), _fx_catch_129);
+                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_344->u.TypRRBVec,
+                        &new_aloc_0, &slit_139, 0), _fx_catch_133);
 
-               _fx_catch_129: ;
-                  goto _fx_endmatch_28;
+               _fx_catch_133: ;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         if (v_309.t1 == 1) {
-            if (v_309.t0 == 1) {
-               _fx_N10Ast__typ_t v_327 = v_309.t2;
-               if (FX_REC_VARIANT_TAG(v_327) == 17) {
-                  _fx_N10Ast__typ_t v_328 = 0;
-                  FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(v_327->u.TypRRBVec, &v_328), _fx_catch_130);
-                  fx_str_t slit_133 =
+         if (v_327.t1 == 1) {
+            if (v_327.t0 == 1) {
+               _fx_N10Ast__typ_t v_345 = v_327.t2;
+               if (FX_REC_VARIANT_TAG(v_345) == 17) {
+                  _fx_N10Ast__typ_t v_346 = 0;
+                  FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(v_345->u.TypRRBVec, &v_346), _fx_catch_134);
+                  fx_str_t slit_140 =
                      FX_MAKE_STR(
                         "incorrect type of the rrbvec range access operation; it gives \'{typ2str(TypRRBVec(et))}\', but \'{typ2str(etyp)}\' is expected");
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_328, &new_aloc_0,
-                        &slit_133, 0), _fx_catch_130);
+                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_346, &new_aloc_0,
+                        &slit_140, 0), _fx_catch_134);
 
-               _fx_catch_130: ;
-                  if (v_328) {
-                     _fx_free_N10Ast__typ_t(&v_328);
+               _fx_catch_134: ;
+                  if (v_346) {
+                     _fx_free_N10Ast__typ_t(&v_346);
                   }
-                  goto _fx_endmatch_28;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         if (v_309.t1 == 0) {
-            if (v_309.t0 == 1) {
-               _fx_N10Ast__typ_t v_329 = v_309.t2;
-               if (FX_REC_VARIANT_TAG(v_329) == 18) {
-                  fx_str_t slit_134 =
+         if (v_327.t1 == 0) {
+            if (v_327.t0 == 1) {
+               _fx_N10Ast__typ_t v_347 = v_327.t2;
+               if (FX_REC_VARIANT_TAG(v_347) == 18) {
+                  fx_str_t slit_141 =
                      FX_MAKE_STR(
                         "incorrect type of the vector element access operation; it gives \'{typ2str(et)}\', but \'{typ2str(etyp)}\' is expected");
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_329->u.TypVector,
-                        &new_aloc_0, &slit_134, 0), _fx_catch_131);
+                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_347->u.TypVector,
+                        &new_aloc_0, &slit_141, 0), _fx_catch_135);
 
-               _fx_catch_131: ;
-                  goto _fx_endmatch_28;
+               _fx_catch_135: ;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         if (v_309.t1 == 1) {
-            if (v_309.t0 == 1) {
-               _fx_N10Ast__typ_t v_330 = v_309.t2;
-               if (FX_REC_VARIANT_TAG(v_330) == 18) {
-                  _fx_N10Ast__typ_t v_331 = 0;
-                  FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(v_330->u.TypVector, &v_331), _fx_catch_132);
-                  fx_str_t slit_135 =
+         if (v_327.t1 == 1) {
+            if (v_327.t0 == 1) {
+               _fx_N10Ast__typ_t v_348 = v_327.t2;
+               if (FX_REC_VARIANT_TAG(v_348) == 18) {
+                  _fx_N10Ast__typ_t v_349 = 0;
+                  FX_CALL(_fx_M3AstFM9TypVectorN10Ast__typ_t1N10Ast__typ_t(v_348->u.TypVector, &v_349), _fx_catch_136);
+                  fx_str_t slit_142 =
                      FX_MAKE_STR(
                         "incorrect type of the vector range access operation; it gives \'{typ2str(TypVector(et))}\', but \'{typ2str(etyp)}\' is expected");
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_331, &new_aloc_0,
-                        &slit_135, 0), _fx_catch_132);
+                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_349, &new_aloc_0,
+                        &slit_142, 0), _fx_catch_136);
 
-               _fx_catch_132: ;
-                  if (v_331) {
-                     _fx_free_N10Ast__typ_t(&v_331);
+               _fx_catch_136: ;
+                  if (v_349) {
+                     _fx_free_N10Ast__typ_t(&v_349);
                   }
-                  goto _fx_endmatch_28;
+                  goto _fx_endmatch_30;
                }
             }
          }
-         _fx_N10Ast__typ_t et_1 = 0;
-         _fx_N10Ast__typ_t v_332 = 0;
-         fx_str_t v_333 = {0};
-         fx_str_t v_334 = {0};
-         _fx_N10Ast__typ_t v_335 = 0;
-         fx_str_t v_336 = {0};
-         fx_str_t v_337 = {0};
-         fx_str_t v_338 = {0};
-         _fx_N10Ast__typ_t v_339 = 0;
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&et_1, 0), _fx_catch_134);
-         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0, et_1, &v_332), _fx_catch_134);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(new_atyp_0, &v_333, 0), _fx_catch_134);
-         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_333, &v_334, 0), _fx_catch_134);
-         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0, et_1, &v_335), _fx_catch_134);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(v_335, &v_336, 0), _fx_catch_134);
-         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_336, &v_337, 0), _fx_catch_134);
-         fx_str_t slit_136 = FX_MAKE_STR("the array type/dimensionality \'");
-         fx_str_t slit_137 = FX_MAKE_STR("\' does not match the expected type/dimensionality \'");
-         fx_str_t slit_138 = FX_MAKE_STR("\'");
+         _fx_N10Ast__typ_t et_3 = 0;
+         _fx_N10Ast__typ_t v_350 = 0;
+         fx_str_t v_351 = {0};
+         fx_str_t v_352 = {0};
+         _fx_N10Ast__typ_t v_353 = 0;
+         fx_str_t v_354 = {0};
+         fx_str_t v_355 = {0};
+         fx_str_t v_356 = {0};
+         _fx_N10Ast__typ_t v_357 = 0;
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&et_3, 0), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0, et_3, &v_350), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(new_atyp_0, &v_351, 0), _fx_catch_138);
+         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_351, &v_352, 0), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0, et_3, &v_353), _fx_catch_138);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(v_353, &v_354, 0), _fx_catch_138);
+         FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_354, &v_355, 0), _fx_catch_138);
+         fx_str_t slit_143 = FX_MAKE_STR("the array type/dimensionality \'");
+         fx_str_t slit_144 = FX_MAKE_STR("\' does not match the expected type/dimensionality \'");
+         fx_str_t slit_145 = FX_MAKE_STR("\'");
          {
-            const fx_str_t strs_15[] = { slit_136, v_334, slit_137, v_337, slit_138 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_15, 5, &v_338), _fx_catch_134);
+            const fx_str_t strs_15[] = { slit_143, v_352, slit_144, v_355, slit_145 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_15, 5, &v_356), _fx_catch_138);
          }
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(new_atyp_0, v_332, &new_aloc_0, &v_338, 0),
-            _fx_catch_134);
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(new_atyp_0, v_350, &new_aloc_0, &v_356, 0),
+            _fx_catch_138);
          if (border_0.tag != 1) {
-            fx_exn_t v_340 = {0};
+            fx_exn_t v_358 = {0};
             int_ elem_sz_0;
-            FX_CALL(_fx_M3AstFM20get_numeric_typ_sizei2N10Ast__typ_tB(et_1, true, &elem_sz_0, 0), _fx_catch_133);
+            FX_CALL(_fx_M3AstFM20get_numeric_typ_sizei2N10Ast__typ_tB(et_3, true, &elem_sz_0, 0), _fx_catch_137);
             if (!(bool)((0 < elem_sz_0) & (elem_sz_0 <= 256))) {
-               fx_str_t slit_139 =
+               fx_str_t slit_146 =
                   FX_MAKE_STR(
                      "border extrapolation is used with an array, which elements are too large ({elem_sz} bytes) or have unsupported type \'{typ2str(et)\'");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_139, &v_340, 0), _fx_catch_133);
-               FX_THROW(&v_340, false, _fx_catch_133);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_146, &v_358, 0), _fx_catch_137);
+               FX_THROW(&v_358, false, _fx_catch_137);
             }
 
-         _fx_catch_133: ;
-            fx_free_exn(&v_340);
+         _fx_catch_137: ;
+            fx_free_exn(&v_358);
          }
-         FX_CHECK_EXN(_fx_catch_134);
+         FX_CHECK_EXN(_fx_catch_138);
          if (nranges_0 == 0) {
-            fx_str_t slit_140 = FX_MAKE_STR("the type of array access expression does not match the array element type");
-            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, et_1, &eloc_0, &slit_140, 0),
-               _fx_catch_134);
+            fx_str_t slit_147 = FX_MAKE_STR("the type of array access expression does not match the array element type");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, et_3, &eloc_0, &slit_147, 0),
+               _fx_catch_138);
          }
          else {
-            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0 - nfirst_scalars_1, et_1, &v_339), _fx_catch_134);
-            fx_str_t slit_141 =
+            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(ndims_0 - nfirst_scalars_1, et_3, &v_357), _fx_catch_138);
+            fx_str_t slit_148 =
                FX_MAKE_STR(
                   "the number of ranges does not match dimensionality of the result, or the element type is incorrect");
             FX_CALL(
-               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_339, &eloc_0, &slit_141, 0),
-               _fx_catch_134);
+               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_357, &eloc_0, &slit_148, 0),
+               _fx_catch_138);
          }
 
-      _fx_catch_134: ;
-         if (v_339) {
-            _fx_free_N10Ast__typ_t(&v_339);
+      _fx_catch_138: ;
+         if (v_357) {
+            _fx_free_N10Ast__typ_t(&v_357);
          }
-         FX_FREE_STR(&v_338);
-         FX_FREE_STR(&v_337);
-         FX_FREE_STR(&v_336);
-         if (v_335) {
-            _fx_free_N10Ast__typ_t(&v_335);
+         FX_FREE_STR(&v_356);
+         FX_FREE_STR(&v_355);
+         FX_FREE_STR(&v_354);
+         if (v_353) {
+            _fx_free_N10Ast__typ_t(&v_353);
          }
-         FX_FREE_STR(&v_334);
-         FX_FREE_STR(&v_333);
-         if (v_332) {
-            _fx_free_N10Ast__typ_t(&v_332);
+         FX_FREE_STR(&v_352);
+         FX_FREE_STR(&v_351);
+         if (v_350) {
+            _fx_free_N10Ast__typ_t(&v_350);
          }
-         if (et_1) {
-            _fx_free_N10Ast__typ_t(&et_1);
+         if (et_3) {
+            _fx_free_N10Ast__typ_t(&et_3);
          }
 
-      _fx_endmatch_28: ;
-         FX_CHECK_EXN(_fx_catch_136);
+      _fx_endmatch_30: ;
+         FX_CHECK_EXN(_fx_catch_140);
          if (interp_0.tag != 1) {
-            fx_exn_t v_341 = {0};
-            fx_str_t slit_142 = FX_MAKE_STR("element interpolation is not supported yet");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_142, &v_341, 0), _fx_catch_135);
-            FX_THROW(&v_341, false, _fx_catch_135);
+            fx_exn_t v_359 = {0};
+            fx_str_t slit_149 = FX_MAKE_STR("element interpolation is not supported yet");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_149, &v_359, 0), _fx_catch_139);
+            FX_THROW(&v_359, false, _fx_catch_139);
 
-         _fx_catch_135: ;
-            fx_free_exn(&v_341);
+         _fx_catch_139: ;
+            fx_free_exn(&v_359);
          }
-         FX_CHECK_EXN(_fx_catch_136);
-         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(new_idxs_0, &v_310, 0), _fx_catch_136);
+         FX_CHECK_EXN(_fx_catch_140);
+         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(new_idxs_0, &v_328, 0), _fx_catch_140);
          FX_CALL(
             _fx_M3AstFM5ExpAtN10Ast__exp_t5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-               new_arr_0, &border_0, &interp_0, v_310, &ctx_0, &result_38), _fx_catch_136);
+               new_arr_0, &border_0, &interp_0, v_328, &ctx_0, &result_40), _fx_catch_140);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_38, &result_0);
-         FX_BREAK(_fx_catch_136);
+         FX_COPY_PTR(result_40, &result_0);
+         FX_BREAK(_fx_catch_140);
 
-      _fx_catch_136: ;
-         if (result_38) {
-            _fx_free_N10Ast__exp_t(&result_38);
+      _fx_catch_140: ;
+         if (result_40) {
+            _fx_free_N10Ast__exp_t(&result_40);
          }
-         if (v_310) {
-            _fx_free_LN10Ast__exp_t(&v_310);
+         if (v_328) {
+            _fx_free_LN10Ast__exp_t(&v_328);
          }
-         _fx_free_T3iiN10Ast__typ_t(&v_309);
-         if (v_308) {
-            _fx_free_N10Ast__typ_t(&v_308);
+         _fx_free_T3iiN10Ast__typ_t(&v_327);
+         if (v_326) {
+            _fx_free_N10Ast__typ_t(&v_326);
          }
          if (idxs_1) {
             _fx_free_LN10Ast__exp_t(&idxs_1);
@@ -25580,89 +25748,89 @@ FX_EXTERN_C int
             _fx_free_LN10Ast__exp_t(&new_idxs_0);
          }
 
-      _fx_endmatch_29: ;
-         FX_CHECK_EXN(_fx_catch_137);
+      _fx_endmatch_31: ;
+         FX_CHECK_EXN(_fx_catch_141);
 
-      _fx_catch_137: ;
-         fx_free_exn(&v_297);
+      _fx_catch_141: ;
+         fx_free_exn(&v_315);
          if (new_atyp_0) {
             _fx_free_N10Ast__typ_t(&new_atyp_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_296);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_314);
          if (new_arr_0) {
             _fx_free_N10Ast__exp_t(&new_arr_0);
          }
          if (arr_0) {
             _fx_free_N10Ast__exp_t(&arr_0);
          }
-         _fx_free_T3N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_t(&v_295);
-         goto _fx_endmatch_41;
+         _fx_free_T3N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_t(&v_313);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 23) {
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_342 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_360 = {0};
          _fx_N10Ast__typ_t ctyp_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_343 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_361 = {0};
          _fx_N10Ast__typ_t typ1_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_344 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_362 = {0};
          _fx_N10Ast__typ_t typ2_0 = 0;
          _fx_N10Ast__exp_t new_c_0 = 0;
          _fx_N10Ast__exp_t new_e1_11 = 0;
          fx_exn_t exn_3 = {0};
          _fx_N10Ast__exp_t new_e2_6 = 0;
          fx_exn_t exn_4 = {0};
-         _fx_N10Ast__exp_t result_39 = 0;
+         _fx_N10Ast__exp_t result_41 = 0;
          _fx_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_22 = &e_2->u.ExpIf;
          _fx_N10Ast__exp_t e2_3 = vcase_22->t2;
          _fx_N10Ast__exp_t e1_4 = vcase_22->t1;
          _fx_N10Ast__exp_t c_0 = vcase_22->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_0, &v_342, 0), _fx_catch_144);
-         FX_COPY_PTR(v_342.t0, &ctyp_0);
-         _fx_R10Ast__loc_t cloc_0 = v_342.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_4, &v_343, 0), _fx_catch_144);
-         FX_COPY_PTR(v_343.t0, &typ1_0);
-         _fx_R10Ast__loc_t loc1_0 = v_343.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e2_3, &v_344, 0), _fx_catch_144);
-         FX_COPY_PTR(v_344.t0, &typ2_0);
-         _fx_R10Ast__loc_t loc2_0 = v_344.t1;
-         fx_str_t slit_143 = FX_MAKE_STR("if() condition should have \'bool\' type");
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_0, &v_360, 0), _fx_catch_148);
+         FX_COPY_PTR(v_360.t0, &ctyp_0);
+         _fx_R10Ast__loc_t cloc_0 = v_360.t1;
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_4, &v_361, 0), _fx_catch_148);
+         FX_COPY_PTR(v_361.t0, &typ1_0);
+         _fx_R10Ast__loc_t loc1_0 = v_361.t1;
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e2_3, &v_362, 0), _fx_catch_148);
+         FX_COPY_PTR(v_362.t0, &typ2_0);
+         _fx_R10Ast__loc_t loc2_0 = v_362.t1;
+         fx_str_t slit_150 = FX_MAKE_STR("if() condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_0, _fx_g22Ast_typecheck__TypBool,
-               &cloc_0, &slit_143, 0), _fx_catch_144);
-         fx_str_t slit_144 = FX_MAKE_STR("if() expression should have the same type as its branches");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(typ1_0, etyp_0, &loc1_0, &slit_144, 0),
-            _fx_catch_144);
-         bool v_345;
+               &cloc_0, &slit_150, 0), _fx_catch_148);
+         fx_str_t slit_151 = FX_MAKE_STR("if() expression should have the same type as its branches");
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(typ1_0, etyp_0, &loc1_0, &slit_151, 0),
+            _fx_catch_148);
+         bool v_363;
          FX_CALL(
-            _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(typ2_0, etyp_0, &loc2_0, true, &v_345,
-               0), _fx_catch_144);
-         if (!v_345) {
+            _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(typ2_0, etyp_0, &loc2_0, true, &v_363,
+               0), _fx_catch_148);
+         if (!v_363) {
             if (FX_REC_VARIANT_TAG(e2_3) == 1) {
-               fx_exn_t v_346 = {0};
-               fx_str_t slit_145 = FX_MAKE_STR("if() expression of non-void type has no \'else\' branch");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&loc2_0, &slit_145, &v_346, 0), _fx_catch_138);
-               FX_THROW(&v_346, false, _fx_catch_138);
+               fx_exn_t v_364 = {0};
+               fx_str_t slit_152 = FX_MAKE_STR("if() expression of non-void type has no \'else\' branch");
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&loc2_0, &slit_152, &v_364, 0), _fx_catch_142);
+               FX_THROW(&v_364, false, _fx_catch_142);
 
-            _fx_catch_138: ;
-               fx_free_exn(&v_346);
+            _fx_catch_142: ;
+               fx_free_exn(&v_364);
             }
             else {
-               fx_str_t slit_146 = FX_MAKE_STR("if() expression should have the same type as its branches");
+               fx_str_t slit_153 = FX_MAKE_STR("if() expression should have the same type as its branches");
                FX_CALL(
-                  _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(typ2_0, etyp_0, &loc2_0, &slit_146, 0),
-                  _fx_catch_139);
+                  _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(typ2_0, etyp_0, &loc2_0, &slit_153, 0),
+                  _fx_catch_143);
 
-            _fx_catch_139: ;
+            _fx_catch_143: ;
             }
-            FX_CHECK_EXN(_fx_catch_144);
+            FX_CHECK_EXN(_fx_catch_148);
          }
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_0, &env_2, sc_2, &new_c_0, 0), _fx_catch_144);
+               c_0, &env_2, sc_2, &new_c_0, 0), _fx_catch_148);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e1_4, &env_2, sc_2, &new_e1_11, 0), _fx_catch_140);
+               e1_4, &env_2, sc_2, &new_e1_11, 0), _fx_catch_144);
 
-      _fx_catch_140: ;
+      _fx_catch_144: ;
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_3);
             fx_status = 0;
@@ -25670,21 +25838,21 @@ FX_EXTERN_C int
                _fx_free_N10Ast__exp_t(&new_e1_11);
             }
             if (exn_3.tag == _FX_EXN_E17Ast__CompileError) {
-               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_141);
+               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_145);
                FX_COPY_PTR(e1_4, &new_e1_11);
 
-            _fx_catch_141: ;
+            _fx_catch_145: ;
             }
             else {
-               FX_RETHROW(&exn_3, _fx_catch_144);
+               FX_RETHROW(&exn_3, _fx_catch_148);
             }
-            FX_CHECK_EXN(_fx_catch_144);
+            FX_CHECK_EXN(_fx_catch_148);
          }
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e2_3, &env_2, sc_2, &new_e2_6, 0), _fx_catch_142);
+               e2_3, &env_2, sc_2, &new_e2_6, 0), _fx_catch_146);
 
-      _fx_catch_142: ;
+      _fx_catch_146: ;
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_4);
             fx_status = 0;
@@ -25692,26 +25860,26 @@ FX_EXTERN_C int
                _fx_free_N10Ast__exp_t(&new_e2_6);
             }
             if (exn_4.tag == _FX_EXN_E17Ast__CompileError) {
-               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_4, 0), _fx_catch_143);
+               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_4, 0), _fx_catch_147);
                FX_COPY_PTR(e2_3, &new_e2_6);
 
-            _fx_catch_143: ;
+            _fx_catch_147: ;
             }
             else {
-               FX_RETHROW(&exn_4, _fx_catch_144);
+               FX_RETHROW(&exn_4, _fx_catch_148);
             }
-            FX_CHECK_EXN(_fx_catch_144);
+            FX_CHECK_EXN(_fx_catch_148);
          }
          FX_CALL(
             _fx_M3AstFM5ExpIfN10Ast__exp_t4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_c_0, new_e1_11,
-               new_e2_6, &ctx_0, &result_39), _fx_catch_144);
+               new_e2_6, &ctx_0, &result_41), _fx_catch_148);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_39, &result_0);
-         FX_BREAK(_fx_catch_144);
+         FX_COPY_PTR(result_41, &result_0);
+         FX_BREAK(_fx_catch_148);
 
-      _fx_catch_144: ;
-         if (result_39) {
-            _fx_free_N10Ast__exp_t(&result_39);
+      _fx_catch_148: ;
+         if (result_41) {
+            _fx_free_N10Ast__exp_t(&result_41);
          }
          fx_free_exn(&exn_4);
          if (new_e2_6) {
@@ -25727,61 +25895,61 @@ FX_EXTERN_C int
          if (typ2_0) {
             _fx_free_N10Ast__typ_t(&typ2_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_344);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_362);
          if (typ1_0) {
             _fx_free_N10Ast__typ_t(&typ1_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_343);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_361);
          if (ctyp_0) {
             _fx_free_N10Ast__typ_t(&ctyp_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_342);
-         goto _fx_endmatch_41;
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_360);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 24) {
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_347 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_365 = {0};
          _fx_N10Ast__typ_t ctyp_1 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_348 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_366 = {0};
          _fx_N10Ast__typ_t btyp_0 = 0;
          _fx_N10Ast__exp_t new_c_1 = 0;
          _fx_LN12Ast__scope_t loop_sc_0 = 0;
          _fx_N10Ast__exp_t new_body_0 = 0;
-         _fx_N10Ast__exp_t result_40 = 0;
+         _fx_N10Ast__exp_t result_42 = 0;
          _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_23 = &e_2->u.ExpWhile;
          _fx_N10Ast__exp_t body_0 = vcase_23->t1;
          _fx_N10Ast__exp_t c_1 = vcase_23->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_1, &v_347, 0), _fx_catch_145);
-         FX_COPY_PTR(v_347.t0, &ctyp_1);
-         _fx_R10Ast__loc_t cloc_1 = v_347.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_0, &v_348, 0), _fx_catch_145);
-         FX_COPY_PTR(v_348.t0, &btyp_0);
-         _fx_R10Ast__loc_t bloc_0 = v_348.t1;
-         fx_str_t slit_147 = FX_MAKE_STR("while() loop condition should have \'bool\' type");
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_1, &v_365, 0), _fx_catch_149);
+         FX_COPY_PTR(v_365.t0, &ctyp_1);
+         _fx_R10Ast__loc_t cloc_1 = v_365.t1;
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_0, &v_366, 0), _fx_catch_149);
+         FX_COPY_PTR(v_366.t0, &btyp_0);
+         _fx_R10Ast__loc_t bloc_0 = v_366.t1;
+         fx_str_t slit_154 = FX_MAKE_STR("while() loop condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_1, _fx_g22Ast_typecheck__TypBool,
-               &cloc_1, &slit_147, 0), _fx_catch_145);
-         fx_str_t slit_148 = FX_MAKE_STR("while() loop body should have \'void\' type");
+               &cloc_1, &slit_154, 0), _fx_catch_149);
+         fx_str_t slit_155 = FX_MAKE_STR("while() loop body should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_0, _fx_g22Ast_typecheck__TypVoid,
-               &bloc_0, &slit_148, 0), _fx_catch_145);
+               &bloc_0, &slit_155, 0), _fx_catch_149);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_1, &env_2, sc_2, &new_c_1, 0), _fx_catch_145);
-         _fx_N12Ast__scope_t v_349;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_349, 0), _fx_catch_145);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_349, sc_2, true, &loop_sc_0), _fx_catch_145);
+               c_1, &env_2, sc_2, &new_c_1, 0), _fx_catch_149);
+         _fx_N12Ast__scope_t v_367;
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_367, 0), _fx_catch_149);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_367, sc_2, true, &loop_sc_0), _fx_catch_149);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               body_0, &env_2, loop_sc_0, &new_body_0, 0), _fx_catch_145);
-         FX_CALL(_fx_M3AstFM8ExpWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_c_1, new_body_0, &eloc_0, &result_40),
-            _fx_catch_145);
+               body_0, &env_2, loop_sc_0, &new_body_0, 0), _fx_catch_149);
+         FX_CALL(_fx_M3AstFM8ExpWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_c_1, new_body_0, &eloc_0, &result_42),
+            _fx_catch_149);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_40, &result_0);
-         FX_BREAK(_fx_catch_145);
+         FX_COPY_PTR(result_42, &result_0);
+         FX_BREAK(_fx_catch_149);
 
-      _fx_catch_145: ;
-         if (result_40) {
-            _fx_free_N10Ast__exp_t(&result_40);
+      _fx_catch_149: ;
+         if (result_42) {
+            _fx_free_N10Ast__exp_t(&result_42);
          }
          if (new_body_0) {
             _fx_free_N10Ast__exp_t(&new_body_0);
@@ -25793,58 +25961,58 @@ FX_EXTERN_C int
          if (btyp_0) {
             _fx_free_N10Ast__typ_t(&btyp_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_348);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_366);
          if (ctyp_1) {
             _fx_free_N10Ast__typ_t(&ctyp_1);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_347);
-         goto _fx_endmatch_41;
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_365);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 25) {
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_350 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_368 = {0};
          _fx_N10Ast__typ_t ctyp_2 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_351 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_369 = {0};
          _fx_N10Ast__typ_t btyp_1 = 0;
          _fx_N10Ast__exp_t new_c_2 = 0;
          _fx_LN12Ast__scope_t loop_sc_1 = 0;
          _fx_N10Ast__exp_t new_body_1 = 0;
-         _fx_N10Ast__exp_t result_41 = 0;
+         _fx_N10Ast__exp_t result_43 = 0;
          _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_24 = &e_2->u.ExpDoWhile;
          _fx_N10Ast__exp_t c_2 = vcase_24->t1;
          _fx_N10Ast__exp_t body_1 = vcase_24->t0;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_2, &v_350, 0), _fx_catch_146);
-         FX_COPY_PTR(v_350.t0, &ctyp_2);
-         _fx_R10Ast__loc_t cloc_2 = v_350.t1;
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_1, &v_351, 0), _fx_catch_146);
-         FX_COPY_PTR(v_351.t0, &btyp_1);
-         _fx_R10Ast__loc_t bloc_1 = v_351.t1;
-         fx_str_t slit_149 = FX_MAKE_STR("do-while() loop condition should have \'bool\' type");
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(c_2, &v_368, 0), _fx_catch_150);
+         FX_COPY_PTR(v_368.t0, &ctyp_2);
+         _fx_R10Ast__loc_t cloc_2 = v_368.t1;
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_1, &v_369, 0), _fx_catch_150);
+         FX_COPY_PTR(v_369.t0, &btyp_1);
+         _fx_R10Ast__loc_t bloc_1 = v_369.t1;
+         fx_str_t slit_156 = FX_MAKE_STR("do-while() loop condition should have \'bool\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(ctyp_2, _fx_g22Ast_typecheck__TypBool,
-               &cloc_2, &slit_149, 0), _fx_catch_146);
-         fx_str_t slit_150 = FX_MAKE_STR("do-while() loop body should have \'void\' type");
+               &cloc_2, &slit_156, 0), _fx_catch_150);
+         fx_str_t slit_157 = FX_MAKE_STR("do-while() loop body should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_1, _fx_g22Ast_typecheck__TypVoid,
-               &bloc_1, &slit_150, 0), _fx_catch_146);
+               &bloc_1, &slit_157, 0), _fx_catch_150);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               c_2, &env_2, sc_2, &new_c_2, 0), _fx_catch_146);
-         _fx_N12Ast__scope_t v_352;
-         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_352, 0), _fx_catch_146);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_352, sc_2, true, &loop_sc_1), _fx_catch_146);
+               c_2, &env_2, sc_2, &new_c_2, 0), _fx_catch_150);
+         _fx_N12Ast__scope_t v_370;
+         FX_CALL(_fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, false, false, &v_370, 0), _fx_catch_150);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_370, sc_2, true, &loop_sc_1), _fx_catch_150);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               body_1, &env_2, loop_sc_1, &new_body_1, 0), _fx_catch_146);
+               body_1, &env_2, loop_sc_1, &new_body_1, 0), _fx_catch_150);
          FX_CALL(
-            _fx_M3AstFM10ExpDoWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_body_1, new_c_2, &eloc_0, &result_41),
-            _fx_catch_146);
+            _fx_M3AstFM10ExpDoWhileN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(new_body_1, new_c_2, &eloc_0, &result_43),
+            _fx_catch_150);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_41, &result_0);
-         FX_BREAK(_fx_catch_146);
+         FX_COPY_PTR(result_43, &result_0);
+         FX_BREAK(_fx_catch_150);
 
-      _fx_catch_146: ;
-         if (result_41) {
-            _fx_free_N10Ast__exp_t(&result_41);
+      _fx_catch_150: ;
+         if (result_43) {
+            _fx_free_N10Ast__exp_t(&result_43);
          }
          if (new_body_1) {
             _fx_free_N10Ast__exp_t(&new_body_1);
@@ -25856,30 +26024,30 @@ FX_EXTERN_C int
          if (btyp_1) {
             _fx_free_N10Ast__typ_t(&btyp_1);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_351);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_369);
          if (ctyp_2) {
             _fx_free_N10Ast__typ_t(&ctyp_2);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_350);
-         goto _fx_endmatch_41;
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_368);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 26) {
-         fx_exn_t v_353 = {0};
+         fx_exn_t v_371 = {0};
          _fx_LN12Ast__scope_t for_sc_0 = 0;
          _fx_T7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t
-            v_354 = {0};
+            v_372 = {0};
          _fx_LN10Ast__exp_t pre_code_0 = 0;
          _fx_LT2N10Ast__pat_tN10Ast__exp_t for_clauses_0 = 0;
          _fx_N10Ast__pat_t idx_pat_0 = 0;
          _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_4 = {0};
          _fx_LN10Ast__exp_t code_0 = 0;
-         _fx_LN10Ast__exp_t v_355 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_356 = {0};
-         _fx_N10Ast__exp_t result_42 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_357 = {0};
+         _fx_LN10Ast__exp_t v_373 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_374 = {0};
+         _fx_N10Ast__exp_t result_44 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_375 = {0};
          _fx_N10Ast__typ_t btyp_2 = 0;
          _fx_N10Ast__exp_t new_body_2 = 0;
-         _fx_N10Ast__exp_t result_43 = 0;
+         _fx_N10Ast__exp_t result_45 = 0;
          _fx_T5LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_25 =
             &e_2->u.ExpFor;
          _fx_R16Ast__for_flags_t* flags_0 = &vcase_25->t3;
@@ -25887,90 +26055,90 @@ FX_EXTERN_C int
          bool is_fold_0 = flags_0->for_flag_fold;
          bool is_nested_0 = flags_0->for_flag_nested;
          if (flags_0->for_flag_unzip) {
-            fx_str_t slit_151 = FX_MAKE_STR("@unzip for does not make sense outside of comprehensions");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_151, &v_353, 0), _fx_catch_148);
-            FX_THROW(&v_353, false, _fx_catch_148);
+            fx_str_t slit_158 = FX_MAKE_STR("@unzip for does not make sense outside of comprehensions");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_158, &v_371, 0), _fx_catch_152);
+            FX_THROW(&v_371, false, _fx_catch_152);
          }
-         _fx_N12Ast__scope_t v_358;
+         _fx_N12Ast__scope_t v_376;
          if (is_fold_0) {
-            FX_CALL(_fx_M3AstFM14new_fold_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_358, 0), _fx_catch_148);
+            FX_CALL(_fx_M3AstFM14new_fold_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_376, 0), _fx_catch_152);
          }
          else {
             FX_CALL(
-               _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, is_nested_0, flags_0->for_flag_parallel, &v_358, 0),
-               _fx_catch_148);
+               _fx_M3AstFM14new_loop_scopeN12Ast__scope_t3iBB(curr_m_idx_0, is_nested_0, flags_0->for_flag_parallel, &v_376, 0),
+               _fx_catch_152);
          }
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_358, sc_2, true, &for_sc_0), _fx_catch_148);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_376, sc_2, true, &for_sc_0), _fx_catch_152);
          FX_CALL(
             _fx_M13Ast_typecheckFM17check_for_clausesT7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tR16Ast__for_flags_tLN12Ast__scope_ti(
-               vcase_25->t0, vcase_25->t1, &env_2, &_fx_g16Ast__empty_idset, flags_0, for_sc_0, curr_m_idx_0, &v_354, 0),
-            _fx_catch_148);
-         int_ trsz_0 = v_354.t0;
-         FX_COPY_PTR(v_354.t1, &pre_code_0);
-         FX_COPY_PTR(v_354.t2, &for_clauses_0);
-         FX_COPY_PTR(v_354.t3, &idx_pat_0);
-         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_354.t5, &env_4);
+               vcase_25->t0, vcase_25->t1, &env_2, &_fx_g16Ast__empty_idset, flags_0, for_sc_0, curr_m_idx_0, &v_372, 0),
+            _fx_catch_152);
+         int_ trsz_0 = v_372.t0;
+         FX_COPY_PTR(v_372.t1, &pre_code_0);
+         FX_COPY_PTR(v_372.t2, &for_clauses_0);
+         FX_COPY_PTR(v_372.t3, &idx_pat_0);
+         _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_372.t5, &env_4);
          if (trsz_0 > 0) {
             _fx_LN10Ast__exp_t lstend_7 = 0;
             for (int_ idx_2 = 0; idx_2 < trsz_0; idx_2++) {
                _fx_N10Ast__exp_t it_j_0 = 0;
-               _fx_T2N10Ast__typ_tR10Ast__loc_t v_359 = {0};
+               _fx_T2N10Ast__typ_tR10Ast__loc_t v_377 = {0};
                _fx_N10Ast__typ_t tj_0 = 0;
                FX_CALL(
                   _fx_M13Ast_typecheckFM20gen_for_in_tuprec_itN10Ast__exp_t8iLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tLN12Ast__scope_t(
-                     idx_2, for_clauses_0, idx_pat_0, body_2, &env_4, for_sc_0, &eloc_0, sc_2, &it_j_0, 0), _fx_catch_147);
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_0, &v_359, 0), _fx_catch_147);
-               FX_COPY_PTR(v_359.t0, &tj_0);
-               _fx_R10Ast__loc_t locj_0 = v_359.t1;
-               fx_str_t slit_152 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
+                     idx_2, for_clauses_0, idx_pat_0, body_2, &env_4, for_sc_0, &eloc_0, sc_2, &it_j_0, 0), _fx_catch_151);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_0, &v_377, 0), _fx_catch_151);
+               FX_COPY_PTR(v_377.t0, &tj_0);
+               _fx_R10Ast__loc_t locj_0 = v_377.t1;
+               fx_str_t slit_159 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
                FX_CALL(
                   _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(tj_0, _fx_g22Ast_typecheck__TypVoid,
-                     &locj_0, &slit_152, 0), _fx_catch_147);
+                     &locj_0, &slit_159, 0), _fx_catch_151);
                _fx_LN10Ast__exp_t node_7 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_0, 0, false, &node_7), _fx_catch_147);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_0, 0, false, &node_7), _fx_catch_151);
                FX_LIST_APPEND(code_0, lstend_7, node_7);
 
-            _fx_catch_147: ;
+            _fx_catch_151: ;
                if (tj_0) {
                   _fx_free_N10Ast__typ_t(&tj_0);
                }
-               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_359);
+               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_377);
                if (it_j_0) {
                   _fx_free_N10Ast__exp_t(&it_j_0);
                }
-               FX_CHECK_EXN(_fx_catch_148);
+               FX_CHECK_EXN(_fx_catch_152);
             }
-            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_0, code_0, &v_355, 0),
-               _fx_catch_148);
-            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g22Ast_typecheck__TypVoid, &eloc_0, &v_356);
-            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_355, &v_356, &result_42),
-               _fx_catch_148);
+            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_0, code_0, &v_373, 0),
+               _fx_catch_152);
+            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(_fx_g22Ast_typecheck__TypVoid, &eloc_0, &v_374);
+            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_373, &v_374, &result_44),
+               _fx_catch_152);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_42, &result_0);
-            FX_BREAK(_fx_catch_148);
+            FX_COPY_PTR(result_44, &result_0);
+            FX_BREAK(_fx_catch_152);
          }
          else {
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_2, &v_357, 0), _fx_catch_148);
-            FX_COPY_PTR(v_357.t0, &btyp_2);
-            _fx_R10Ast__loc_t bloc_2 = v_357.t1;
-            fx_str_t slit_153 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_2, &v_375, 0), _fx_catch_152);
+            FX_COPY_PTR(v_375.t0, &btyp_2);
+            _fx_R10Ast__loc_t bloc_2 = v_375.t1;
+            fx_str_t slit_160 = FX_MAKE_STR("\'for()\' body should have \'void\' type");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(btyp_2, _fx_g22Ast_typecheck__TypVoid,
-                  &bloc_2, &slit_153, 0), _fx_catch_148);
+                  &bloc_2, &slit_160, 0), _fx_catch_152);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  body_2, &env_4, for_sc_0, &new_body_2, 0), _fx_catch_148);
+                  body_2, &env_4, for_sc_0, &new_body_2, 0), _fx_catch_152);
             FX_CALL(
                _fx_M3AstFM6ExpForN10Ast__exp_t5LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRM11for_flags_tRM5loc_t(
-                  for_clauses_0, idx_pat_0, new_body_2, flags_0, &eloc_0, &result_43), _fx_catch_148);
+                  for_clauses_0, idx_pat_0, new_body_2, flags_0, &eloc_0, &result_45), _fx_catch_152);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_43, &result_0);
-            FX_BREAK(_fx_catch_148);
+            FX_COPY_PTR(result_45, &result_0);
+            FX_BREAK(_fx_catch_152);
          }
 
-      _fx_catch_148: ;
-         if (result_43) {
-            _fx_free_N10Ast__exp_t(&result_43);
+      _fx_catch_152: ;
+         if (result_45) {
+            _fx_free_N10Ast__exp_t(&result_45);
          }
          if (new_body_2) {
             _fx_free_N10Ast__exp_t(&new_body_2);
@@ -25978,13 +26146,13 @@ FX_EXTERN_C int
          if (btyp_2) {
             _fx_free_N10Ast__typ_t(&btyp_2);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_357);
-         if (result_42) {
-            _fx_free_N10Ast__exp_t(&result_42);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_375);
+         if (result_44) {
+            _fx_free_N10Ast__exp_t(&result_44);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_356);
-         if (v_355) {
-            _fx_free_LN10Ast__exp_t(&v_355);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_374);
+         if (v_373) {
+            _fx_free_LN10Ast__exp_t(&v_373);
          }
          if (code_0) {
             _fx_free_LN10Ast__exp_t(&code_0);
@@ -26000,10 +26168,10 @@ FX_EXTERN_C int
             _fx_free_LN10Ast__exp_t(&pre_code_0);
          }
          _fx_free_T7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
-            &v_354);
+            &v_372);
          FX_FREE_LIST_SIMPLE(&for_sc_0);
-         fx_free_exn(&v_353);
-         goto _fx_endmatch_41;
+         fx_free_exn(&v_371);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 27) {
          _fx_LN12Ast__scope_t for_sc_1 = 0;
@@ -26015,10 +26183,10 @@ FX_EXTERN_C int
          _fx_LN10Ast__exp_t pre_code_2 = 0;
          _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t map_clauses_1 = 0;
          _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_5 = {0};
-         fx_exn_t v_360 = {0};
+         fx_exn_t v_378 = {0};
          fx_str_t coll_name_0 = {0};
-         fx_exn_t v_361 = {0};
-         _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_362 = {0};
+         fx_exn_t v_379 = {0};
+         _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_380 = {0};
          _fx_LT2N10Ast__pat_tN10Ast__exp_t for_clauses_1 = 0;
          _fx_N10Ast__pat_t idx_pat_1 = 0;
          _fx_N10Ast__typ_t elem_typ_0 = 0;
@@ -26026,50 +26194,50 @@ FX_EXTERN_C int
          _fx_N10Ast__exp_t mk_struct_exp_0 = 0;
          _fx_FPN10Ast__typ_t1N10Ast__exp_t get_exp_typ_0 = {0};
          _fx_LN10Ast__typ_t tl_1 = 0;
-         _fx_N10Ast__typ_t v_363 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_364 = {0};
+         _fx_N10Ast__typ_t v_381 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_382 = {0};
          _fx_N10Ast__typ_t ltyp_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_365 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_383 = {0};
          _fx_N10Ast__exp_t l_exp_0 = 0;
-         _fx_LN10Ast__exp_t v_366 = 0;
-         _fx_N10Ast__typ_t v_367 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_368 = {0};
-         _fx_LLN10Ast__exp_t v_369 = 0;
-         _fx_N10Ast__typ_t v_370 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_371 = {0};
+         _fx_LN10Ast__exp_t v_384 = 0;
+         _fx_N10Ast__typ_t v_385 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_386 = {0};
+         _fx_LLN10Ast__exp_t v_387 = 0;
+         _fx_N10Ast__typ_t v_388 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_389 = {0};
          _fx_N10Ast__typ_t coll_typ_0 = 0;
-         fx_str_t v_372 = {0};
-         fx_str_t v_373 = {0};
-         _fx_LN10Ast__exp_t v_374 = 0;
-         _fx_LN10Ast__exp_t v_375 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_376 = {0};
-         _fx_N10Ast__exp_t result_44 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_377 = {0};
+         fx_str_t v_390 = {0};
+         fx_str_t v_391 = {0};
+         _fx_LN10Ast__exp_t v_392 = 0;
+         _fx_LN10Ast__exp_t v_393 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_394 = {0};
+         _fx_N10Ast__exp_t result_46 = 0;
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_395 = {0};
          _fx_N10Ast__typ_t btyp_3 = 0;
          _fx_N10Ast__exp_t new_body_3 = 0;
-         _fx_N10Ast__typ_t v_378 = 0;
-         _fx_N10Ast__typ_t v_379 = 0;
-         _fx_Nt6option1N10Ast__typ_t v_380 = 0;
-         _fx_N10Ast__typ_t v_381 = 0;
-         _fx_N10Ast__typ_t v_382 = 0;
-         _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_383 = 0;
-         _fx_N10Ast__exp_t result_45 = 0;
+         _fx_N10Ast__typ_t v_396 = 0;
+         _fx_N10Ast__typ_t v_397 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_398 = 0;
+         _fx_N10Ast__typ_t v_399 = 0;
+         _fx_N10Ast__typ_t v_400 = 0;
+         _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_401 = 0;
+         _fx_N10Ast__exp_t result_47 = 0;
          _fx_T4LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tR16Ast__for_flags_tT2N10Ast__typ_tR10Ast__loc_t*
             vcase_26 = &e_2->u.ExpMap;
          _fx_R16Ast__for_flags_t* flags_1 = &vcase_26->t2;
          _fx_N10Ast__exp_t body_3 = vcase_26->t1;
-         _fx_N15Ast__for_make_t v_384 = flags_1->for_flag_make;
-         bool make_list_0 = v_384.tag == 3;
-         _fx_N15Ast__for_make_t v_385 = flags_1->for_flag_make;
-         bool make_tuple_0 = v_385.tag == 6;
-         _fx_N15Ast__for_make_t v_386 = flags_1->for_flag_make;
-         bool make_vector_0 = v_386.tag == 4;
-         _fx_N15Ast__for_make_t v_387 = flags_1->for_flag_make;
-         bool make_vec_0 = v_387.tag == 5;
+         _fx_N15Ast__for_make_t v_402 = flags_1->for_flag_make;
+         bool make_list_0 = v_402.tag == 3;
+         _fx_N15Ast__for_make_t v_403 = flags_1->for_flag_make;
+         bool make_tuple_0 = v_403.tag == 6;
+         _fx_N15Ast__for_make_t v_404 = flags_1->for_flag_make;
+         bool make_vector_0 = v_404.tag == 4;
+         _fx_N15Ast__for_make_t v_405 = flags_1->for_flag_make;
+         bool make_vec_0 = v_405.tag == 5;
          bool unzip_mode_0 = flags_1->for_flag_unzip;
-         _fx_N12Ast__scope_t v_388;
+         _fx_N12Ast__scope_t v_406;
          if (make_tuple_0) {
-            FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_388, 0), _fx_catch_160);
+            FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_406, 0), _fx_catch_164);
          }
          else {
             bool t_10;
@@ -26087,13 +26255,13 @@ FX_EXTERN_C int
                t_11 = make_vec_0;
             }
             if (t_11) {
-               FX_CALL(_fx_M3AstFM13new_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_388, 0), _fx_catch_160);
+               FX_CALL(_fx_M3AstFM13new_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_406, 0), _fx_catch_164);
             }
             else {
-               FX_CALL(_fx_M3AstFM17new_arr_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_388, 0), _fx_catch_160);
+               FX_CALL(_fx_M3AstFM17new_arr_map_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_406, 0), _fx_catch_164);
             }
          }
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_388, sc_2, true, &for_sc_1), _fx_catch_160);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_406, sc_2, true, &for_sc_1), _fx_catch_164);
          int_ trsz_1 = 0;
          int_ total_dims_0 = 0;
          _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_2, &env_acc_0);
@@ -26104,53 +26272,53 @@ FX_EXTERN_C int
             _fx_LT2N10Ast__pat_tN10Ast__exp_t for_clauses_2 = 0;
             _fx_N10Ast__pat_t idx_pat_2 = 0;
             _fx_T7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t
-               v_389 = {0};
+               v_407 = {0};
             _fx_LN10Ast__exp_t pre_code_k_0 = 0;
             _fx_LT2N10Ast__pat_tN10Ast__exp_t for_clauses_3 = 0;
             _fx_N10Ast__pat_t idx_pat_3 = 0;
             _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env_6 = {0};
             _fx_Rt6Set__t1R9Ast__id_t idset_0 = {0};
-            _fx_LN10Ast__exp_t v_390 = 0;
-            _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_391 = {0};
-            _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_392 = 0;
+            _fx_LN10Ast__exp_t v_408 = 0;
+            _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_409 = {0};
+            _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t v_410 = 0;
             _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t* __pat___2 = &lst_10->hd;
             FX_COPY_PTR(__pat___2->t0, &for_clauses_2);
             FX_COPY_PTR(__pat___2->t1, &idx_pat_2);
             FX_CALL(
                _fx_M13Ast_typecheckFM17check_for_clausesT7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tR16Ast__for_flags_tLN12Ast__scope_ti(
-                  for_clauses_2, idx_pat_2, &env_acc_0, &idset_acc_0, flags_1, for_sc_1, curr_m_idx_0, &v_389, 0),
-               _fx_catch_149);
-            int_ trsz_k_0 = v_389.t0;
-            FX_COPY_PTR(v_389.t1, &pre_code_k_0);
-            FX_COPY_PTR(v_389.t2, &for_clauses_3);
-            FX_COPY_PTR(v_389.t3, &idx_pat_3);
-            int_ dims_0 = v_389.t4;
-            _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_389.t5, &env_6);
-            _fx_copy_Rt6Set__t1R9Ast__id_t(&v_389.t6, &idset_0);
+                  for_clauses_2, idx_pat_2, &env_acc_0, &idset_acc_0, flags_1, for_sc_1, curr_m_idx_0, &v_407, 0),
+               _fx_catch_153);
+            int_ trsz_k_0 = v_407.t0;
+            FX_COPY_PTR(v_407.t1, &pre_code_k_0);
+            FX_COPY_PTR(v_407.t2, &for_clauses_3);
+            FX_COPY_PTR(v_407.t3, &idx_pat_3);
+            int_ dims_0 = v_407.t4;
+            _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_407.t5, &env_6);
+            _fx_copy_Rt6Set__t1R9Ast__id_t(&v_407.t6, &idset_0);
             trsz_1 = trsz_1 + trsz_k_0;
             FX_CALL(
-               _fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_k_0, pre_code_1, &v_390, 0),
-               _fx_catch_149);
+               _fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_k_0, pre_code_1, &v_408, 0),
+               _fx_catch_153);
             _fx_free_LN10Ast__exp_t(&pre_code_1);
-            FX_COPY_PTR(v_390, &pre_code_1);
-            _fx_make_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(for_clauses_3, idx_pat_3, &v_391);
-            FX_CALL(_fx_cons_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_391, map_clauses_acc_0, true, &v_392),
-               _fx_catch_149);
+            FX_COPY_PTR(v_408, &pre_code_1);
+            _fx_make_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(for_clauses_3, idx_pat_3, &v_409);
+            FX_CALL(_fx_cons_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_409, map_clauses_acc_0, true, &v_410),
+               _fx_catch_153);
             _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&map_clauses_acc_0);
-            FX_COPY_PTR(v_392, &map_clauses_acc_0);
+            FX_COPY_PTR(v_410, &map_clauses_acc_0);
             total_dims_0 = total_dims_0 + dims_0;
             _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_acc_0);
             _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_6, &env_acc_0);
             _fx_free_Rt6Set__t1R9Ast__id_t(&idset_acc_0);
             _fx_copy_Rt6Set__t1R9Ast__id_t(&idset_0, &idset_acc_0);
 
-         _fx_catch_149: ;
-            if (v_392) {
-               _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_392);
+         _fx_catch_153: ;
+            if (v_410) {
+               _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_410);
             }
-            _fx_free_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_391);
-            if (v_390) {
-               _fx_free_LN10Ast__exp_t(&v_390);
+            _fx_free_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_409);
+            if (v_408) {
+               _fx_free_LN10Ast__exp_t(&v_408);
             }
             _fx_free_Rt6Set__t1R9Ast__id_t(&idset_0);
             _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_6);
@@ -26164,14 +26332,14 @@ FX_EXTERN_C int
                _fx_free_LN10Ast__exp_t(&pre_code_k_0);
             }
             _fx_free_T7iLN10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_t(
-               &v_389);
+               &v_407);
             if (idx_pat_2) {
                _fx_free_N10Ast__pat_t(&idx_pat_2);
             }
             if (for_clauses_2) {
                _fx_free_LT2N10Ast__pat_tN10Ast__exp_t(&for_clauses_2);
             }
-            FX_CHECK_EXN(_fx_catch_160);
+            FX_CHECK_EXN(_fx_catch_164);
          }
          int_ trsz_2 = trsz_1;
          FX_COPY_PTR(pre_code_1, &pre_code_2);
@@ -26186,220 +26354,220 @@ FX_EXTERN_C int
             t_12 = false;
          }
          if (t_12) {
-            fx_str_t slit_154 =
+            fx_str_t slit_161 =
                FX_MAKE_STR("tuple comprehension with iteration over non-tuples and non-records is not supported");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_154, &v_360, 0), _fx_catch_160);
-            FX_THROW(&v_360, false, _fx_catch_160);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_161, &v_378, 0), _fx_catch_164);
+            FX_THROW(&v_378, false, _fx_catch_164);
          }
          if (make_list_0) {
-            fx_str_t slit_155 = FX_MAKE_STR("list"); fx_copy_str(&slit_155, &coll_name_0);
+            fx_str_t slit_162 = FX_MAKE_STR("list"); fx_copy_str(&slit_162, &coll_name_0);
          }
          else if (make_tuple_0) {
-            fx_str_t slit_156 = FX_MAKE_STR("tuple"); fx_copy_str(&slit_156, &coll_name_0);
+            fx_str_t slit_163 = FX_MAKE_STR("tuple"); fx_copy_str(&slit_163, &coll_name_0);
          }
          else if (make_vector_0) {
-            fx_str_t slit_157 = FX_MAKE_STR("rrbvec"); fx_copy_str(&slit_157, &coll_name_0);
+            fx_str_t slit_164 = FX_MAKE_STR("rrbvec"); fx_copy_str(&slit_164, &coll_name_0);
          }
          else if (make_vec_0) {
-            fx_str_t slit_158 = FX_MAKE_STR("vector"); fx_copy_str(&slit_158, &coll_name_0);
+            fx_str_t slit_165 = FX_MAKE_STR("vector"); fx_copy_str(&slit_165, &coll_name_0);
          }
          else {
-            fx_str_t slit_159 = FX_MAKE_STR("array"); fx_copy_str(&slit_159, &coll_name_0);
+            fx_str_t slit_166 = FX_MAKE_STR("array"); fx_copy_str(&slit_166, &coll_name_0);
          }
          if (trsz_2 > 0) {
             if (flags_1->for_flag_unzip) {
-               fx_str_t slit_160 = FX_MAKE_STR("@unzip for is not supported in tuple/record comprehensions");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_160, &v_361, 0), _fx_catch_160);
-               FX_THROW(&v_361, false, _fx_catch_160);
+               fx_str_t slit_167 = FX_MAKE_STR("@unzip for is not supported in tuple/record comprehensions");
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_167, &v_379, 0), _fx_catch_164);
+               FX_THROW(&v_379, false, _fx_catch_164);
             }
             if (map_clauses_1 != 0) {
                if (map_clauses_1->tl == 0) {
-                  _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t* v_393 = &map_clauses_1->hd;
-                  _fx_make_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(v_393->t0, v_393->t1, &v_362);
-                  goto _fx_endmatch_30;
+                  _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t* v_411 = &map_clauses_1->hd;
+                  _fx_make_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(v_411->t0, v_411->t1, &v_380);
+                  goto _fx_endmatch_32;
                }
             }
-            fx_exn_t v_394 = {0};
-            fx_str_t slit_161 = FX_MAKE_STR("tuple comprehension with nested for is not supported yet");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_161, &v_394, 0), _fx_catch_150);
-            FX_THROW(&v_394, false, _fx_catch_150);
+            fx_exn_t v_412 = {0};
+            fx_str_t slit_168 = FX_MAKE_STR("tuple comprehension with nested for is not supported yet");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_168, &v_412, 0), _fx_catch_154);
+            FX_THROW(&v_412, false, _fx_catch_154);
 
-         _fx_catch_150: ;
-            fx_free_exn(&v_394);
+         _fx_catch_154: ;
+            fx_free_exn(&v_412);
 
-         _fx_endmatch_30: ;
-            FX_CHECK_EXN(_fx_catch_160);
-            FX_COPY_PTR(v_362.t0, &for_clauses_1);
-            FX_COPY_PTR(v_362.t1, &idx_pat_1);
-            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elem_typ_0, 0), _fx_catch_160);
+         _fx_endmatch_32: ;
+            FX_CHECK_EXN(_fx_catch_164);
+            FX_COPY_PTR(v_380.t0, &for_clauses_1);
+            FX_COPY_PTR(v_380.t1, &idx_pat_1);
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elem_typ_0, 0), _fx_catch_164);
             _fx_LN10Ast__exp_t lstend_8 = 0;
             for (int_ idx_3 = 0; idx_3 < trsz_2; idx_3++) {
                _fx_N10Ast__exp_t it_j_1 = 0;
-               _fx_T2N10Ast__typ_tR10Ast__loc_t v_395 = {0};
+               _fx_T2N10Ast__typ_tR10Ast__loc_t v_413 = {0};
                _fx_N10Ast__typ_t tj_1 = 0;
-               fx_str_t v_396 = {0};
-               fx_str_t v_397 = {0};
+               fx_str_t v_414 = {0};
+               fx_str_t v_415 = {0};
                FX_CALL(
                   _fx_M13Ast_typecheckFM20gen_for_in_tuprec_itN10Ast__exp_t8iLT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_tLN12Ast__scope_t(
-                     idx_3, for_clauses_1, idx_pat_1, body_3, &env_5, for_sc_1, &eloc_0, sc_2, &it_j_1, 0), _fx_catch_151);
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_1, &v_395, 0), _fx_catch_151);
-               FX_COPY_PTR(v_395.t0, &tj_1);
-               _fx_R10Ast__loc_t locj_1 = v_395.t1;
+                     idx_3, for_clauses_1, idx_pat_1, body_3, &env_5, for_sc_1, &eloc_0, sc_2, &it_j_1, 0), _fx_catch_155);
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(it_j_1, &v_413, 0), _fx_catch_155);
+               FX_COPY_PTR(v_413.t0, &tj_1);
+               _fx_R10Ast__loc_t locj_1 = v_413.t1;
                if (!make_tuple_0) {
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_396, 0), _fx_catch_151);
-                  fx_str_t slit_162 = FX_MAKE_STR(" comprehension should produce elements of the same type");
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_414, 0), _fx_catch_155);
+                  fx_str_t slit_169 = FX_MAKE_STR(" comprehension should produce elements of the same type");
                   {
-                     const fx_str_t strs_16[] = { v_396, slit_162 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_16, 2, &v_397), _fx_catch_151);
+                     const fx_str_t strs_16[] = { v_414, slit_169 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_16, 2, &v_415), _fx_catch_155);
                   }
                   FX_CALL(
-                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(tj_1, elem_typ_0, &locj_1, &v_397,
-                        0), _fx_catch_151);
+                     _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(tj_1, elem_typ_0, &locj_1, &v_415,
+                        0), _fx_catch_155);
                }
                _fx_LN10Ast__exp_t node_8 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_1, 0, false, &node_8), _fx_catch_151);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(it_j_1, 0, false, &node_8), _fx_catch_155);
                FX_LIST_APPEND(elems_0, lstend_8, node_8);
 
-            _fx_catch_151: ;
-               FX_FREE_STR(&v_397);
-               FX_FREE_STR(&v_396);
+            _fx_catch_155: ;
+               FX_FREE_STR(&v_415);
+               FX_FREE_STR(&v_414);
                if (tj_1) {
                   _fx_free_N10Ast__typ_t(&tj_1);
                }
-               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_395);
+               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_413);
                if (it_j_1) {
                   _fx_free_N10Ast__exp_t(&it_j_1);
                }
-               FX_CHECK_EXN(_fx_catch_160);
+               FX_CHECK_EXN(_fx_catch_164);
             }
             if (make_tuple_0) {
                _fx_FPN10Ast__typ_t1N10Ast__exp_t get_exp_typ_fp_0 = { _fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t, 0 };
                FX_COPY_FP(&get_exp_typ_fp_0, &get_exp_typ_0);
                FX_CALL(
                   _fx_M13Ast_typecheckFM3mapLN10Ast__typ_t2LN10Ast__exp_tFPN10Ast__typ_t1N10Ast__exp_t(elems_0, &get_exp_typ_0,
-                     &tl_1, 0), _fx_catch_160);
-               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_1, &v_363), _fx_catch_160);
-               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_363, &eloc_0, &v_364);
+                     &tl_1, 0), _fx_catch_164);
+               FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(tl_1, &v_381), _fx_catch_164);
+               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_381, &eloc_0, &v_382);
                FX_CALL(
-                  _fx_M3AstFM10ExpMkTupleN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_364, &mk_struct_exp_0),
-                  _fx_catch_160);
+                  _fx_M3AstFM10ExpMkTupleN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_382, &mk_struct_exp_0),
+                  _fx_catch_164);
             }
             else if (make_list_0) {
-               FX_CALL(_fx_M3AstFM7TypListN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &ltyp_0), _fx_catch_160);
-               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_365);
+               FX_CALL(_fx_M3AstFM7TypListN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &ltyp_0), _fx_catch_164);
+               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_383);
                FX_CALL(
-                  _fx_M3AstFM6ExpLitN10Ast__exp_t2N10Ast__lit_tT2N10Ast__typ_tRM5loc_t(&_fx_g23Ast_typecheck__LitEmpty, &v_365,
-                     &l_exp_0), _fx_catch_160);
-               FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_0, &v_366, 0), _fx_catch_160);
-               _fx_LN10Ast__exp_t lst_11 = v_366;
+                  _fx_M3AstFM6ExpLitN10Ast__exp_t2N10Ast__lit_tT2N10Ast__typ_tRM5loc_t(&_fx_g23Ast_typecheck__LitEmpty, &v_383,
+                     &l_exp_0), _fx_catch_164);
+               FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_0, &v_384, 0), _fx_catch_164);
+               _fx_LN10Ast__exp_t lst_11 = v_384;
                for (; lst_11; lst_11 = lst_11->tl) {
-                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_398 = {0};
-                  _fx_N10Ast__exp_t v_399 = 0;
+                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_416 = {0};
+                  _fx_N10Ast__exp_t v_417 = 0;
                   _fx_N10Ast__exp_t ej_0 = lst_11->hd;
-                  _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_398);
+                  _fx_make_T2N10Ast__typ_tR10Ast__loc_t(ltyp_0, &eloc_0, &v_416);
                   FX_CALL(
                      _fx_M3AstFM9ExpBinaryN10Ast__exp_t4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                        _fx_g21Ast_typecheck__OpCons, ej_0, l_exp_0, &v_398, &v_399), _fx_catch_152);
+                        _fx_g21Ast_typecheck__OpCons, ej_0, l_exp_0, &v_416, &v_417), _fx_catch_156);
                   _fx_free_N10Ast__exp_t(&l_exp_0);
-                  FX_COPY_PTR(v_399, &l_exp_0);
+                  FX_COPY_PTR(v_417, &l_exp_0);
 
-               _fx_catch_152: ;
-                  if (v_399) {
-                     _fx_free_N10Ast__exp_t(&v_399);
+               _fx_catch_156: ;
+                  if (v_417) {
+                     _fx_free_N10Ast__exp_t(&v_417);
                   }
-                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_398);
-                  FX_CHECK_EXN(_fx_catch_160);
+                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_416);
+                  FX_CHECK_EXN(_fx_catch_164);
                }
                FX_COPY_PTR(l_exp_0, &mk_struct_exp_0);
             }
             else if (make_vector_0) {
-               FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &v_367), _fx_catch_160);
-               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_367, &eloc_0, &v_368);
+               FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(elem_typ_0, &v_385), _fx_catch_164);
+               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_385, &eloc_0, &v_386);
                FX_CALL(
-                  _fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_368,
-                     &mk_struct_exp_0), _fx_catch_160);
+                  _fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(elems_0, &v_386,
+                     &mk_struct_exp_0), _fx_catch_164);
             }
             else {
-               FX_CALL(_fx_cons_LLN10Ast__exp_t(elems_0, 0, true, &v_369), _fx_catch_160);
-               FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, elem_typ_0, &v_370), _fx_catch_160);
-               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_370, &eloc_0, &v_371);
+               FX_CALL(_fx_cons_LLN10Ast__exp_t(elems_0, 0, true, &v_387), _fx_catch_164);
+               FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, elem_typ_0, &v_388), _fx_catch_164);
+               _fx_make_T2N10Ast__typ_tR10Ast__loc_t(v_388, &eloc_0, &v_389);
                FX_CALL(
-                  _fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_369, &v_371, &mk_struct_exp_0),
-                  _fx_catch_160);
+                  _fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_387, &v_389, &mk_struct_exp_0),
+                  _fx_catch_164);
             }
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(mk_struct_exp_0, &coll_typ_0, 0), _fx_catch_160);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_372, 0), _fx_catch_160);
-            fx_str_t slit_163 = FX_MAKE_STR("inconsistent type of the constructed ");
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(mk_struct_exp_0, &coll_typ_0, 0), _fx_catch_164);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&coll_name_0, &v_390, 0), _fx_catch_164);
+            fx_str_t slit_170 = FX_MAKE_STR("inconsistent type of the constructed ");
             {
-               const fx_str_t strs_17[] = { slit_163, v_372 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_17, 2, &v_373), _fx_catch_160);
+               const fx_str_t strs_17[] = { slit_170, v_390 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_17, 2, &v_391), _fx_catch_164);
             }
             FX_CALL(
-               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, coll_typ_0, &eloc_0, &v_373, 0),
-               _fx_catch_160);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(mk_struct_exp_0, 0, true, &v_374), _fx_catch_160);
-            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_2, v_374, &v_375, 0),
-               _fx_catch_160);
-            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(coll_typ_0, &eloc_0, &v_376);
-            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_375, &v_376, &result_44),
-               _fx_catch_160);
+               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, coll_typ_0, &eloc_0, &v_391, 0),
+               _fx_catch_164);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(mk_struct_exp_0, 0, true, &v_392), _fx_catch_164);
+            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(pre_code_2, v_392, &v_393, 0),
+               _fx_catch_164);
+            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(coll_typ_0, &eloc_0, &v_394);
+            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_393, &v_394, &result_46),
+               _fx_catch_164);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_44, &result_0);
-            FX_BREAK(_fx_catch_160);
+            FX_COPY_PTR(result_46, &result_0);
+            FX_BREAK(_fx_catch_164);
          }
          else {
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_3, &v_377, 0), _fx_catch_160);
-            FX_COPY_PTR(v_377.t0, &btyp_3);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(body_3, &v_395, 0), _fx_catch_164);
+            FX_COPY_PTR(v_395.t0, &btyp_3);
             if (!unzip_mode_0) {
                FX_CALL(
                   _fx_M13Ast_typecheckFM13check_map_typv8N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBBi(btyp_3, etyp_0, -1,
-                     &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_160);
+                     &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_164);
             }
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  body_3, &env_5, for_sc_1, &new_body_3, 0), _fx_catch_160);
+                  body_3, &env_5, for_sc_1, &new_body_3, 0), _fx_catch_164);
             bool new_unzip_mode_0;
             if (unzip_mode_0) {
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(btyp_3, &v_378, 0), _fx_catch_160);
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_379, 0), _fx_catch_160);
-               if (FX_REC_VARIANT_TAG(v_379) == 1) {
-                  FX_COPY_PTR(v_379->u.TypVar->data, &v_380);
-                  if ((v_380 != 0) + 1 == 1) {
-                     if (FX_REC_VARIANT_TAG(v_378) == 19) {
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(btyp_3, &v_396, 0), _fx_catch_164);
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_397, 0), _fx_catch_164);
+               if (FX_REC_VARIANT_TAG(v_397) == 1) {
+                  FX_COPY_PTR(v_397->u.TypVar->data, &v_398);
+                  if ((v_398 != 0) + 1 == 1) {
+                     if (FX_REC_VARIANT_TAG(v_396) == 19) {
                         _fx_LN10Ast__typ_t colls_0 = 0;
                         _fx_LN10Ast__typ_t b_elems_0 = 0;
-                        _fx_N10Ast__typ_t v_400 = 0;
+                        _fx_N10Ast__typ_t v_418 = 0;
                         _fx_LN10Ast__typ_t lstend_9 = 0;
                         int_ i_0 = 0;
-                        FX_COPY_PTR(v_378->u.TypTuple, &b_elems_0);
+                        FX_COPY_PTR(v_396->u.TypTuple, &b_elems_0);
                         _fx_LN10Ast__typ_t lst_12 = b_elems_0;
                         for (; lst_12; lst_12 = lst_12->tl, i_0 += 1) {
                            _fx_N10Ast__typ_t ct_0 = 0;
                            _fx_N10Ast__typ_t bt_0 = lst_12->hd;
-                           FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&ct_0, 0), _fx_catch_153);
+                           FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&ct_0, 0), _fx_catch_157);
                            FX_CALL(
                               _fx_M13Ast_typecheckFM13check_map_typv8N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBBi(bt_0, ct_0,
-                                 i_0, &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_153);
+                                 i_0, &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_157);
                            _fx_LN10Ast__typ_t node_9 = 0;
-                           FX_CALL(_fx_cons_LN10Ast__typ_t(ct_0, 0, false, &node_9), _fx_catch_153);
+                           FX_CALL(_fx_cons_LN10Ast__typ_t(ct_0, 0, false, &node_9), _fx_catch_157);
                            FX_LIST_APPEND(colls_0, lstend_9, node_9);
 
-                        _fx_catch_153: ;
+                        _fx_catch_157: ;
                            if (ct_0) {
                               _fx_free_N10Ast__typ_t(&ct_0);
                            }
-                           FX_CHECK_EXN(_fx_catch_154);
+                           FX_CHECK_EXN(_fx_catch_158);
                         }
-                        FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(colls_0, &v_400), _fx_catch_154);
-                        fx_str_t slit_164 = FX_MAKE_STR("incorrect type of @unzip\'ped comprehension");
+                        FX_CALL(_fx_M3AstFM8TypTupleN10Ast__typ_t1LN10Ast__typ_t(colls_0, &v_418), _fx_catch_158);
+                        fx_str_t slit_171 = FX_MAKE_STR("incorrect type of @unzip\'ped comprehension");
                         FX_CALL(
-                           _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_400, &eloc_0,
-                              &slit_164, 0), _fx_catch_154);
+                           _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, v_418, &eloc_0,
+                              &slit_171, 0), _fx_catch_158);
                         new_unzip_mode_0 = true;
 
-                     _fx_catch_154: ;
-                        if (v_400) {
-                           _fx_free_N10Ast__typ_t(&v_400);
+                     _fx_catch_158: ;
+                        if (v_418) {
+                           _fx_free_N10Ast__typ_t(&v_418);
                         }
                         if (b_elems_0) {
                            _fx_free_LN10Ast__typ_t(&b_elems_0);
@@ -26407,37 +26575,37 @@ FX_EXTERN_C int
                         if (colls_0) {
                            _fx_free_LN10Ast__typ_t(&colls_0);
                         }
-                        goto _fx_endmatch_31;
+                        goto _fx_endmatch_33;
                      }
                   }
                }
-               if (FX_REC_VARIANT_TAG(v_379) == 19) {
-                  if (FX_REC_VARIANT_TAG(v_378) == 19) {
-                     fx_str_t v_401 = {0};
-                     fx_str_t v_402 = {0};
-                     fx_str_t v_403 = {0};
-                     fx_exn_t v_404 = {0};
+               if (FX_REC_VARIANT_TAG(v_397) == 19) {
+                  if (FX_REC_VARIANT_TAG(v_396) == 19) {
+                     fx_str_t v_419 = {0};
+                     fx_str_t v_420 = {0};
+                     fx_str_t v_421 = {0};
+                     fx_exn_t v_422 = {0};
                      _fx_LN10Ast__typ_t b_elems_1 = 0;
                      _fx_LN10Ast__typ_t colls_1 = 0;
-                     _fx_LN10Ast__typ_t b_elems_2 = v_378->u.TypTuple;
-                     _fx_LN10Ast__typ_t colls_2 = v_379->u.TypTuple;
+                     _fx_LN10Ast__typ_t b_elems_2 = v_396->u.TypTuple;
+                     _fx_LN10Ast__typ_t colls_2 = v_397->u.TypTuple;
                      int_ nb_elems_0;
-                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(b_elems_2, &nb_elems_0, 0), _fx_catch_156);
+                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(b_elems_2, &nb_elems_0, 0), _fx_catch_160);
                      int_ ncolls_0;
-                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(colls_2, &ncolls_0, 0), _fx_catch_156);
+                     FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__typ_t(colls_2, &ncolls_0, 0), _fx_catch_160);
                      if (nb_elems_0 != ncolls_0) {
-                        FX_CALL(_fx_F6stringS1i(nb_elems_0, &v_401, 0), _fx_catch_156);
-                        FX_CALL(_fx_F6stringS1i(ncolls_0, &v_402, 0), _fx_catch_156);
-                        fx_str_t slit_165 =
+                        FX_CALL(_fx_F6stringS1i(nb_elems_0, &v_419, 0), _fx_catch_160);
+                        FX_CALL(_fx_F6stringS1i(ncolls_0, &v_420, 0), _fx_catch_160);
+                        fx_str_t slit_172 =
                            FX_MAKE_STR("the number of elements in a tuple produced by the @unzip\'pped comprehension (=");
-                        fx_str_t slit_166 = FX_MAKE_STR(") and in the output tuple (=");
-                        fx_str_t slit_167 = FX_MAKE_STR(") do not match");
+                        fx_str_t slit_173 = FX_MAKE_STR(") and in the output tuple (=");
+                        fx_str_t slit_174 = FX_MAKE_STR(") do not match");
                         {
-                           const fx_str_t strs_18[] = { slit_165, v_401, slit_166, v_402, slit_167 };
-                           FX_CALL(fx_strjoin(0, 0, 0, strs_18, 5, &v_403), _fx_catch_156);
+                           const fx_str_t strs_18[] = { slit_172, v_419, slit_173, v_420, slit_174 };
+                           FX_CALL(fx_strjoin(0, 0, 0, strs_18, 5, &v_421), _fx_catch_160);
                         }
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_403, &v_404, 0), _fx_catch_156);
-                        FX_THROW(&v_404, false, _fx_catch_156);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_421, &v_422, 0), _fx_catch_160);
+                        FX_THROW(&v_422, false, _fx_catch_160);
                      }
                      int_ i_1 = 0;
                      FX_COPY_PTR(b_elems_2, &b_elems_1);
@@ -26449,132 +26617,132 @@ FX_EXTERN_C int
                         _fx_N10Ast__typ_t bt_1 = lst_13->hd;
                         FX_CALL(
                            _fx_M13Ast_typecheckFM13check_map_typv8N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBBi(bt_1, ct_1, i_1,
-                              &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_155);
+                              &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_159);
 
-                     _fx_catch_155: ;
-                        FX_CHECK_EXN(_fx_catch_156);
+                     _fx_catch_159: ;
+                        FX_CHECK_EXN(_fx_catch_160);
                      }
                      int s_0 = !lst_13 + !lst_14;
-                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_156);
+                     FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_160);
                      new_unzip_mode_0 = true;
 
-                  _fx_catch_156: ;
+                  _fx_catch_160: ;
                      if (colls_1) {
                         _fx_free_LN10Ast__typ_t(&colls_1);
                      }
                      if (b_elems_1) {
                         _fx_free_LN10Ast__typ_t(&b_elems_1);
                      }
-                     fx_free_exn(&v_404);
-                     FX_FREE_STR(&v_403);
-                     FX_FREE_STR(&v_402);
-                     FX_FREE_STR(&v_401);
-                     goto _fx_endmatch_31;
+                     fx_free_exn(&v_422);
+                     FX_FREE_STR(&v_421);
+                     FX_FREE_STR(&v_420);
+                     FX_FREE_STR(&v_419);
+                     goto _fx_endmatch_33;
                   }
                }
                bool res_36;
-               if (FX_REC_VARIANT_TAG(v_378) == 19) {
+               if (FX_REC_VARIANT_TAG(v_396) == 19) {
                   res_36 = true;
                }
-               else if (FX_REC_VARIANT_TAG(v_379) == 19) {
+               else if (FX_REC_VARIANT_TAG(v_397) == 19) {
                   res_36 = true;
                }
                else {
                   res_36 = false;
                }
-               FX_CHECK_EXN(_fx_catch_160);
+               FX_CHECK_EXN(_fx_catch_164);
                if (res_36) {
-                  fx_str_t v_405 = {0};
-                  fx_str_t v_406 = {0};
-                  fx_str_t v_407 = {0};
-                  fx_str_t v_408 = {0};
-                  fx_str_t v_409 = {0};
-                  fx_exn_t v_410 = {0};
-                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(btyp_3, &v_405, 0), _fx_catch_157);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_405, &v_406, 0), _fx_catch_157);
-                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(etyp_0, &v_407, 0), _fx_catch_157);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_407, &v_408, 0), _fx_catch_157);
-                  fx_str_t slit_168 = FX_MAKE_STR("in the case of @unzip comprehension either both the body type \'");
-                  fx_str_t slit_169 = FX_MAKE_STR("\' and the result type (\'");
-                  fx_str_t slit_170 = FX_MAKE_STR("\') should be tuples or none of them");
+                  fx_str_t v_423 = {0};
+                  fx_str_t v_424 = {0};
+                  fx_str_t v_425 = {0};
+                  fx_str_t v_426 = {0};
+                  fx_str_t v_427 = {0};
+                  fx_exn_t v_428 = {0};
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(btyp_3, &v_423, 0), _fx_catch_161);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_423, &v_424, 0), _fx_catch_161);
+                  FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(etyp_0, &v_425, 0), _fx_catch_161);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_425, &v_426, 0), _fx_catch_161);
+                  fx_str_t slit_175 = FX_MAKE_STR("in the case of @unzip comprehension either both the body type \'");
+                  fx_str_t slit_176 = FX_MAKE_STR("\' and the result type (\'");
+                  fx_str_t slit_177 = FX_MAKE_STR("\') should be tuples or none of them");
                   {
-                     const fx_str_t strs_19[] = { slit_168, v_406, slit_169, v_408, slit_170 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_19, 5, &v_409), _fx_catch_157);
+                     const fx_str_t strs_19[] = { slit_175, v_424, slit_176, v_426, slit_177 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_19, 5, &v_427), _fx_catch_161);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_409, &v_410, 0), _fx_catch_157);
-                  FX_THROW(&v_410, false, _fx_catch_157);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_427, &v_428, 0), _fx_catch_161);
+                  FX_THROW(&v_428, false, _fx_catch_161);
 
-               _fx_catch_157: ;
-                  fx_free_exn(&v_410);
-                  FX_FREE_STR(&v_409);
-                  FX_FREE_STR(&v_408);
-                  FX_FREE_STR(&v_407);
-                  FX_FREE_STR(&v_406);
-                  FX_FREE_STR(&v_405);
-                  goto _fx_endmatch_31;
+               _fx_catch_161: ;
+                  fx_free_exn(&v_428);
+                  FX_FREE_STR(&v_427);
+                  FX_FREE_STR(&v_426);
+                  FX_FREE_STR(&v_425);
+                  FX_FREE_STR(&v_424);
+                  FX_FREE_STR(&v_423);
+                  goto _fx_endmatch_33;
                }
                FX_CALL(
                   _fx_M13Ast_typecheckFM13check_map_typv8N10Ast__typ_tN10Ast__typ_tiR10Ast__loc_tBBBi(btyp_3, etyp_0, -1,
-                     &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_158);
+                     &eloc_0, make_list_0, make_vec_0, make_vector_0, total_dims_1, 0), _fx_catch_162);
                new_unzip_mode_0 = false;
 
-            _fx_catch_158: ;
+            _fx_catch_162: ;
 
-            _fx_endmatch_31: ;
-               FX_CHECK_EXN(_fx_catch_160);
+            _fx_endmatch_33: ;
+               FX_CHECK_EXN(_fx_catch_164);
             }
             else {
-               FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_body_3, &v_381, 0), _fx_catch_160);
-               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_381, &v_382, 0), _fx_catch_160);
-               if (FX_REC_VARIANT_TAG(v_382) == 14) {
-                  fx_exn_t v_411 = {0};
-                  fx_str_t slit_171 = FX_MAKE_STR("comprehension body cannot have \'void\' type");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_171, &v_411, 0), _fx_catch_159);
-                  FX_THROW(&v_411, false, _fx_catch_159);
+               FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_body_3, &v_399, 0), _fx_catch_164);
+               FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_399, &v_400, 0), _fx_catch_164);
+               if (FX_REC_VARIANT_TAG(v_400) == 14) {
+                  fx_exn_t v_429 = {0};
+                  fx_str_t slit_178 = FX_MAKE_STR("comprehension body cannot have \'void\' type");
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_178, &v_429, 0), _fx_catch_163);
+                  FX_THROW(&v_429, false, _fx_catch_163);
 
-               _fx_catch_159: ;
-                  fx_free_exn(&v_411);
+               _fx_catch_163: ;
+                  fx_free_exn(&v_429);
                }
                else {
                   new_unzip_mode_0 = false;
                }
-               FX_CHECK_EXN(_fx_catch_160);
+               FX_CHECK_EXN(_fx_catch_164);
             }
             FX_CALL(
                _fx_M13Ast_typecheckFM3revLT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t1LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(
-                  map_clauses_1, &v_383, 0), _fx_catch_160);
-            _fx_R16Ast__for_flags_t v_412 =
+                  map_clauses_1, &v_401, 0), _fx_catch_164);
+            _fx_R16Ast__for_flags_t v_430 =
                { flags_1->for_flag_parallel, flags_1->for_flag_make, new_unzip_mode_0, flags_1->for_flag_fold,
                   flags_1->for_flag_nested };
             FX_CALL(
                _fx_M3AstFM6ExpMapN10Ast__exp_t4LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tRM11for_flags_tT2N10Ast__typ_tRM5loc_t(
-                  v_383, new_body_3, &v_412, &vcase_26->t3, &result_45), _fx_catch_160);
+                  v_401, new_body_3, &v_430, &vcase_26->t3, &result_47), _fx_catch_164);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_45, &result_0);
-            FX_BREAK(_fx_catch_160);
+            FX_COPY_PTR(result_47, &result_0);
+            FX_BREAK(_fx_catch_164);
          }
 
-      _fx_catch_160: ;
-         if (result_45) {
-            _fx_free_N10Ast__exp_t(&result_45);
+      _fx_catch_164: ;
+         if (result_47) {
+            _fx_free_N10Ast__exp_t(&result_47);
          }
-         if (v_383) {
-            _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_383);
+         if (v_401) {
+            _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_401);
          }
-         if (v_382) {
-            _fx_free_N10Ast__typ_t(&v_382);
+         if (v_400) {
+            _fx_free_N10Ast__typ_t(&v_400);
          }
-         if (v_381) {
-            _fx_free_N10Ast__typ_t(&v_381);
+         if (v_399) {
+            _fx_free_N10Ast__typ_t(&v_399);
          }
-         if (v_380) {
-            _fx_free_Nt6option1N10Ast__typ_t(&v_380);
+         if (v_398) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_398);
          }
-         if (v_379) {
-            _fx_free_N10Ast__typ_t(&v_379);
+         if (v_397) {
+            _fx_free_N10Ast__typ_t(&v_397);
          }
-         if (v_378) {
-            _fx_free_N10Ast__typ_t(&v_378);
+         if (v_396) {
+            _fx_free_N10Ast__typ_t(&v_396);
          }
          if (new_body_3) {
             _fx_free_N10Ast__exp_t(&new_body_3);
@@ -26582,46 +26750,46 @@ FX_EXTERN_C int
          if (btyp_3) {
             _fx_free_N10Ast__typ_t(&btyp_3);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_377);
-         if (result_44) {
-            _fx_free_N10Ast__exp_t(&result_44);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_395);
+         if (result_46) {
+            _fx_free_N10Ast__exp_t(&result_46);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_376);
-         if (v_375) {
-            _fx_free_LN10Ast__exp_t(&v_375);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_394);
+         if (v_393) {
+            _fx_free_LN10Ast__exp_t(&v_393);
          }
-         if (v_374) {
-            _fx_free_LN10Ast__exp_t(&v_374);
+         if (v_392) {
+            _fx_free_LN10Ast__exp_t(&v_392);
          }
-         FX_FREE_STR(&v_373);
-         FX_FREE_STR(&v_372);
+         FX_FREE_STR(&v_391);
+         FX_FREE_STR(&v_390);
          if (coll_typ_0) {
             _fx_free_N10Ast__typ_t(&coll_typ_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_371);
-         if (v_370) {
-            _fx_free_N10Ast__typ_t(&v_370);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_389);
+         if (v_388) {
+            _fx_free_N10Ast__typ_t(&v_388);
          }
-         if (v_369) {
-            _fx_free_LLN10Ast__exp_t(&v_369);
+         if (v_387) {
+            _fx_free_LLN10Ast__exp_t(&v_387);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_368);
-         if (v_367) {
-            _fx_free_N10Ast__typ_t(&v_367);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_386);
+         if (v_385) {
+            _fx_free_N10Ast__typ_t(&v_385);
          }
-         if (v_366) {
-            _fx_free_LN10Ast__exp_t(&v_366);
+         if (v_384) {
+            _fx_free_LN10Ast__exp_t(&v_384);
          }
          if (l_exp_0) {
             _fx_free_N10Ast__exp_t(&l_exp_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_365);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_383);
          if (ltyp_0) {
             _fx_free_N10Ast__typ_t(&ltyp_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_364);
-         if (v_363) {
-            _fx_free_N10Ast__typ_t(&v_363);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_382);
+         if (v_381) {
+            _fx_free_N10Ast__typ_t(&v_381);
          }
          if (tl_1) {
             _fx_free_LN10Ast__typ_t(&tl_1);
@@ -26642,10 +26810,10 @@ FX_EXTERN_C int
          if (for_clauses_1) {
             _fx_free_LT2N10Ast__pat_tN10Ast__exp_t(&for_clauses_1);
          }
-         _fx_free_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_362);
-         fx_free_exn(&v_361);
+         _fx_free_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&v_380);
+         fx_free_exn(&v_379);
          FX_FREE_STR(&coll_name_0);
-         fx_free_exn(&v_360);
+         fx_free_exn(&v_378);
          _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_5);
          if (map_clauses_1) {
             _fx_free_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t(&map_clauses_1);
@@ -26665,122 +26833,122 @@ FX_EXTERN_C int
             _fx_free_LN10Ast__exp_t(&pre_code_1);
          }
          FX_FREE_LIST_SIMPLE(&for_sc_1);
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 2) {
          FX_CALL(
             _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(e_2->u.ExpBreak.t0, true, false, sc_2,
-               &eloc_0, 0), _fx_catch_161);
+               &eloc_0, 0), _fx_catch_165);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(e_2, &result_0);
-         FX_BREAK(_fx_catch_161);
+         FX_BREAK(_fx_catch_165);
 
-      _fx_catch_161: ;
-         goto _fx_endmatch_41;
+      _fx_catch_165: ;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 3) {
          FX_CALL(
             _fx_M13Ast_typecheckFM16check_inside_forv5BBBLN12Ast__scope_tR10Ast__loc_t(false, false, false, sc_2, &eloc_0, 0),
-            _fx_catch_162);
+            _fx_catch_166);
          _fx_free_N10Ast__exp_t(&result_0);
          FX_COPY_PTR(e_2, &result_0);
-         FX_BREAK(_fx_catch_162);
+         FX_BREAK(_fx_catch_166);
 
-      _fx_catch_162: ;
-         goto _fx_endmatch_41;
+      _fx_catch_166: ;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 4) {
          _fx_N10Ast__typ_t t_13 = 0;
          _fx_LT3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t all_func_ctx_0 = 0;
-         _fx_Nt6option1N10Ast__exp_t v_413 = 0;
-         _fx_N10Ast__exp_t result_46 = 0;
+         _fx_Nt6option1N10Ast__exp_t v_431 = 0;
+         _fx_N10Ast__exp_t result_48 = 0;
          _fx_Nt6option1N10Ast__exp_t e_opt_0 = e_2->u.ExpReturn.t0;
-         fx_str_t slit_172 = FX_MAKE_STR("return statement should have \'void\' type");
+         fx_str_t slit_179 = FX_MAKE_STR("return statement should have \'void\' type");
          FX_CALL(
             _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, _fx_g22Ast_typecheck__TypVoid,
-               &eloc_0, &slit_172, 0), _fx_catch_167);
+               &eloc_0, &slit_179, 0), _fx_catch_171);
          if ((e_opt_0 != 0) + 1 == 2) {
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_opt_0->u.Some, &t_13, 0), _fx_catch_163);
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_opt_0->u.Some, &t_13, 0), _fx_catch_167);
 
-         _fx_catch_163: ;
+         _fx_catch_167: ;
          }
          else {
             FX_COPY_PTR(_fx_g22Ast_typecheck__TypVoid, &t_13);
          }
-         FX_CHECK_EXN(_fx_catch_167);
+         FX_CHECK_EXN(_fx_catch_171);
          FX_COPY_PTR(_fx_g17Ast__all_func_ctx, &all_func_ctx_0);
          if (all_func_ctx_0 != 0) {
-            fx_str_t v_414 = {0};
-            fx_str_t v_415 = {0};
-            fx_str_t v_416 = {0};
-            fx_str_t v_417 = {0};
-            fx_str_t v_418 = {0};
-            fx_str_t v_419 = {0};
-            fx_str_t v_420 = {0};
-            _fx_T3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t* v_421 = &all_func_ctx_0->hd;
-            _fx_N10Ast__typ_t rt_0 = v_421->t1;
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_13, &v_414, 0), _fx_catch_164);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_414, &v_415, 0), _fx_catch_164);
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(rt_0, &v_416, 0), _fx_catch_164);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_416, &v_417, 0), _fx_catch_164);
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_421->t0, &v_418, 0), _fx_catch_164);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_418, &v_419, 0), _fx_catch_164);
-            fx_str_t slit_173 = FX_MAKE_STR("the return statement type ");
-            fx_str_t slit_174 = FX_MAKE_STR(" is inconsistent with the previously deduced type ");
-            fx_str_t slit_175 = FX_MAKE_STR(" of function ");
+            fx_str_t v_432 = {0};
+            fx_str_t v_433 = {0};
+            fx_str_t v_434 = {0};
+            fx_str_t v_435 = {0};
+            fx_str_t v_436 = {0};
+            fx_str_t v_437 = {0};
+            fx_str_t v_438 = {0};
+            _fx_T3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t* v_439 = &all_func_ctx_0->hd;
+            _fx_N10Ast__typ_t rt_0 = v_439->t1;
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_13, &v_432, 0), _fx_catch_168);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_432, &v_433, 0), _fx_catch_168);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(rt_0, &v_434, 0), _fx_catch_168);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_434, &v_435, 0), _fx_catch_168);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&v_439->t0, &v_436, 0), _fx_catch_168);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_436, &v_437, 0), _fx_catch_168);
+            fx_str_t slit_180 = FX_MAKE_STR("the return statement type ");
+            fx_str_t slit_181 = FX_MAKE_STR(" is inconsistent with the previously deduced type ");
+            fx_str_t slit_182 = FX_MAKE_STR(" of function ");
             {
-               const fx_str_t strs_20[] = { slit_173, v_415, slit_174, v_417, slit_175, v_419 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_20, 6, &v_420), _fx_catch_164);
+               const fx_str_t strs_20[] = { slit_180, v_433, slit_181, v_435, slit_182, v_437 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_20, 6, &v_438), _fx_catch_168);
             }
-            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_13, rt_0, &eloc_0, &v_420, 0),
-               _fx_catch_164);
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_13, rt_0, &eloc_0, &v_438, 0),
+               _fx_catch_168);
 
-         _fx_catch_164: ;
-            FX_FREE_STR(&v_420);
-            FX_FREE_STR(&v_419);
-            FX_FREE_STR(&v_418);
-            FX_FREE_STR(&v_417);
-            FX_FREE_STR(&v_416);
-            FX_FREE_STR(&v_415);
-            FX_FREE_STR(&v_414);
+         _fx_catch_168: ;
+            FX_FREE_STR(&v_438);
+            FX_FREE_STR(&v_437);
+            FX_FREE_STR(&v_436);
+            FX_FREE_STR(&v_435);
+            FX_FREE_STR(&v_434);
+            FX_FREE_STR(&v_433);
+            FX_FREE_STR(&v_432);
          }
          else {
-            fx_exn_t v_422 = {0};
-            fx_str_t slit_176 = FX_MAKE_STR("return statement occurs outside of a function body");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_176, &v_422, 0), _fx_catch_165);
-            FX_THROW(&v_422, false, _fx_catch_165);
+            fx_exn_t v_440 = {0};
+            fx_str_t slit_183 = FX_MAKE_STR("return statement occurs outside of a function body");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_183, &v_440, 0), _fx_catch_169);
+            FX_THROW(&v_440, false, _fx_catch_169);
 
-         _fx_catch_165: ;
-            fx_free_exn(&v_422);
+         _fx_catch_169: ;
+            fx_free_exn(&v_440);
          }
-         FX_CHECK_EXN(_fx_catch_167);
+         FX_CHECK_EXN(_fx_catch_171);
          if ((e_opt_0 != 0) + 1 == 2) {
-            _fx_N10Ast__exp_t v_423 = 0;
+            _fx_N10Ast__exp_t v_441 = 0;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  e_opt_0->u.Some, &env_2, sc_2, &v_423, 0), _fx_catch_166);
-            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(v_423, &v_413), _fx_catch_166);
+                  e_opt_0->u.Some, &env_2, sc_2, &v_441, 0), _fx_catch_170);
+            FX_CALL(_fx_M13Ast_typecheckFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(v_441, &v_431), _fx_catch_170);
 
-         _fx_catch_166: ;
-            if (v_423) {
-               _fx_free_N10Ast__exp_t(&v_423);
+         _fx_catch_170: ;
+            if (v_441) {
+               _fx_free_N10Ast__exp_t(&v_441);
             }
          }
          else {
-            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &v_413);
+            FX_COPY_PTR(_fx_g22Ast_typecheck__None14_, &v_431);
          }
-         FX_CHECK_EXN(_fx_catch_167);
-         FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_413, &eloc_0, &result_46), _fx_catch_167);
+         FX_CHECK_EXN(_fx_catch_171);
+         FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(v_431, &eloc_0, &result_48), _fx_catch_171);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_46, &result_0);
-         FX_BREAK(_fx_catch_167);
+         FX_COPY_PTR(result_48, &result_0);
+         FX_BREAK(_fx_catch_171);
 
-      _fx_catch_167: ;
-         if (result_46) {
-            _fx_free_N10Ast__exp_t(&result_46);
+      _fx_catch_171: ;
+         if (result_48) {
+            _fx_free_N10Ast__exp_t(&result_48);
          }
-         if (v_413) {
-            _fx_free_Nt6option1N10Ast__exp_t(&v_413);
+         if (v_431) {
+            _fx_free_Nt6option1N10Ast__exp_t(&v_431);
          }
          if (all_func_ctx_0) {
             _fx_free_LT3R9Ast__id_tN10Ast__typ_tR10Ast__loc_t(&all_func_ctx_0);
@@ -26788,7 +26956,7 @@ FX_EXTERN_C int
          if (t_13) {
             _fx_free_N10Ast__typ_t(&t_13);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 14) {
          _fx_N10Ast__typ_t elemtyp_1 = 0;
@@ -26796,9 +26964,9 @@ FX_EXTERN_C int
          _fx_LLN10Ast__exp_t arows_0 = 0;
          _fx_LLN10Ast__exp_t arows_1 = 0;
          _fx_N10Ast__typ_t atyp_0 = 0;
-         _fx_LLN10Ast__exp_t v_424 = 0;
-         _fx_N10Ast__exp_t result_47 = 0;
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_1, 0), _fx_catch_176);
+         _fx_LLN10Ast__exp_t v_442 = 0;
+         _fx_N10Ast__exp_t result_49 = 0;
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_1, 0), _fx_catch_180);
          int_ ncols_0 = 0;
          bool have_expanded_acc_0 = false;
          int_ dims_acc_0 = -1;
@@ -26808,165 +26976,165 @@ FX_EXTERN_C int
          for (; lst_15; lst_15 = lst_15->tl, k_0 += 1) {
             _fx_LN10Ast__exp_t arow_acc_0 = 0;
             _fx_LN10Ast__exp_t arow_0 = 0;
-            fx_str_t v_425 = {0};
-            fx_str_t v_426 = {0};
-            fx_str_t v_427 = {0};
-            fx_str_t v_428 = {0};
-            fx_exn_t v_429 = {0};
-            fx_str_t v_430 = {0};
-            fx_str_t v_431 = {0};
-            fx_str_t v_432 = {0};
-            fx_str_t v_433 = {0};
-            fx_exn_t v_434 = {0};
-            _fx_LN10Ast__exp_t v_435 = 0;
-            _fx_LLN10Ast__exp_t v_436 = 0;
+            fx_str_t v_443 = {0};
+            fx_str_t v_444 = {0};
+            fx_str_t v_445 = {0};
+            fx_str_t v_446 = {0};
+            fx_exn_t v_447 = {0};
+            fx_str_t v_448 = {0};
+            fx_str_t v_449 = {0};
+            fx_str_t v_450 = {0};
+            fx_str_t v_451 = {0};
+            fx_exn_t v_452 = {0};
+            _fx_LN10Ast__exp_t v_453 = 0;
+            _fx_LLN10Ast__exp_t v_454 = 0;
             _fx_LN10Ast__exp_t arow_1 = lst_15->hd;
             bool have_expanded_i_0 = false;
             int_ row_dims_acc_0 = -1;
             _fx_LN10Ast__exp_t lst_16 = arow_1;
             for (; lst_16; lst_16 = lst_16->tl) {
-               _fx_T4BiN10Ast__exp_tR10Ast__loc_t v_437 = {0};
+               _fx_T4BiN10Ast__exp_tR10Ast__loc_t v_455 = {0};
                _fx_N10Ast__exp_t elem1_0 = 0;
-               fx_str_t v_438 = {0};
-               fx_str_t v_439 = {0};
-               fx_str_t v_440 = {0};
-               fx_exn_t v_441 = {0};
-               _fx_LN10Ast__exp_t v_442 = 0;
-               _fx_N10Ast__exp_t elem_0 = lst_16->hd;
-               if (FX_REC_VARIANT_TAG(elem_0) == 9) {
-                  _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_27 = &elem_0->u.ExpUnary;
+               fx_str_t v_456 = {0};
+               fx_str_t v_457 = {0};
+               fx_str_t v_458 = {0};
+               fx_exn_t v_459 = {0};
+               _fx_LN10Ast__exp_t v_460 = 0;
+               _fx_N10Ast__exp_t elem_2 = lst_16->hd;
+               if (FX_REC_VARIANT_TAG(elem_2) == 9) {
+                  _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_27 = &elem_2->u.ExpUnary;
                   if (vcase_27->t0.tag == 8) {
                      _fx_N10Ast__exp_t e1_5 = 0;
-                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_443 = {0};
+                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_461 = {0};
                      _fx_N10Ast__typ_t arrtyp1_0 = 0;
-                     _fx_N10Ast__typ_t v_444 = 0;
-                     _fx_T3SiN10Ast__typ_t v_445 = {0};
+                     _fx_N10Ast__typ_t v_462 = 0;
+                     _fx_T3SiN10Ast__typ_t v_463 = {0};
                      fx_str_t collname_0 = {0};
                      _fx_N10Ast__typ_t elemtyp1_0 = 0;
-                     fx_exn_t v_446 = {0};
-                     fx_str_t v_447 = {0};
-                     fx_str_t v_448 = {0};
-                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_449 = {0};
-                     _fx_N10Ast__exp_t v_450 = 0;
-                     _fx_T2N10Ast__typ_tR10Ast__loc_t* v_451 = &vcase_27->t2;
-                     _fx_R10Ast__loc_t* loc_0 = &v_451->t1;
+                     fx_exn_t v_464 = {0};
+                     fx_str_t v_465 = {0};
+                     fx_str_t v_466 = {0};
+                     _fx_T2N10Ast__typ_tR10Ast__loc_t v_467 = {0};
+                     _fx_N10Ast__exp_t v_468 = 0;
+                     _fx_T2N10Ast__typ_tR10Ast__loc_t* v_469 = &vcase_27->t2;
+                     _fx_R10Ast__loc_t* loc_0 = &v_469->t1;
                      FX_CALL(
                         _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                           vcase_27->t1, &env_2, sc_2, &e1_5, 0), _fx_catch_169);
-                     FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_5, &v_443, 0), _fx_catch_169);
-                     FX_COPY_PTR(v_443.t0, &arrtyp1_0);
-                     _fx_R10Ast__loc_t eloc1_8 = v_443.t1;
-                     fx_str_t slit_177 = FX_MAKE_STR("incorrect type of expanded collection");
+                           vcase_27->t1, &env_2, sc_2, &e1_5, 0), _fx_catch_173);
+                     FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_5, &v_461, 0), _fx_catch_173);
+                     FX_COPY_PTR(v_461.t0, &arrtyp1_0);
+                     _fx_R10Ast__loc_t eloc1_8 = v_461.t1;
+                     fx_str_t slit_184 = FX_MAKE_STR("incorrect type of expanded collection");
                      FX_CALL(
-                        _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_451->t0, arrtyp1_0, loc_0,
-                           &slit_177, 0), _fx_catch_169);
-                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(arrtyp1_0, &v_444, 0), _fx_catch_169);
-                     int tag_12 = FX_REC_VARIANT_TAG(v_444);
-                     if (tag_12 == 21) {
-                        _fx_T2iN10Ast__typ_t* vcase_28 = &v_444->u.TypArray;
-                        fx_str_t slit_178 = FX_MAKE_STR("array");
-                        _fx_make_T3SiN10Ast__typ_t(&slit_178, vcase_28->t0, vcase_28->t1, &v_445);
+                        _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_469->t0, arrtyp1_0, loc_0,
+                           &slit_184, 0), _fx_catch_173);
+                     FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(arrtyp1_0, &v_462, 0), _fx_catch_173);
+                     int tag_13 = FX_REC_VARIANT_TAG(v_462);
+                     if (tag_13 == 21) {
+                        _fx_T2iN10Ast__typ_t* vcase_28 = &v_462->u.TypArray;
+                        fx_str_t slit_185 = FX_MAKE_STR("array");
+                        _fx_make_T3SiN10Ast__typ_t(&slit_185, vcase_28->t0, vcase_28->t1, &v_463);
                      }
-                     else if (tag_12 == 16) {
-                        fx_str_t slit_179 = FX_MAKE_STR("list");
-                        _fx_make_T3SiN10Ast__typ_t(&slit_179, 1, v_444->u.TypList, &v_445);
+                     else if (tag_13 == 16) {
+                        fx_str_t slit_186 = FX_MAKE_STR("list");
+                        _fx_make_T3SiN10Ast__typ_t(&slit_186, 1, v_462->u.TypList, &v_463);
                      }
-                     else if (tag_12 == 11) {
-                        fx_str_t slit_180 = FX_MAKE_STR("string");
-                        _fx_make_T3SiN10Ast__typ_t(&slit_180, 1, _fx_g22Ast_typecheck__TypChar, &v_445);
+                     else if (tag_13 == 11) {
+                        fx_str_t slit_187 = FX_MAKE_STR("string");
+                        _fx_make_T3SiN10Ast__typ_t(&slit_187, 1, _fx_g22Ast_typecheck__TypChar, &v_463);
                      }
                      else {
-                        fx_exn_t v_452 = {0};
-                        fx_str_t slit_181 =
+                        fx_exn_t v_470 = {0};
+                        fx_str_t slit_188 =
                            FX_MAKE_STR("incorrect type of expanded collection (it should be an array, list or string)");
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_181, &v_452, 0), _fx_catch_168);
-                        FX_THROW(&v_452, false, _fx_catch_168);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_188, &v_470, 0), _fx_catch_172);
+                        FX_THROW(&v_470, false, _fx_catch_172);
 
-                     _fx_catch_168: ;
-                        fx_free_exn(&v_452);
+                     _fx_catch_172: ;
+                        fx_free_exn(&v_470);
                      }
-                     FX_CHECK_EXN(_fx_catch_169);
-                     fx_copy_str(&v_445.t0, &collname_0);
-                     int_ d_0 = v_445.t1;
-                     FX_COPY_PTR(v_445.t2, &elemtyp1_0);
+                     FX_CHECK_EXN(_fx_catch_173);
+                     fx_copy_str(&v_463.t0, &collname_0);
+                     int_ d_0 = v_463.t1;
+                     FX_COPY_PTR(v_463.t2, &elemtyp1_0);
                      if (d_0 > 2) {
-                        fx_str_t slit_182 =
+                        fx_str_t slit_189 =
                            FX_MAKE_STR("currently expansion of more than 2-dimensional arrays is not supported");
-                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_182, &v_446, 0), _fx_catch_169);
-                        FX_THROW(&v_446, false, _fx_catch_169);
+                        FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_189, &v_464, 0), _fx_catch_173);
+                        FX_THROW(&v_464, false, _fx_catch_173);
                      }
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_0, &v_447, 0), _fx_catch_169);
-                     fx_str_t slit_183 = FX_MAKE_STR("the expanded ");
-                     fx_str_t slit_184 = FX_MAKE_STR(" elem type does not match the previous elements");
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_0, &v_465, 0), _fx_catch_173);
+                     fx_str_t slit_190 = FX_MAKE_STR("the expanded ");
+                     fx_str_t slit_191 = FX_MAKE_STR(" elem type does not match the previous elements");
                      {
-                        const fx_str_t strs_21[] = { slit_183, v_447, slit_184 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_21, 3, &v_448), _fx_catch_169);
+                        const fx_str_t strs_21[] = { slit_190, v_465, slit_191 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_21, 3, &v_466), _fx_catch_173);
                      }
                      FX_CALL(
                         _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_1, elemtyp1_0, &eloc1_8,
-                           &v_448, 0), _fx_catch_169);
-                     _fx_make_T2N10Ast__typ_tR10Ast__loc_t(arrtyp1_0, loc_0, &v_449);
+                           &v_466, 0), _fx_catch_173);
+                     _fx_make_T2N10Ast__typ_tR10Ast__loc_t(arrtyp1_0, loc_0, &v_467);
                      FX_CALL(
                         _fx_M3AstFM8ExpUnaryN10Ast__exp_t3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                           &_fx_g23Ast_typecheck__OpExpand, e1_5, &v_449, &v_450), _fx_catch_169);
-                     _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(true, d_0, v_450, loc_0, &v_437);
+                           &_fx_g23Ast_typecheck__OpExpand, e1_5, &v_467, &v_468), _fx_catch_173);
+                     _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(true, d_0, v_468, loc_0, &v_455);
 
-                  _fx_catch_169: ;
-                     if (v_450) {
-                        _fx_free_N10Ast__exp_t(&v_450);
+                  _fx_catch_173: ;
+                     if (v_468) {
+                        _fx_free_N10Ast__exp_t(&v_468);
                      }
-                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_449);
-                     FX_FREE_STR(&v_448);
-                     FX_FREE_STR(&v_447);
-                     fx_free_exn(&v_446);
+                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_467);
+                     FX_FREE_STR(&v_466);
+                     FX_FREE_STR(&v_465);
+                     fx_free_exn(&v_464);
                      if (elemtyp1_0) {
                         _fx_free_N10Ast__typ_t(&elemtyp1_0);
                      }
                      FX_FREE_STR(&collname_0);
-                     _fx_free_T3SiN10Ast__typ_t(&v_445);
-                     if (v_444) {
-                        _fx_free_N10Ast__typ_t(&v_444);
+                     _fx_free_T3SiN10Ast__typ_t(&v_463);
+                     if (v_462) {
+                        _fx_free_N10Ast__typ_t(&v_462);
                      }
                      if (arrtyp1_0) {
                         _fx_free_N10Ast__typ_t(&arrtyp1_0);
                      }
-                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_443);
+                     _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_461);
                      if (e1_5) {
                         _fx_free_N10Ast__exp_t(&e1_5);
                      }
-                     goto _fx_endmatch_32;
+                     goto _fx_endmatch_34;
                   }
                }
-               _fx_T2N10Ast__typ_tR10Ast__loc_t v_453 = {0};
+               _fx_T2N10Ast__typ_tR10Ast__loc_t v_471 = {0};
                _fx_N10Ast__typ_t elemtyp1_1 = 0;
-               _fx_N10Ast__exp_t v_454 = 0;
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_0, &v_453, 0), _fx_catch_170);
-               FX_COPY_PTR(v_453.t0, &elemtyp1_1);
-               _fx_R10Ast__loc_t eloc1_9 = v_453.t1;
-               fx_str_t slit_185 = FX_MAKE_STR("all the scalar elements of the array should have the same type");
+               _fx_N10Ast__exp_t v_472 = 0;
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_2, &v_471, 0), _fx_catch_174);
+               FX_COPY_PTR(v_471.t0, &elemtyp1_1);
+               _fx_R10Ast__loc_t eloc1_9 = v_471.t1;
+               fx_str_t slit_192 = FX_MAKE_STR("all the scalar elements of the array should have the same type");
                FX_CALL(
                   _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_1, elemtyp1_1, &eloc1_9,
-                     &slit_185, 0), _fx_catch_170);
+                     &slit_192, 0), _fx_catch_174);
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     elem_0, &env_2, sc_2, &v_454, 0), _fx_catch_170);
-               _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(false, 1, v_454, &eloc1_9, &v_437);
+                     elem_2, &env_2, sc_2, &v_472, 0), _fx_catch_174);
+               _fx_make_T4BiN10Ast__exp_tR10Ast__loc_t(false, 1, v_472, &eloc1_9, &v_455);
 
-            _fx_catch_170: ;
-               if (v_454) {
-                  _fx_free_N10Ast__exp_t(&v_454);
+            _fx_catch_174: ;
+               if (v_472) {
+                  _fx_free_N10Ast__exp_t(&v_472);
                }
                if (elemtyp1_1) {
                   _fx_free_N10Ast__typ_t(&elemtyp1_1);
                }
-               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_453);
+               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_471);
 
-            _fx_endmatch_32: ;
-               FX_CHECK_EXN(_fx_catch_171);
-               bool is_expanded_0 = v_437.t0;
-               int_ elem_dims_0 = v_437.t1;
-               FX_COPY_PTR(v_437.t2, &elem1_0);
-               _fx_R10Ast__loc_t elem_loc_0 = v_437.t3;
+            _fx_endmatch_34: ;
+               FX_CHECK_EXN(_fx_catch_175);
+               bool is_expanded_0 = v_455.t0;
+               int_ elem_dims_0 = v_455.t1;
+               FX_COPY_PTR(v_455.t2, &elem1_0);
+               _fx_R10Ast__loc_t elem_loc_0 = v_455.t3;
                int_ row_dims_0;
                if (row_dims_acc_0 >= 0) {
                   row_dims_0 = row_dims_acc_0;
@@ -26975,17 +27143,17 @@ FX_EXTERN_C int
                   row_dims_0 = elem_dims_0;
                }
                if (row_dims_0 != elem_dims_0) {
-                  FX_CALL(_fx_F6stringS1i(elem_dims_0, &v_438, 0), _fx_catch_171);
-                  FX_CALL(_fx_F6stringS1i(row_dims_0, &v_439, 0), _fx_catch_171);
-                  fx_str_t slit_186 = FX_MAKE_STR("dimensionality of array element (=");
-                  fx_str_t slit_187 = FX_MAKE_STR(") does not match the previous elements dimensionality (=");
-                  fx_str_t slit_188 = FX_MAKE_STR(") in the same row");
+                  FX_CALL(_fx_F6stringS1i(elem_dims_0, &v_456, 0), _fx_catch_175);
+                  FX_CALL(_fx_F6stringS1i(row_dims_0, &v_457, 0), _fx_catch_175);
+                  fx_str_t slit_193 = FX_MAKE_STR("dimensionality of array element (=");
+                  fx_str_t slit_194 = FX_MAKE_STR(") does not match the previous elements dimensionality (=");
+                  fx_str_t slit_195 = FX_MAKE_STR(") in the same row");
                   {
-                     const fx_str_t strs_22[] = { slit_186, v_438, slit_187, v_439, slit_188 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_22, 5, &v_440), _fx_catch_171);
+                     const fx_str_t strs_22[] = { slit_193, v_456, slit_194, v_457, slit_195 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_22, 5, &v_458), _fx_catch_175);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_0, &v_440, &v_441, 0), _fx_catch_171);
-                  FX_THROW(&v_441, false, _fx_catch_171);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_0, &v_458, &v_459, 0), _fx_catch_175);
+                  FX_THROW(&v_459, false, _fx_catch_175);
                }
                bool t_14;
                if (have_expanded_i_0) {
@@ -26996,71 +27164,71 @@ FX_EXTERN_C int
                }
                have_expanded_i_0 = t_14;
                row_dims_acc_0 = row_dims_0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(elem1_0, arow_acc_0, true, &v_442), _fx_catch_171);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(elem1_0, arow_acc_0, true, &v_460), _fx_catch_175);
                _fx_free_LN10Ast__exp_t(&arow_acc_0);
-               FX_COPY_PTR(v_442, &arow_acc_0);
+               FX_COPY_PTR(v_460, &arow_acc_0);
 
-            _fx_catch_171: ;
-               if (v_442) {
-                  _fx_free_LN10Ast__exp_t(&v_442);
+            _fx_catch_175: ;
+               if (v_460) {
+                  _fx_free_LN10Ast__exp_t(&v_460);
                }
-               fx_free_exn(&v_441);
-               FX_FREE_STR(&v_440);
-               FX_FREE_STR(&v_439);
-               FX_FREE_STR(&v_438);
+               fx_free_exn(&v_459);
+               FX_FREE_STR(&v_458);
+               FX_FREE_STR(&v_457);
+               FX_FREE_STR(&v_456);
                if (elem1_0) {
                   _fx_free_N10Ast__exp_t(&elem1_0);
                }
-               _fx_free_T4BiN10Ast__exp_tR10Ast__loc_t(&v_437);
-               FX_CHECK_EXN(_fx_catch_175);
+               _fx_free_T4BiN10Ast__exp_tR10Ast__loc_t(&v_455);
+               FX_CHECK_EXN(_fx_catch_179);
             }
             FX_COPY_PTR(arow_acc_0, &arow_0);
             int_ row_dims_1 = row_dims_acc_0;
             int_ ncols_i_0;
-            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__exp_t(arow_0, &ncols_i_0, 0), _fx_catch_175);
+            FX_CALL(_fx_M13Ast_typecheckFM8length1_i1LN10Ast__exp_t(arow_0, &ncols_i_0, 0), _fx_catch_179);
             _fx_R10Ast__loc_t elem_loc_1;
             if (arow_0 != 0) {
-               FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arow_0->hd, &elem_loc_1, 0), _fx_catch_172);
+               FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arow_0->hd, &elem_loc_1, 0), _fx_catch_176);
 
-            _fx_catch_172: ;
+            _fx_catch_176: ;
             }
             else {
                _fx_LLN10Ast__exp_t arows_acc_1 = 0;
                FX_COPY_PTR(arows_acc_0, &arows_acc_1);
                if (arows_acc_1 != 0) {
-                  _fx_N10Ast__exp_t v_455 = 0;
-                  FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(arows_acc_1->hd, &v_455, 0), _fx_catch_173);
-                  FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_455, &elem_loc_1, 0), _fx_catch_173);
+                  _fx_N10Ast__exp_t v_473 = 0;
+                  FX_CALL(_fx_M13Ast_typecheckFM4lastN10Ast__exp_t1LN10Ast__exp_t(arows_acc_1->hd, &v_473, 0), _fx_catch_177);
+                  FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(v_473, &elem_loc_1, 0), _fx_catch_177);
 
-               _fx_catch_173: ;
-                  if (v_455) {
-                     _fx_free_N10Ast__exp_t(&v_455);
+               _fx_catch_177: ;
+                  if (v_473) {
+                     _fx_free_N10Ast__exp_t(&v_473);
                   }
                }
                else {
                   elem_loc_1 = eloc_0;
                }
-               FX_CHECK_EXN(_fx_catch_174);
+               FX_CHECK_EXN(_fx_catch_178);
 
-            _fx_catch_174: ;
+            _fx_catch_178: ;
                if (arows_acc_1) {
                   _fx_free_LLN10Ast__exp_t(&arows_acc_1);
                }
             }
-            FX_CHECK_EXN(_fx_catch_175);
+            FX_CHECK_EXN(_fx_catch_179);
             if (ncols_i_0 == 0) {
-               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_425, 0), _fx_catch_175);
-               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_426, 0), _fx_catch_175);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_426, &v_427, 0), _fx_catch_175);
-               fx_str_t slit_189 = FX_MAKE_STR("the ");
-               fx_str_t slit_190 = FX_MAKE_STR("-");
-               fx_str_t slit_191 = FX_MAKE_STR(" matrix row is empty");
+               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_443, 0), _fx_catch_179);
+               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_444, 0), _fx_catch_179);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_444, &v_445, 0), _fx_catch_179);
+               fx_str_t slit_196 = FX_MAKE_STR("the ");
+               fx_str_t slit_197 = FX_MAKE_STR("-");
+               fx_str_t slit_198 = FX_MAKE_STR(" matrix row is empty");
                {
-                  const fx_str_t strs_23[] = { slit_189, v_425, slit_190, v_427, slit_191 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_23, 5, &v_428), _fx_catch_175);
+                  const fx_str_t strs_23[] = { slit_196, v_443, slit_197, v_445, slit_198 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_23, 5, &v_446), _fx_catch_179);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_428, &v_429, 0), _fx_catch_175);
-               FX_THROW(&v_429, false, _fx_catch_175);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_446, &v_447, 0), _fx_catch_179);
+               FX_THROW(&v_447, false, _fx_catch_179);
             }
             bool have_expanded_0;
             if (have_expanded_acc_0) {
@@ -27084,18 +27252,18 @@ FX_EXTERN_C int
                t_16 = false;
             }
             if (t_16) {
-               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_430, 0), _fx_catch_175);
-               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_431, 0), _fx_catch_175);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_431, &v_432, 0), _fx_catch_175);
-               fx_str_t slit_192 = FX_MAKE_STR("the ");
-               fx_str_t slit_193 = FX_MAKE_STR("-");
-               fx_str_t slit_194 = FX_MAKE_STR(" matrix row contains a different number of elements");
+               FX_CALL(_fx_F6stringS1i(k_0 + 1, &v_448, 0), _fx_catch_179);
+               FX_CALL(_fx_M6StringFM10num_suffixS1i(k_0 + 1, &v_449, 0), _fx_catch_179);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_449, &v_450, 0), _fx_catch_179);
+               fx_str_t slit_199 = FX_MAKE_STR("the ");
+               fx_str_t slit_200 = FX_MAKE_STR("-");
+               fx_str_t slit_201 = FX_MAKE_STR(" matrix row contains a different number of elements");
                {
-                  const fx_str_t strs_24[] = { slit_192, v_430, slit_193, v_432, slit_194 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_24, 5, &v_433), _fx_catch_175);
+                  const fx_str_t strs_24[] = { slit_199, v_448, slit_200, v_450, slit_201 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_24, 5, &v_451), _fx_catch_179);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_433, &v_434, 0), _fx_catch_175);
-               FX_THROW(&v_434, false, _fx_catch_175);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&elem_loc_1, &v_451, &v_452, 0), _fx_catch_179);
+               FX_THROW(&v_452, false, _fx_catch_179);
             }
             int_ dims_1;
             if (dims_acc_0 < 0) {
@@ -27112,57 +27280,57 @@ FX_EXTERN_C int
                t_17 = ncols_0;
             }
             ncols_0 = t_17;
-            FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(arow_0, &v_435, 0), _fx_catch_175);
-            FX_CALL(_fx_cons_LLN10Ast__exp_t(v_435, arows_acc_0, true, &v_436), _fx_catch_175);
+            FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(arow_0, &v_453, 0), _fx_catch_179);
+            FX_CALL(_fx_cons_LLN10Ast__exp_t(v_453, arows_acc_0, true, &v_454), _fx_catch_179);
             _fx_free_LLN10Ast__exp_t(&arows_acc_0);
-            FX_COPY_PTR(v_436, &arows_acc_0);
+            FX_COPY_PTR(v_454, &arows_acc_0);
             have_expanded_acc_0 = have_expanded_0;
             dims_acc_0 = dims_1;
 
-         _fx_catch_175: ;
-            if (v_436) {
-               _fx_free_LLN10Ast__exp_t(&v_436);
+         _fx_catch_179: ;
+            if (v_454) {
+               _fx_free_LLN10Ast__exp_t(&v_454);
             }
-            if (v_435) {
-               _fx_free_LN10Ast__exp_t(&v_435);
+            if (v_453) {
+               _fx_free_LN10Ast__exp_t(&v_453);
             }
-            fx_free_exn(&v_434);
-            FX_FREE_STR(&v_433);
-            FX_FREE_STR(&v_432);
-            FX_FREE_STR(&v_431);
-            FX_FREE_STR(&v_430);
-            fx_free_exn(&v_429);
-            FX_FREE_STR(&v_428);
-            FX_FREE_STR(&v_427);
-            FX_FREE_STR(&v_426);
-            FX_FREE_STR(&v_425);
+            fx_free_exn(&v_452);
+            FX_FREE_STR(&v_451);
+            FX_FREE_STR(&v_450);
+            FX_FREE_STR(&v_449);
+            FX_FREE_STR(&v_448);
+            fx_free_exn(&v_447);
+            FX_FREE_STR(&v_446);
+            FX_FREE_STR(&v_445);
+            FX_FREE_STR(&v_444);
+            FX_FREE_STR(&v_443);
             if (arow_0) {
                _fx_free_LN10Ast__exp_t(&arow_0);
             }
             if (arow_acc_0) {
                _fx_free_LN10Ast__exp_t(&arow_acc_0);
             }
-            FX_CHECK_EXN(_fx_catch_176);
+            FX_CHECK_EXN(_fx_catch_180);
          }
          FX_COPY_PTR(arows_acc_0, &arows_1);
          int_ dims_2 = dims_acc_0;
-         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(dims_2, elemtyp_1, &atyp_0), _fx_catch_176);
-         fx_str_t slit_195 = FX_MAKE_STR("the array literal should produce an array");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(atyp_0, etyp_0, &eloc_0, &slit_195, 0),
-            _fx_catch_176);
-         FX_CALL(_fx_M13Ast_typecheckFM3revLLN10Ast__exp_t1LLN10Ast__exp_t(arows_1, &v_424, 0), _fx_catch_176);
-         FX_CALL(_fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_424, &ctx_0, &result_47),
-            _fx_catch_176);
+         FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(dims_2, elemtyp_1, &atyp_0), _fx_catch_180);
+         fx_str_t slit_202 = FX_MAKE_STR("the array literal should produce an array");
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(atyp_0, etyp_0, &eloc_0, &slit_202, 0),
+            _fx_catch_180);
+         FX_CALL(_fx_M13Ast_typecheckFM3revLLN10Ast__exp_t1LLN10Ast__exp_t(arows_1, &v_442, 0), _fx_catch_180);
+         FX_CALL(_fx_M3AstFM10ExpMkArrayN10Ast__exp_t2LLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_442, &ctx_0, &result_49),
+            _fx_catch_180);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_47, &result_0);
-         FX_BREAK(_fx_catch_176);
+         FX_COPY_PTR(result_49, &result_0);
+         FX_BREAK(_fx_catch_180);
 
-      _fx_catch_176: ;
-         if (result_47) {
-            _fx_free_N10Ast__exp_t(&result_47);
+      _fx_catch_180: ;
+         if (result_49) {
+            _fx_free_N10Ast__exp_t(&result_49);
          }
-         if (v_424) {
-            _fx_free_LLN10Ast__exp_t(&v_424);
+         if (v_442) {
+            _fx_free_LLN10Ast__exp_t(&v_442);
          }
          if (atyp_0) {
             _fx_free_N10Ast__typ_t(&atyp_0);
@@ -27179,7 +27347,7 @@ FX_EXTERN_C int
          if (elemtyp_1) {
             _fx_free_N10Ast__typ_t(&elemtyp_1);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 15) {
          _fx_N10Ast__typ_t elemtyp_2 = 0;
@@ -27187,182 +27355,182 @@ FX_EXTERN_C int
          _fx_LN10Ast__exp_t elems_1 = 0;
          _fx_LN10Ast__exp_t elems_2 = 0;
          _fx_N10Ast__typ_t vectyp_0 = 0;
-         _fx_LN10Ast__exp_t v_456 = 0;
-         _fx_N10Ast__exp_t result_48 = 0;
-         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_2, 0), _fx_catch_181);
+         _fx_LN10Ast__exp_t v_474 = 0;
+         _fx_N10Ast__exp_t result_50 = 0;
+         FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&elemtyp_2, 0), _fx_catch_185);
          FX_COPY_PTR(e_2->u.ExpMkVector.t0, &elems_1);
          _fx_LN10Ast__exp_t lst_17 = elems_1;
          for (; lst_17; lst_17 = lst_17->tl) {
-            _fx_N10Ast__exp_t elem_1 = lst_17->hd;
-            if (FX_REC_VARIANT_TAG(elem_1) == 9) {
-               _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_29 = &elem_1->u.ExpUnary;
+            _fx_N10Ast__exp_t elem_3 = lst_17->hd;
+            if (FX_REC_VARIANT_TAG(elem_3) == 9) {
+               _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_29 = &elem_3->u.ExpUnary;
                if (vcase_29->t0.tag == 8) {
                   _fx_N10Ast__exp_t e1_6 = 0;
-                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_457 = {0};
+                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_475 = {0};
                   _fx_N10Ast__typ_t etyp1_11 = 0;
-                  _fx_N10Ast__typ_t v_458 = 0;
-                  _fx_T2SN10Ast__typ_t v_459 = {0};
+                  _fx_N10Ast__typ_t v_476 = 0;
+                  _fx_T2SN10Ast__typ_t v_477 = {0};
                   fx_str_t collname_1 = {0};
                   _fx_N10Ast__typ_t elemtyp1_2 = 0;
-                  fx_str_t v_460 = {0};
-                  fx_str_t v_461 = {0};
-                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_462 = {0};
-                  _fx_N10Ast__exp_t v_463 = 0;
-                  _fx_LN10Ast__exp_t v_464 = 0;
-                  _fx_T2N10Ast__typ_tR10Ast__loc_t* v_465 = &vcase_29->t2;
-                  _fx_N10Ast__typ_t t_18 = v_465->t0;
+                  fx_str_t v_478 = {0};
+                  fx_str_t v_479 = {0};
+                  _fx_T2N10Ast__typ_tR10Ast__loc_t v_480 = {0};
+                  _fx_N10Ast__exp_t v_481 = 0;
+                  _fx_LN10Ast__exp_t v_482 = 0;
+                  _fx_T2N10Ast__typ_tR10Ast__loc_t* v_483 = &vcase_29->t2;
+                  _fx_N10Ast__typ_t t_18 = v_483->t0;
                   FX_CALL(
                      _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                        vcase_29->t1, &env_2, sc_2, &e1_6, 0), _fx_catch_178);
-                  FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_6, &v_457, 0), _fx_catch_178);
-                  FX_COPY_PTR(v_457.t0, &etyp1_11);
-                  _fx_R10Ast__loc_t eloc1_10 = v_457.t1;
-                  fx_str_t slit_196 = FX_MAKE_STR("incorrect type of expanded collection");
+                        vcase_29->t1, &env_2, sc_2, &e1_6, 0), _fx_catch_182);
+                  FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_6, &v_475, 0), _fx_catch_182);
+                  FX_COPY_PTR(v_475.t0, &etyp1_11);
+                  _fx_R10Ast__loc_t eloc1_10 = v_475.t1;
+                  fx_str_t slit_203 = FX_MAKE_STR("incorrect type of expanded collection");
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_18, etyp1_11, &eloc1_10,
-                        &slit_196, 0), _fx_catch_178);
-                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_11, &v_458, 0), _fx_catch_178);
-                  int tag_13 = FX_REC_VARIANT_TAG(v_458);
-                  if (tag_13 == 21) {
-                     _fx_T2iN10Ast__typ_t* vcase_30 = &v_458->u.TypArray;
+                        &slit_203, 0), _fx_catch_182);
+                  FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp1_11, &v_476, 0), _fx_catch_182);
+                  int tag_14 = FX_REC_VARIANT_TAG(v_476);
+                  if (tag_14 == 21) {
+                     _fx_T2iN10Ast__typ_t* vcase_30 = &v_476->u.TypArray;
                      if (vcase_30->t0 == 1) {
-                        fx_str_t slit_197 = FX_MAKE_STR("array");
-                        _fx_make_T2SN10Ast__typ_t(&slit_197, vcase_30->t1, &v_459);
-                        goto _fx_endmatch_33;
+                        fx_str_t slit_204 = FX_MAKE_STR("array");
+                        _fx_make_T2SN10Ast__typ_t(&slit_204, vcase_30->t1, &v_477);
+                        goto _fx_endmatch_35;
                      }
                   }
-                  if (tag_13 == 17) {
-                     fx_str_t slit_198 = FX_MAKE_STR("rrbvec");
-                     _fx_make_T2SN10Ast__typ_t(&slit_198, v_458->u.TypRRBVec, &v_459);
-                     goto _fx_endmatch_33;
+                  if (tag_14 == 17) {
+                     fx_str_t slit_205 = FX_MAKE_STR("rrbvec");
+                     _fx_make_T2SN10Ast__typ_t(&slit_205, v_476->u.TypRRBVec, &v_477);
+                     goto _fx_endmatch_35;
                   }
-                  if (tag_13 == 16) {
-                     fx_str_t slit_199 = FX_MAKE_STR("list");
-                     _fx_make_T2SN10Ast__typ_t(&slit_199, v_458->u.TypList, &v_459);
-                     goto _fx_endmatch_33;
+                  if (tag_14 == 16) {
+                     fx_str_t slit_206 = FX_MAKE_STR("list");
+                     _fx_make_T2SN10Ast__typ_t(&slit_206, v_476->u.TypList, &v_477);
+                     goto _fx_endmatch_35;
                   }
-                  if (tag_13 == 11) {
-                     fx_str_t slit_200 = FX_MAKE_STR("string");
-                     _fx_make_T2SN10Ast__typ_t(&slit_200, _fx_g22Ast_typecheck__TypChar, &v_459);
-                     goto _fx_endmatch_33;
+                  if (tag_14 == 11) {
+                     fx_str_t slit_207 = FX_MAKE_STR("string");
+                     _fx_make_T2SN10Ast__typ_t(&slit_207, _fx_g22Ast_typecheck__TypChar, &v_477);
+                     goto _fx_endmatch_35;
                   }
-                  fx_exn_t v_466 = {0};
-                  fx_str_t slit_201 =
+                  fx_exn_t v_484 = {0};
+                  fx_str_t slit_208 =
                      FX_MAKE_STR(
                         "incorrect type \'{typ2str(etyp1)} of the expanded collection (it should be an 1D array, list or string)");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc1_10, &slit_201, &v_466, 0), _fx_catch_177);
-                  FX_THROW(&v_466, false, _fx_catch_177);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc1_10, &slit_208, &v_484, 0), _fx_catch_181);
+                  FX_THROW(&v_484, false, _fx_catch_181);
 
-               _fx_catch_177: ;
-                  fx_free_exn(&v_466);
+               _fx_catch_181: ;
+                  fx_free_exn(&v_484);
 
-               _fx_endmatch_33: ;
-                  FX_CHECK_EXN(_fx_catch_178);
-                  fx_copy_str(&v_459.t0, &collname_1);
-                  FX_COPY_PTR(v_459.t1, &elemtyp1_2);
-                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_1, &v_460, 0), _fx_catch_178);
-                  fx_str_t slit_202 = FX_MAKE_STR("the expanded \'");
-                  fx_str_t slit_203 = FX_MAKE_STR("\' elem type does not match the previous elements");
+               _fx_endmatch_35: ;
+                  FX_CHECK_EXN(_fx_catch_182);
+                  fx_copy_str(&v_477.t0, &collname_1);
+                  FX_COPY_PTR(v_477.t1, &elemtyp1_2);
+                  FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&collname_1, &v_478, 0), _fx_catch_182);
+                  fx_str_t slit_209 = FX_MAKE_STR("the expanded \'");
+                  fx_str_t slit_210 = FX_MAKE_STR("\' elem type does not match the previous elements");
                   {
-                     const fx_str_t strs_25[] = { slit_202, v_460, slit_203 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_25, 3, &v_461), _fx_catch_178);
+                     const fx_str_t strs_25[] = { slit_209, v_478, slit_210 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_25, 3, &v_479), _fx_catch_182);
                   }
                   FX_CALL(
                      _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_2, elemtyp1_2, &eloc1_10,
-                        &v_461, 0), _fx_catch_178);
-                  _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t_18, &v_465->t1, &v_462);
+                        &v_479, 0), _fx_catch_182);
+                  _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t_18, &v_483->t1, &v_480);
                   FX_CALL(
                      _fx_M3AstFM8ExpUnaryN10Ast__exp_t3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                        &_fx_g23Ast_typecheck__OpExpand, e1_6, &v_462, &v_463), _fx_catch_178);
-                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_463, elems_acc_0, true, &v_464), _fx_catch_178);
+                        &_fx_g23Ast_typecheck__OpExpand, e1_6, &v_480, &v_481), _fx_catch_182);
+                  FX_CALL(_fx_cons_LN10Ast__exp_t(v_481, elems_acc_0, true, &v_482), _fx_catch_182);
                   _fx_free_LN10Ast__exp_t(&elems_acc_0);
-                  FX_COPY_PTR(v_464, &elems_acc_0);
+                  FX_COPY_PTR(v_482, &elems_acc_0);
 
-               _fx_catch_178: ;
-                  if (v_464) {
-                     _fx_free_LN10Ast__exp_t(&v_464);
+               _fx_catch_182: ;
+                  if (v_482) {
+                     _fx_free_LN10Ast__exp_t(&v_482);
                   }
-                  if (v_463) {
-                     _fx_free_N10Ast__exp_t(&v_463);
+                  if (v_481) {
+                     _fx_free_N10Ast__exp_t(&v_481);
                   }
-                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_462);
-                  FX_FREE_STR(&v_461);
-                  FX_FREE_STR(&v_460);
+                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_480);
+                  FX_FREE_STR(&v_479);
+                  FX_FREE_STR(&v_478);
                   if (elemtyp1_2) {
                      _fx_free_N10Ast__typ_t(&elemtyp1_2);
                   }
                   FX_FREE_STR(&collname_1);
-                  _fx_free_T2SN10Ast__typ_t(&v_459);
-                  if (v_458) {
-                     _fx_free_N10Ast__typ_t(&v_458);
+                  _fx_free_T2SN10Ast__typ_t(&v_477);
+                  if (v_476) {
+                     _fx_free_N10Ast__typ_t(&v_476);
                   }
                   if (etyp1_11) {
                      _fx_free_N10Ast__typ_t(&etyp1_11);
                   }
-                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_457);
+                  _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_475);
                   if (e1_6) {
                      _fx_free_N10Ast__exp_t(&e1_6);
                   }
-                  goto _fx_endmatch_34;
+                  goto _fx_endmatch_36;
                }
             }
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_467 = {0};
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_485 = {0};
             _fx_N10Ast__typ_t elemtyp1_3 = 0;
-            _fx_N10Ast__exp_t v_468 = 0;
-            _fx_LN10Ast__exp_t v_469 = 0;
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_1, &v_467, 0), _fx_catch_179);
-            FX_COPY_PTR(v_467.t0, &elemtyp1_3);
-            _fx_R10Ast__loc_t eloc1_11 = v_467.t1;
-            fx_str_t slit_204 = FX_MAKE_STR("all the scalar elements of the rrbvec should have the same type");
+            _fx_N10Ast__exp_t v_486 = 0;
+            _fx_LN10Ast__exp_t v_487 = 0;
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(elem_3, &v_485, 0), _fx_catch_183);
+            FX_COPY_PTR(v_485.t0, &elemtyp1_3);
+            _fx_R10Ast__loc_t eloc1_11 = v_485.t1;
+            fx_str_t slit_211 = FX_MAKE_STR("all the scalar elements of the rrbvec should have the same type");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(elemtyp_2, elemtyp1_3, &eloc1_11,
-                  &slit_204, 0), _fx_catch_179);
+                  &slit_211, 0), _fx_catch_183);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  elem_1, &env_2, sc_2, &v_468, 0), _fx_catch_179);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(v_468, elems_acc_0, true, &v_469), _fx_catch_179);
+                  elem_3, &env_2, sc_2, &v_486, 0), _fx_catch_183);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_486, elems_acc_0, true, &v_487), _fx_catch_183);
             _fx_free_LN10Ast__exp_t(&elems_acc_0);
-            FX_COPY_PTR(v_469, &elems_acc_0);
+            FX_COPY_PTR(v_487, &elems_acc_0);
 
-         _fx_catch_179: ;
-            if (v_469) {
-               _fx_free_LN10Ast__exp_t(&v_469);
+         _fx_catch_183: ;
+            if (v_487) {
+               _fx_free_LN10Ast__exp_t(&v_487);
             }
-            if (v_468) {
-               _fx_free_N10Ast__exp_t(&v_468);
+            if (v_486) {
+               _fx_free_N10Ast__exp_t(&v_486);
             }
             if (elemtyp1_3) {
                _fx_free_N10Ast__typ_t(&elemtyp1_3);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_467);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_485);
 
-         _fx_endmatch_34: ;
-            FX_CHECK_EXN(_fx_catch_180);
+         _fx_endmatch_36: ;
+            FX_CHECK_EXN(_fx_catch_184);
 
-         _fx_catch_180: ;
-            FX_CHECK_EXN(_fx_catch_181);
+         _fx_catch_184: ;
+            FX_CHECK_EXN(_fx_catch_185);
          }
          FX_COPY_PTR(elems_acc_0, &elems_2);
-         FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(elemtyp_2, &vectyp_0), _fx_catch_181);
-         fx_str_t slit_205 =
+         FX_CALL(_fx_M3AstFM9TypRRBVecN10Ast__typ_t1N10Ast__typ_t(elemtyp_2, &vectyp_0), _fx_catch_185);
+         fx_str_t slit_212 =
             FX_MAKE_STR(
                "the constructed rrbvec has type \'{typ2str(vectype)}\', but is expected to have type \'{typ2str(etyp)}\'");
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(vectyp_0, etyp_0, &eloc_0, &slit_205, 0),
-            _fx_catch_181);
-         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_2, &v_456, 0), _fx_catch_181);
-         FX_CALL(_fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_456, &ctx_0, &result_48),
-            _fx_catch_181);
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(vectyp_0, etyp_0, &eloc_0, &slit_212, 0),
+            _fx_catch_185);
+         FX_CALL(_fx_M13Ast_typecheckFM3revLN10Ast__exp_t1LN10Ast__exp_t(elems_2, &v_474, 0), _fx_catch_185);
+         FX_CALL(_fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_474, &ctx_0, &result_50),
+            _fx_catch_185);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_48, &result_0);
-         FX_BREAK(_fx_catch_181);
+         FX_COPY_PTR(result_50, &result_0);
+         FX_BREAK(_fx_catch_185);
 
-      _fx_catch_181: ;
-         if (result_48) {
-            _fx_free_N10Ast__exp_t(&result_48);
+      _fx_catch_185: ;
+         if (result_50) {
+            _fx_free_N10Ast__exp_t(&result_50);
          }
-         if (v_456) {
-            _fx_free_LN10Ast__exp_t(&v_456);
+         if (v_474) {
+            _fx_free_LN10Ast__exp_t(&v_474);
          }
          if (vectyp_0) {
             _fx_free_N10Ast__typ_t(&vectyp_0);
@@ -27379,19 +27547,19 @@ FX_EXTERN_C int
          if (elemtyp_2) {
             _fx_free_N10Ast__typ_t(&elemtyp_2);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 16) {
-         _fx_LR9Ast__id_t v_470 = 0;
+         _fx_LR9Ast__id_t v_488 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_0 = 0;
-         _fx_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_471 = {0};
+         _fx_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_489 = {0};
          _fx_LT2R9Ast__id_tN10Ast__exp_t lst_18 = 0;
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_19 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_1 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_new_initializers_0 = 0;
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_1 = 0;
-         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_472 = {0};
-         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_473 = 0;
+         _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_490 = {0};
+         _fx_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_491 = 0;
          _fx_N10Ast__typ_t rtyp_0 = 0;
          _fx_T3N10Ast__exp_tLT2R9Ast__id_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_31 = &e_2->u.ExpMkRecord;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_2 = vcase_31->t1;
@@ -27402,14 +27570,14 @@ FX_EXTERN_C int
          for (; lst_20; lst_20 = lst_20->tl) {
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___3 = &lst_20->hd;
             _fx_LR9Ast__id_t node_10 = 0;
-            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___3->t0, 0, false, &node_10), _fx_catch_182);
-            FX_LIST_APPEND(v_470, lstend_10, node_10);
+            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___3->t0, 0, false, &node_10), _fx_catch_186);
+            FX_LIST_APPEND(v_488, lstend_10, node_10);
 
-         _fx_catch_182: ;
-            FX_CHECK_EXN(_fx_catch_186);
+         _fx_catch_186: ;
+            FX_CHECK_EXN(_fx_catch_190);
          }
-         FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_470, &eloc_0, 0),
-            _fx_catch_186);
+         FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_488, &eloc_0, 0),
+            _fx_catch_190);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_11 = 0;
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lstend_12 = 0;
          FX_COPY_PTR(r_initializers_2, &r_initializers_1);
@@ -27417,112 +27585,112 @@ FX_EXTERN_C int
          for (; lst_21; lst_21 = lst_21->tl) {
             _fx_N10Ast__exp_t e_7 = 0;
             _fx_N10Ast__exp_t e_8 = 0;
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_474 = {0};
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_492 = {0};
             _fx_N10Ast__typ_t etypi_0 = 0;
-            _fx_T2R9Ast__id_tN10Ast__exp_t v_475 = {0};
-            _fx_R16Ast__val_flags_t v_476 = {0};
-            _fx_N10Ast__exp_t v_477 = 0;
-            _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_478 = {0};
+            _fx_T2R9Ast__id_tN10Ast__exp_t v_493 = {0};
+            _fx_R16Ast__val_flags_t v_494 = {0};
+            _fx_N10Ast__exp_t v_495 = 0;
+            _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_496 = {0};
             _fx_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t tup_0 = {0};
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___4 = &lst_21->hd;
             _fx_R9Ast__id_t n_1 = __pat___4->t0;
             FX_COPY_PTR(__pat___4->t1, &e_7);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  e_7, &env_2, sc_2, &e_8, 0), _fx_catch_183);
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_8, &v_474, 0), _fx_catch_183);
-            FX_COPY_PTR(v_474.t0, &etypi_0);
-            _fx_R10Ast__loc_t eloci_0 = v_474.t1;
-            _fx_make_T2R9Ast__id_tN10Ast__exp_t(&n_1, e_8, &v_475);
-            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_476, 0), _fx_catch_183);
-            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloci_0, &v_477), _fx_catch_183);
-            _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_476, &n_1, etypi_0, v_477, &v_478);
-            _fx_make_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_475, &v_478,
+                  e_7, &env_2, sc_2, &e_8, 0), _fx_catch_187);
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_8, &v_492, 0), _fx_catch_187);
+            FX_COPY_PTR(v_492.t0, &etypi_0);
+            _fx_R10Ast__loc_t eloci_0 = v_492.t1;
+            _fx_make_T2R9Ast__id_tN10Ast__exp_t(&n_1, e_8, &v_493);
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_494, 0), _fx_catch_187);
+            FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&eloci_0, &v_495), _fx_catch_187);
+            _fx_make_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_494, &n_1, etypi_0, v_495, &v_496);
+            _fx_make_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_493, &v_496,
                &tup_0);
             _fx_LT2R9Ast__id_tN10Ast__exp_t node_11 = 0;
-            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&tup_0.t0, 0, false, &node_11), _fx_catch_183);
+            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&tup_0.t0, 0, false, &node_11), _fx_catch_187);
             FX_LIST_APPEND(lst_18, lstend_11, node_11);
             _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t node_12 = 0;
             FX_CALL(_fx_cons_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0.t1, 0, false, &node_12),
-               _fx_catch_183);
+               _fx_catch_187);
             FX_LIST_APPEND(lst_19, lstend_12, node_12);
 
-         _fx_catch_183: ;
+         _fx_catch_187: ;
             _fx_free_T2T2R9Ast__id_tN10Ast__exp_tT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&tup_0);
-            _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_478);
-            if (v_477) {
-               _fx_free_N10Ast__exp_t(&v_477);
+            _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_496);
+            if (v_495) {
+               _fx_free_N10Ast__exp_t(&v_495);
             }
-            _fx_free_R16Ast__val_flags_t(&v_476);
-            _fx_free_T2R9Ast__id_tN10Ast__exp_t(&v_475);
+            _fx_free_R16Ast__val_flags_t(&v_494);
+            _fx_free_T2R9Ast__id_tN10Ast__exp_t(&v_493);
             if (etypi_0) {
                _fx_free_N10Ast__typ_t(&etypi_0);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_474);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_492);
             if (e_8) {
                _fx_free_N10Ast__exp_t(&e_8);
             }
             if (e_7) {
                _fx_free_N10Ast__exp_t(&e_7);
             }
-            FX_CHECK_EXN(_fx_catch_186);
+            FX_CHECK_EXN(_fx_catch_190);
          }
          _fx_make_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(lst_18, lst_19,
-            &v_471);
-         FX_COPY_PTR(v_471.t0, &r_new_initializers_0);
-         FX_COPY_PTR(v_471.t1, &relems_1);
-         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(relems_1, false, &v_472);
-         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_472, &v_473), _fx_catch_186);
-         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_473, &rtyp_0),
-            _fx_catch_186);
+            &v_489);
+         FX_COPY_PTR(v_489.t0, &r_new_initializers_0);
+         FX_COPY_PTR(v_489.t1, &relems_1);
+         _fx_make_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(relems_1, false, &v_490);
+         FX_CALL(_fx_make_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_490, &v_491), _fx_catch_190);
+         FX_CALL(_fx_M3AstFM9TypRecordN10Ast__typ_t1rT2LT4RM11val_flags_tRM4id_tN10Ast__typ_tN10Ast__exp_tB(v_491, &rtyp_0),
+            _fx_catch_190);
          if (FX_REC_VARIANT_TAG(r_e_0) == 1) {
-            _fx_N10Ast__exp_t result_49 = 0;
-            fx_str_t slit_206 = FX_MAKE_STR("unexpected record type");
+            _fx_N10Ast__exp_t result_51 = 0;
+            fx_str_t slit_213 = FX_MAKE_STR("unexpected record type");
             FX_CALL(
-               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, rtyp_0, &eloc_0, &slit_206, 0),
-               _fx_catch_184);
+               _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, rtyp_0, &eloc_0, &slit_213, 0),
+               _fx_catch_188);
             FX_CALL(
                _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(r_e_0,
-                  r_new_initializers_0, &ctx_0, &result_49), _fx_catch_184);
+                  r_new_initializers_0, &ctx_0, &result_51), _fx_catch_188);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_49, &result_0);
-            FX_BREAK(_fx_catch_184);
+            FX_COPY_PTR(result_51, &result_0);
+            FX_BREAK(_fx_catch_188);
 
-         _fx_catch_184: ;
-            if (result_49) {
-               _fx_free_N10Ast__exp_t(&result_49);
+         _fx_catch_188: ;
+            if (result_51) {
+               _fx_free_N10Ast__exp_t(&result_51);
             }
          }
          else {
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_479 = {0};
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_497 = {0};
             _fx_N10Ast__typ_t r_etyp_0 = 0;
-            _fx_LN10Ast__typ_t v_480 = 0;
+            _fx_LN10Ast__typ_t v_498 = 0;
             _fx_N10Ast__typ_t r_expected_typ_0 = 0;
             _fx_N10Ast__exp_t new_r_e_0 = 0;
-            _fx_N10Ast__exp_t result_50 = 0;
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_0, &v_479, 0), _fx_catch_185);
-            FX_COPY_PTR(v_479.t0, &r_etyp_0);
-            _fx_R10Ast__loc_t r_eloc_0 = v_479.t1;
-            FX_CALL(_fx_cons_LN10Ast__typ_t(rtyp_0, 0, true, &v_480), _fx_catch_185);
-            FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_480, etyp_0, &r_expected_typ_0),
-               _fx_catch_185);
-            fx_str_t slit_207 = FX_MAKE_STR("there is no proper record constructor/function with record argument");
+            _fx_N10Ast__exp_t result_52 = 0;
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_0, &v_497, 0), _fx_catch_189);
+            FX_COPY_PTR(v_497.t0, &r_etyp_0);
+            _fx_R10Ast__loc_t r_eloc_0 = v_497.t1;
+            FX_CALL(_fx_cons_LN10Ast__typ_t(rtyp_0, 0, true, &v_498), _fx_catch_189);
+            FX_CALL(_fx_M3AstFM6TypFunN10Ast__typ_t2LN10Ast__typ_tN10Ast__typ_t(v_498, etyp_0, &r_expected_typ_0),
+               _fx_catch_189);
+            fx_str_t slit_214 = FX_MAKE_STR("there is no proper record constructor/function with record argument");
             FX_CALL(
                _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(r_etyp_0, r_expected_typ_0, &r_eloc_0,
-                  &slit_207, 0), _fx_catch_185);
+                  &slit_214, 0), _fx_catch_189);
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                  r_e_0, &env_2, sc_2, &new_r_e_0, 0), _fx_catch_185);
+                  r_e_0, &env_2, sc_2, &new_r_e_0, 0), _fx_catch_189);
             FX_CALL(
                _fx_M3AstFM11ExpMkRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_r_e_0,
-                  r_new_initializers_0, &ctx_0, &result_50), _fx_catch_185);
+                  r_new_initializers_0, &ctx_0, &result_52), _fx_catch_189);
             _fx_free_N10Ast__exp_t(&result_0);
-            FX_COPY_PTR(result_50, &result_0);
-            FX_BREAK(_fx_catch_185);
+            FX_COPY_PTR(result_52, &result_0);
+            FX_BREAK(_fx_catch_189);
 
-         _fx_catch_185: ;
-            if (result_50) {
-               _fx_free_N10Ast__exp_t(&result_50);
+         _fx_catch_189: ;
+            if (result_52) {
+               _fx_free_N10Ast__exp_t(&result_52);
             }
             if (new_r_e_0) {
                _fx_free_N10Ast__exp_t(&new_r_e_0);
@@ -27530,24 +27698,24 @@ FX_EXTERN_C int
             if (r_expected_typ_0) {
                _fx_free_N10Ast__typ_t(&r_expected_typ_0);
             }
-            if (v_480) {
-               _fx_free_LN10Ast__typ_t(&v_480);
+            if (v_498) {
+               _fx_free_LN10Ast__typ_t(&v_498);
             }
             if (r_etyp_0) {
                _fx_free_N10Ast__typ_t(&r_etyp_0);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_479);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_497);
          }
-         FX_CHECK_EXN(_fx_catch_186);
+         FX_CHECK_EXN(_fx_catch_190);
 
-      _fx_catch_186: ;
+      _fx_catch_190: ;
          if (rtyp_0) {
             _fx_free_N10Ast__typ_t(&rtyp_0);
          }
-         if (v_473) {
-            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_473);
+         if (v_491) {
+            _fx_free_rT2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_491);
          }
-         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_472);
+         _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_490);
          if (relems_1) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_1);
          }
@@ -27563,24 +27731,24 @@ FX_EXTERN_C int
          if (lst_18) {
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&lst_18);
          }
-         _fx_free_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_471);
+         _fx_free_T2LT2R9Ast__id_tN10Ast__exp_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_489);
          if (r_initializers_0) {
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&r_initializers_0);
          }
-         FX_FREE_LIST_SIMPLE(&v_470);
-         goto _fx_endmatch_41;
+         FX_FREE_LIST_SIMPLE(&v_488);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 17) {
-         _fx_LR9Ast__id_t v_481 = 0;
+         _fx_LR9Ast__id_t v_499 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_3 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_482 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_500 = {0};
          _fx_N10Ast__typ_t rtyp_1 = 0;
          _fx_N10Ast__exp_t new_r_e_1 = 0;
-         _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_483 = {0};
+         _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_501 = {0};
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_2 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t new_r_initializers_0 = 0;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_4 = 0;
-         _fx_N10Ast__exp_t result_51 = 0;
+         _fx_N10Ast__exp_t result_53 = 0;
          _fx_T3N10Ast__exp_tLT2R9Ast__id_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_32 = &e_2->u.ExpUpdateRecord;
          _fx_LT2R9Ast__id_tN10Ast__exp_t r_initializers_5 = vcase_32->t1;
          _fx_N10Ast__exp_t r_e_1 = vcase_32->t0;
@@ -27590,127 +27758,127 @@ FX_EXTERN_C int
          for (; lst_22; lst_22 = lst_22->tl) {
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___5 = &lst_22->hd;
             _fx_LR9Ast__id_t node_13 = 0;
-            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___5->t0, 0, false, &node_13), _fx_catch_187);
-            FX_LIST_APPEND(v_481, lstend_13, node_13);
+            FX_CALL(_fx_cons_LR9Ast__id_t(&__pat___5->t0, 0, false, &node_13), _fx_catch_191);
+            FX_LIST_APPEND(v_499, lstend_13, node_13);
 
-         _fx_catch_187: ;
-            FX_CHECK_EXN(_fx_catch_191);
+         _fx_catch_191: ;
+            FX_CHECK_EXN(_fx_catch_195);
          }
-         FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_481, &eloc_0, 0),
-            _fx_catch_191);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_1, &v_482, 0), _fx_catch_191);
-         FX_COPY_PTR(v_482.t0, &rtyp_1);
-         _fx_R10Ast__loc_t rloc_0 = v_482.t1;
-         fx_str_t slit_208 = FX_MAKE_STR("the types of the update-record argument and the result do not match");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(rtyp_1, etyp_0, &eloc_0, &slit_208, 0),
-            _fx_catch_191);
+         FX_CALL(_fx_M13Ast_typecheckFM30check_for_rec_field_duplicatesv2LR9Ast__id_tR10Ast__loc_t(v_499, &eloc_0, 0),
+            _fx_catch_195);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(r_e_1, &v_500, 0), _fx_catch_195);
+         FX_COPY_PTR(v_500.t0, &rtyp_1);
+         _fx_R10Ast__loc_t rloc_0 = v_500.t1;
+         fx_str_t slit_215 = FX_MAKE_STR("the types of the update-record argument and the result do not match");
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(rtyp_1, etyp_0, &eloc_0, &slit_215, 0),
+            _fx_catch_195);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_191);
+               r_e_1, &env_2, sc_2, &new_r_e_1, 0), _fx_catch_195);
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &_fx_g22Ast_typecheck__None13_, rtyp_1, false, &rloc_0, &v_483, 0), _fx_catch_191);
-         FX_COPY_PTR(v_483.t1, &relems_2);
+               &_fx_g22Ast_typecheck__None13_, rtyp_1, false, &rloc_0, &v_501, 0), _fx_catch_195);
+         FX_COPY_PTR(v_501.t1, &relems_2);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lstend_14 = 0;
          FX_COPY_PTR(r_initializers_5, &r_initializers_4);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lst_23 = r_initializers_4;
          for (; lst_23; lst_23 = lst_23->tl) {
             _fx_N10Ast__exp_t ei_0 = 0;
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_484 = {0};
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_502 = {0};
             _fx_N10Ast__typ_t ei_typ_0 = 0;
             _fx_FPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t __lambda___1 = {0};
-            _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_485 = {0};
+            _fx_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_503 = {0};
             _fx_T2R9Ast__id_tN10Ast__exp_t res_37 = {0};
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___6 = &lst_23->hd;
             _fx_R9Ast__id_t ni_0 = __pat___6->t0;
             FX_COPY_PTR(__pat___6->t1, &ei_0);
-            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(ei_0, &v_484, 0), _fx_catch_190);
-            FX_COPY_PTR(v_484.t0, &ei_typ_0);
-            _fx_R10Ast__loc_t ei_loc_0 = v_484.t1;
+            FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(ei_0, &v_502, 0), _fx_catch_194);
+            FX_COPY_PTR(v_502.t0, &ei_typ_0);
+            _fx_R10Ast__loc_t ei_loc_0 = v_502.t1;
             _fx_M13Ast_typecheckFM9make_fp1_FPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t1R9Ast__id_t(&ni_0,
                &__lambda___1);
             FX_CALL(
                _fx_M13Ast_typecheckFM8find_optNt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tFPB1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
-                  relems_2, &__lambda___1, &v_485, 0), _fx_catch_190);
-            if (v_485.tag == 2) {
-               fx_str_t v_486 = {0};
-               fx_str_t v_487 = {0};
-               fx_str_t v_488 = {0};
+                  relems_2, &__lambda___1, &v_503, 0), _fx_catch_194);
+            if (v_503.tag == 2) {
+               fx_str_t v_504 = {0};
+               fx_str_t v_505 = {0};
+               fx_str_t v_506 = {0};
                _fx_N10Ast__exp_t new_ei_0 = 0;
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_486, 0), _fx_catch_188);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_486, &v_487, 0), _fx_catch_188);
-               fx_str_t slit_209 = FX_MAKE_STR("invalid type of the initializer of record field \'");
-               fx_str_t slit_210 = FX_MAKE_STR("\'");
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_504, 0), _fx_catch_192);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_504, &v_505, 0), _fx_catch_192);
+               fx_str_t slit_216 = FX_MAKE_STR("invalid type of the initializer of record field \'");
+               fx_str_t slit_217 = FX_MAKE_STR("\'");
                {
-                  const fx_str_t strs_26[] = { slit_209, v_487, slit_210 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_488), _fx_catch_188);
+                  const fx_str_t strs_26[] = { slit_216, v_505, slit_217 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_506), _fx_catch_192);
                }
                FX_CALL(
-                  _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_485.u.Some.t2, ei_typ_0, &ei_loc_0,
-                     &v_488, 0), _fx_catch_188);
+                  _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(v_503.u.Some.t2, ei_typ_0, &ei_loc_0,
+                     &v_506, 0), _fx_catch_192);
                FX_CALL(
                   _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-                     ei_0, &env_2, sc_2, &new_ei_0, 0), _fx_catch_188);
+                     ei_0, &env_2, sc_2, &new_ei_0, 0), _fx_catch_192);
                _fx_make_T2R9Ast__id_tN10Ast__exp_t(&ni_0, new_ei_0, &res_37);
 
-            _fx_catch_188: ;
+            _fx_catch_192: ;
                if (new_ei_0) {
                   _fx_free_N10Ast__exp_t(&new_ei_0);
                }
-               FX_FREE_STR(&v_488);
-               FX_FREE_STR(&v_487);
-               FX_FREE_STR(&v_486);
+               FX_FREE_STR(&v_506);
+               FX_FREE_STR(&v_505);
+               FX_FREE_STR(&v_504);
             }
             else {
-               fx_str_t v_489 = {0};
-               fx_str_t v_490 = {0};
-               fx_str_t v_491 = {0};
-               fx_exn_t v_492 = {0};
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_489, 0), _fx_catch_189);
-               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_489, &v_490, 0), _fx_catch_189);
-               fx_str_t slit_211 = FX_MAKE_STR("there is no record field \'");
-               fx_str_t slit_212 = FX_MAKE_STR("\' in the updated record");
+               fx_str_t v_507 = {0};
+               fx_str_t v_508 = {0};
+               fx_str_t v_509 = {0};
+               fx_exn_t v_510 = {0};
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_507, 0), _fx_catch_193);
+               FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_507, &v_508, 0), _fx_catch_193);
+               fx_str_t slit_218 = FX_MAKE_STR("there is no record field \'");
+               fx_str_t slit_219 = FX_MAKE_STR("\' in the updated record");
                {
-                  const fx_str_t strs_27[] = { slit_211, v_490, slit_212 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_491), _fx_catch_189);
+                  const fx_str_t strs_27[] = { slit_218, v_508, slit_219 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_509), _fx_catch_193);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&ei_loc_0, &v_491, &v_492, 0), _fx_catch_189);
-               FX_THROW(&v_492, false, _fx_catch_189);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&ei_loc_0, &v_509, &v_510, 0), _fx_catch_193);
+               FX_THROW(&v_510, false, _fx_catch_193);
 
-            _fx_catch_189: ;
-               fx_free_exn(&v_492);
-               FX_FREE_STR(&v_491);
-               FX_FREE_STR(&v_490);
-               FX_FREE_STR(&v_489);
+            _fx_catch_193: ;
+               fx_free_exn(&v_510);
+               FX_FREE_STR(&v_509);
+               FX_FREE_STR(&v_508);
+               FX_FREE_STR(&v_507);
             }
-            FX_CHECK_EXN(_fx_catch_190);
+            FX_CHECK_EXN(_fx_catch_194);
             _fx_LT2R9Ast__id_tN10Ast__exp_t node_14 = 0;
-            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&res_37, 0, false, &node_14), _fx_catch_190);
+            FX_CALL(_fx_cons_LT2R9Ast__id_tN10Ast__exp_t(&res_37, 0, false, &node_14), _fx_catch_194);
             FX_LIST_APPEND(new_r_initializers_0, lstend_14, node_14);
 
-         _fx_catch_190: ;
+         _fx_catch_194: ;
             _fx_free_T2R9Ast__id_tN10Ast__exp_t(&res_37);
-            _fx_free_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_485);
+            _fx_free_Nt6option1T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_503);
             FX_FREE_FP(&__lambda___1);
             if (ei_typ_0) {
                _fx_free_N10Ast__typ_t(&ei_typ_0);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_484);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_502);
             if (ei_0) {
                _fx_free_N10Ast__exp_t(&ei_0);
             }
-            FX_CHECK_EXN(_fx_catch_191);
+            FX_CHECK_EXN(_fx_catch_195);
          }
          FX_CALL(
             _fx_M3AstFM15ExpUpdateRecordN10Ast__exp_t3N10Ast__exp_tLT2RM4id_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_r_e_1,
-               new_r_initializers_0, &ctx_0, &result_51), _fx_catch_191);
+               new_r_initializers_0, &ctx_0, &result_53), _fx_catch_195);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_51, &result_0);
-         FX_BREAK(_fx_catch_191);
+         FX_COPY_PTR(result_53, &result_0);
+         FX_BREAK(_fx_catch_195);
 
-      _fx_catch_191: ;
-         if (result_51) {
-            _fx_free_N10Ast__exp_t(&result_51);
+      _fx_catch_195: ;
+         if (result_53) {
+            _fx_free_N10Ast__exp_t(&result_53);
          }
          if (r_initializers_4) {
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&r_initializers_4);
@@ -27721,55 +27889,55 @@ FX_EXTERN_C int
          if (relems_2) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_2);
          }
-         _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_483);
+         _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_501);
          if (new_r_e_1) {
             _fx_free_N10Ast__exp_t(&new_r_e_1);
          }
          if (rtyp_1) {
             _fx_free_N10Ast__typ_t(&rtyp_1);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_482);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_500);
          if (r_initializers_3) {
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&r_initializers_3);
          }
-         FX_FREE_LIST_SIMPLE(&v_481);
-         goto _fx_endmatch_41;
+         FX_FREE_LIST_SIMPLE(&v_499);
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 28) {
          _fx_LN12Ast__scope_t sc_3 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_493 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_511 = {0};
          _fx_N10Ast__typ_t e1typ_0 = 0;
          _fx_N10Ast__exp_t new_e1_12 = 0;
          _fx_LT2N10Ast__pat_tN10Ast__exp_t new_cases_0 = 0;
-         _fx_N10Ast__exp_t result_52 = 0;
+         _fx_N10Ast__exp_t result_54 = 0;
          _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_33 = &e_2->u.ExpTryCatch;
          _fx_N10Ast__exp_t e1_7 = vcase_33->t0;
-         _fx_N12Ast__scope_t v_494;
-         FX_CALL(_fx_M3AstFM13new_try_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_494, 0), _fx_catch_192);
-         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_494, sc_2, true, &sc_3), _fx_catch_192);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_7, &v_493, 0), _fx_catch_192);
-         FX_COPY_PTR(v_493.t0, &e1typ_0);
-         _fx_R10Ast__loc_t e1loc_0 = v_493.t1;
-         fx_str_t slit_213 = FX_MAKE_STR("try body type does match the whole try-catch type");
+         _fx_N12Ast__scope_t v_512;
+         FX_CALL(_fx_M3AstFM13new_try_scopeN12Ast__scope_t1i(curr_m_idx_0, &v_512, 0), _fx_catch_196);
+         FX_CALL(_fx_cons_LN12Ast__scope_t(&v_512, sc_2, true, &sc_3), _fx_catch_196);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_7, &v_511, 0), _fx_catch_196);
+         FX_COPY_PTR(v_511.t0, &e1typ_0);
+         _fx_R10Ast__loc_t e1loc_0 = v_511.t1;
+         fx_str_t slit_220 = FX_MAKE_STR("try body type does match the whole try-catch type");
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, e1typ_0, &e1loc_0, &slit_213, 0),
-            _fx_catch_192);
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, e1typ_0, &e1loc_0, &slit_220, 0),
+            _fx_catch_196);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e1_7, &env_2, sc_3, &new_e1_12, 0), _fx_catch_192);
+               e1_7, &env_2, sc_3, &new_e1_12, 0), _fx_catch_196);
          FX_CALL(
             _fx_M13Ast_typecheckFM11check_casesLT2N10Ast__pat_tN10Ast__exp_t6LT2N10Ast__pat_tN10Ast__exp_tN10Ast__typ_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_33->t1, _fx_g21Ast_typecheck__TypExn, etyp_0, &env_2, sc_3, &eloc_0, &new_cases_0, 0), _fx_catch_192);
+               vcase_33->t1, _fx_g21Ast_typecheck__TypExn, etyp_0, &env_2, sc_3, &eloc_0, &new_cases_0, 0), _fx_catch_196);
          FX_CALL(
             _fx_M3AstFM11ExpTryCatchN10Ast__exp_t3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_e1_12,
-               new_cases_0, &ctx_0, &result_52), _fx_catch_192);
+               new_cases_0, &ctx_0, &result_54), _fx_catch_196);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_52, &result_0);
-         FX_BREAK(_fx_catch_192);
+         FX_COPY_PTR(result_54, &result_0);
+         FX_BREAK(_fx_catch_196);
 
-      _fx_catch_192: ;
-         if (result_52) {
-            _fx_free_N10Ast__exp_t(&result_52);
+      _fx_catch_196: ;
+         if (result_54) {
+            _fx_free_N10Ast__exp_t(&result_54);
          }
          if (new_cases_0) {
             _fx_free_LT2N10Ast__pat_tN10Ast__exp_t(&new_cases_0);
@@ -27780,33 +27948,33 @@ FX_EXTERN_C int
          if (e1typ_0) {
             _fx_free_N10Ast__typ_t(&e1typ_0);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_493);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_511);
          FX_FREE_LIST_SIMPLE(&sc_3);
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 29) {
          _fx_N10Ast__exp_t new_e1_13 = 0;
          _fx_N10Ast__typ_t new_e1typ_0 = 0;
          _fx_LT2N10Ast__pat_tN10Ast__exp_t new_cases_1 = 0;
-         _fx_N10Ast__exp_t result_53 = 0;
+         _fx_N10Ast__exp_t result_55 = 0;
          _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_34 = &e_2->u.ExpMatch;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               vcase_34->t0, &env_2, sc_2, &new_e1_13, 0), _fx_catch_193);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_e1_13, &new_e1typ_0, 0), _fx_catch_193);
+               vcase_34->t0, &env_2, sc_2, &new_e1_13, 0), _fx_catch_197);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(new_e1_13, &new_e1typ_0, 0), _fx_catch_197);
          FX_CALL(
             _fx_M13Ast_typecheckFM11check_casesLT2N10Ast__pat_tN10Ast__exp_t6LT2N10Ast__pat_tN10Ast__exp_tN10Ast__typ_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_34->t1, new_e1typ_0, etyp_0, &env_2, sc_2, &eloc_0, &new_cases_1, 0), _fx_catch_193);
+               vcase_34->t1, new_e1typ_0, etyp_0, &env_2, sc_2, &eloc_0, &new_cases_1, 0), _fx_catch_197);
          FX_CALL(
             _fx_M3AstFM8ExpMatchN10Ast__exp_t3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(new_e1_13,
-               new_cases_1, &ctx_0, &result_53), _fx_catch_193);
+               new_cases_1, &ctx_0, &result_55), _fx_catch_197);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_53, &result_0);
-         FX_BREAK(_fx_catch_193);
+         FX_COPY_PTR(result_55, &result_0);
+         FX_BREAK(_fx_catch_197);
 
-      _fx_catch_193: ;
-         if (result_53) {
-            _fx_free_N10Ast__exp_t(&result_53);
+      _fx_catch_197: ;
+         if (result_55) {
+            _fx_free_N10Ast__exp_t(&result_55);
          }
          if (new_cases_1) {
             _fx_free_LT2N10Ast__pat_tN10Ast__exp_t(&new_cases_1);
@@ -27817,29 +27985,29 @@ FX_EXTERN_C int
          if (new_e1_13) {
             _fx_free_N10Ast__exp_t(&new_e1_13);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 30) {
          _fx_N10Ast__typ_t t2_0 = 0;
          _fx_N10Ast__exp_t e1_8 = 0;
          _fx_N10Ast__typ_t t1_0 = 0;
-         _fx_N10Ast__typ_t v_495 = 0;
-         _fx_N10Ast__typ_t v_496 = 0;
-         _fx_T2N10Ast__exp_tLN10Ast__exp_t v_497 = {0};
+         _fx_N10Ast__typ_t v_513 = 0;
+         _fx_N10Ast__typ_t v_514 = 0;
+         _fx_T2N10Ast__exp_tLN10Ast__exp_t v_515 = {0};
          _fx_N10Ast__exp_t e1_9 = 0;
          _fx_LN10Ast__exp_t code_1 = 0;
-         _fx_N10Ast__typ_t v_498 = 0;
-         _fx_N10Ast__typ_t v_499 = 0;
+         _fx_N10Ast__typ_t v_516 = 0;
+         _fx_N10Ast__typ_t v_517 = 0;
          _fx_T3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tR10Ast__loc_t* vcase_35 = &e_2->u.ExpCast;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_35->t1, &env_2, sc_2, &eloc_0, &t2_0, 0), _fx_catch_208);
+               vcase_35->t1, &env_2, sc_2, &eloc_0, &t2_0, 0), _fx_catch_212);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               vcase_35->t0, &env_2, sc_2, &e1_8, 0), _fx_catch_208);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_8, &t1_0, 0), _fx_catch_208);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_495, 0), _fx_catch_208);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_496, 0), _fx_catch_208);
+               vcase_35->t0, &env_2, sc_2, &e1_8, 0), _fx_catch_212);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_8, &t1_0, 0), _fx_catch_212);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_513, 0), _fx_catch_212);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_514, 0), _fx_catch_212);
          bool res_38;
          if (FX_REC_VARIANT_TAG(e1_8) == 7) {
             res_38 = true;
@@ -27850,411 +28018,411 @@ FX_EXTERN_C int
          else {
             res_38 = false;
          }
-         FX_CHECK_EXN(_fx_catch_208);
+         FX_CHECK_EXN(_fx_catch_212);
          if (res_38) {
-            _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_497); goto _fx_endmatch_35;
+            _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_515); goto _fx_endmatch_37;
          }
          bool res_39;
-         if (FX_REC_VARIANT_TAG(v_496) == 19) {
+         if (FX_REC_VARIANT_TAG(v_514) == 19) {
             res_39 = true;
          }
-         else if (FX_REC_VARIANT_TAG(v_495) == 19) {
+         else if (FX_REC_VARIANT_TAG(v_513) == 19) {
             res_39 = true;
          }
          else {
             res_39 = false;
          }
-         FX_CHECK_EXN(_fx_catch_208);
+         FX_CHECK_EXN(_fx_catch_212);
          if (res_39) {
             _fx_R16Ast__val_flags_t flags_2 = {0};
             _fx_R13Ast__defval_t dv_0 = {0};
-            _fx_N14Ast__id_info_t v_500 = {0};
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_501 = {0};
-            _fx_N10Ast__exp_t v_502 = 0;
-            _fx_N10Ast__pat_t v_503 = 0;
-            _fx_N10Ast__exp_t v_504 = 0;
-            _fx_LN10Ast__exp_t v_505 = 0;
+            _fx_N14Ast__id_info_t v_518 = {0};
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_519 = {0};
+            _fx_N10Ast__exp_t v_520 = 0;
+            _fx_N10Ast__pat_t v_521 = 0;
+            _fx_N10Ast__exp_t v_522 = 0;
+            _fx_LN10Ast__exp_t v_523 = 0;
             _fx_R9Ast__id_t temp_id_0;
-            fx_str_t slit_214 = FX_MAKE_STR("v");
-            FX_CALL(_fx_M3AstFM6gen_idRM4id_t2iS(curr_m_idx_0, &slit_214, &temp_id_0, 0), _fx_catch_194);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&flags_2, 0), _fx_catch_194);
+            fx_str_t slit_221 = FX_MAKE_STR("v");
+            FX_CALL(_fx_M3AstFM6gen_idRM4id_t2iS(curr_m_idx_0, &slit_221, &temp_id_0, 0), _fx_catch_198);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&flags_2, 0), _fx_catch_198);
             _fx_make_R13Ast__defval_t(&temp_id_0, t1_0, &flags_2, sc_2, &eloc_0, &dv_0);
-            _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_0, &v_500);
-            FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&temp_id_0, &v_500, 0), _fx_catch_194);
-            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t1_0, &eloc_0, &v_501);
-            FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&temp_id_0, &v_501, &v_502),
-               _fx_catch_194);
-            FX_CALL(_fx_M3AstFM8PatIdentN10Ast__pat_t2RM4id_tRM5loc_t(&temp_id_0, &eloc_0, &v_503), _fx_catch_194);
+            _fx_M3AstFM6IdDValN14Ast__id_info_t1RM8defval_t(&dv_0, &v_518);
+            FX_CALL(_fx_M3AstFM12set_id_entryv2RM4id_tN14Ast__id_info_t(&temp_id_0, &v_518, 0), _fx_catch_198);
+            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t1_0, &eloc_0, &v_519);
+            FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&temp_id_0, &v_519, &v_520),
+               _fx_catch_198);
+            FX_CALL(_fx_M3AstFM8PatIdentN10Ast__pat_t2RM4id_tRM5loc_t(&temp_id_0, &eloc_0, &v_521), _fx_catch_198);
             FX_CALL(
-               _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(v_503, e1_8, &flags_2, &eloc_0,
-                  &v_504), _fx_catch_194);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(v_504, 0, true, &v_505), _fx_catch_194);
-            _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(v_502, v_505, &v_497);
+               _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(v_521, e1_8, &flags_2, &eloc_0,
+                  &v_522), _fx_catch_198);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(v_522, 0, true, &v_523), _fx_catch_198);
+            _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(v_520, v_523, &v_515);
 
-         _fx_catch_194: ;
-            if (v_505) {
-               _fx_free_LN10Ast__exp_t(&v_505);
+         _fx_catch_198: ;
+            if (v_523) {
+               _fx_free_LN10Ast__exp_t(&v_523);
             }
-            if (v_504) {
-               _fx_free_N10Ast__exp_t(&v_504);
+            if (v_522) {
+               _fx_free_N10Ast__exp_t(&v_522);
             }
-            if (v_503) {
-               _fx_free_N10Ast__pat_t(&v_503);
+            if (v_521) {
+               _fx_free_N10Ast__pat_t(&v_521);
             }
-            if (v_502) {
-               _fx_free_N10Ast__exp_t(&v_502);
+            if (v_520) {
+               _fx_free_N10Ast__exp_t(&v_520);
             }
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_501);
-            _fx_free_N14Ast__id_info_t(&v_500);
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_519);
+            _fx_free_N14Ast__id_info_t(&v_518);
             _fx_free_R13Ast__defval_t(&dv_0);
             _fx_free_R16Ast__val_flags_t(&flags_2);
-            goto _fx_endmatch_35;
+            goto _fx_endmatch_37;
          }
-         _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_497);
+         _fx_make_T2N10Ast__exp_tLN10Ast__exp_t(e1_8, 0, &v_515);
 
-      _fx_endmatch_35: ;
-         FX_CHECK_EXN(_fx_catch_208);
-         FX_COPY_PTR(v_497.t0, &e1_9);
-         FX_COPY_PTR(v_497.t1, &code_1);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_498, 0), _fx_catch_208);
-         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_499, 0), _fx_catch_208);
-         if (FX_REC_VARIANT_TAG(v_499) == 26) {
-            _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_36 = &v_499->u.TypApp;
+      _fx_endmatch_37: ;
+         FX_CHECK_EXN(_fx_catch_212);
+         FX_COPY_PTR(v_515.t0, &e1_9);
+         FX_COPY_PTR(v_515.t1, &code_1);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_516, 0), _fx_catch_212);
+         FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_517, 0), _fx_catch_212);
+         if (FX_REC_VARIANT_TAG(v_517) == 26) {
+            _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_36 = &v_517->u.TypApp;
             if (vcase_36->t0 == 0) {
-               if (FX_REC_VARIANT_TAG(v_498) == 26) {
-                  _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_37 = &v_498->u.TypApp;
+               if (FX_REC_VARIANT_TAG(v_516) == 26) {
+                  _fx_T2LN10Ast__typ_tR9Ast__id_t* vcase_37 = &v_516->u.TypApp;
                   if (vcase_37->t0 == 0) {
                      _fx_N10Ast__exp_t new_e1_14 = 0;
-                     _fx_N14Ast__id_info_t v_506 = {0};
-                     _fx_N14Ast__id_info_t v_507 = {0};
+                     _fx_N14Ast__id_info_t v_524 = {0};
+                     _fx_N14Ast__id_info_t v_525 = {0};
                      _fx_R9Ast__id_t* tn1_0 = &vcase_37->t1;
                      _fx_R9Ast__id_t* tn2_0 = &vcase_36->t1;
                      bool res_40;
-                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(tn1_0, tn2_0, &res_40, 0), _fx_catch_201);
+                     FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(tn1_0, tn2_0, &res_40, 0), _fx_catch_205);
                      if (res_40) {
                         FX_COPY_PTR(e1_9, &new_e1_14);
                      }
                      else {
-                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn1_0, &eloc_0, &v_506, 0), _fx_catch_201);
-                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn2_0, &eloc_0, &v_507, 0), _fx_catch_201);
-                        if (v_506.tag == 6) {
-                           if (v_507.tag == 6) {
-                              fx_str_t v_508 = {0};
-                              fx_str_t v_509 = {0};
-                              fx_str_t v_510 = {0};
-                              fx_str_t v_511 = {0};
-                              fx_str_t v_512 = {0};
-                              fx_exn_t v_513 = {0};
-                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_508, 0), _fx_catch_195);
-                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_508, &v_509, 0), _fx_catch_195);
-                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn2_0, &v_510, 0), _fx_catch_195);
-                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_510, &v_511, 0), _fx_catch_195);
-                              fx_str_t slit_215 = FX_MAKE_STR("variant/record type \'");
-                              fx_str_t slit_216 = FX_MAKE_STR("\' cannot be casted to another variant/record type \'");
-                              fx_str_t slit_217 = FX_MAKE_STR("\'; define a custom function to do the conversion and call it");
-                              {
-                                 const fx_str_t strs_28[] = { slit_215, v_509, slit_216, v_511, slit_217 };
-                                 FX_CALL(fx_strjoin(0, 0, 0, strs_28, 5, &v_512), _fx_catch_195);
-                              }
-                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_512, &v_513, 0), _fx_catch_195);
-                              FX_THROW(&v_513, false, _fx_catch_195);
-
-                           _fx_catch_195: ;
-                              fx_free_exn(&v_513);
-                              FX_FREE_STR(&v_512);
-                              FX_FREE_STR(&v_511);
-                              FX_FREE_STR(&v_510);
-                              FX_FREE_STR(&v_509);
-                              FX_FREE_STR(&v_508);
-                              goto _fx_endmatch_36;
-                           }
-                        }
-                        if (v_507.tag == 7) {
-                           if (v_506.tag == 6) {
-                              _fx_R17Ast__defvariant_t v_514 = {0};
-                              _fx_R19Ast__definterface_t v_515 = {0};
-                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t dvar_ifaces_0 = 0;
-                              fx_str_t v_516 = {0};
-                              fx_str_t v_517 = {0};
-                              fx_str_t v_518 = {0};
-                              fx_str_t v_519 = {0};
-                              fx_str_t v_520 = {0};
-                              fx_exn_t v_521 = {0};
-                              _fx_LN10Ast__exp_t v_522 = 0;
-                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_523 = {0};
-                              _fx_copy_R17Ast__defvariant_t(&v_506.u.IdVariant->data, &v_514);
-                              _fx_copy_R19Ast__definterface_t(&v_507.u.IdInterface->data, &v_515);
-                              _fx_R9Ast__id_t* di_name_0 = &v_515.di_name;
-                              bool __fold_result___1 = false;
-                              FX_COPY_PTR(v_514.dvar_ifaces, &dvar_ifaces_0);
-                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t lst_24 = dvar_ifaces_0;
-                              for (; lst_24; lst_24 = lst_24->tl) {
-                                 _fx_T2R9Ast__id_tLTa2R9Ast__id_t* __pat___7 = &lst_24->hd;
-                                 _fx_R9Ast__id_t i_2 = __pat___7->t0;
-                                 bool v_524;
-                                 FX_CALL(
-                                    _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_2, di_name_0, &eloc_0, &v_524, 0),
-                                    _fx_catch_196);
-                                 if (v_524) {
-                                    __fold_result___1 = true; FX_BREAK(_fx_catch_196);
-                                 }
-
-                              _fx_catch_196: ;
-                                 FX_CHECK_BREAK();
-                                 FX_CHECK_EXN(_fx_catch_197);
-                              }
-                              if (!__fold_result___1) {
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_516, 0), _fx_catch_197);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_516, &v_517, 0), _fx_catch_197);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_0, &v_518, 0), _fx_catch_197);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_518, &v_519, 0), _fx_catch_197);
-                                 fx_str_t slit_218 = FX_MAKE_STR("variant/record type \'");
-                                 fx_str_t slit_219 = FX_MAKE_STR("\' is casted to interface \'");
-                                 fx_str_t slit_220 =
-                                    FX_MAKE_STR(
-                                       "\', but the type does not implement any of the interfaces that can be casted to the interface");
-                                 {
-                                    const fx_str_t strs_29[] = { slit_218, v_517, slit_219, v_519, slit_220 };
-                                    FX_CALL(fx_strjoin(0, 0, 0, strs_29, 5, &v_520), _fx_catch_197);
-                                 }
-                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_520, &v_521, 0), _fx_catch_197);
-                                 FX_THROW(&v_521, false, _fx_catch_197);
-                              }
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_522), _fx_catch_197);
-                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_523);
-                              FX_CALL(
-                                 _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_522, &v_523, &new_e1_14), _fx_catch_197);
-
-                           _fx_catch_197: ;
-                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_523);
-                              if (v_522) {
-                                 _fx_free_LN10Ast__exp_t(&v_522);
-                              }
-                              fx_free_exn(&v_521);
-                              FX_FREE_STR(&v_520);
-                              FX_FREE_STR(&v_519);
-                              FX_FREE_STR(&v_518);
-                              FX_FREE_STR(&v_517);
-                              FX_FREE_STR(&v_516);
-                              if (dvar_ifaces_0) {
-                                 _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dvar_ifaces_0);
-                              }
-                              _fx_free_R19Ast__definterface_t(&v_515);
-                              _fx_free_R17Ast__defvariant_t(&v_514);
-                              goto _fx_endmatch_36;
-                           }
-                        }
-                        if (v_507.tag == 6) {
-                           if (v_506.tag == 7) {
-                              _fx_R19Ast__definterface_t v_525 = {0};
-                              _fx_R17Ast__defvariant_t v_526 = {0};
-                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t dvar_ifaces_1 = 0;
+                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn1_0, &eloc_0, &v_524, 0), _fx_catch_205);
+                        FX_CALL(_fx_M3AstFM7id_infoN14Ast__id_info_t2RM4id_tRM5loc_t(tn2_0, &eloc_0, &v_525, 0), _fx_catch_205);
+                        if (v_524.tag == 6) {
+                           if (v_525.tag == 6) {
+                              fx_str_t v_526 = {0};
                               fx_str_t v_527 = {0};
                               fx_str_t v_528 = {0};
                               fx_str_t v_529 = {0};
                               fx_str_t v_530 = {0};
-                              fx_str_t v_531 = {0};
-                              fx_str_t v_532 = {0};
-                              fx_str_t v_533 = {0};
-                              fx_exn_t v_534 = {0};
-                              _fx_LN10Ast__exp_t v_535 = 0;
-                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_536 = {0};
-                              _fx_copy_R19Ast__definterface_t(&v_506.u.IdInterface->data, &v_525);
-                              _fx_R9Ast__id_t* di_name_1 = &v_525.di_name;
-                              _fx_copy_R17Ast__defvariant_t(&v_507.u.IdVariant->data, &v_526);
-                              bool __fold_result___2 = false;
-                              FX_COPY_PTR(v_526.dvar_ifaces, &dvar_ifaces_1);
-                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t lst_25 = dvar_ifaces_1;
-                              for (; lst_25; lst_25 = lst_25->tl) {
-                                 _fx_T2R9Ast__id_tLTa2R9Ast__id_t* __pat___8 = &lst_25->hd;
-                                 _fx_R9Ast__id_t i_3 = __pat___8->t0;
-                                 bool v_537;
-                                 FX_CALL(
-                                    _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_3, di_name_1, &eloc_0, &v_537, 0),
-                                    _fx_catch_198);
-                                 if (v_537) {
-                                    __fold_result___2 = true; FX_BREAK(_fx_catch_198);
-                                 }
-
-                              _fx_catch_198: ;
-                                 FX_CHECK_BREAK();
-                                 FX_CHECK_EXN(_fx_catch_199);
+                              fx_exn_t v_531 = {0};
+                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_526, 0), _fx_catch_199);
+                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_526, &v_527, 0), _fx_catch_199);
+                              FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn2_0, &v_528, 0), _fx_catch_199);
+                              FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_528, &v_529, 0), _fx_catch_199);
+                              fx_str_t slit_222 = FX_MAKE_STR("variant/record type \'");
+                              fx_str_t slit_223 = FX_MAKE_STR("\' cannot be casted to another variant/record type \'");
+                              fx_str_t slit_224 = FX_MAKE_STR("\'; define a custom function to do the conversion and call it");
+                              {
+                                 const fx_str_t strs_28[] = { slit_222, v_527, slit_223, v_529, slit_224 };
+                                 FX_CALL(fx_strjoin(0, 0, 0, strs_28, 5, &v_530), _fx_catch_199);
                               }
-                              if (!__fold_result___2) {
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_527, 0), _fx_catch_199);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_527, &v_528, 0), _fx_catch_199);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_529, 0), _fx_catch_199);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_529, &v_530, 0), _fx_catch_199);
-                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_531, 0), _fx_catch_199);
-                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_531, &v_532, 0), _fx_catch_199);
-                                 fx_str_t slit_221 = FX_MAKE_STR("interface \'");
-                                 fx_str_t slit_222 = FX_MAKE_STR("\' is casted to variant/record type \'");
-                                 fx_str_t slit_223 = FX_MAKE_STR("\', but the type does not implement neither \'");
-                                 fx_str_t slit_224 = FX_MAKE_STR("\' nor anything derived from it");
-                                 {
-                                    const fx_str_t strs_30[] = { slit_221, v_528, slit_222, v_530, slit_223, v_532, slit_224 };
-                                    FX_CALL(fx_strjoin(0, 0, 0, strs_30, 7, &v_533), _fx_catch_199);
-                                 }
-                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_533, &v_534, 0), _fx_catch_199);
-                                 FX_THROW(&v_534, false, _fx_catch_199);
-                              }
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_535), _fx_catch_199);
-                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_536);
-                              FX_CALL(
-                                 _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g30Ast_typecheck__IntrinGetObject, v_535, &v_536, &new_e1_14), _fx_catch_199);
+                              FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_530, &v_531, 0), _fx_catch_199);
+                              FX_THROW(&v_531, false, _fx_catch_199);
 
                            _fx_catch_199: ;
-                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_536);
-                              if (v_535) {
-                                 _fx_free_LN10Ast__exp_t(&v_535);
-                              }
-                              fx_free_exn(&v_534);
-                              FX_FREE_STR(&v_533);
-                              FX_FREE_STR(&v_532);
-                              FX_FREE_STR(&v_531);
+                              fx_free_exn(&v_531);
                               FX_FREE_STR(&v_530);
                               FX_FREE_STR(&v_529);
                               FX_FREE_STR(&v_528);
                               FX_FREE_STR(&v_527);
+                              FX_FREE_STR(&v_526);
+                              goto _fx_endmatch_38;
+                           }
+                        }
+                        if (v_525.tag == 7) {
+                           if (v_524.tag == 6) {
+                              _fx_R17Ast__defvariant_t v_532 = {0};
+                              _fx_R19Ast__definterface_t v_533 = {0};
+                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t dvar_ifaces_0 = 0;
+                              fx_str_t v_534 = {0};
+                              fx_str_t v_535 = {0};
+                              fx_str_t v_536 = {0};
+                              fx_str_t v_537 = {0};
+                              fx_str_t v_538 = {0};
+                              fx_exn_t v_539 = {0};
+                              _fx_LN10Ast__exp_t v_540 = 0;
+                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_541 = {0};
+                              _fx_copy_R17Ast__defvariant_t(&v_524.u.IdVariant->data, &v_532);
+                              _fx_copy_R19Ast__definterface_t(&v_525.u.IdInterface->data, &v_533);
+                              _fx_R9Ast__id_t* di_name_0 = &v_533.di_name;
+                              bool __fold_result___1 = false;
+                              FX_COPY_PTR(v_532.dvar_ifaces, &dvar_ifaces_0);
+                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t lst_24 = dvar_ifaces_0;
+                              for (; lst_24; lst_24 = lst_24->tl) {
+                                 _fx_T2R9Ast__id_tLTa2R9Ast__id_t* __pat___7 = &lst_24->hd;
+                                 _fx_R9Ast__id_t i_2 = __pat___7->t0;
+                                 bool v_542;
+                                 FX_CALL(
+                                    _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_2, di_name_0, &eloc_0, &v_542, 0),
+                                    _fx_catch_200);
+                                 if (v_542) {
+                                    __fold_result___1 = true; FX_BREAK(_fx_catch_200);
+                                 }
+
+                              _fx_catch_200: ;
+                                 FX_CHECK_BREAK();
+                                 FX_CHECK_EXN(_fx_catch_201);
+                              }
+                              if (!__fold_result___1) {
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_534, 0), _fx_catch_201);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_534, &v_535, 0), _fx_catch_201);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_0, &v_536, 0), _fx_catch_201);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_536, &v_537, 0), _fx_catch_201);
+                                 fx_str_t slit_225 = FX_MAKE_STR("variant/record type \'");
+                                 fx_str_t slit_226 = FX_MAKE_STR("\' is casted to interface \'");
+                                 fx_str_t slit_227 =
+                                    FX_MAKE_STR(
+                                       "\', but the type does not implement any of the interfaces that can be casted to the interface");
+                                 {
+                                    const fx_str_t strs_29[] = { slit_225, v_535, slit_226, v_537, slit_227 };
+                                    FX_CALL(fx_strjoin(0, 0, 0, strs_29, 5, &v_538), _fx_catch_201);
+                                 }
+                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_538, &v_539, 0), _fx_catch_201);
+                                 FX_THROW(&v_539, false, _fx_catch_201);
+                              }
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_540), _fx_catch_201);
+                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_541);
+                              FX_CALL(
+                                 _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
+                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_540, &v_541, &new_e1_14), _fx_catch_201);
+
+                           _fx_catch_201: ;
+                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_541);
+                              if (v_540) {
+                                 _fx_free_LN10Ast__exp_t(&v_540);
+                              }
+                              fx_free_exn(&v_539);
+                              FX_FREE_STR(&v_538);
+                              FX_FREE_STR(&v_537);
+                              FX_FREE_STR(&v_536);
+                              FX_FREE_STR(&v_535);
+                              FX_FREE_STR(&v_534);
+                              if (dvar_ifaces_0) {
+                                 _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dvar_ifaces_0);
+                              }
+                              _fx_free_R19Ast__definterface_t(&v_533);
+                              _fx_free_R17Ast__defvariant_t(&v_532);
+                              goto _fx_endmatch_38;
+                           }
+                        }
+                        if (v_525.tag == 6) {
+                           if (v_524.tag == 7) {
+                              _fx_R19Ast__definterface_t v_543 = {0};
+                              _fx_R17Ast__defvariant_t v_544 = {0};
+                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t dvar_ifaces_1 = 0;
+                              fx_str_t v_545 = {0};
+                              fx_str_t v_546 = {0};
+                              fx_str_t v_547 = {0};
+                              fx_str_t v_548 = {0};
+                              fx_str_t v_549 = {0};
+                              fx_str_t v_550 = {0};
+                              fx_str_t v_551 = {0};
+                              fx_exn_t v_552 = {0};
+                              _fx_LN10Ast__exp_t v_553 = 0;
+                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_554 = {0};
+                              _fx_copy_R19Ast__definterface_t(&v_524.u.IdInterface->data, &v_543);
+                              _fx_R9Ast__id_t* di_name_1 = &v_543.di_name;
+                              _fx_copy_R17Ast__defvariant_t(&v_525.u.IdVariant->data, &v_544);
+                              bool __fold_result___2 = false;
+                              FX_COPY_PTR(v_544.dvar_ifaces, &dvar_ifaces_1);
+                              _fx_LT2R9Ast__id_tLTa2R9Ast__id_t lst_25 = dvar_ifaces_1;
+                              for (; lst_25; lst_25 = lst_25->tl) {
+                                 _fx_T2R9Ast__id_tLTa2R9Ast__id_t* __pat___8 = &lst_25->hd;
+                                 _fx_R9Ast__id_t i_3 = __pat___8->t0;
+                                 bool v_555;
+                                 FX_CALL(
+                                    _fx_M3AstFM14same_or_parentB3RM4id_tRM4id_tRM5loc_t(&i_3, di_name_1, &eloc_0, &v_555, 0),
+                                    _fx_catch_202);
+                                 if (v_555) {
+                                    __fold_result___2 = true; FX_BREAK(_fx_catch_202);
+                                 }
+
+                              _fx_catch_202: ;
+                                 FX_CHECK_BREAK();
+                                 FX_CHECK_EXN(_fx_catch_203);
+                              }
+                              if (!__fold_result___2) {
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_545, 0), _fx_catch_203);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_545, &v_546, 0), _fx_catch_203);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(tn1_0, &v_547, 0), _fx_catch_203);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_547, &v_548, 0), _fx_catch_203);
+                                 FX_CALL(_fx_M3AstFM2ppS1RM4id_t(di_name_1, &v_549, 0), _fx_catch_203);
+                                 FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_549, &v_550, 0), _fx_catch_203);
+                                 fx_str_t slit_228 = FX_MAKE_STR("interface \'");
+                                 fx_str_t slit_229 = FX_MAKE_STR("\' is casted to variant/record type \'");
+                                 fx_str_t slit_230 = FX_MAKE_STR("\', but the type does not implement neither \'");
+                                 fx_str_t slit_231 = FX_MAKE_STR("\' nor anything derived from it");
+                                 {
+                                    const fx_str_t strs_30[] = { slit_228, v_546, slit_229, v_548, slit_230, v_550, slit_231 };
+                                    FX_CALL(fx_strjoin(0, 0, 0, strs_30, 7, &v_551), _fx_catch_203);
+                                 }
+                                 FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_551, &v_552, 0), _fx_catch_203);
+                                 FX_THROW(&v_552, false, _fx_catch_203);
+                              }
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_553), _fx_catch_203);
+                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_554);
+                              FX_CALL(
+                                 _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
+                                    &_fx_g30Ast_typecheck__IntrinGetObject, v_553, &v_554, &new_e1_14), _fx_catch_203);
+
+                           _fx_catch_203: ;
+                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_554);
+                              if (v_553) {
+                                 _fx_free_LN10Ast__exp_t(&v_553);
+                              }
+                              fx_free_exn(&v_552);
+                              FX_FREE_STR(&v_551);
+                              FX_FREE_STR(&v_550);
+                              FX_FREE_STR(&v_549);
+                              FX_FREE_STR(&v_548);
+                              FX_FREE_STR(&v_547);
+                              FX_FREE_STR(&v_546);
+                              FX_FREE_STR(&v_545);
                               if (dvar_ifaces_1) {
                                  _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dvar_ifaces_1);
                               }
-                              _fx_free_R17Ast__defvariant_t(&v_526);
-                              _fx_free_R19Ast__definterface_t(&v_525);
-                              goto _fx_endmatch_36;
+                              _fx_free_R17Ast__defvariant_t(&v_544);
+                              _fx_free_R19Ast__definterface_t(&v_543);
+                              goto _fx_endmatch_38;
                            }
                         }
-                        if (v_506.tag == 7) {
-                           if (v_507.tag == 7) {
-                              _fx_LN10Ast__exp_t v_538 = 0;
-                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_539 = {0};
-                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_538), _fx_catch_200);
-                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_539);
+                        if (v_524.tag == 7) {
+                           if (v_525.tag == 7) {
+                              _fx_LN10Ast__exp_t v_556 = 0;
+                              _fx_T2N10Ast__typ_tR10Ast__loc_t v_557 = {0};
+                              FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_556), _fx_catch_204);
+                              _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_0, &eloc_0, &v_557);
                               FX_CALL(
                                  _fx_M3AstFM9ExpIntrinN10Ast__exp_t3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_538, &v_539, &new_e1_14), _fx_catch_200);
+                                    &_fx_g31Ast_typecheck__IntrinQueryIface, v_556, &v_557, &new_e1_14), _fx_catch_204);
 
-                           _fx_catch_200: ;
-                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_539);
-                              if (v_538) {
-                                 _fx_free_LN10Ast__exp_t(&v_538);
+                           _fx_catch_204: ;
+                              _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_557);
+                              if (v_556) {
+                                 _fx_free_LN10Ast__exp_t(&v_556);
                               }
-                              goto _fx_endmatch_36;
+                              goto _fx_endmatch_38;
                            }
                         }
-                        FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_201);
+                        FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_205);
 
-                     _fx_endmatch_36: ;
-                        FX_CHECK_EXN(_fx_catch_201);
+                     _fx_endmatch_38: ;
+                        FX_CHECK_EXN(_fx_catch_205);
                      }
-                     fx_str_t slit_225 =
+                     fx_str_t slit_232 =
                         FX_MAKE_STR("the output type of cast operation \'{t2}\' does not match the expected type \'{etyp}\'");
                      FX_CALL(
-                        _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t2_0, etyp_0, &eloc_0, &slit_225,
-                           0), _fx_catch_201);
+                        _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t2_0, etyp_0, &eloc_0, &slit_232,
+                           0), _fx_catch_205);
                      _fx_free_N10Ast__exp_t(&result_0);
                      FX_COPY_PTR(new_e1_14, &result_0);
-                     FX_BREAK(_fx_catch_201);
+                     FX_BREAK(_fx_catch_205);
 
-                  _fx_catch_201: ;
-                     _fx_free_N14Ast__id_info_t(&v_507);
-                     _fx_free_N14Ast__id_info_t(&v_506);
+                  _fx_catch_205: ;
+                     _fx_free_N14Ast__id_info_t(&v_525);
+                     _fx_free_N14Ast__id_info_t(&v_524);
                      if (new_e1_14) {
                         _fx_free_N10Ast__exp_t(&new_e1_14);
                      }
-                     goto _fx_endmatch_38;
+                     goto _fx_endmatch_40;
                   }
                }
             }
          }
-         _fx_N10Ast__typ_t v_540 = 0;
-         _fx_N10Ast__typ_t v_541 = 0;
-         fx_str_t v_542 = {0};
-         fx_str_t v_543 = {0};
-         fx_str_t v_544 = {0};
-         fx_str_t v_545 = {0};
-         fx_str_t v_546 = {0};
-         fx_exn_t v_547 = {0};
-         _fx_N10Ast__exp_t result_54 = 0;
+         _fx_N10Ast__typ_t v_558 = 0;
+         _fx_N10Ast__typ_t v_559 = 0;
+         fx_str_t v_560 = {0};
+         fx_str_t v_561 = {0};
+         fx_str_t v_562 = {0};
+         fx_str_t v_563 = {0};
+         fx_str_t v_564 = {0};
+         fx_exn_t v_565 = {0};
+         _fx_N10Ast__exp_t result_56 = 0;
          fx_exn_t exn_5 = {0};
-         bool v_548;
-         FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t1_0, &v_548, 0), _fx_catch_207);
-         bool v_549;
+         bool v_566;
+         FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t1_0, &v_566, 0), _fx_catch_211);
+         bool v_567;
          bool t_19;
-         if (!v_548) {
-            bool v_550; FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t2_0, &v_550, 0), _fx_catch_207); t_19 = !v_550;
+         if (!v_566) {
+            bool v_568; FX_CALL(_fx_M3AstFM13is_typ_scalarB1N10Ast__typ_t(t2_0, &v_568, 0), _fx_catch_211); t_19 = !v_568;
          }
          else {
             t_19 = false;
          }
          if (t_19) {
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_540, 0), _fx_catch_207);
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_541, 0), _fx_catch_207);
-            if (FX_REC_VARIANT_TAG(v_540) == 19) {
-               if (FX_REC_VARIANT_TAG(v_541) == 19) {
-                  v_549 = false; goto _fx_endmatch_37;
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t1_0, &v_558, 0), _fx_catch_211);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t2_0, &v_559, 0), _fx_catch_211);
+            if (FX_REC_VARIANT_TAG(v_558) == 19) {
+               if (FX_REC_VARIANT_TAG(v_559) == 19) {
+                  v_567 = false; goto _fx_endmatch_39;
                }
             }
-            v_549 = true;
+            v_567 = true;
 
-         _fx_endmatch_37: ;
-            FX_CHECK_EXN(_fx_catch_207);
+         _fx_endmatch_39: ;
+            FX_CHECK_EXN(_fx_catch_211);
          }
          else {
-            v_549 = false;
+            v_567 = false;
          }
-         if (v_549) {
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_542, 0), _fx_catch_207);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_542, &v_543, 0), _fx_catch_207);
-            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_544, 0), _fx_catch_207);
-            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_544, &v_545, 0), _fx_catch_207);
-            fx_str_t slit_226 = FX_MAKE_STR("invalid cast operation: \'");
-            fx_str_t slit_227 = FX_MAKE_STR("\' to \'");
-            fx_str_t slit_228 = FX_MAKE_STR("\'");
+         if (v_567) {
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_560, 0), _fx_catch_211);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_560, &v_561, 0), _fx_catch_211);
+            FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_562, 0), _fx_catch_211);
+            FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_562, &v_563, 0), _fx_catch_211);
+            fx_str_t slit_233 = FX_MAKE_STR("invalid cast operation: \'");
+            fx_str_t slit_234 = FX_MAKE_STR("\' to \'");
+            fx_str_t slit_235 = FX_MAKE_STR("\'");
             {
-               const fx_str_t strs_31[] = { slit_226, v_543, slit_227, v_545, slit_228 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_31, 5, &v_546), _fx_catch_207);
+               const fx_str_t strs_31[] = { slit_233, v_561, slit_234, v_563, slit_235 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_31, 5, &v_564), _fx_catch_211);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_546, &v_547, 0), _fx_catch_207);
-            FX_THROW(&v_547, false, _fx_catch_207);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_564, &v_565, 0), _fx_catch_211);
+            FX_THROW(&v_565, false, _fx_catch_211);
          }
          _fx_N10Ast__exp_t e2_4 = 0;
          _fx_N10Ast__typ_t t2_1 = 0;
          FX_CALL(
             _fx_M13Ast_typecheckFM9make_castN10Ast__exp_t4N10Ast__exp_tN10Ast__typ_tN10Ast__typ_tR10Ast__loc_t(e1_9, t1_0, t2_0,
-               &eloc_0, &e2_4, 0), _fx_catch_203);
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e2_4, &t2_1, 0), _fx_catch_203);
-         fx_str_t slit_229 = FX_MAKE_STR("unexpected type of cast operation");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t2_1, &eloc_0, &slit_229, 0),
-            _fx_catch_203);
+               &eloc_0, &e2_4, 0), _fx_catch_207);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e2_4, &t2_1, 0), _fx_catch_207);
+         fx_str_t slit_236 = FX_MAKE_STR("unexpected type of cast operation");
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t2_1, &eloc_0, &slit_236, 0),
+            _fx_catch_207);
          if (code_1 != 0) {
-            _fx_LN10Ast__exp_t v_551 = 0;
-            _fx_LN10Ast__exp_t v_552 = 0;
-            _fx_T2N10Ast__typ_tR10Ast__loc_t v_553 = {0};
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e2_4, 0, true, &v_551), _fx_catch_202);
-            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(code_1, v_551, &v_552, 0),
-               _fx_catch_202);
-            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_1, &eloc_0, &v_553);
-            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_552, &v_553, &result_54),
-               _fx_catch_202);
+            _fx_LN10Ast__exp_t v_569 = 0;
+            _fx_LN10Ast__exp_t v_570 = 0;
+            _fx_T2N10Ast__typ_tR10Ast__loc_t v_571 = {0};
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e2_4, 0, true, &v_569), _fx_catch_206);
+            FX_CALL(_fx_M13Ast_typecheckFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(code_1, v_569, &v_570, 0),
+               _fx_catch_206);
+            _fx_make_T2N10Ast__typ_tR10Ast__loc_t(t2_1, &eloc_0, &v_571);
+            FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_570, &v_571, &result_56),
+               _fx_catch_206);
 
-         _fx_catch_202: ;
-            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_553);
-            if (v_552) {
-               _fx_free_LN10Ast__exp_t(&v_552);
+         _fx_catch_206: ;
+            _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_571);
+            if (v_570) {
+               _fx_free_LN10Ast__exp_t(&v_570);
             }
-            if (v_551) {
-               _fx_free_LN10Ast__exp_t(&v_551);
+            if (v_569) {
+               _fx_free_LN10Ast__exp_t(&v_569);
             }
          }
          else {
-            FX_COPY_PTR(e2_4, &result_54);
+            FX_COPY_PTR(e2_4, &result_56);
          }
-         FX_CHECK_EXN(_fx_catch_203);
+         FX_CHECK_EXN(_fx_catch_207);
 
-      _fx_catch_203: ;
+      _fx_catch_207: ;
          if (e2_4) {
             _fx_free_N10Ast__exp_t(&e2_4);
          }
@@ -28264,103 +28432,103 @@ FX_EXTERN_C int
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_5);
             fx_status = 0;
-            if (result_54) {
-               _fx_free_N10Ast__exp_t(&result_54);
+            if (result_56) {
+               _fx_free_N10Ast__exp_t(&result_56);
             }
             if (exn_5.tag == _FX_EXN_E17Ast__CompileError) {
                fx_exn_t exn_6 = {0};
-               _fx_LN10Ast__exp_t v_554 = 0;
+               _fx_LN10Ast__exp_t v_572 = 0;
                _fx_R9Ast__id_t fname_0;
-               FX_CALL(_fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(t2_0, &eloc_0, &fname_0, 0), _fx_catch_204);
-               FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_554), _fx_catch_204);
+               FX_CALL(_fx_M3AstFM14get_cast_fnameRM4id_t2N10Ast__typ_tRM5loc_t(t2_0, &eloc_0, &fname_0, 0), _fx_catch_208);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(e1_9, 0, true, &v_572), _fx_catch_208);
                FX_CALL(
                   _fx_M13Ast_typecheckFM19check_and_make_callN10Ast__exp_t7R9Ast__id_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_tR10Ast__loc_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tN10Ast__typ_tLN12Ast__scope_t(
-                     &fname_0, v_554, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &result_54, 0), _fx_catch_204);
+                     &fname_0, v_572, &ctx_0, &eloc_0, &env_2, etyp_0, sc_2, &result_56, 0), _fx_catch_208);
 
-            _fx_catch_204: ;
-               if (v_554) {
-                  _fx_free_LN10Ast__exp_t(&v_554);
+            _fx_catch_208: ;
+               if (v_572) {
+                  _fx_free_LN10Ast__exp_t(&v_572);
                }
                if (fx_status < 0) {
                   fx_exn_get_and_reset(fx_status, &exn_6);
                   fx_status = 0;
-                  if (result_54) {
-                     _fx_free_N10Ast__exp_t(&result_54);
+                  if (result_56) {
+                     _fx_free_N10Ast__exp_t(&result_56);
                   }
                   if (exn_6.tag == _FX_EXN_E17Ast__CompileError) {
-                     fx_str_t v_555 = {0};
-                     fx_str_t v_556 = {0};
-                     fx_str_t v_557 = {0};
-                     fx_str_t v_558 = {0};
-                     fx_str_t v_559 = {0};
-                     fx_exn_t v_560 = {0};
-                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_555, 0), _fx_catch_205);
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_555, &v_556, 0), _fx_catch_205);
-                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_557, 0), _fx_catch_205);
-                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_557, &v_558, 0), _fx_catch_205);
-                     fx_str_t slit_230 = FX_MAKE_STR("invalid cast operation: \'");
-                     fx_str_t slit_231 = FX_MAKE_STR("\' to \'");
-                     fx_str_t slit_232 = FX_MAKE_STR("\'");
+                     fx_str_t v_573 = {0};
+                     fx_str_t v_574 = {0};
+                     fx_str_t v_575 = {0};
+                     fx_str_t v_576 = {0};
+                     fx_str_t v_577 = {0};
+                     fx_exn_t v_578 = {0};
+                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t1_0, &v_573, 0), _fx_catch_209);
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_573, &v_574, 0), _fx_catch_209);
+                     FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t2_0, &v_575, 0), _fx_catch_209);
+                     FX_CALL(_fx_M13Ast_typecheckFM6stringS1S(&v_575, &v_576, 0), _fx_catch_209);
+                     fx_str_t slit_237 = FX_MAKE_STR("invalid cast operation: \'");
+                     fx_str_t slit_238 = FX_MAKE_STR("\' to \'");
+                     fx_str_t slit_239 = FX_MAKE_STR("\'");
                      {
-                        const fx_str_t strs_32[] = { slit_230, v_556, slit_231, v_558, slit_232 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_559), _fx_catch_205);
+                        const fx_str_t strs_32[] = { slit_237, v_574, slit_238, v_576, slit_239 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_577), _fx_catch_209);
                      }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_559, &v_560, 0), _fx_catch_205);
-                     FX_THROW(&v_560, false, _fx_catch_205);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_577, &v_578, 0), _fx_catch_209);
+                     FX_THROW(&v_578, false, _fx_catch_209);
 
-                  _fx_catch_205: ;
-                     fx_free_exn(&v_560);
-                     FX_FREE_STR(&v_559);
-                     FX_FREE_STR(&v_558);
-                     FX_FREE_STR(&v_557);
-                     FX_FREE_STR(&v_556);
-                     FX_FREE_STR(&v_555);
+                  _fx_catch_209: ;
+                     fx_free_exn(&v_578);
+                     FX_FREE_STR(&v_577);
+                     FX_FREE_STR(&v_576);
+                     FX_FREE_STR(&v_575);
+                     FX_FREE_STR(&v_574);
+                     FX_FREE_STR(&v_573);
                   }
                   else {
-                     FX_RETHROW(&exn_6, _fx_catch_206);
+                     FX_RETHROW(&exn_6, _fx_catch_210);
                   }
-                  FX_CHECK_EXN(_fx_catch_206);
+                  FX_CHECK_EXN(_fx_catch_210);
                }
 
-            _fx_catch_206: ;
+            _fx_catch_210: ;
                fx_free_exn(&exn_6);
             }
             else {
-               FX_RETHROW(&exn_5, _fx_catch_207);
+               FX_RETHROW(&exn_5, _fx_catch_211);
             }
-            FX_CHECK_EXN(_fx_catch_207);
+            FX_CHECK_EXN(_fx_catch_211);
          }
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_54, &result_0);
-         FX_BREAK(_fx_catch_207);
+         FX_COPY_PTR(result_56, &result_0);
+         FX_BREAK(_fx_catch_211);
 
-      _fx_catch_207: ;
+      _fx_catch_211: ;
          fx_free_exn(&exn_5);
-         if (result_54) {
-            _fx_free_N10Ast__exp_t(&result_54);
+         if (result_56) {
+            _fx_free_N10Ast__exp_t(&result_56);
          }
-         fx_free_exn(&v_547);
-         FX_FREE_STR(&v_546);
-         FX_FREE_STR(&v_545);
-         FX_FREE_STR(&v_544);
-         FX_FREE_STR(&v_543);
-         FX_FREE_STR(&v_542);
-         if (v_541) {
-            _fx_free_N10Ast__typ_t(&v_541);
+         fx_free_exn(&v_565);
+         FX_FREE_STR(&v_564);
+         FX_FREE_STR(&v_563);
+         FX_FREE_STR(&v_562);
+         FX_FREE_STR(&v_561);
+         FX_FREE_STR(&v_560);
+         if (v_559) {
+            _fx_free_N10Ast__typ_t(&v_559);
          }
-         if (v_540) {
-            _fx_free_N10Ast__typ_t(&v_540);
+         if (v_558) {
+            _fx_free_N10Ast__typ_t(&v_558);
          }
 
-      _fx_endmatch_38: ;
-         FX_CHECK_EXN(_fx_catch_208);
+      _fx_endmatch_40: ;
+         FX_CHECK_EXN(_fx_catch_212);
 
-      _fx_catch_208: ;
-         if (v_499) {
-            _fx_free_N10Ast__typ_t(&v_499);
+      _fx_catch_212: ;
+         if (v_517) {
+            _fx_free_N10Ast__typ_t(&v_517);
          }
-         if (v_498) {
-            _fx_free_N10Ast__typ_t(&v_498);
+         if (v_516) {
+            _fx_free_N10Ast__typ_t(&v_516);
          }
          if (code_1) {
             _fx_free_LN10Ast__exp_t(&code_1);
@@ -28368,12 +28536,12 @@ FX_EXTERN_C int
          if (e1_9) {
             _fx_free_N10Ast__exp_t(&e1_9);
          }
-         _fx_free_T2N10Ast__exp_tLN10Ast__exp_t(&v_497);
-         if (v_496) {
-            _fx_free_N10Ast__typ_t(&v_496);
+         _fx_free_T2N10Ast__exp_tLN10Ast__exp_t(&v_515);
+         if (v_514) {
+            _fx_free_N10Ast__typ_t(&v_514);
          }
-         if (v_495) {
-            _fx_free_N10Ast__typ_t(&v_495);
+         if (v_513) {
+            _fx_free_N10Ast__typ_t(&v_513);
          }
          if (t1_0) {
             _fx_free_N10Ast__typ_t(&t1_0);
@@ -28384,43 +28552,43 @@ FX_EXTERN_C int
          if (t2_0) {
             _fx_free_N10Ast__typ_t(&t2_0);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 31) {
          _fx_N10Ast__typ_t new_t1_0 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_561 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_579 = {0};
          _fx_N10Ast__typ_t e1typ_1 = 0;
          _fx_N10Ast__exp_t new_e1_15 = 0;
-         _fx_N10Ast__exp_t result_55 = 0;
+         _fx_N10Ast__exp_t result_57 = 0;
          _fx_T3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tR10Ast__loc_t* vcase_38 = &e_2->u.ExpTyped;
          _fx_N10Ast__exp_t e1_10 = vcase_38->t0;
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-               vcase_38->t1, &env_2, sc_2, &eloc_0, &new_t1_0, 0), _fx_catch_209);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_10, &v_561, 0), _fx_catch_209);
-         FX_COPY_PTR(v_561.t0, &e1typ_1);
-         _fx_R10Ast__loc_t e1loc_1 = v_561.t1;
-         fx_str_t slit_233 = FX_MAKE_STR("improper explicit type of the expression");
+               vcase_38->t1, &env_2, sc_2, &eloc_0, &new_t1_0, 0), _fx_catch_213);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e1_10, &v_579, 0), _fx_catch_213);
+         FX_COPY_PTR(v_579.t0, &e1typ_1);
+         _fx_R10Ast__loc_t e1loc_1 = v_579.t1;
+         fx_str_t slit_240 = FX_MAKE_STR("improper explicit type of the expression");
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, new_t1_0, &eloc_0, &slit_233, 0),
-            _fx_catch_209);
-         fx_str_t slit_234 = FX_MAKE_STR("improper explicit type of the expression");
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, new_t1_0, &eloc_0, &slit_240, 0),
+            _fx_catch_213);
+         fx_str_t slit_241 = FX_MAKE_STR("improper explicit type of the expression");
          FX_CALL(
-            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(e1typ_1, new_t1_0, &e1loc_1, &slit_234, 0),
-            _fx_catch_209);
+            _fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(e1typ_1, new_t1_0, &e1loc_1, &slit_241, 0),
+            _fx_catch_213);
          FX_CALL(
             _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-               e1_10, &env_2, sc_2, &new_e1_15, 0), _fx_catch_209);
+               e1_10, &env_2, sc_2, &new_e1_15, 0), _fx_catch_213);
          FX_CALL(
             _fx_M3AstFM8ExpTypedN10Ast__exp_t3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tRM5loc_t(new_e1_15, new_t1_0, &ctx_0,
-               &result_55), _fx_catch_209);
+               &result_57), _fx_catch_213);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_55, &result_0);
-         FX_BREAK(_fx_catch_209);
+         FX_COPY_PTR(result_57, &result_0);
+         FX_BREAK(_fx_catch_213);
 
-      _fx_catch_209: ;
-         if (result_55) {
-            _fx_free_N10Ast__exp_t(&result_55);
+      _fx_catch_213: ;
+         if (result_57) {
+            _fx_free_N10Ast__exp_t(&result_57);
          }
          if (new_e1_15) {
             _fx_free_N10Ast__exp_t(&new_e1_15);
@@ -28428,124 +28596,124 @@ FX_EXTERN_C int
          if (e1typ_1) {
             _fx_free_N10Ast__typ_t(&e1typ_1);
          }
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_561);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_579);
          if (new_t1_0) {
             _fx_free_N10Ast__typ_t(&new_t1_0);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 32) {
          if (sc_2 != 0) {
             if (sc_2->hd.tag == 10) {
                _fx_free_N10Ast__exp_t(&result_0);
                FX_COPY_PTR(e_2, &result_0);
-               FX_BREAK(_fx_catch_210);
+               FX_BREAK(_fx_catch_214);
 
-            _fx_catch_210: ;
-               goto _fx_endmatch_39;
+            _fx_catch_214: ;
+               goto _fx_endmatch_41;
             }
          }
          fx_str_t str_0 = {0};
          fx_str_t str_1 = {0};
-         _fx_N10Ast__exp_t result_56 = 0;
-         FX_CALL(_fx_M6StringFM5stripS1S(&e_2->u.ExpCCode.t0, &str_0, 0), _fx_catch_211);
-         bool v_562;
+         _fx_N10Ast__exp_t result_58 = 0;
+         FX_CALL(_fx_M6StringFM5stripS1S(&e_2->u.ExpCCode.t0, &str_0, 0), _fx_catch_215);
+         bool v_580;
          if (_fx_M6StringFM8endswithB2SC(&str_0, (char_)125, 0)) {
-            v_562 = true;
+            v_580 = true;
          }
          else {
-            v_562 = _fx_M6StringFM8endswithB2SC(&str_0, (char_)59, 0);
+            v_580 = _fx_M6StringFM8endswithB2SC(&str_0, (char_)59, 0);
          }
-         if (v_562) {
+         if (v_580) {
             fx_copy_str(&str_0, &str_1);
          }
          else {
             const fx_str_t strs_33[] = { str_0, FX_MAKE_STR1(";") };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &str_1), _fx_catch_211);
+            FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &str_1), _fx_catch_215);
          }
-         FX_CALL(_fx_M3AstFM8ExpCCodeN10Ast__exp_t2ST2N10Ast__typ_tRM5loc_t(&str_1, &ctx_0, &result_56), _fx_catch_211);
+         FX_CALL(_fx_M3AstFM8ExpCCodeN10Ast__exp_t2ST2N10Ast__typ_tRM5loc_t(&str_1, &ctx_0, &result_58), _fx_catch_215);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_56, &result_0);
-         FX_BREAK(_fx_catch_211);
+         FX_COPY_PTR(result_58, &result_0);
+         FX_BREAK(_fx_catch_215);
 
-      _fx_catch_211: ;
-         if (result_56) {
-            _fx_free_N10Ast__exp_t(&result_56);
+      _fx_catch_215: ;
+         if (result_58) {
+            _fx_free_N10Ast__exp_t(&result_58);
          }
          FX_FREE_STR(&str_1);
          FX_FREE_STR(&str_0);
 
-      _fx_endmatch_39: ;
-         FX_CHECK_EXN(_fx_catch_212);
+      _fx_endmatch_41: ;
+         FX_CHECK_EXN(_fx_catch_216);
 
-      _fx_catch_212: ;
-         goto _fx_endmatch_41;
+      _fx_catch_216: ;
+         goto _fx_endmatch_43;
       }
       if (tag_0 == 33) {
          _fx_N10Ast__typ_t t_20 = 0;
-         _fx_N10Ast__typ_t v_563 = 0;
-         _fx_Nt6option1N10Ast__typ_t v_564 = 0;
-         _fx_N10Ast__exp_t result_57 = 0;
+         _fx_N10Ast__typ_t v_581 = 0;
+         _fx_Nt6option1N10Ast__typ_t v_582 = 0;
+         _fx_N10Ast__exp_t result_59 = 0;
          _fx_T3SST2N10Ast__typ_tR10Ast__loc_t* vcase_39 = &e_2->u.ExpData;
          fx_str_t* kind_0 = &vcase_39->t0;
-         bool v_565;
-         fx_str_t slit_235 = FX_MAKE_STR("text");
-         v_565 = _fx_F6__eq__B2SS(kind_0, &slit_235, 0);
-         if (v_565) {
+         bool v_583;
+         fx_str_t slit_242 = FX_MAKE_STR("text");
+         v_583 = _fx_F6__eq__B2SS(kind_0, &slit_242, 0);
+         if (v_583) {
             FX_COPY_PTR(_fx_g24Ast_typecheck__TypString, &t_20);
          }
          else {
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_563, 0), _fx_catch_215);
-            if (FX_REC_VARIANT_TAG(v_563) == 1) {
-               FX_COPY_PTR(v_563->u.TypVar->data, &v_564);
-               if ((v_564 != 0) + 1 == 1) {
-                  _fx_N10Ast__typ_t v_566 = 0;
-                  FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_566), _fx_catch_213);
-                  FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_566, &t_20), _fx_catch_213);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_581, 0), _fx_catch_219);
+            if (FX_REC_VARIANT_TAG(v_581) == 1) {
+               FX_COPY_PTR(v_581->u.TypVar->data, &v_582);
+               if ((v_582 != 0) + 1 == 1) {
+                  _fx_N10Ast__typ_t v_584 = 0;
+                  FX_CALL(_fx_M3AstFM7TypUIntN10Ast__typ_t1i(8, &v_584), _fx_catch_217);
+                  FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_584, &t_20), _fx_catch_217);
 
-               _fx_catch_213: ;
-                  if (v_566) {
-                     _fx_free_N10Ast__typ_t(&v_566);
+               _fx_catch_217: ;
+                  if (v_584) {
+                     _fx_free_N10Ast__typ_t(&v_584);
                   }
-                  goto _fx_endmatch_40;
+                  goto _fx_endmatch_42;
                }
             }
-            _fx_N10Ast__typ_t v_567 = 0;
-            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_567, 0), _fx_catch_214);
-            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_567, &t_20), _fx_catch_214);
+            _fx_N10Ast__typ_t v_585 = 0;
+            FX_CALL(_fx_M3AstFM12make_new_typN10Ast__typ_t0(&v_585, 0), _fx_catch_218);
+            FX_CALL(_fx_M3AstFM8TypArrayN10Ast__typ_t2iN10Ast__typ_t(1, v_585, &t_20), _fx_catch_218);
 
-         _fx_catch_214: ;
-            if (v_567) {
-               _fx_free_N10Ast__typ_t(&v_567);
+         _fx_catch_218: ;
+            if (v_585) {
+               _fx_free_N10Ast__typ_t(&v_585);
             }
 
-         _fx_endmatch_40: ;
-            FX_CHECK_EXN(_fx_catch_215);
+         _fx_endmatch_42: ;
+            FX_CHECK_EXN(_fx_catch_219);
          }
-         fx_str_t slit_236 =
+         fx_str_t slit_243 =
             FX_MAKE_STR("the output type of @data/@text \'{typ2str(t)}\' does not match the expected one \'{typ2str(etyp)}\'");
-         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t_20, &eloc_0, &slit_236, 0),
-            _fx_catch_215);
-         FX_CALL(_fx_M3AstFM7ExpDataN10Ast__exp_t3SST2N10Ast__typ_tRM5loc_t(kind_0, &vcase_39->t1, &ctx_0, &result_57),
-            _fx_catch_215);
+         FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(etyp_0, t_20, &eloc_0, &slit_243, 0),
+            _fx_catch_219);
+         FX_CALL(_fx_M3AstFM7ExpDataN10Ast__exp_t3SST2N10Ast__typ_tRM5loc_t(kind_0, &vcase_39->t1, &ctx_0, &result_59),
+            _fx_catch_219);
          _fx_free_N10Ast__exp_t(&result_0);
-         FX_COPY_PTR(result_57, &result_0);
-         FX_BREAK(_fx_catch_215);
+         FX_COPY_PTR(result_59, &result_0);
+         FX_BREAK(_fx_catch_219);
 
-      _fx_catch_215: ;
-         if (result_57) {
-            _fx_free_N10Ast__exp_t(&result_57);
+      _fx_catch_219: ;
+         if (result_59) {
+            _fx_free_N10Ast__exp_t(&result_59);
          }
-         if (v_564) {
-            _fx_free_Nt6option1N10Ast__typ_t(&v_564);
+         if (v_582) {
+            _fx_free_Nt6option1N10Ast__typ_t(&v_582);
          }
-         if (v_563) {
-            _fx_free_N10Ast__typ_t(&v_563);
+         if (v_581) {
+            _fx_free_N10Ast__typ_t(&v_581);
          }
          if (t_20) {
             _fx_free_N10Ast__typ_t(&t_20);
          }
-         goto _fx_endmatch_41;
+         goto _fx_endmatch_43;
       }
       bool res_41;
       if (tag_0 == 34) {
@@ -28578,24 +28746,24 @@ FX_EXTERN_C int
       else {
          res_41 = false;
       }
-      FX_CHECK_EXN(_fx_catch_217);
+      FX_CHECK_EXN(_fx_catch_221);
       if (res_41) {
-         fx_exn_t v_568 = {0};
-         fx_str_t slit_237 =
+         fx_exn_t v_586 = {0};
+         fx_str_t slit_244 =
             FX_MAKE_STR("internal err: should not get here; all the declarations and directives must be handled in check_eseq");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_237, &v_568, 0), _fx_catch_216);
-         FX_THROW(&v_568, false, _fx_catch_216);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_244, &v_586, 0), _fx_catch_220);
+         FX_THROW(&v_586, false, _fx_catch_220);
 
-      _fx_catch_216: ;
-         fx_free_exn(&v_568);
-         goto _fx_endmatch_41;
+      _fx_catch_220: ;
+         fx_free_exn(&v_586);
+         goto _fx_endmatch_43;
       }
-      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_217);
+      FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_221);
 
-   _fx_endmatch_41: ;
-      FX_CHECK_EXN(_fx_catch_217);
+   _fx_endmatch_43: ;
+      FX_CHECK_EXN(_fx_catch_221);
 
-   _fx_catch_217: ;
+   _fx_catch_221: ;
       if (etyp_0) {
          _fx_free_N10Ast__typ_t(&etyp_0);
       }

--- a/compiler/bootstrap/C_form.c
+++ b/compiler/bootstrap/C_form.c
@@ -142,263 +142,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_N12Map__color_t {
    int tag;
 } _fx_N12Map__color_t;
@@ -424,6 +167,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
          Node;
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -478,6 +261,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -559,6 +366,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -578,6 +409,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -774,6 +615,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -946,6 +925,27 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
 
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
+
 typedef struct _fx_Li_data_t {
    int_ rc;
    struct _fx_Li_data_t* tl;
@@ -1066,134 +1066,11 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -1459,6 +1336,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1504,6 +1483,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_R9Ast__id_t t0;
@@ -1692,172 +1692,6 @@ typedef struct _fx_FPN15C_form__cstmt_t1N15C_form__cstmt_t {
    fx_fcv_t* fcv;
 } _fx_FPN15C_form__cstmt_t1N15C_form__cstmt_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
-
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
-
-typedef struct _fx_T2N15C_form__cinfo_tB {
-   struct _fx_N15C_form__cinfo_t t0;
-   bool t1;
-} _fx_T2N15C_form__cinfo_tB;
-
-typedef struct _fx_T2N15K_form__kinfo_tB {
-   struct _fx_N15K_form__kinfo_t t0;
-   bool t1;
-} _fx_T2N15K_form__kinfo_tB;
-
-typedef struct _fx_T2N14Ast__id_info_tB {
-   struct _fx_N14Ast__id_info_t t0;
-   bool t1;
-} _fx_T2N14Ast__id_info_tB;
-
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
    struct _fx_R10Ast__loc_t t1;
@@ -1877,6 +1711,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -2079,6 +1927,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -2130,6 +2068,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_FPLN15C_form__cstmt_t2LN15C_form__cstmt_tR17C_form__c_callb_t {
    int (*fp)(
@@ -2215,561 +2200,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_LN16Ast__env_entry_t(struct _fx_LN16Ast__env_entry_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN16Ast__env_entry_t, _fx_free_N16Ast__env_entry_t);
@@ -2834,6 +2264,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
 }
 
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
@@ -2939,6 +2392,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3896,6 +3402,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4365,6 +4277,79 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_Li, FX_COPY_SIMPLE);
@@ -4644,150 +4629,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -4800,256 +4641,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -6068,6 +5659,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -6152,6 +6060,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(struct _fx_T2R9Ast__id_tN14C_form__ctyp_t* dst)
@@ -6462,165 +6447,21 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+   fx_free_str(&dst->t0);
 }
 
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
 {
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
+   fx_copy_str(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
 }
 
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
+static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
 {
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+   fx_copy_str(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
 }
 
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
@@ -6656,379 +6497,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2N15C_form__cinfo_tB(struct _fx_T2N15C_form__cinfo_tB* dst)
-{
-   _fx_free_N15C_form__cinfo_t(&dst->t0);
-}
-
-static void _fx_copy_T2N15C_form__cinfo_tB(struct _fx_T2N15C_form__cinfo_tB* src, struct _fx_T2N15C_form__cinfo_tB* dst)
-{
-   _fx_copy_N15C_form__cinfo_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N15C_form__cinfo_tB(
-   struct _fx_N15C_form__cinfo_t* t0,
-   bool t1,
-   struct _fx_T2N15C_form__cinfo_tB* fx_result)
-{
-   _fx_copy_N15C_form__cinfo_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
-}
-
-static void _fx_free_T2N15K_form__kinfo_tB(struct _fx_T2N15K_form__kinfo_tB* dst)
-{
-   _fx_free_N15K_form__kinfo_t(&dst->t0);
-}
-
-static void _fx_copy_T2N15K_form__kinfo_tB(struct _fx_T2N15K_form__kinfo_tB* src, struct _fx_T2N15K_form__kinfo_tB* dst)
-{
-   _fx_copy_N15K_form__kinfo_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N15K_form__kinfo_tB(
-   struct _fx_N15K_form__kinfo_t* t0,
-   bool t1,
-   struct _fx_T2N15K_form__kinfo_tB* fx_result)
-{
-   _fx_copy_N15K_form__kinfo_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
-}
-
-static void _fx_free_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_free_N14Ast__id_info_t(&dst->t0);
-}
-
-static void _fx_copy_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* src, struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_copy_N14Ast__id_info_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N14Ast__id_info_tB(struct _fx_N14Ast__id_info_t* t0, bool t1, struct _fx_T2N14Ast__id_info_tB* fx_result)
-{
-   _fx_copy_N14Ast__id_info_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
-}
-
-static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_free_str(&dst->t0);
-}
-
-static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_copy_str(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
-{
-   fx_copy_str(t0, &fx_result->t0);
-   fx_result->t1 = *t1;
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -7780,6 +7248,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -7894,6 +7656,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2SR9Ast__id_t(struct _fx_T2SR9Ast__id_t* dst)
@@ -8051,10 +7979,6 @@ _fx_R9Ast__id_t _fx_g25C_form__std_fx_free_iface;
 _fx_R9Ast__id_t _fx_g26C_form__std_fx_query_iface;
 _fx_R9Ast__id_t _fx_g25C_form__std_fx_get_object;
 _fx_R9Ast__id_t _fx_g25C_form__std_fx_make_iface;
-FX_EXTERN_C int _fx_F9make_FailE1S(fx_str_t*, fx_exn_t*);
-
-FX_EXTERN_C_VAL(fx_arr_t _fx_g16Ast__all_modules)
-FX_EXTERN_C_VAL(fx_arr_t _fx_g16K_form__all_idks)
 FX_EXTERN_C int _fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(
    struct _fx_R9Ast__id_t*,
    struct _fx_R10Ast__loc_t*,
@@ -8063,6 +7987,10 @@ FX_EXTERN_C int _fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(
 
 FX_EXTERN_C int _fx_M3AstFM13get_id_prefixi1S(fx_str_t*, int_*, void*);
 
+FX_EXTERN_C int _fx_F9make_FailE1S(fx_str_t*, fx_exn_t*);
+
+FX_EXTERN_C_VAL(fx_arr_t _fx_g16Ast__all_modules)
+FX_EXTERN_C_VAL(fx_arr_t _fx_g16K_form__all_idks)
 FX_EXTERN_C int _fx_M3AstFM6id2idxTa2i1RM4id_t(struct _fx_R9Ast__id_t*, struct _fx_Ta2i*, void*);
 
 FX_EXTERN_C_VAL(bool _fx_g15Ast__freeze_ids)
@@ -8442,42 +8370,6 @@ FX_EXTERN_C int _fx_M6C_formFM3mapLN15C_form__cstmt_t2LN15C_form__cstmt_tFPN15C_
 
 _fx_cleanup: ;
    return fx_status;
-}
-
-FX_EXTERN_C int _fx_M6C_formFM10push_back_v2VN15C_form__cinfo_tT2N15C_form__cinfo_tB(
-   fx_vec_t v,
-   struct _fx_T2N15C_form__cinfo_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
-}
-
-FX_EXTERN_C int _fx_M6C_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(
-   fx_vec_t v,
-   struct _fx_T2N15K_form__kinfo_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
-}
-
-FX_EXTERN_C int _fx_M6C_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(
-   fx_vec_t v,
-   struct _fx_T2N14Ast__id_info_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
 }
 
 FX_EXTERN_C void _fx_M6C_formFM6COpCmpN17C_form__cbinary_t1N12Ast__cmpop_t(
@@ -9103,67 +8995,6 @@ FX_EXTERN_C void _fx_M6C_formFM6CMacroN15C_form__cinfo_t1rRM11cdefmacro_t(
    FX_COPY_PTR(arg0, &fx_result->u.CMacro);
 }
 
-FX_EXTERN_C int _fx_M6C_formFM11new_idc_idxi1i(int_ m_idx_0, int_* fx_result, void* fx_fv)
-{
-   fx_exn_t v_0 = {0};
-   fx_vec_t v_1 = 0;
-   _fx_T2N14Ast__id_info_tB v_2 = {0};
-   fx_vec_t v_3 = 0;
-   _fx_T2N15K_form__kinfo_tB v_4 = {0};
-   fx_vec_t v_5 = 0;
-   _fx_T2N15C_form__cinfo_tB v_6 = {0};
-   fx_exn_t v_7 = {0};
-   int fx_status = 0;
-   if (_fx_g19C_form__freeze_idcs) {
-      fx_str_t slit_0 = FX_MAKE_STR("internal error: attempt to add new idc when they are frozen");
-      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_0), _fx_cleanup);
-      FX_THROW(&v_0, true, _fx_cleanup);
-   }
-   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_8 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   FX_COPY_PTR(v_8->u.defmodule_t.t9, &v_1);
-   _fx_make_T2N14Ast__id_info_tB(&_fx_g14C_form__IdNone, true, &v_2);
-   FX_CALL(_fx_M6C_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_1, &v_2, 0), _fx_cleanup);
-   int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
-   FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_cleanup);
-   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_3);
-   _fx_make_T2N15K_form__kinfo_tB(&_fx_g13C_form__KNone, true, &v_4);
-   FX_CALL(_fx_M6C_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(v_3, &v_4, 0), _fx_cleanup);
-   int_ new_kidx_0 = FX_VEC_SIZE(v_3) - 1;
-   FX_CHKIDX(FX_CHKIDX1(_fx_g16C_form__all_idcs, 0, m_idx_0), _fx_cleanup);
-   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16C_form__all_idcs, m_idx_0), &v_5);
-   _fx_make_T2N15C_form__cinfo_tB(&_fx_g13C_form__CNone, true, &v_6);
-   FX_CALL(_fx_M6C_formFM10push_back_v2VN15C_form__cinfo_tT2N15C_form__cinfo_tB(v_5, &v_6, 0), _fx_cleanup);
-   int_ new_cidx_0 = FX_VEC_SIZE(v_5) - 1;
-   bool t_0;
-   if (new_idx_0 == new_kidx_0) {
-      t_0 = new_idx_0 == new_cidx_0;
-   }
-   else {
-      t_0 = false;
-   }
-   if (t_0) {
-      *fx_result = new_idx_0;
-   }
-   else {
-      fx_str_t slit_1 =
-         FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx(), new_idk_idx() and new_idc_idx()");
-      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_7), _fx_cleanup);
-      FX_THROW(&v_7, true, _fx_cleanup);
-   }
-
-_fx_cleanup: ;
-   fx_free_exn(&v_0);
-   FX_FREE_VEC(&v_1);
-   _fx_free_T2N14Ast__id_info_tB(&v_2);
-   FX_FREE_VEC(&v_3);
-   _fx_free_T2N15K_form__kinfo_tB(&v_4);
-   FX_FREE_VEC(&v_5);
-   _fx_free_T2N15C_form__cinfo_tB(&v_6);
-   fx_free_exn(&v_7);
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t* i_0,
    struct _fx_R10Ast__loc_t* loc_0,
@@ -9190,15 +9021,58 @@ FX_EXTERN_C int _fx_M6C_formFM7gen_idcR9Ast__id_t2iS(
    struct _fx_R9Ast__id_t* fx_result,
    void* fx_fv)
 {
+   fx_exn_t v_0 = {0};
+   fx_vec_t v_1 = 0;
+   fx_vec_t v_2 = 0;
+   fx_vec_t v_3 = 0;
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
    int_ i_0;
    FX_CALL(_fx_M3AstFM13get_id_prefixi1S(s_0, &i_0, 0), _fx_cleanup);
+   if (_fx_g19C_form__freeze_idcs) {
+      fx_str_t slit_0 = FX_MAKE_STR("internal error: attempt to add new idc when they are frozen");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_0), _fx_cleanup);
+      FX_THROW(&v_0, true, _fx_cleanup);
+   }
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
+   _fx_N16Ast__defmodule_t v_5 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_5->u.defmodule_t.t9, &v_1);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g14C_form__IdNone, _fx_cleanup);
+   int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_cleanup);
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_2);
+   FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_2, _fx_g13C_form__KNone, _fx_cleanup);
+   int_ new_kidx_0 = FX_VEC_SIZE(v_2) - 1;
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16C_form__all_idcs, 0, m_idx_0), _fx_cleanup);
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16C_form__all_idcs, m_idx_0), &v_3);
+   FX_VEC_PUSH_BACK(_fx_N15C_form__cinfo_t, v_3, _fx_g13C_form__CNone, _fx_cleanup);
+   int_ new_cidx_0 = FX_VEC_SIZE(v_3) - 1;
+   bool t_0;
+   if (new_idx_0 == new_kidx_0) {
+      t_0 = new_idx_0 == new_cidx_0;
+   }
+   else {
+      t_0 = false;
+   }
    int_ j_0;
-   FX_CALL(_fx_M6C_formFM11new_idc_idxi1i(m_idx_0, &j_0, 0), _fx_cleanup);
+   if (t_0) {
+      j_0 = new_idx_0;
+   }
+   else {
+      fx_str_t slit_1 =
+         FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx(), new_idk_idx() and new_idc_idx()");
+      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
+   }
    _fx_R9Ast__id_t rec_0 = { m_idx_0, i_0, j_0 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
+   fx_free_exn(&v_0);
+   FX_FREE_VEC(&v_1);
+   FX_FREE_VEC(&v_2);
+   FX_FREE_VEC(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 
@@ -9208,13 +9082,56 @@ FX_EXTERN_C int _fx_M6C_formFM7dup_idcR9Ast__id_t2iR9Ast__id_t(
    struct _fx_R9Ast__id_t* fx_result,
    void* fx_fv)
 {
+   fx_exn_t v_0 = {0};
+   fx_vec_t v_1 = 0;
+   fx_vec_t v_2 = 0;
+   fx_vec_t v_3 = 0;
+   fx_exn_t v_4 = {0};
    int fx_status = 0;
-   int_ v_0;
-   FX_CALL(_fx_M6C_formFM11new_idc_idxi1i(m_idx_0, &v_0, 0), _fx_cleanup);
-   _fx_R9Ast__id_t rec_0 = { m_idx_0, old_id_0->i, v_0 };
+   if (_fx_g19C_form__freeze_idcs) {
+      fx_str_t slit_0 = FX_MAKE_STR("internal error: attempt to add new idc when they are frozen");
+      FX_CALL(_fx_F9make_FailE1S(&slit_0, &v_0), _fx_cleanup);
+      FX_THROW(&v_0, true, _fx_cleanup);
+   }
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
+   _fx_N16Ast__defmodule_t v_5 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_5->u.defmodule_t.t9, &v_1);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g14C_form__IdNone, _fx_cleanup);
+   int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_cleanup);
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_2);
+   FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_2, _fx_g13C_form__KNone, _fx_cleanup);
+   int_ new_kidx_0 = FX_VEC_SIZE(v_2) - 1;
+   FX_CHKIDX(FX_CHKIDX1(_fx_g16C_form__all_idcs, 0, m_idx_0), _fx_cleanup);
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16C_form__all_idcs, m_idx_0), &v_3);
+   FX_VEC_PUSH_BACK(_fx_N15C_form__cinfo_t, v_3, _fx_g13C_form__CNone, _fx_cleanup);
+   int_ new_cidx_0 = FX_VEC_SIZE(v_3) - 1;
+   bool t_0;
+   if (new_idx_0 == new_kidx_0) {
+      t_0 = new_idx_0 == new_cidx_0;
+   }
+   else {
+      t_0 = false;
+   }
+   int_ v_6;
+   if (t_0) {
+      v_6 = new_idx_0;
+   }
+   else {
+      fx_str_t slit_1 =
+         FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx(), new_idk_idx() and new_idc_idx()");
+      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_4), _fx_cleanup);
+      FX_THROW(&v_4, true, _fx_cleanup);
+   }
+   _fx_R9Ast__id_t rec_0 = { m_idx_0, old_id_0->i, v_6 };
    *fx_result = rec_0;
 
 _fx_cleanup: ;
+   fx_free_exn(&v_0);
+   FX_FREE_VEC(&v_1);
+   FX_FREE_VEC(&v_2);
+   FX_FREE_VEC(&v_3);
+   fx_free_exn(&v_4);
    return fx_status;
 }
 

--- a/compiler/bootstrap/C_form.c
+++ b/compiler/bootstrap/C_form.c
@@ -8444,19 +8444,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M6C_formFM7resize_v3VN15C_form__cinfo_tiT2N15C_form__cinfo_tB(
-   fx_vec_t v,
-   int_ size,
-   struct _fx_T2N15C_form__cinfo_tB* val0_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_resize(v, size, val0_);
-
-}
-
 FX_EXTERN_C int _fx_M6C_formFM10push_back_v2VN15C_form__cinfo_tT2N15C_form__cinfo_tB(
    fx_vec_t v,
    struct _fx_T2N15C_form__cinfo_tB* elem_,
@@ -9269,18 +9256,22 @@ FX_EXTERN_C int _fx_M6C_formFM13init_all_idcsv0(void* fx_fv)
    dstptr_0 = (fx_vec_t*)v_0.data;
    for (int_ i_0 = 0; i_0 < ni_0; i_0++, dstptr_0++) {
       fx_vec_t k_0 = 0;
-      fx_vec_t z_0 = 0;
-      _fx_T2N15C_form__cinfo_tB v_1 = {0};
+      fx_vec_t vec_0 = 0;
       FX_COPY_PTR(ptr_all_idks_0[i_0], &k_0);
-      fx_make_vec(0, 0, sizeof(_fx_N15C_form__cinfo_t), (fx_free_t)_fx_free_N15C_form__cinfo_t,
-         (fx_copy_t)_fx_copy_N15C_form__cinfo_t, 0, &z_0);
-      _fx_make_T2N15C_form__cinfo_tB(&_fx_g13C_form__CNone, true, &v_1);
-      FX_CALL(_fx_M6C_formFM7resize_v3VN15C_form__cinfo_tiT2N15C_form__cinfo_tB(z_0, FX_VEC_SIZE(k_0), &v_1, 0), _fx_catch_0);
-      FX_COPY_PTR(z_0, dstptr_0);
+      _fx_N15C_form__cinfo_t* dstptr_1 = 0;
+      int_ v_1 = FX_VEC_SIZE(k_0);
+      FX_CALL(
+         fx_make_vec(v_1, v_1, sizeof(_fx_N15C_form__cinfo_t), (fx_free_t)_fx_free_N15C_form__cinfo_t,
+            (fx_copy_t)_fx_copy_N15C_form__cinfo_t, 0, &vec_0), _fx_catch_0);
+      dstptr_1 = (_fx_N15C_form__cinfo_t*)vec_0->data;
+      for (int_ i_1 = 0; i_1 < v_1; i_1++) {
+         _fx_copy_N15C_form__cinfo_t(&_fx_g13C_form__CNone, dstptr_1); dstptr_1++;
+      }
+      vec_0->size = dstptr_1 - (_fx_N15C_form__cinfo_t*)vec_0->data;
+      FX_COPY_PTR(vec_0, dstptr_0);
 
    _fx_catch_0: ;
-      _fx_free_T2N15C_form__cinfo_tB(&v_1);
-      FX_FREE_VEC(&z_0);
+      FX_FREE_VEC(&vec_0);
       FX_FREE_VEC(&k_0);
       FX_CHECK_EXN(_fx_cleanup);
    }

--- a/compiler/bootstrap/C_gen_code.c
+++ b/compiler/bootstrap/C_gen_code.c
@@ -1839,6 +1839,11 @@ typedef struct _fx_T2N17C_form__cbinary_tN14C_form__ctyp_t {
    struct _fx_N14C_form__ctyp_t_data_t* t1;
 } _fx_T2N17C_form__cbinary_tN14C_form__ctyp_t;
 
+typedef struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t {
+   int_ t0;
+   struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t t1;
+} _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t;
+
 typedef struct _fx_FPT2N14C_form__cexp_tLN15C_form__cstmt_t18LN14K_form__kexp_tLN15C_form__cstmt_trLrR23C_gen_code__block_ctx_trNt10Hashset__t1R9Ast__id_trNt6option1N14C_form__cexp_tN14C_form__cexp_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t {
    int (*fp)(
       struct _fx_LN14K_form__kexp_t_data_t*, struct _fx_LN15C_form__cstmt_t_data_t*,
@@ -1886,11 +1891,6 @@ typedef struct _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t {
    struct _fx_LN14C_form__cexp_t_data_t* t1;
    struct _fx_N14C_form__cexp_t_data_t* t2;
 } _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t;
-
-typedef struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t {
-   int_ t0;
-   struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t t1;
-} _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t;
 
 typedef struct _fx_Ta2N14K_form__kexp_t {
    struct _fx_N14K_form__kexp_t_data_t* t0;
@@ -7009,6 +7009,28 @@ static void _fx_make_T2N17C_form__cbinary_tN14C_form__ctyp_t(
    FX_COPY_PTR(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
+{
+   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&dst->t1);
+}
+
+static void _fx_copy_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(
+   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* src,
+   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_T2N14C_form__cexp_tLN15C_form__cstmt_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(
+   int_ t0,
+   struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* t1,
+   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* fx_result)
+{
+   fx_result->t0 = t0;
+   _fx_copy_T2N14C_form__cexp_tLN15C_form__cstmt_t(t1, &fx_result->t1);
+}
+
 static void _fx_free_T2R9Ast__id_tN15C_form__cinfo_t(struct _fx_T2R9Ast__id_tN15C_form__cinfo_t* dst)
 {
    _fx_free_N15C_form__cinfo_t(&dst->t1);
@@ -7158,28 +7180,6 @@ static void _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
    FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
-{
-   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&dst->t1);
-}
-
-static void _fx_copy_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(
-   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* src,
-   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_T2N14C_form__cexp_tLN15C_form__cstmt_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(
-   int_ t0,
-   struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* t1,
-   struct _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t* fx_result)
-{
-   fx_result->t0 = t0;
-   _fx_copy_T2N14C_form__cexp_tLN15C_form__cstmt_t(t1, &fx_result->t1);
 }
 
 static void _fx_free_Ta2N14K_form__kexp_t(struct _fx_Ta2N14K_form__kexp_t* dst)
@@ -21168,7 +21168,7 @@ static int
    FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &dummy_exp_0, 0), _fx_cleanup);
    int tag_0 = FX_REC_VARIANT_TAG(kexp_0);
    if (tag_0 == 1) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    if (tag_0 == 2) {
       _fx_N15C_form__cstmt_t break_stmt_0 = 0;
@@ -21186,7 +21186,7 @@ static int
       if (break_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&break_stmt_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 3) {
       _fx_N15C_form__cstmt_t continue_stmt_0 = 0;
@@ -21204,7 +21204,7 @@ static int
       if (continue_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&continue_stmt_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 4) {
       _fx_rR23C_gen_code__block_ctx_t bctx_0 = 0;
@@ -21295,7 +21295,7 @@ static int
       if (bctx_0) {
          _fx_free_rR23C_gen_code__block_ctx_t(&bctx_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 5) {
       _fx_N14K_form__atom_t* v_14 = &kexp_0->u.KExpAtom.t0;
@@ -21352,7 +21352,7 @@ static int
                if (v_15) {
                   _fx_free_N14K_form__ktyp_t(&v_15);
                }
-               goto _fx_endmatch_55;
+               goto _fx_endmatch_58;
             }
          }
       }
@@ -21382,7 +21382,7 @@ static int
          _fx_free_N14C_form__cexp_t(&e_1);
       }
       _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_18);
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 6) {
       _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_19 = {0};
@@ -22210,7 +22210,7 @@ static int
          _fx_free_N14C_form__cexp_t(&ce1_0);
       }
       _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_19);
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 7) {
       _fx_T3N12Ast__unary_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_1 = &kexp_0->u.KExpUnary;
@@ -22251,7 +22251,7 @@ static int
             _fx_free_N14C_form__cexp_t(&ce1_5);
          }
          _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_77);
-         goto _fx_endmatch_55;
+         goto _fx_endmatch_58;
       }
    }
    if (tag_0 == 7) {
@@ -22301,7 +22301,7 @@ static int
             _fx_free_N14C_form__cexp_t(&ce_0);
          }
          _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_79);
-         goto _fx_endmatch_55;
+         goto _fx_endmatch_58;
       }
    }
    if (tag_0 == 7) {
@@ -22393,7 +22393,7 @@ static int
          _fx_free_N14C_form__cexp_t(&ce1_6);
       }
       _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_82);
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 8) {
       _fx_T3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_4 = &kexp_0->u.KExpIntrin;
@@ -22599,7 +22599,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&cv_1);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_88);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -22843,7 +22843,7 @@ static int
                      _fx_free_N14C_form__cexp_t(&cv_2);
                   }
                   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_114);
-                  goto _fx_endmatch_16;
+                  goto _fx_endmatch_19;
                }
             }
          }
@@ -22879,7 +22879,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&cl_0);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_144);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -22914,7 +22914,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&cl_1);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_147);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -23179,7 +23179,7 @@ static int
                   _fx_free_rR23C_form__cdefinterface_t(&dst_iface_0);
                }
                _fx_free_Nt6option1rR23C_form__cdefinterface_t(&v_150);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -23413,7 +23413,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&src_exp_1);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_186);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -23477,7 +23477,7 @@ static int
                _fx_free_N14C_form__cexp_t(&dst_exp_4);
             }
             _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_217);
-            goto _fx_endmatch_16;
+            goto _fx_endmatch_19;
          }
       }
       if (intr_0->tag == 8) {
@@ -23725,7 +23725,7 @@ static int
          if (strs_13) {
             _fx_free_LN14C_form__cexp_t(&strs_13);
          }
-         goto _fx_endmatch_16;
+         goto _fx_endmatch_19;
       }
       if (intr_0->tag == 9) {
          if (args_0 != 0) {
@@ -23854,7 +23854,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&arr_exp_0);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_250);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -24015,7 +24015,7 @@ static int
                            _fx_free_N14C_form__cexp_t(&arr_exp_1);
                         }
                         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_269);
-                        goto _fx_endmatch_16;
+                        goto _fx_endmatch_19;
                      }
                   }
                }
@@ -24094,7 +24094,7 @@ static int
                   if (lbl_3) {
                      _fx_free_N14C_form__cexp_t(&lbl_3);
                   }
-                  goto _fx_endmatch_16;
+                  goto _fx_endmatch_19;
                }
             }
          }
@@ -24243,7 +24243,7 @@ static int
                               if (lbl_4) {
                                  _fx_free_N14C_form__cexp_t(&lbl_4);
                               }
-                              goto _fx_endmatch_16;
+                              goto _fx_endmatch_19;
                            }
                         }
                      }
@@ -24307,7 +24307,7 @@ static int
                      _fx_free_N14C_form__cexp_t(&dst_exp_6);
                   }
                   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_308);
-                  goto _fx_endmatch_16;
+                  goto _fx_endmatch_19;
                }
             }
          }
@@ -24761,7 +24761,7 @@ static int
                                                                _fx_free_N14C_form__cexp_t(&m1exp_0);
                                                             }
                                                             _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_328);
-                                                            goto _fx_endmatch_16;
+                                                            goto _fx_endmatch_19;
                                                          }
                                                       }
                                                    }
@@ -24780,7 +24780,7 @@ static int
             }
          }
       }
-      if (intr_0->tag == 18) {
+      if (intr_0->tag == 19) {
          _fx_LN14C_form__cexp_t cargs_0 = 0;
          _fx_LN15C_form__cstmt_t ccode_58 = 0;
          _fx_LN14K_form__atom_t args_2 = 0;
@@ -24912,11 +24912,11 @@ static int
          if (cargs_0) {
             _fx_free_LN14C_form__cexp_t(&cargs_0);
          }
-         goto _fx_endmatch_16;
+         goto _fx_endmatch_19;
       }
       if (args_0 != 0) {
          if (args_0->tl == 0) {
-            if (intr_0->tag == 19) {
+            if (intr_0->tag == 20) {
                _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_367 = {0};
                _fx_N14C_form__cexp_t c_exp_2 = 0;
                _fx_LN15C_form__cstmt_t ccode_59 = 0;
@@ -25050,7 +25050,7 @@ static int
                   _fx_free_N14C_form__cexp_t(&c_exp_2);
                }
                _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_367);
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
@@ -25194,7 +25194,7 @@ static int
                _fx_free_N14C_form__cexp_t(&arr_exp_2);
             }
             _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_379);
-            goto _fx_endmatch_16;
+            goto _fx_endmatch_19;
          }
       }
       if (intr_0->tag == 15) {
@@ -25245,7 +25245,7 @@ static int
                      _fx_free_N14C_form__cexp_t(&ptr_exp_0);
                   }
                   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_392);
-                  goto _fx_endmatch_16;
+                  goto _fx_endmatch_19;
                }
             }
          }
@@ -25381,7 +25381,7 @@ static int
                   if (lbl_5) {
                      _fx_free_N14C_form__cexp_t(&lbl_5);
                   }
-                  goto _fx_endmatch_16;
+                  goto _fx_endmatch_19;
                }
             }
          }
@@ -25484,166 +25484,372 @@ static int
                if (lbl_6) {
                   _fx_free_N14C_form__cexp_t(&lbl_6);
                }
-               goto _fx_endmatch_16;
+               goto _fx_endmatch_19;
             }
          }
       }
-      fx_str_t v_416 = {0};
-      fx_str_t v_417 = {0};
-      fx_str_t v_418 = {0};
-      fx_exn_t v_419 = {0};
-      FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(intr_0, &v_416, 0), _fx_catch_97);
-      int_ v_420;
-      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14K_form__atom_t(args_0, &v_420, 0), _fx_catch_97);
-      FX_CALL(_fx_F6stringS1i(v_420, &v_417, 0), _fx_catch_97);
-      fx_str_t slit_111 = FX_MAKE_STR("cgen: unsupported KExpIntrin(");
-      fx_str_t slit_112 = FX_MAKE_STR(", ...) or the wrong number of arguments (");
-      fx_str_t slit_113 = FX_MAKE_STR(")");
-      {
-         const fx_str_t strs_25[] = { slit_111, v_416, slit_112, v_417, slit_113 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_25, 5, &v_418), _fx_catch_97);
+      if (intr_0->tag == 18) {
+         if (args_0 != 0) {
+            _fx_LN14K_form__atom_t v_416 = args_0->tl;
+            if (v_416 != 0) {
+               _fx_LN14K_form__atom_t v_417 = v_416->tl;
+               if (v_417 != 0) {
+                  _fx_LN14K_form__atom_t v_418 = v_417->tl;
+                  if (v_418 != 0) {
+                     _fx_LN14K_form__atom_t v_419 = v_418->tl;
+                     if (v_419 != 0) {
+                        if (v_419->tl == 0) {
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_420 = {0};
+                           _fx_N14C_form__cexp_t vec_exp_2 = 0;
+                           _fx_LN15C_form__cstmt_t ccode_67 = 0;
+                           _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_421 = {0};
+                           _fx_N14C_form__cexp_t a_exp_1 = 0;
+                           _fx_LN15C_form__cstmt_t ccode_68 = 0;
+                           _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_422 = {0};
+                           _fx_N14C_form__cexp_t b_exp_1 = 0;
+                           _fx_LN15C_form__cstmt_t ccode_69 = 0;
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_423 = {0};
+                           _fx_N14C_form__cexp_t delta_exp_1 = 0;
+                           _fx_LN15C_form__cstmt_t ccode_70 = 0;
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_424 = {0};
+                           _fx_N14C_form__cexp_t rhs_exp_0 = 0;
+                           _fx_LN15C_form__cstmt_t ccode_71 = 0;
+                           _fx_N14C_form__cexp_t v_425 = 0;
+                           _fx_LN14C_form__cexp_t v_426 = 0;
+                           _fx_N14C_form__cexp_t call_splice_0 = 0;
+                           _fx_LN15C_form__cstmt_t v_427 = 0;
+                           _fx_N14K_form__atom_t* delta_0 = &v_418->hd;
+                           _fx_N14K_form__atom_t* b_0 = &v_417->hd;
+                           _fx_N14K_form__atom_t* a_2 = &v_416->hd;
+                           FX_CALL(
+                              atom2cexp_0.fp(&args_0->hd, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                                 fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_420, atom2cexp_0.fcv), _fx_catch_103);
+                           FX_COPY_PTR(v_420.t0, &vec_exp_2);
+                           FX_COPY_PTR(v_420.t1, &ccode_67);
+                           if (a_2->tag == 2) {
+                              if (a_2->u.AtomLit.tag == 8) {
+                                 _fx_N14C_form__cexp_t v_428 = 0;
+                                 _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_429 = {0};
+                                 FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_428, 0),
+                                    _fx_catch_97);
+                                 _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_428, ccode_67, &v_429);
+                                 _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_429, &v_421);
+
+                              _fx_catch_97: ;
+                                 _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_429);
+                                 if (v_428) {
+                                    _fx_free_N14C_form__cexp_t(&v_428);
+                                 }
+                                 goto _fx_endmatch_16;
+                              }
+                           }
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_430 = {0};
+                           FX_CALL(
+                              atom2cexp_0.fp(a_2, ccode_67, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                                 i2e_ref_0, km_idx_0, &v_430, atom2cexp_0.fcv), _fx_catch_98);
+                           _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_430, &v_421);
+
+                        _fx_catch_98: ;
+                           _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_430);
+
+                        _fx_endmatch_16: ;
+                           FX_CHECK_EXN(_fx_catch_103);
+                           int_ mask_0 = v_421.t0;
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_431 = &v_421.t1;
+                           FX_COPY_PTR(v_431->t0, &a_exp_1);
+                           FX_COPY_PTR(v_431->t1, &ccode_68);
+                           if (b_0->tag == 2) {
+                              if (b_0->u.AtomLit.tag == 8) {
+                                 _fx_N14C_form__cexp_t v_432 = 0;
+                                 _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_433 = {0};
+                                 FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_432, 0),
+                                    _fx_catch_99);
+                                 _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_432, ccode_68, &v_433);
+                                 _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_0, &v_433, &v_422);
+
+                              _fx_catch_99: ;
+                                 _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_433);
+                                 if (v_432) {
+                                    _fx_free_N14C_form__cexp_t(&v_432);
+                                 }
+                                 goto _fx_endmatch_17;
+                              }
+                           }
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_434 = {0};
+                           FX_CALL(
+                              atom2cexp_0.fp(b_0, ccode_68, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                                 i2e_ref_0, km_idx_0, &v_434, atom2cexp_0.fcv), _fx_catch_100);
+                           _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_0, &v_434, &v_422);
+
+                        _fx_catch_100: ;
+                           _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_434);
+
+                        _fx_endmatch_17: ;
+                           FX_CHECK_EXN(_fx_catch_103);
+                           int_ mask_1 = v_422.t0;
+                           _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_435 = &v_422.t1;
+                           FX_COPY_PTR(v_435->t0, &b_exp_1);
+                           FX_COPY_PTR(v_435->t1, &ccode_69);
+                           if (delta_0->tag == 2) {
+                              if (delta_0->u.AtomLit.tag == 8) {
+                                 _fx_N14C_form__cexp_t v_436 = 0;
+                                 FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_436, 0),
+                                    _fx_catch_101);
+                                 _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_436, ccode_69, &v_423);
+
+                              _fx_catch_101: ;
+                                 if (v_436) {
+                                    _fx_free_N14C_form__cexp_t(&v_436);
+                                 }
+                                 goto _fx_endmatch_18;
+                              }
+                           }
+                           FX_CALL(
+                              atom2cexp_0.fp(delta_0, ccode_69, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                                 fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_423, atom2cexp_0.fcv), _fx_catch_102);
+
+                        _fx_catch_102: ;
+
+                        _fx_endmatch_18: ;
+                           FX_CHECK_EXN(_fx_catch_103);
+                           FX_COPY_PTR(v_423.t0, &delta_exp_1);
+                           FX_COPY_PTR(v_423.t1, &ccode_70);
+                           FX_CALL(
+                              atom2cexp_0.fp(&v_419->hd, ccode_70, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                                 fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_424, atom2cexp_0.fcv), _fx_catch_103);
+                           FX_COPY_PTR(v_424.t0, &rhs_exp_0);
+                           FX_COPY_PTR(v_424.t1, &ccode_71);
+                           _fx_R9Ast__id_t v_437;
+                           fx_str_t slit_111 = FX_MAKE_STR("fx_vec_splice");
+                           FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_111, &v_437, 0), _fx_catch_103);
+                           FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_1, &kloc_0, &v_425, 0),
+                              _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(rhs_exp_0, 0, true, &v_426), _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(v_425, v_426, false, &v_426), _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_1, v_426, false, &v_426), _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_1, v_426, false, &v_426), _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_1, v_426, false, &v_426), _fx_catch_103);
+                           FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_exp_2, v_426, false, &v_426), _fx_catch_103);
+                           FX_CALL(
+                              _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                                 &v_437, v_426, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_splice_0, 0), _fx_catch_103);
+                           FX_CALL(
+                              _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+                                 call_splice_0, ccode_71, &kloc_0, block_stack_ref_0, &v_427, 0), _fx_catch_103);
+                           _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_427, &v_1);
+
+                        _fx_catch_103: ;
+                           if (v_427) {
+                              _fx_free_LN15C_form__cstmt_t(&v_427);
+                           }
+                           if (call_splice_0) {
+                              _fx_free_N14C_form__cexp_t(&call_splice_0);
+                           }
+                           if (v_426) {
+                              _fx_free_LN14C_form__cexp_t(&v_426);
+                           }
+                           if (v_425) {
+                              _fx_free_N14C_form__cexp_t(&v_425);
+                           }
+                           if (ccode_71) {
+                              _fx_free_LN15C_form__cstmt_t(&ccode_71);
+                           }
+                           if (rhs_exp_0) {
+                              _fx_free_N14C_form__cexp_t(&rhs_exp_0);
+                           }
+                           _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_424);
+                           if (ccode_70) {
+                              _fx_free_LN15C_form__cstmt_t(&ccode_70);
+                           }
+                           if (delta_exp_1) {
+                              _fx_free_N14C_form__cexp_t(&delta_exp_1);
+                           }
+                           _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_423);
+                           if (ccode_69) {
+                              _fx_free_LN15C_form__cstmt_t(&ccode_69);
+                           }
+                           if (b_exp_1) {
+                              _fx_free_N14C_form__cexp_t(&b_exp_1);
+                           }
+                           _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_422);
+                           if (ccode_68) {
+                              _fx_free_LN15C_form__cstmt_t(&ccode_68);
+                           }
+                           if (a_exp_1) {
+                              _fx_free_N14C_form__cexp_t(&a_exp_1);
+                           }
+                           _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_421);
+                           if (ccode_67) {
+                              _fx_free_LN15C_form__cstmt_t(&ccode_67);
+                           }
+                           if (vec_exp_2) {
+                              _fx_free_N14C_form__cexp_t(&vec_exp_2);
+                           }
+                           _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_420);
+                           goto _fx_endmatch_19;
+                        }
+                     }
+                  }
+               }
+            }
+         }
       }
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_418, &v_419, 0), _fx_catch_97);
-      FX_THROW(&v_419, false, _fx_catch_97);
+      fx_str_t v_438 = {0};
+      fx_str_t v_439 = {0};
+      fx_str_t v_440 = {0};
+      fx_exn_t v_441 = {0};
+      FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(intr_0, &v_438, 0), _fx_catch_104);
+      int_ v_442;
+      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14K_form__atom_t(args_0, &v_442, 0), _fx_catch_104);
+      FX_CALL(_fx_F6stringS1i(v_442, &v_439, 0), _fx_catch_104);
+      fx_str_t slit_112 = FX_MAKE_STR("cgen: unsupported KExpIntrin(");
+      fx_str_t slit_113 = FX_MAKE_STR(", ...) or the wrong number of arguments (");
+      fx_str_t slit_114 = FX_MAKE_STR(")");
+      {
+         const fx_str_t strs_25[] = { slit_112, v_438, slit_113, v_439, slit_114 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_25, 5, &v_440), _fx_catch_104);
+      }
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_440, &v_441, 0), _fx_catch_104);
+      FX_THROW(&v_441, false, _fx_catch_104);
 
-   _fx_catch_97: ;
-      fx_free_exn(&v_419);
-      FX_FREE_STR(&v_418);
-      FX_FREE_STR(&v_417);
-      FX_FREE_STR(&v_416);
+   _fx_catch_104: ;
+      fx_free_exn(&v_441);
+      FX_FREE_STR(&v_440);
+      FX_FREE_STR(&v_439);
+      FX_FREE_STR(&v_438);
 
-   _fx_endmatch_16: ;
-      FX_CHECK_EXN(_fx_catch_98);
+   _fx_endmatch_19: ;
+      FX_CHECK_EXN(_fx_catch_105);
 
-   _fx_catch_98: ;
-      goto _fx_endmatch_55;
+   _fx_catch_105: ;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 10) {
       _fx_FPT2N14C_form__cexp_tLN15C_form__cstmt_t18LN14K_form__kexp_tLN15C_form__cstmt_trLrR23C_gen_code__block_ctx_trNt10Hashset__t1R9Ast__id_trNt6option1N14C_form__cexp_tN14C_form__cexp_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t
          process_seq_0 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_421 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_443 = {0};
       _fx_N14C_form__cexp_t e_8 = 0;
-      _fx_LN15C_form__cstmt_t ccode_67 = 0;
+      _fx_LN15C_form__cstmt_t ccode_72 = 0;
       _fx_M10C_gen_codeFM7make_fpFPT2N14C_form__cexp_tLN15C_form__cstmt_t18LN14K_form__kexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trNt6option1N14C_form__cexp_tN14C_form__cexp_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t5rLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
          block_stack_ref_1, defined_syms_ref_1, fwd_fdecls_ref_1, i2e_ref_1, *km_idx_1, &process_seq_0);
       FX_CALL(
          process_seq_0.fp(kexp_0->u.KExpSeq.t0, ccode_0, block_stack_ref_0, defined_syms_ref_0, dstexp_r_0, dummy_exp_0,
             for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0,
-            mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_421, process_seq_0.fcv),
-         _fx_catch_99);
-      FX_COPY_PTR(v_421.t0, &e_8);
-      FX_COPY_PTR(v_421.t1, &ccode_67);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, e_8, ccode_67, &v_1);
+            mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_443, process_seq_0.fcv),
+         _fx_catch_106);
+      FX_COPY_PTR(v_443.t0, &e_8);
+      FX_COPY_PTR(v_443.t1, &ccode_72);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, e_8, ccode_72, &v_1);
 
-   _fx_catch_99: ;
-      if (ccode_67) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_67);
+   _fx_catch_106: ;
+      if (ccode_72) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_72);
       }
       if (e_8) {
          _fx_free_N14C_form__cexp_t(&e_8);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_421);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_443);
       FX_FREE_FP(&process_seq_0);
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 9) {
       _fx_N14C_form__cexp_t parent_lbl_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_422 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_444 = {0};
       _fx_N14C_form__cexp_t dst_exp_8 = 0;
-      _fx_LN15C_form__cstmt_t ccode_68 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_423 = {0};
+      _fx_LN15C_form__cstmt_t ccode_73 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_445 = {0};
       _fx_LN15C_form__cstmt_t sync_ccode_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t bctx_sync_0 = 0;
       _fx_LN15C_form__cstmt_t bctx_cleanup_0 = 0;
       _fx_LN15C_form__cstmt_t bctx_prologue_0 = 0;
       _fx_LN15C_form__cstmt_t epilogue_0 = 0;
-      _fx_N15C_form__cstmt_t v_424 = 0;
-      _fx_LN15C_form__cstmt_t v_425 = 0;
-      _fx_LN15C_form__cstmt_t v_426 = 0;
+      _fx_N15C_form__cstmt_t v_446 = 0;
+      _fx_LN15C_form__cstmt_t v_447 = 0;
+      _fx_LN15C_form__cstmt_t v_448 = 0;
       _fx_LN15C_form__cstmt_t sync_ccode_1 = 0;
       _fx_N15C_form__cstmt_t c_e_2 = 0;
-      _fx_LN14C_form__cexp_t v_427 = 0;
+      _fx_LN14C_form__cexp_t v_449 = 0;
       _fx_N14C_form__cexp_t check_exn_0 = 0;
-      _fx_N15C_form__cstmt_t v_428 = 0;
-      _fx_N15C_form__cstmt_t v_429 = 0;
-      _fx_LN15C_form__cstmt_t v_430 = 0;
+      _fx_N15C_form__cstmt_t v_450 = 0;
+      _fx_N15C_form__cstmt_t v_451 = 0;
+      _fx_LN15C_form__cstmt_t v_452 = 0;
       _fx_T2R9Ast__id_tN14K_form__kexp_t* vcase_5 = &kexp_0->u.KExpSync;
       _fx_N14K_form__kexp_t e_9 = vcase_5->t1;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &parent_lbl_0, 0), _fx_catch_100);
-      fx_str_t slit_114 = FX_MAKE_STR("t");
+            &parent_lbl_0, 0), _fx_catch_107);
+      fx_str_t slit_115 = FX_MAKE_STR("t");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_114, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_422, 0), _fx_catch_100);
-      FX_COPY_PTR(v_422.t0, &dst_exp_8);
-      FX_COPY_PTR(v_422.t1, &ccode_68);
+            dstexp_r_0, &slit_115, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_444, 0), _fx_catch_107);
+      FX_COPY_PTR(v_444.t0, &dst_exp_8);
+      FX_COPY_PTR(v_444.t1, &ccode_73);
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_100);
+            &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_107);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e_9, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_423, fx_fv), _fx_catch_100);
-      FX_COPY_PTR(v_423.t1, &sync_ccode_0);
+            top_inline_ccode_ref_0, u1vals_0, &v_445, fx_fv), _fx_catch_107);
+      FX_COPY_PTR(v_445.t1, &sync_ccode_0);
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_sync_0, 0), _fx_catch_100);
-      _fx_R23C_gen_code__block_ctx_t* v_431 = &bctx_sync_0->data;
-      int_ bctx_label_used_0 = v_431->bctx_label_used;
-      _fx_R9Ast__id_t bctx_label_0 = v_431->bctx_label;
-      FX_COPY_PTR(v_431->bctx_cleanup, &bctx_cleanup_0);
-      FX_COPY_PTR(v_431->bctx_prologue, &bctx_prologue_0);
+            &bctx_sync_0, 0), _fx_catch_107);
+      _fx_R23C_gen_code__block_ctx_t* v_453 = &bctx_sync_0->data;
+      int_ bctx_label_used_0 = v_453->bctx_label_used;
+      _fx_R9Ast__id_t bctx_label_0 = v_453->bctx_label;
+      FX_COPY_PTR(v_453->bctx_cleanup, &bctx_cleanup_0);
+      FX_COPY_PTR(v_453->bctx_prologue, &bctx_prologue_0);
       if (bctx_label_used_0 == 0) {
          FX_COPY_PTR(bctx_cleanup_0, &epilogue_0);
       }
       else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_0, &kloc_0, &v_424),
-            _fx_catch_100);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_424, 0, true, &v_425), _fx_catch_100);
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_0, &kloc_0, &v_446),
+            _fx_catch_107);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_446, 0, true, &v_447), _fx_catch_107);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_0, v_425,
-               &epilogue_0, 0), _fx_catch_100);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_0, v_447,
+               &epilogue_0, 0), _fx_catch_107);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(sync_ccode_0, bctx_prologue_0,
-            &v_426, 0), _fx_catch_100);
+            &v_448, 0), _fx_catch_107);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_0, v_426, &sync_ccode_1,
-            0), _fx_catch_100);
-      _fx_R10Ast__loc_t v_432;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e_9, &v_432, 0), _fx_catch_100);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sync_ccode_1, &v_432, &c_e_2, 0),
-         _fx_catch_100);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_0, v_448, &sync_ccode_1,
+            0), _fx_catch_107);
+      _fx_R10Ast__loc_t v_454;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e_9, &v_454, 0), _fx_catch_107);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sync_ccode_1, &v_454, &c_e_2, 0),
+         _fx_catch_107);
       FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
-         _fx_catch_100);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(parent_lbl_0, 0, true, &v_427), _fx_catch_100);
+         _fx_catch_107);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(parent_lbl_0, 0, true, &v_449), _fx_catch_107);
       FX_CALL(
          _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g24C_form__std_FX_CHECK_EXN, v_427, _fx_g20C_gen_code__CTypVoid, &kloc_0, &check_exn_0, 0), _fx_catch_100);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(check_exn_0, &v_428), _fx_catch_100);
-      FX_CALL(_fx_M6C_formFM9CStmtSyncN15C_form__cstmt_t2R9Ast__id_tN15C_form__cstmt_t(&vcase_5->t0, c_e_2, &v_429),
-         _fx_catch_100);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_429, ccode_68, true, &v_430), _fx_catch_100);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_428, v_430, false, &v_430), _fx_catch_100);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_8, v_430, &v_1);
+            &_fx_g24C_form__std_FX_CHECK_EXN, v_449, _fx_g20C_gen_code__CTypVoid, &kloc_0, &check_exn_0, 0), _fx_catch_107);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(check_exn_0, &v_450), _fx_catch_107);
+      FX_CALL(_fx_M6C_formFM9CStmtSyncN15C_form__cstmt_t2R9Ast__id_tN15C_form__cstmt_t(&vcase_5->t0, c_e_2, &v_451),
+         _fx_catch_107);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_451, ccode_73, true, &v_452), _fx_catch_107);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_450, v_452, false, &v_452), _fx_catch_107);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_8, v_452, &v_1);
 
-   _fx_catch_100: ;
-      if (v_430) {
-         _fx_free_LN15C_form__cstmt_t(&v_430);
+   _fx_catch_107: ;
+      if (v_452) {
+         _fx_free_LN15C_form__cstmt_t(&v_452);
       }
-      if (v_429) {
-         _fx_free_N15C_form__cstmt_t(&v_429);
+      if (v_451) {
+         _fx_free_N15C_form__cstmt_t(&v_451);
       }
-      if (v_428) {
-         _fx_free_N15C_form__cstmt_t(&v_428);
+      if (v_450) {
+         _fx_free_N15C_form__cstmt_t(&v_450);
       }
       if (check_exn_0) {
          _fx_free_N14C_form__cexp_t(&check_exn_0);
       }
-      if (v_427) {
-         _fx_free_LN14C_form__cexp_t(&v_427);
+      if (v_449) {
+         _fx_free_LN14C_form__cexp_t(&v_449);
       }
       if (c_e_2) {
          _fx_free_N15C_form__cstmt_t(&c_e_2);
@@ -25651,14 +25857,14 @@ static int
       if (sync_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&sync_ccode_1);
       }
-      if (v_426) {
-         _fx_free_LN15C_form__cstmt_t(&v_426);
+      if (v_448) {
+         _fx_free_LN15C_form__cstmt_t(&v_448);
       }
-      if (v_425) {
-         _fx_free_LN15C_form__cstmt_t(&v_425);
+      if (v_447) {
+         _fx_free_LN15C_form__cstmt_t(&v_447);
       }
-      if (v_424) {
-         _fx_free_N15C_form__cstmt_t(&v_424);
+      if (v_446) {
+         _fx_free_N15C_form__cstmt_t(&v_446);
       }
       if (epilogue_0) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_0);
@@ -25675,84 +25881,84 @@ static int
       if (sync_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&sync_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_423);
-      if (ccode_68) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_68);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_445);
+      if (ccode_73) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_73);
       }
       if (dst_exp_8) {
          _fx_free_N14C_form__cexp_t(&dst_exp_8);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_422);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_444);
       if (parent_lbl_0) {
          _fx_free_N14C_form__cexp_t(&parent_lbl_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 11) {
-      _fx_rNt6option1N14C_form__cexp_t v_433 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_434 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_455 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_456 = {0};
       _fx_N14C_form__cexp_t cc_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_69 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_435 = {0};
+      _fx_LN15C_form__cstmt_t ccode_74 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_457 = {0};
       _fx_N14C_form__cexp_t dst_exp_9 = 0;
-      _fx_LN15C_form__cstmt_t ccode_70 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_436 = {0};
+      _fx_LN15C_form__cstmt_t ccode_75 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_458 = {0};
       _fx_LN15C_form__cstmt_t ccode1_3 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_437 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_459 = {0};
       _fx_LN15C_form__cstmt_t ccode2_0 = 0;
       _fx_N15C_form__cstmt_t c_e1_0 = 0;
       _fx_N15C_form__cstmt_t c_e2_0 = 0;
-      _fx_N15C_form__cstmt_t v_438 = 0;
-      _fx_LN15C_form__cstmt_t v_439 = 0;
+      _fx_N15C_form__cstmt_t v_460 = 0;
+      _fx_LN15C_form__cstmt_t v_461 = 0;
       _fx_T4N14K_form__kexp_tN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_6 = &kexp_0->u.KExpIf;
       _fx_N14K_form__kexp_t e2_0 = vcase_6->t2;
       _fx_N14K_form__kexp_t e1_0 = vcase_6->t1;
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_433), _fx_catch_101);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_455), _fx_catch_108);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_6->t0, v_433, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_6->t0, v_455, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_434, fx_fv), _fx_catch_101);
-      FX_COPY_PTR(v_434.t0, &cc_0);
-      FX_COPY_PTR(v_434.t1, &ccode_69);
-      fx_str_t slit_115 = FX_MAKE_STR("t");
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_456, fx_fv), _fx_catch_108);
+      FX_COPY_PTR(v_456.t0, &cc_0);
+      FX_COPY_PTR(v_456.t1, &ccode_74);
+      fx_str_t slit_116 = FX_MAKE_STR("t");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_115, ctyp_0, ccode_69, &kloc_0, block_stack_ref_0, km_idx_0, &v_435, 0), _fx_catch_101);
-      FX_COPY_PTR(v_435.t0, &dst_exp_9);
-      FX_COPY_PTR(v_435.t1, &ccode_70);
+            dstexp_r_0, &slit_116, ctyp_0, ccode_74, &kloc_0, block_stack_ref_0, km_idx_0, &v_457, 0), _fx_catch_108);
+      FX_COPY_PTR(v_457.t0, &dst_exp_9);
+      FX_COPY_PTR(v_457.t1, &ccode_75);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e1_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_436, fx_fv), _fx_catch_101);
-      FX_COPY_PTR(v_436.t1, &ccode1_3);
+            top_inline_ccode_ref_0, u1vals_0, &v_458, fx_fv), _fx_catch_108);
+      FX_COPY_PTR(v_458.t1, &ccode1_3);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e2_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_437, fx_fv), _fx_catch_101);
-      FX_COPY_PTR(v_437.t1, &ccode2_0);
-      _fx_R10Ast__loc_t v_440;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e1_0, &v_440, 0), _fx_catch_101);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode1_3, &v_440, &c_e1_0, 0),
-         _fx_catch_101);
-      _fx_R10Ast__loc_t v_441;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e2_0, &v_441, 0), _fx_catch_101);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode2_0, &v_441, &c_e2_0, 0),
-         _fx_catch_101);
+            top_inline_ccode_ref_0, u1vals_0, &v_459, fx_fv), _fx_catch_108);
+      FX_COPY_PTR(v_459.t1, &ccode2_0);
+      _fx_R10Ast__loc_t v_462;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e1_0, &v_462, 0), _fx_catch_108);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode1_3, &v_462, &c_e1_0, 0),
+         _fx_catch_108);
+      _fx_R10Ast__loc_t v_463;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e2_0, &v_463, 0), _fx_catch_108);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode2_0, &v_463, &c_e2_0, 0),
+         _fx_catch_108);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(cc_0,
-            c_e1_0, c_e2_0, &kloc_0, &v_438, 0), _fx_catch_101);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_438, ccode_70, true, &v_439), _fx_catch_101);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_9, v_439, &v_1);
+            c_e1_0, c_e2_0, &kloc_0, &v_460, 0), _fx_catch_108);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_460, ccode_75, true, &v_461), _fx_catch_108);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_9, v_461, &v_1);
 
-   _fx_catch_101: ;
-      if (v_439) {
-         _fx_free_LN15C_form__cstmt_t(&v_439);
+   _fx_catch_108: ;
+      if (v_461) {
+         _fx_free_LN15C_form__cstmt_t(&v_461);
       }
-      if (v_438) {
-         _fx_free_N15C_form__cstmt_t(&v_438);
+      if (v_460) {
+         _fx_free_N15C_form__cstmt_t(&v_460);
       }
       if (c_e2_0) {
          _fx_free_N15C_form__cstmt_t(&c_e2_0);
@@ -25763,90 +25969,90 @@ static int
       if (ccode2_0) {
          _fx_free_LN15C_form__cstmt_t(&ccode2_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_437);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_459);
       if (ccode1_3) {
          _fx_free_LN15C_form__cstmt_t(&ccode1_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_436);
-      if (ccode_70) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_70);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_458);
+      if (ccode_75) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_75);
       }
       if (dst_exp_9) {
          _fx_free_N14C_form__cexp_t(&dst_exp_9);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_435);
-      if (ccode_69) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_69);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_457);
+      if (ccode_74) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_74);
       }
       if (cc_0) {
          _fx_free_N14C_form__cexp_t(&cc_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_434);
-      if (v_433) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_433);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_456);
+      if (v_455) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_455);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 12) {
       _fx_LN14C_form__cexp_t cargs_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_71 = 0;
+      _fx_LN15C_form__cstmt_t ccode_76 = 0;
       _fx_LN14K_form__atom_t args_3 = 0;
-      _fx_N15C_form__cinfo_t v_442 = {0};
-      _fx_T2R9Ast__id_tN15C_form__cinfo_t v_443 = {0};
+      _fx_N15C_form__cinfo_t v_464 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cinfo_t v_465 = {0};
       _fx_N15C_form__cinfo_t ci_0 = {0};
-      _fx_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t v_444 = {0};
+      _fx_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t v_466 = {0};
       _fx_N14C_form__cexp_t f_exp_1 = 0;
       _fx_LN14C_form__cexp_t fv_args_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_72 = 0;
-      _fx_LN14C_form__cexp_t v_445 = 0;
+      _fx_LN15C_form__cstmt_t ccode_77 = 0;
+      _fx_LN14C_form__cexp_t v_467 = 0;
       _fx_LN14C_form__cexp_t args_4 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_446 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_468 = {0};
       _fx_N14C_form__cexp_t call_exp_2 = 0;
-      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_447 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_448 = {0};
+      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_469 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_470 = {0};
       _fx_N14C_form__cexp_t dst_exp_10 = 0;
-      _fx_LN15C_form__cstmt_t ccode_73 = 0;
-      _fx_N14C_form__cexp_t v_449 = 0;
-      _fx_LN14C_form__cexp_t v_450 = 0;
+      _fx_LN15C_form__cstmt_t ccode_78 = 0;
+      _fx_N14C_form__cexp_t v_471 = 0;
+      _fx_LN14C_form__cexp_t v_472 = 0;
       _fx_LN14C_form__cexp_t args_5 = 0;
       _fx_N14C_form__cexp_t dst_exp_11 = 0;
-      _fx_LN15C_form__cstmt_t ccode_74 = 0;
-      _fx_LN14C_form__cexp_t v_451 = 0;
+      _fx_LN15C_form__cstmt_t ccode_79 = 0;
+      _fx_LN14C_form__cexp_t v_473 = 0;
       _fx_LN14C_form__cexp_t args_6 = 0;
       _fx_N14C_form__ctyp_t fcall_rt_0 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_452 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_474 = {0};
       _fx_N14C_form__cexp_t fcall_exp_0 = 0;
-      _fx_N15C_form__cstmt_t v_453 = 0;
-      _fx_LN15C_form__cstmt_t v_454 = 0;
-      _fx_LN15C_form__cstmt_t ccode_75 = 0;
+      _fx_N15C_form__cstmt_t v_475 = 0;
+      _fx_LN15C_form__cstmt_t v_476 = 0;
+      _fx_LN15C_form__cstmt_t ccode_80 = 0;
       _fx_T3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_7 = &kexp_0->u.KExpCall;
       _fx_R9Ast__id_t* f_2 = &vcase_7->t0;
-      FX_COPY_PTR(ccode_0, &ccode_71);
+      FX_COPY_PTR(ccode_0, &ccode_76);
       FX_COPY_PTR(vcase_7->t1, &args_3);
       _fx_LN14K_form__atom_t lst_5 = args_3;
       for (; lst_5; lst_5 = lst_5->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_455 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_477 = {0};
          _fx_N14C_form__cexp_t carg_0 = 0;
          _fx_LN15C_form__cstmt_t ccode1_4 = 0;
          _fx_N14C_form__cexp_t carg_1 = 0;
-         _fx_LN14C_form__cexp_t v_456 = 0;
+         _fx_LN14C_form__cexp_t v_478 = 0;
          _fx_N14K_form__atom_t* arg_1 = &lst_5->hd;
          FX_CALL(
-            atom2cexp_0.fp(arg_1, ccode_71, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_455, atom2cexp_0.fcv), _fx_catch_102);
-         FX_COPY_PTR(v_455.t0, &carg_0);
-         FX_COPY_PTR(v_455.t1, &ccode1_4);
+            atom2cexp_0.fp(arg_1, ccode_76, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_477, atom2cexp_0.fcv), _fx_catch_109);
+         FX_COPY_PTR(v_477.t0, &carg_0);
+         FX_COPY_PTR(v_477.t1, &ccode1_4);
          FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(carg_0, &kloc_0, &carg_1, 0),
-            _fx_catch_102);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_1, cargs_1, true, &v_456), _fx_catch_102);
+            _fx_catch_109);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_1, cargs_1, true, &v_478), _fx_catch_109);
          _fx_free_LN14C_form__cexp_t(&cargs_1);
-         FX_COPY_PTR(v_456, &cargs_1);
-         _fx_free_LN15C_form__cstmt_t(&ccode_71);
-         FX_COPY_PTR(ccode1_4, &ccode_71);
+         FX_COPY_PTR(v_478, &cargs_1);
+         _fx_free_LN15C_form__cstmt_t(&ccode_76);
+         FX_COPY_PTR(ccode1_4, &ccode_76);
 
-      _fx_catch_102: ;
-         if (v_456) {
-            _fx_free_LN14C_form__cexp_t(&v_456);
+      _fx_catch_109: ;
+         if (v_478) {
+            _fx_free_LN14C_form__cexp_t(&v_478);
          }
          if (carg_1) {
             _fx_free_N14C_form__cexp_t(&carg_1);
@@ -25857,109 +26063,109 @@ static int
          if (carg_0) {
             _fx_free_N14C_form__cexp_t(&carg_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_455);
-         FX_CHECK_EXN(_fx_catch_107);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_477);
+         FX_CHECK_EXN(_fx_catch_114);
       }
-      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(f_2, &kloc_0, &v_442, 0), _fx_catch_107);
-      if (v_442.tag == 5) {
-         _fx_R17C_form__cdefexn_t v_457 = {0};
-         _fx_N15C_form__cinfo_t v_458 = {0};
-         _fx_copy_R17C_form__cdefexn_t(&v_442.u.CExn->data, &v_457);
-         _fx_R9Ast__id_t* cexn_make_0 = &v_457.cexn_make;
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(cexn_make_0, &kloc_0, &v_458, 0),
-            _fx_catch_103);
-         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(cexn_make_0, &v_458, &v_443);
+      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(f_2, &kloc_0, &v_464, 0), _fx_catch_114);
+      if (v_464.tag == 5) {
+         _fx_R17C_form__cdefexn_t v_479 = {0};
+         _fx_N15C_form__cinfo_t v_480 = {0};
+         _fx_copy_R17C_form__cdefexn_t(&v_464.u.CExn->data, &v_479);
+         _fx_R9Ast__id_t* cexn_make_0 = &v_479.cexn_make;
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(cexn_make_0, &kloc_0, &v_480, 0),
+            _fx_catch_110);
+         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(cexn_make_0, &v_480, &v_465);
 
-      _fx_catch_103: ;
-         _fx_free_N15C_form__cinfo_t(&v_458);
-         _fx_free_R17C_form__cdefexn_t(&v_457);
+      _fx_catch_110: ;
+         _fx_free_N15C_form__cinfo_t(&v_480);
+         _fx_free_R17C_form__cdefexn_t(&v_479);
       }
       else {
-         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(f_2, &v_442, &v_443);
+         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(f_2, &v_464, &v_465);
       }
-      FX_CHECK_EXN(_fx_catch_107);
-      _fx_R9Ast__id_t f_3 = v_443.t0;
-      _fx_copy_N15C_form__cinfo_t(&v_443.t1, &ci_0);
+      FX_CHECK_EXN(_fx_catch_114);
+      _fx_R9Ast__id_t f_3 = v_465.t0;
+      _fx_copy_N15C_form__cinfo_t(&v_465.t1, &ci_0);
       int tag_12 = ci_0.tag;
       if (tag_12 == 3) {
          fx_str_t cf_cname_0 = {0};
          _fx_N14C_form__ctyp_t cf_rt_0 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t cf_args_0 = 0;
-         _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_459 = {0};
+         _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_481 = {0};
          _fx_N14C_form__cexp_t f_exp_2 = 0;
          _fx_LN14C_form__cexp_t fv_args_1 = 0;
-         _fx_N14C_form__cexp_t v_460 = 0;
-         _fx_N14C_form__cexp_t v_461 = 0;
-         fx_str_t v_462 = {0};
-         fx_str_t v_463 = {0};
-         fx_exn_t v_464 = {0};
-         _fx_R17C_form__cdeffun_t* v_465 = &ci_0.u.CFun->data;
-         _fx_R10Ast__loc_t cf_loc_0 = v_465->cf_loc;
-         fx_copy_str(&v_465->cf_cname, &cf_cname_0);
-         _fx_R16Ast__fun_flags_t cf_flags_0 = v_465->cf_flags;
-         FX_COPY_PTR(v_465->cf_rt, &cf_rt_0);
-         FX_COPY_PTR(v_465->cf_args, &cf_args_0);
+         _fx_N14C_form__cexp_t v_482 = 0;
+         _fx_N14C_form__cexp_t v_483 = 0;
+         fx_str_t v_484 = {0};
+         fx_str_t v_485 = {0};
+         fx_exn_t v_486 = {0};
+         _fx_R17C_form__cdeffun_t* v_487 = &ci_0.u.CFun->data;
+         _fx_R10Ast__loc_t cf_loc_0 = v_487->cf_loc;
+         fx_copy_str(&v_487->cf_cname, &cf_cname_0);
+         _fx_R16Ast__fun_flags_t cf_flags_0 = v_487->cf_flags;
+         FX_COPY_PTR(v_487->cf_rt, &cf_rt_0);
+         FX_COPY_PTR(v_487->cf_args, &cf_args_0);
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_104);
+               &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_111);
          bool is_nothrow_0 = cf_flags_0.fun_flag_nothrow;
          FX_CALL(
             _fx_M10C_gen_codeFM15unpack_fun_argsT4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB3LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tB(
-               cf_args_0, cf_rt_0, is_nothrow_0, &v_459, 0), _fx_catch_104);
-         _fx_R9Ast__id_t ret_id_0 = v_459.t1;
-         bool have_fv_arg_0 = v_459.t3;
+               cf_args_0, cf_rt_0, is_nothrow_0, &v_481, 0), _fx_catch_111);
+         _fx_R9Ast__id_t ret_id_0 = v_481.t1;
+         bool have_fv_arg_0 = v_481.t3;
          FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &cf_loc_0, &f_exp_2, 0),
-            _fx_catch_104);
+            _fx_catch_111);
          if (have_fv_arg_0) {
             if (!cf_flags_0.fun_flag_uses_fv) {
-               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_460, 0), _fx_catch_104);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_460, 0, true, &fv_args_1), _fx_catch_104);
+               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_482, 0), _fx_catch_111);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_482, 0, true, &fv_args_1), _fx_catch_111);
             }
             else {
-               _fx_R9Ast__id_t v_466;
+               _fx_R9Ast__id_t v_488;
                FX_CALL(
-                  _fx_M10C_gen_codeFM9curr_funcR9Ast__id_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, &v_466,
-                     0), _fx_catch_104);
+                  _fx_M10C_gen_codeFM9curr_funcR9Ast__id_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, &v_488,
+                     0), _fx_catch_111);
                bool res_12;
-               FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&f_3, &v_466, &res_12, 0), _fx_catch_104);
+               FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&f_3, &v_488, &res_12, 0), _fx_catch_111);
                if (res_12) {
-                  _fx_R9Ast__id_t v_467;
-                  fx_str_t slit_116 = FX_MAKE_STR("fx_fv");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_116, &v_467, 0), _fx_catch_104);
+                  _fx_R9Ast__id_t v_489;
+                  fx_str_t slit_117 = FX_MAKE_STR("fx_fv");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_117, &v_489, 0), _fx_catch_111);
                   FX_CALL(
-                     _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_467,
-                        _fx_g23C_form__std_CTypVoidPtr, &cf_loc_0, &v_461, 0), _fx_catch_104);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_461, 0, true, &fv_args_1), _fx_catch_104);
+                     _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_489,
+                        _fx_g23C_form__std_CTypVoidPtr, &cf_loc_0, &v_483, 0), _fx_catch_111);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_483, 0, true, &fv_args_1), _fx_catch_111);
                }
                else {
-                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&cf_cname_0, &v_462, 0), _fx_catch_104);
-                  fx_str_t slit_117 = FX_MAKE_STR("cgen: looks like lambda lifting did not transform \'");
-                  fx_str_t slit_118 =
+                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&cf_cname_0, &v_484, 0), _fx_catch_111);
+                  fx_str_t slit_118 = FX_MAKE_STR("cgen: looks like lambda lifting did not transform \'");
+                  fx_str_t slit_119 =
                      FX_MAKE_STR(
                         "\' call correctly. Functions that access free variables must be called via closure (except for the case when function calls itself)");
                   {
-                     const fx_str_t strs_26[] = { slit_117, v_462, slit_118 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_463), _fx_catch_104);
+                     const fx_str_t strs_26[] = { slit_118, v_484, slit_119 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_485), _fx_catch_111);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_463, &v_464, 0), _fx_catch_104);
-                  FX_THROW(&v_464, false, _fx_catch_104);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_485, &v_486, 0), _fx_catch_111);
+                  FX_THROW(&v_486, false, _fx_catch_111);
                }
             }
          }
          bool res_13;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&ret_id_0, &_fx_g9Ast__noid, &res_13, 0), _fx_catch_104);
-         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_2, res_13, fv_args_1, is_nothrow_0, ccode_71,
-            &v_444);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&ret_id_0, &_fx_g9Ast__noid, &res_13, 0), _fx_catch_111);
+         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_2, res_13, fv_args_1, is_nothrow_0, ccode_76,
+            &v_466);
 
-      _fx_catch_104: ;
-         fx_free_exn(&v_464);
-         FX_FREE_STR(&v_463);
-         FX_FREE_STR(&v_462);
-         if (v_461) {
-            _fx_free_N14C_form__cexp_t(&v_461);
+      _fx_catch_111: ;
+         fx_free_exn(&v_486);
+         FX_FREE_STR(&v_485);
+         FX_FREE_STR(&v_484);
+         if (v_483) {
+            _fx_free_N14C_form__cexp_t(&v_483);
          }
-         if (v_460) {
-            _fx_free_N14C_form__cexp_t(&v_460);
+         if (v_482) {
+            _fx_free_N14C_form__cexp_t(&v_482);
          }
          if (fv_args_1) {
             _fx_free_LN14C_form__cexp_t(&fv_args_1);
@@ -25967,7 +26173,7 @@ static int
          if (f_exp_2) {
             _fx_free_N14C_form__cexp_t(&f_exp_2);
          }
-         _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_459);
+         _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_481);
          if (cf_args_0) {
             _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&cf_args_0);
          }
@@ -25977,18 +26183,18 @@ static int
          FX_FREE_STR(&cf_cname_0);
       }
       else if (tag_12 == 2) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_468 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_490 = {0};
          _fx_N14C_form__cexp_t fclo_exp_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_76 = 0;
-         _fx_N14K_form__ktyp_t v_469 = 0;
+         _fx_LN15C_form__cstmt_t ccode_81 = 0;
+         _fx_N14K_form__ktyp_t v_491 = 0;
          _fx_N14K_form__ktyp_t ftyp_0 = 0;
          _fx_N14C_form__ctyp_t cftyp_0 = 0;
          _fx_N14C_form__cexp_t f_exp_3 = 0;
-         _fx_N14C_form__cexp_t v_470 = 0;
+         _fx_N14C_form__cexp_t v_492 = 0;
          _fx_LN14C_form__cexp_t fv_args_2 = 0;
          _fx_R16Ast__val_flags_t* cv_flags_0 = &ci_0.u.CVal.cv_flags;
          bool res_14;
-         FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(cv_flags_0, &res_14, 0), _fx_catch_105);
+         FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(cv_flags_0, &res_14, 0), _fx_catch_112);
          bool t_7;
          if (res_14) {
             t_7 = true;
@@ -25999,41 +26205,41 @@ static int
          if (t_7) {
             FX_CALL(
                _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-                  &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_105);
+                  &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_112);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
-               &f_3, false, ccode_71, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_468, 0), _fx_catch_105);
-         FX_COPY_PTR(v_468.t0, &fclo_exp_0);
-         FX_COPY_PTR(v_468.t1, &ccode_76);
-         FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_469, 0),
-            _fx_catch_105);
-         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_469, &kloc_0, &ftyp_0, 0),
-            _fx_catch_105);
+               &f_3, false, ccode_76, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
+               &v_490, 0), _fx_catch_112);
+         FX_COPY_PTR(v_490.t0, &fclo_exp_0);
+         FX_COPY_PTR(v_490.t1, &ccode_81);
+         FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_491, 0),
+            _fx_catch_112);
+         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_491, &kloc_0, &ftyp_0, 0),
+            _fx_catch_112);
          FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(ftyp_0, &kloc_0, &cftyp_0, 0),
-            _fx_catch_105);
-         _fx_R9Ast__id_t v_471;
-         fx_str_t slit_119 = FX_MAKE_STR("fp");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_119, &v_471, 0), _fx_catch_105);
+            _fx_catch_112);
+         _fx_R9Ast__id_t v_493;
+         fx_str_t slit_120 = FX_MAKE_STR("fp");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_120, &v_493, 0), _fx_catch_112);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_471, cftyp_0,
-               &f_exp_3, 0), _fx_catch_105);
-         _fx_R9Ast__id_t v_472;
-         fx_str_t slit_120 = FX_MAKE_STR("fcv");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_120, &v_472, 0), _fx_catch_105);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_493, cftyp_0,
+               &f_exp_3, 0), _fx_catch_112);
+         _fx_R9Ast__id_t v_494;
+         fx_str_t slit_121 = FX_MAKE_STR("fcv");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_121, &v_494, 0), _fx_catch_112);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_472,
-               _fx_g23C_form__std_CTypVoidPtr, &v_470, 0), _fx_catch_105);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_470, 0, true, &fv_args_2), _fx_catch_105);
-         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_3, true, fv_args_2, false, ccode_76, &v_444);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_494,
+               _fx_g23C_form__std_CTypVoidPtr, &v_492, 0), _fx_catch_112);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_492, 0, true, &fv_args_2), _fx_catch_112);
+         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_3, true, fv_args_2, false, ccode_81, &v_466);
 
-      _fx_catch_105: ;
+      _fx_catch_112: ;
          if (fv_args_2) {
             _fx_free_LN14C_form__cexp_t(&fv_args_2);
          }
-         if (v_470) {
-            _fx_free_N14C_form__cexp_t(&v_470);
+         if (v_492) {
+            _fx_free_N14C_form__cexp_t(&v_492);
          }
          if (f_exp_3) {
             _fx_free_N14C_form__cexp_t(&f_exp_3);
@@ -26044,45 +26250,45 @@ static int
          if (ftyp_0) {
             _fx_free_N14K_form__ktyp_t(&ftyp_0);
          }
-         if (v_469) {
-            _fx_free_N14K_form__ktyp_t(&v_469);
+         if (v_491) {
+            _fx_free_N14K_form__ktyp_t(&v_491);
          }
-         if (ccode_76) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_76);
+         if (ccode_81) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_81);
          }
          if (fclo_exp_0) {
             _fx_free_N14C_form__cexp_t(&fclo_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_468);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_490);
       }
       else {
-         fx_str_t v_473 = {0};
-         fx_str_t v_474 = {0};
-         fx_str_t v_475 = {0};
-         fx_exn_t v_476 = {0};
-         FX_CALL(_fx_M6C_formFM7idc2strS2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_473, 0), _fx_catch_106);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_473, &v_474, 0), _fx_catch_106);
-         fx_str_t slit_121 = FX_MAKE_STR("cgen: the called \'");
-         fx_str_t slit_122 = FX_MAKE_STR("\' is not a function nor value");
+         fx_str_t v_495 = {0};
+         fx_str_t v_496 = {0};
+         fx_str_t v_497 = {0};
+         fx_exn_t v_498 = {0};
+         FX_CALL(_fx_M6C_formFM7idc2strS2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_495, 0), _fx_catch_113);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_495, &v_496, 0), _fx_catch_113);
+         fx_str_t slit_122 = FX_MAKE_STR("cgen: the called \'");
+         fx_str_t slit_123 = FX_MAKE_STR("\' is not a function nor value");
          {
-            const fx_str_t strs_27[] = { slit_121, v_474, slit_122 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_475), _fx_catch_106);
+            const fx_str_t strs_27[] = { slit_122, v_496, slit_123 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_497), _fx_catch_113);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_475, &v_476, 0), _fx_catch_106);
-         FX_THROW(&v_476, false, _fx_catch_106);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_497, &v_498, 0), _fx_catch_113);
+         FX_THROW(&v_498, false, _fx_catch_113);
 
-      _fx_catch_106: ;
-         fx_free_exn(&v_476);
-         FX_FREE_STR(&v_475);
-         FX_FREE_STR(&v_474);
-         FX_FREE_STR(&v_473);
+      _fx_catch_113: ;
+         fx_free_exn(&v_498);
+         FX_FREE_STR(&v_497);
+         FX_FREE_STR(&v_496);
+         FX_FREE_STR(&v_495);
       }
-      FX_CHECK_EXN(_fx_catch_107);
-      FX_COPY_PTR(v_444.t0, &f_exp_1);
-      bool have_out_arg_0 = v_444.t1;
-      FX_COPY_PTR(v_444.t2, &fv_args_0);
-      bool is_nothrow_1 = v_444.t3;
-      FX_COPY_PTR(v_444.t4, &ccode_72);
+      FX_CHECK_EXN(_fx_catch_114);
+      FX_COPY_PTR(v_466.t0, &f_exp_1);
+      bool have_out_arg_0 = v_466.t1;
+      FX_COPY_PTR(v_466.t2, &fv_args_0);
+      bool is_nothrow_1 = v_466.t3;
+      FX_COPY_PTR(v_466.t4, &ccode_77);
       bool t_8;
       if (!have_out_arg_0) {
          t_8 = FX_REC_VARIANT_TAG(ctyp_0) != 8;
@@ -26092,85 +26298,85 @@ static int
       }
       if (t_8) {
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, cargs_1, &v_445, 0),
-            _fx_catch_107);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_445, &args_4, 0), _fx_catch_107);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_446);
+            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, cargs_1, &v_467, 0),
+            _fx_catch_114);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_467, &args_4, 0), _fx_catch_114);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_468);
          FX_CALL(
             _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-               f_exp_1, args_4, &v_446, &call_exp_2), _fx_catch_107);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, call_exp_2, ccode_72, &v_1);
+               f_exp_1, args_4, &v_468, &call_exp_2), _fx_catch_114);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, call_exp_2, ccode_77, &v_1);
       }
       else {
          if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
-            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_1, dummy_exp_0, ccode_72, &v_447);
+            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_1, dummy_exp_0, ccode_77, &v_469);
          }
          else {
-            fx_str_t slit_123 = FX_MAKE_STR("res");
+            fx_str_t slit_124 = FX_MAKE_STR("res");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_123, ctyp_0, ccode_72, &kloc_0, block_stack_ref_0, km_idx_0, &v_448, 0), _fx_catch_107);
-            FX_COPY_PTR(v_448.t0, &dst_exp_10);
-            FX_COPY_PTR(v_448.t1, &ccode_73);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_10, &v_449, 0), _fx_catch_107);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_449, cargs_1, true, &v_450), _fx_catch_107);
-            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_450, dst_exp_10, ccode_73, &v_447);
+                  dstexp_r_0, &slit_124, ctyp_0, ccode_77, &kloc_0, block_stack_ref_0, km_idx_0, &v_470, 0), _fx_catch_114);
+            FX_COPY_PTR(v_470.t0, &dst_exp_10);
+            FX_COPY_PTR(v_470.t1, &ccode_78);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_10, &v_471, 0), _fx_catch_114);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_471, cargs_1, true, &v_472), _fx_catch_114);
+            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_472, dst_exp_10, ccode_78, &v_469);
          }
-         FX_COPY_PTR(v_447.t0, &args_5);
-         FX_COPY_PTR(v_447.t1, &dst_exp_11);
-         FX_COPY_PTR(v_447.t2, &ccode_74);
+         FX_COPY_PTR(v_469.t0, &args_5);
+         FX_COPY_PTR(v_469.t1, &dst_exp_11);
+         FX_COPY_PTR(v_469.t2, &ccode_79);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, args_5, &v_451, 0),
-            _fx_catch_107);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_451, &args_6, 0), _fx_catch_107);
+            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, args_5, &v_473, 0),
+            _fx_catch_114);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_473, &args_6, 0), _fx_catch_114);
          if (is_nothrow_1) {
             FX_COPY_PTR(_fx_g20C_gen_code__CTypVoid, &fcall_rt_0);
          }
          else {
             FX_COPY_PTR(_fx_g20C_gen_code__CTypCInt, &fcall_rt_0);
          }
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(fcall_rt_0, &kloc_0, &v_452);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(fcall_rt_0, &kloc_0, &v_474);
          FX_CALL(
             _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-               f_exp_1, args_6, &v_452, &fcall_exp_0), _fx_catch_107);
+               f_exp_1, args_6, &v_474, &fcall_exp_0), _fx_catch_114);
          if (is_nothrow_1) {
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(fcall_exp_0, &v_453), _fx_catch_107);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_453, ccode_74, true, &v_454), _fx_catch_107);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, v_454, &v_1);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(fcall_exp_0, &v_475), _fx_catch_114);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_475, ccode_79, true, &v_476), _fx_catch_114);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, v_476, &v_1);
          }
          else {
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  fcall_exp_0, ccode_74, &kloc_0, block_stack_ref_0, &ccode_75, 0), _fx_catch_107);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, ccode_75, &v_1);
+                  fcall_exp_0, ccode_79, &kloc_0, block_stack_ref_0, &ccode_80, 0), _fx_catch_114);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, ccode_80, &v_1);
          }
       }
 
-   _fx_catch_107: ;
-      if (ccode_75) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_75);
+   _fx_catch_114: ;
+      if (ccode_80) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_80);
       }
-      if (v_454) {
-         _fx_free_LN15C_form__cstmt_t(&v_454);
+      if (v_476) {
+         _fx_free_LN15C_form__cstmt_t(&v_476);
       }
-      if (v_453) {
-         _fx_free_N15C_form__cstmt_t(&v_453);
+      if (v_475) {
+         _fx_free_N15C_form__cstmt_t(&v_475);
       }
       if (fcall_exp_0) {
          _fx_free_N14C_form__cexp_t(&fcall_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_452);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_474);
       if (fcall_rt_0) {
          _fx_free_N14C_form__ctyp_t(&fcall_rt_0);
       }
       if (args_6) {
          _fx_free_LN14C_form__cexp_t(&args_6);
       }
-      if (v_451) {
-         _fx_free_LN14C_form__cexp_t(&v_451);
+      if (v_473) {
+         _fx_free_LN14C_form__cexp_t(&v_473);
       }
-      if (ccode_74) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_74);
+      if (ccode_79) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_79);
       }
       if (dst_exp_11) {
          _fx_free_N14C_form__cexp_t(&dst_exp_11);
@@ -26178,32 +26384,32 @@ static int
       if (args_5) {
          _fx_free_LN14C_form__cexp_t(&args_5);
       }
-      if (v_450) {
-         _fx_free_LN14C_form__cexp_t(&v_450);
+      if (v_472) {
+         _fx_free_LN14C_form__cexp_t(&v_472);
       }
-      if (v_449) {
-         _fx_free_N14C_form__cexp_t(&v_449);
+      if (v_471) {
+         _fx_free_N14C_form__cexp_t(&v_471);
       }
-      if (ccode_73) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_73);
+      if (ccode_78) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_78);
       }
       if (dst_exp_10) {
          _fx_free_N14C_form__cexp_t(&dst_exp_10);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_448);
-      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_447);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_470);
+      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_469);
       if (call_exp_2) {
          _fx_free_N14C_form__cexp_t(&call_exp_2);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_446);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_468);
       if (args_4) {
          _fx_free_LN14C_form__cexp_t(&args_4);
       }
-      if (v_445) {
-         _fx_free_LN14C_form__cexp_t(&v_445);
+      if (v_467) {
+         _fx_free_LN14C_form__cexp_t(&v_467);
       }
-      if (ccode_72) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_72);
+      if (ccode_77) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_77);
       }
       if (fv_args_0) {
          _fx_free_LN14C_form__cexp_t(&fv_args_0);
@@ -26211,95 +26417,95 @@ static int
       if (f_exp_1) {
          _fx_free_N14C_form__cexp_t(&f_exp_1);
       }
-      _fx_free_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(&v_444);
+      _fx_free_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(&v_466);
       _fx_free_N15C_form__cinfo_t(&ci_0);
-      _fx_free_T2R9Ast__id_tN15C_form__cinfo_t(&v_443);
-      _fx_free_N15C_form__cinfo_t(&v_442);
+      _fx_free_T2R9Ast__id_tN15C_form__cinfo_t(&v_465);
+      _fx_free_N15C_form__cinfo_t(&v_464);
       if (args_3) {
          _fx_free_LN14K_form__atom_t(&args_3);
       }
-      if (ccode_71) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_71);
+      if (ccode_76) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_76);
       }
       if (cargs_1) {
          _fx_free_LN14C_form__cexp_t(&cargs_1);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 13) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_477 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_499 = {0};
       _fx_N14C_form__cexp_t io_cexp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_77 = 0;
+      _fx_LN15C_form__cstmt_t ccode_82 = 0;
       _fx_N14C_form__cexp_t obj_cexp_0 = 0;
-      _fx_N14C_form__cexp_t v_478 = 0;
+      _fx_N14C_form__cexp_t v_500 = 0;
       _fx_LN14C_form__cexp_t cargs_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_78 = 0;
+      _fx_LN15C_form__cstmt_t ccode_83 = 0;
       _fx_LN14K_form__atom_t args_7 = 0;
       _fx_N14C_form__ctyp_t t_9 = 0;
-      _fx_Nt6option1rR23C_form__cdefinterface_t v_479 = {0};
+      _fx_Nt6option1rR23C_form__cdefinterface_t v_501 = {0};
       _fx_rR23C_form__cdefinterface_t obj_iface_0 = 0;
-      _fx_LT2R9Ast__id_tN14C_form__ctyp_t v_480 = 0;
-      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_481 = {0};
+      _fx_LT2R9Ast__id_tN14C_form__ctyp_t v_502 = 0;
+      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_503 = {0};
       _fx_N14C_form__ctyp_t mt_0 = 0;
       _fx_N14C_form__cexp_t vtbl_0 = 0;
       _fx_N14C_form__cexp_t mexp_0 = 0;
-      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_482 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_483 = {0};
+      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_504 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_505 = {0};
       _fx_N14C_form__cexp_t dst_exp_12 = 0;
-      _fx_LN15C_form__cstmt_t ccode_79 = 0;
-      _fx_N14C_form__cexp_t v_484 = 0;
-      _fx_LN14C_form__cexp_t v_485 = 0;
+      _fx_LN15C_form__cstmt_t ccode_84 = 0;
+      _fx_N14C_form__cexp_t v_506 = 0;
+      _fx_LN14C_form__cexp_t v_507 = 0;
       _fx_LN14C_form__cexp_t args_8 = 0;
       _fx_N14C_form__cexp_t dst_exp_13 = 0;
-      _fx_LN15C_form__cstmt_t ccode_80 = 0;
-      _fx_N14C_form__cexp_t v_486 = 0;
+      _fx_LN15C_form__cstmt_t ccode_85 = 0;
+      _fx_N14C_form__cexp_t v_508 = 0;
       _fx_LN14C_form__cexp_t args_9 = 0;
-      _fx_LN14C_form__cexp_t v_487 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_488 = {0};
+      _fx_LN14C_form__cexp_t v_509 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_510 = {0};
       _fx_N14C_form__cexp_t mcall_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_81 = 0;
+      _fx_LN15C_form__cstmt_t ccode_86 = 0;
       _fx_T4R9Ast__id_tiLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_8 = &kexp_0->u.KExpICall;
       FX_CALL(
          _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
             &vcase_8->t0, true, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-            &v_477, 0), _fx_catch_110);
-      FX_COPY_PTR(v_477.t0, &io_cexp_0);
-      FX_COPY_PTR(v_477.t1, &ccode_77);
-      _fx_R9Ast__id_t v_489;
-      fx_str_t slit_124 = FX_MAKE_STR("obj");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_124, &v_489, 0), _fx_catch_110);
+            &v_499, 0), _fx_catch_117);
+      FX_COPY_PTR(v_499.t0, &io_cexp_0);
+      FX_COPY_PTR(v_499.t1, &ccode_82);
+      _fx_R9Ast__id_t v_511;
+      fx_str_t slit_125 = FX_MAKE_STR("obj");
+      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_125, &v_511, 0), _fx_catch_117);
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_489,
-            _fx_g23C_form__std_CTypVoidPtr, &obj_cexp_0, 0), _fx_catch_110);
-      FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(obj_cexp_0, &kloc_0, &v_478, 0),
-         _fx_catch_110);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_478, 0, true, &cargs_2), _fx_catch_110);
-      FX_COPY_PTR(ccode_77, &ccode_78);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_511,
+            _fx_g23C_form__std_CTypVoidPtr, &obj_cexp_0, 0), _fx_catch_117);
+      FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(obj_cexp_0, &kloc_0, &v_500, 0),
+         _fx_catch_117);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_500, 0, true, &cargs_2), _fx_catch_117);
+      FX_COPY_PTR(ccode_82, &ccode_83);
       FX_COPY_PTR(vcase_8->t2, &args_7);
       _fx_LN14K_form__atom_t lst_6 = args_7;
       for (; lst_6; lst_6 = lst_6->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_490 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_512 = {0};
          _fx_N14C_form__cexp_t carg_2 = 0;
          _fx_LN15C_form__cstmt_t ccode1_5 = 0;
          _fx_N14C_form__cexp_t carg_3 = 0;
-         _fx_LN14C_form__cexp_t v_491 = 0;
+         _fx_LN14C_form__cexp_t v_513 = 0;
          _fx_N14K_form__atom_t* arg_2 = &lst_6->hd;
          FX_CALL(
-            atom2cexp_0.fp(arg_2, ccode_78, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_490, atom2cexp_0.fcv), _fx_catch_108);
-         FX_COPY_PTR(v_490.t0, &carg_2);
-         FX_COPY_PTR(v_490.t1, &ccode1_5);
+            atom2cexp_0.fp(arg_2, ccode_83, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_512, atom2cexp_0.fcv), _fx_catch_115);
+         FX_COPY_PTR(v_512.t0, &carg_2);
+         FX_COPY_PTR(v_512.t1, &ccode1_5);
          FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(carg_2, &kloc_0, &carg_3, 0),
-            _fx_catch_108);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_3, cargs_2, true, &v_491), _fx_catch_108);
+            _fx_catch_115);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_3, cargs_2, true, &v_513), _fx_catch_115);
          _fx_free_LN14C_form__cexp_t(&cargs_2);
-         FX_COPY_PTR(v_491, &cargs_2);
-         _fx_free_LN15C_form__cstmt_t(&ccode_78);
-         FX_COPY_PTR(ccode1_5, &ccode_78);
+         FX_COPY_PTR(v_513, &cargs_2);
+         _fx_free_LN15C_form__cstmt_t(&ccode_83);
+         FX_COPY_PTR(ccode1_5, &ccode_83);
 
-      _fx_catch_108: ;
-         if (v_491) {
-            _fx_free_LN14C_form__cexp_t(&v_491);
+      _fx_catch_115: ;
+         if (v_513) {
+            _fx_free_LN14C_form__cexp_t(&v_513);
          }
          if (carg_3) {
             _fx_free_N14C_form__cexp_t(&carg_3);
@@ -26310,106 +26516,106 @@ static int
          if (carg_2) {
             _fx_free_N14C_form__cexp_t(&carg_2);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_490);
-         FX_CHECK_EXN(_fx_catch_110);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_512);
+         FX_CHECK_EXN(_fx_catch_117);
       }
-      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(io_cexp_0, &t_9, 0), _fx_catch_110);
+      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(io_cexp_0, &t_9, 0), _fx_catch_117);
       FX_CALL(
-         _fx_M6C_formFM18get_cinterface_optNt6option1rRM15cdefinterface_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_479,
-            0), _fx_catch_110);
-      if (v_479.tag == 2) {
-         FX_COPY_PTR(v_479.u.Some, &obj_iface_0);
+         _fx_M6C_formFM18get_cinterface_optNt6option1rRM15cdefinterface_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_501,
+            0), _fx_catch_117);
+      if (v_501.tag == 2) {
+         FX_COPY_PTR(v_501.u.Some, &obj_iface_0);
       }
       else {
-         _fx_T2SR9Ast__id_t v_492 = {0};
-         fx_str_t v_493 = {0};
-         fx_str_t v_494 = {0};
-         fx_str_t v_495 = {0};
-         fx_exn_t v_496 = {0};
-         FX_CALL(_fx_M6C_formFM8ctyp2strT2SR9Ast__id_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_492, 0), _fx_catch_109);
-         fx_copy_str(&v_492.t0, &v_493);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_493, &v_494, 0), _fx_catch_109);
-         fx_str_t slit_125 = FX_MAKE_STR("the first parameter (of type \'");
-         fx_str_t slit_126 = FX_MAKE_STR("\') of KExpICall is not an interface");
+         _fx_T2SR9Ast__id_t v_514 = {0};
+         fx_str_t v_515 = {0};
+         fx_str_t v_516 = {0};
+         fx_str_t v_517 = {0};
+         fx_exn_t v_518 = {0};
+         FX_CALL(_fx_M6C_formFM8ctyp2strT2SR9Ast__id_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_514, 0), _fx_catch_116);
+         fx_copy_str(&v_514.t0, &v_515);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_515, &v_516, 0), _fx_catch_116);
+         fx_str_t slit_126 = FX_MAKE_STR("the first parameter (of type \'");
+         fx_str_t slit_127 = FX_MAKE_STR("\') of KExpICall is not an interface");
          {
-            const fx_str_t strs_28[] = { slit_125, v_494, slit_126 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_28, 3, &v_495), _fx_catch_109);
+            const fx_str_t strs_28[] = { slit_126, v_516, slit_127 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_28, 3, &v_517), _fx_catch_116);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_495, &v_496, 0), _fx_catch_109);
-         FX_THROW(&v_496, false, _fx_catch_109);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_517, &v_518, 0), _fx_catch_116);
+         FX_THROW(&v_518, false, _fx_catch_116);
 
-      _fx_catch_109: ;
-         fx_free_exn(&v_496);
-         FX_FREE_STR(&v_495);
-         FX_FREE_STR(&v_494);
-         FX_FREE_STR(&v_493);
-         _fx_free_T2SR9Ast__id_t(&v_492);
+      _fx_catch_116: ;
+         fx_free_exn(&v_518);
+         FX_FREE_STR(&v_517);
+         FX_FREE_STR(&v_516);
+         FX_FREE_STR(&v_515);
+         _fx_free_T2SR9Ast__id_t(&v_514);
       }
-      FX_CHECK_EXN(_fx_catch_110);
-      _fx_R23C_form__cdefinterface_t* v_497 = &obj_iface_0->data;
-      FX_COPY_PTR(v_497->ci_all_methods, &v_480);
+      FX_CHECK_EXN(_fx_catch_117);
+      _fx_R23C_form__cdefinterface_t* v_519 = &obj_iface_0->data;
+      FX_COPY_PTR(v_519->ci_all_methods, &v_502);
       FX_CALL(
-         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(v_480, vcase_8->t1, &v_481, 0),
-         _fx_catch_110);
-      _fx_R9Ast__id_t mname_0 = v_481.t0;
-      FX_COPY_PTR(v_481.t1, &mt_0);
-      _fx_R9Ast__id_t v_498;
-      fx_str_t slit_127 = FX_MAKE_STR("vtbl");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_127, &v_498, 0), _fx_catch_110);
+         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(v_502, vcase_8->t1, &v_503, 0),
+         _fx_catch_117);
+      _fx_R9Ast__id_t mname_0 = v_503.t0;
+      FX_COPY_PTR(v_503.t1, &mt_0);
+      _fx_R9Ast__id_t v_520;
+      fx_str_t slit_128 = FX_MAKE_STR("vtbl");
+      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_128, &v_520, 0), _fx_catch_117);
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_498,
-            _fx_g23C_form__std_CTypVoidPtr, &vtbl_0, 0), _fx_catch_110);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_520,
+            _fx_g23C_form__std_CTypVoidPtr, &vtbl_0, 0), _fx_catch_117);
       FX_CALL(
          _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(vtbl_0, &mname_0, mt_0,
-            &mexp_0, 0), _fx_catch_110);
+            &mexp_0, 0), _fx_catch_117);
       if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
-         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_2, dummy_exp_0, ccode_78, &v_482);
+         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_2, dummy_exp_0, ccode_83, &v_504);
       }
       else {
-         fx_str_t slit_128 = FX_MAKE_STR("res");
+         fx_str_t slit_129 = FX_MAKE_STR("res");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_128, ctyp_0, ccode_78, &kloc_0, block_stack_ref_0, km_idx_0, &v_483, 0), _fx_catch_110);
-         FX_COPY_PTR(v_483.t0, &dst_exp_12);
-         FX_COPY_PTR(v_483.t1, &ccode_79);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_12, &v_484, 0), _fx_catch_110);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_484, cargs_2, true, &v_485), _fx_catch_110);
-         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_485, dst_exp_12, ccode_79, &v_482);
+               dstexp_r_0, &slit_129, ctyp_0, ccode_83, &kloc_0, block_stack_ref_0, km_idx_0, &v_505, 0), _fx_catch_117);
+         FX_COPY_PTR(v_505.t0, &dst_exp_12);
+         FX_COPY_PTR(v_505.t1, &ccode_84);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_12, &v_506, 0), _fx_catch_117);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_506, cargs_2, true, &v_507), _fx_catch_117);
+         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_507, dst_exp_12, ccode_84, &v_504);
       }
-      FX_COPY_PTR(v_482.t0, &args_8);
-      FX_COPY_PTR(v_482.t1, &dst_exp_13);
-      FX_COPY_PTR(v_482.t2, &ccode_80);
-      FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_486, 0), _fx_catch_110);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_486, args_8, true, &args_9), _fx_catch_110);
-      FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(args_9, &v_487, 0), _fx_catch_110);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypCInt, &kloc_0, &v_488);
+      FX_COPY_PTR(v_504.t0, &args_8);
+      FX_COPY_PTR(v_504.t1, &dst_exp_13);
+      FX_COPY_PTR(v_504.t2, &ccode_85);
+      FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_508, 0), _fx_catch_117);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_508, args_8, true, &args_9), _fx_catch_117);
+      FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(args_9, &v_509, 0), _fx_catch_117);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypCInt, &kloc_0, &v_510);
       FX_CALL(
          _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(mexp_0,
-            v_487, &v_488, &mcall_exp_0), _fx_catch_110);
+            v_509, &v_510, &mcall_exp_0), _fx_catch_117);
       FX_CALL(
          _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-            mcall_exp_0, ccode_80, &kloc_0, block_stack_ref_0, &ccode_81, 0), _fx_catch_110);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_13, ccode_81, &v_1);
+            mcall_exp_0, ccode_85, &kloc_0, block_stack_ref_0, &ccode_86, 0), _fx_catch_117);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_13, ccode_86, &v_1);
 
-   _fx_catch_110: ;
-      if (ccode_81) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_81);
+   _fx_catch_117: ;
+      if (ccode_86) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_86);
       }
       if (mcall_exp_0) {
          _fx_free_N14C_form__cexp_t(&mcall_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_488);
-      if (v_487) {
-         _fx_free_LN14C_form__cexp_t(&v_487);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_510);
+      if (v_509) {
+         _fx_free_LN14C_form__cexp_t(&v_509);
       }
       if (args_9) {
          _fx_free_LN14C_form__cexp_t(&args_9);
       }
-      if (v_486) {
-         _fx_free_N14C_form__cexp_t(&v_486);
+      if (v_508) {
+         _fx_free_N14C_form__cexp_t(&v_508);
       }
-      if (ccode_80) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_80);
+      if (ccode_85) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_85);
       }
       if (dst_exp_13) {
          _fx_free_N14C_form__cexp_t(&dst_exp_13);
@@ -26417,20 +26623,20 @@ static int
       if (args_8) {
          _fx_free_LN14C_form__cexp_t(&args_8);
       }
-      if (v_485) {
-         _fx_free_LN14C_form__cexp_t(&v_485);
+      if (v_507) {
+         _fx_free_LN14C_form__cexp_t(&v_507);
       }
-      if (v_484) {
-         _fx_free_N14C_form__cexp_t(&v_484);
+      if (v_506) {
+         _fx_free_N14C_form__cexp_t(&v_506);
       }
-      if (ccode_79) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_79);
+      if (ccode_84) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_84);
       }
       if (dst_exp_12) {
          _fx_free_N14C_form__cexp_t(&dst_exp_12);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_483);
-      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_482);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_505);
+      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_504);
       if (mexp_0) {
          _fx_free_N14C_form__cexp_t(&mexp_0);
       }
@@ -26440,40 +26646,40 @@ static int
       if (mt_0) {
          _fx_free_N14C_form__ctyp_t(&mt_0);
       }
-      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_481);
-      if (v_480) {
-         _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&v_480);
+      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_503);
+      if (v_502) {
+         _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&v_502);
       }
       if (obj_iface_0) {
          _fx_free_rR23C_form__cdefinterface_t(&obj_iface_0);
       }
-      _fx_free_Nt6option1rR23C_form__cdefinterface_t(&v_479);
+      _fx_free_Nt6option1rR23C_form__cdefinterface_t(&v_501);
       if (t_9) {
          _fx_free_N14C_form__ctyp_t(&t_9);
       }
       if (args_7) {
          _fx_free_LN14K_form__atom_t(&args_7);
       }
-      if (ccode_78) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_78);
+      if (ccode_83) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_83);
       }
       if (cargs_2) {
          _fx_free_LN14C_form__cexp_t(&cargs_2);
       }
-      if (v_478) {
-         _fx_free_N14C_form__cexp_t(&v_478);
+      if (v_500) {
+         _fx_free_N14C_form__cexp_t(&v_500);
       }
       if (obj_cexp_0) {
          _fx_free_N14C_form__cexp_t(&obj_cexp_0);
       }
-      if (ccode_77) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_77);
+      if (ccode_82) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_82);
       }
       if (io_cexp_0) {
          _fx_free_N14C_form__cexp_t(&io_cexp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_477);
-      goto _fx_endmatch_55;
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_499);
+      goto _fx_endmatch_58;
    }
    bool res_15;
    if (tag_0 == 14) {
@@ -26487,84 +26693,84 @@ static int
    }
    FX_CHECK_EXN(_fx_cleanup);
    if (res_15) {
-      _fx_T2LN14K_form__atom_tS v_499 = {0};
+      _fx_T2LN14K_form__atom_tS v_521 = {0};
       _fx_LN14K_form__atom_t args_10 = 0;
       fx_str_t prefix_2 = {0};
       _fx_LN14C_form__cexp_t cargs_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_82 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_500 = {0};
+      _fx_LN15C_form__cstmt_t ccode_87 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_522 = {0};
       _fx_N14C_form__cexp_t t_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_83 = 0;
-      _fx_LN14C_form__cexp_t v_501 = 0;
-      _fx_N14C_form__cexp_t v_502 = 0;
-      _fx_LN14C_form__cexp_t v_503 = 0;
-      _fx_LN14C_form__cexp_t v_504 = 0;
+      _fx_LN15C_form__cstmt_t ccode_88 = 0;
+      _fx_LN14C_form__cexp_t v_523 = 0;
+      _fx_N14C_form__cexp_t v_524 = 0;
+      _fx_LN14C_form__cexp_t v_525 = 0;
+      _fx_LN14C_form__cexp_t v_526 = 0;
       _fx_N14C_form__cexp_t call_mktup_0 = 0;
-      _fx_N15C_form__cstmt_t v_505 = 0;
-      _fx_LN15C_form__cstmt_t v_506 = 0;
-      _fx_LN14C_form__cexp_t v_507 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_508 = {0};
+      _fx_N15C_form__cstmt_t v_527 = 0;
+      _fx_LN15C_form__cstmt_t v_528 = 0;
+      _fx_LN14C_form__cexp_t v_529 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_530 = {0};
       _fx_N14C_form__cexp_t e0_0 = 0;
-      _fx_R16Ast__val_flags_t v_509 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_510 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_511 = {0};
+      _fx_R16Ast__val_flags_t v_531 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_532 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_533 = {0};
       _fx_N14C_form__cexp_t t_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_84 = 0;
+      _fx_LN15C_form__cstmt_t ccode_89 = 0;
       int tag_13 = FX_REC_VARIANT_TAG(kexp_0);
       if (tag_13 == 14) {
-         fx_str_t slit_129 = FX_MAKE_STR("tup"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkTuple.t0, &slit_129, &v_499);
+         fx_str_t slit_130 = FX_MAKE_STR("tup"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkTuple.t0, &slit_130, &v_521);
       }
       else if (tag_13 == 15) {
-         fx_str_t slit_130 = FX_MAKE_STR("rec"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkRecord.t0, &slit_130, &v_499);
+         fx_str_t slit_131 = FX_MAKE_STR("rec"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkRecord.t0, &slit_131, &v_521);
       }
       else {
-         fx_exn_t v_512 = {0};
-         fx_str_t slit_131 = FX_MAKE_STR("unexpected expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_131, &v_512, 0), _fx_catch_111);
-         FX_THROW(&v_512, false, _fx_catch_111);
+         fx_exn_t v_534 = {0};
+         fx_str_t slit_132 = FX_MAKE_STR("unexpected expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_132, &v_534, 0), _fx_catch_118);
+         FX_THROW(&v_534, false, _fx_catch_118);
 
-      _fx_catch_111: ;
-         fx_free_exn(&v_512);
+      _fx_catch_118: ;
+         fx_free_exn(&v_534);
       }
-      FX_CHECK_EXN(_fx_catch_113);
-      FX_COPY_PTR(v_499.t0, &args_10);
-      fx_copy_str(&v_499.t1, &prefix_2);
+      FX_CHECK_EXN(_fx_catch_120);
+      FX_COPY_PTR(v_521.t0, &args_10);
+      fx_copy_str(&v_521.t1, &prefix_2);
       _fx_R9Ast__id_t tcon_0;
       FX_CALL(
          _fx_M11C_gen_typesFM15get_constructorR9Ast__id_t3N14C_form__ctyp_tBR10Ast__loc_t(ctyp_0, false, &kloc_0, &tcon_0, 0),
-         _fx_catch_113);
-      FX_COPY_PTR(ccode_0, &ccode_82);
+         _fx_catch_120);
+      FX_COPY_PTR(ccode_0, &ccode_87);
       _fx_LN14K_form__atom_t lst_7 = args_10;
       for (; lst_7; lst_7 = lst_7->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_513 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_535 = {0};
          _fx_N14C_form__cexp_t ca_0 = 0;
          _fx_LN15C_form__cstmt_t ccode1_6 = 0;
          _fx_N14C_form__cexp_t ca_1 = 0;
-         _fx_LN14C_form__cexp_t v_514 = 0;
-         _fx_N14K_form__atom_t* a_2 = &lst_7->hd;
+         _fx_LN14C_form__cexp_t v_536 = 0;
+         _fx_N14K_form__atom_t* a_3 = &lst_7->hd;
          FX_CALL(
-            atom2cexp_0.fp(a_2, ccode_82, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_513, atom2cexp_0.fcv), _fx_catch_112);
-         FX_COPY_PTR(v_513.t0, &ca_0);
-         FX_COPY_PTR(v_513.t1, &ccode1_6);
+            atom2cexp_0.fp(a_3, ccode_87, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
+               &v_535, atom2cexp_0.fcv), _fx_catch_119);
+         FX_COPY_PTR(v_535.t0, &ca_0);
+         FX_COPY_PTR(v_535.t1, &ccode1_6);
          bool res_16;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&tcon_0, &_fx_g9Ast__noid, &res_16, 0), _fx_catch_112);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&tcon_0, &_fx_g9Ast__noid, &res_16, 0), _fx_catch_119);
          if (res_16) {
             FX_COPY_PTR(ca_0, &ca_1);
          }
          else {
             FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(ca_0, &kloc_0, &ca_1, 0),
-               _fx_catch_112);
+               _fx_catch_119);
          }
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_1, cargs_3, true, &v_514), _fx_catch_112);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_1, cargs_3, true, &v_536), _fx_catch_119);
          _fx_free_LN14C_form__cexp_t(&cargs_3);
-         FX_COPY_PTR(v_514, &cargs_3);
-         _fx_free_LN15C_form__cstmt_t(&ccode_82);
-         FX_COPY_PTR(ccode1_6, &ccode_82);
+         FX_COPY_PTR(v_536, &cargs_3);
+         _fx_free_LN15C_form__cstmt_t(&ccode_87);
+         FX_COPY_PTR(ccode1_6, &ccode_87);
 
-      _fx_catch_112: ;
-         if (v_514) {
-            _fx_free_LN14C_form__cexp_t(&v_514);
+      _fx_catch_119: ;
+         if (v_536) {
+            _fx_free_LN14C_form__cexp_t(&v_536);
          }
          if (ca_1) {
             _fx_free_N14C_form__cexp_t(&ca_1);
@@ -26575,244 +26781,73 @@ static int
          if (ca_0) {
             _fx_free_N14C_form__cexp_t(&ca_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_513);
-         FX_CHECK_EXN(_fx_catch_113);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_535);
+         FX_CHECK_EXN(_fx_catch_120);
       }
       bool res_17;
-      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&tcon_0, &_fx_g9Ast__noid, &res_17, 0), _fx_catch_113);
+      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&tcon_0, &_fx_g9Ast__noid, &res_17, 0), _fx_catch_120);
       if (res_17) {
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &prefix_2, ctyp_0, ccode_82, &kloc_0, block_stack_ref_0, km_idx_0, &v_500, 0), _fx_catch_113);
-         FX_COPY_PTR(v_500.t0, &t_exp_0);
-         FX_COPY_PTR(v_500.t1, &ccode_83);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_501, 0), _fx_catch_113);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_0, &v_502, 0), _fx_catch_113);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_502, 0, true, &v_503), _fx_catch_113);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_501, v_503, &v_504, 0),
-            _fx_catch_113);
+               dstexp_r_0, &prefix_2, ctyp_0, ccode_87, &kloc_0, block_stack_ref_0, km_idx_0, &v_522, 0), _fx_catch_120);
+         FX_COPY_PTR(v_522.t0, &t_exp_0);
+         FX_COPY_PTR(v_522.t1, &ccode_88);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_523, 0), _fx_catch_120);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_0, &v_524, 0), _fx_catch_120);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_524, 0, true, &v_525), _fx_catch_120);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_523, v_525, &v_526, 0),
+            _fx_catch_120);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&tcon_0,
-               v_504, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_0, 0), _fx_catch_113);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_0, &v_505), _fx_catch_113);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_505, ccode_83, true, &v_506), _fx_catch_113);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, t_exp_0, v_506, &v_1);
+               v_526, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_0, 0), _fx_catch_120);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_0, &v_527), _fx_catch_120);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_527, ccode_88, true, &v_528), _fx_catch_120);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, t_exp_0, v_528, &v_1);
       }
       else {
          _fx_R9Ast__id_t tup_2;
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &prefix_2, &tup_2, 0), _fx_catch_113);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_507, 0), _fx_catch_113);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_508);
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &prefix_2, &tup_2, 0), _fx_catch_120);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_529, 0), _fx_catch_120);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_530);
          FX_CALL(
-            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_507, &v_508, &e0_0),
-            _fx_catch_113);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_509, 0), _fx_catch_113);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_0, &v_510);
-         fx_str_t slit_132 = FX_MAKE_STR("");
+            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_529, &v_530, &e0_0),
+            _fx_catch_120);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_531, 0), _fx_catch_120);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_0, &v_532);
+         fx_str_t slit_133 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &tup_2, ctyp_0, &v_509, &slit_132, &v_510, ccode_82, &kloc_0, &v_511, 0), _fx_catch_113);
-         FX_COPY_PTR(v_511.t0, &t_exp_1);
-         FX_COPY_PTR(v_511.t1, &ccode_84);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, t_exp_1, ccode_84, &v_1);
+               &tup_2, ctyp_0, &v_531, &slit_133, &v_532, ccode_87, &kloc_0, &v_533, 0), _fx_catch_120);
+         FX_COPY_PTR(v_533.t0, &t_exp_1);
+         FX_COPY_PTR(v_533.t1, &ccode_89);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, t_exp_1, ccode_89, &v_1);
       }
 
-   _fx_catch_113: ;
-      if (ccode_84) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_84);
+   _fx_catch_120: ;
+      if (ccode_89) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_89);
       }
       if (t_exp_1) {
          _fx_free_N14C_form__cexp_t(&t_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_511);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_510);
-      _fx_free_R16Ast__val_flags_t(&v_509);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_533);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_532);
+      _fx_free_R16Ast__val_flags_t(&v_531);
       if (e0_0) {
          _fx_free_N14C_form__cexp_t(&e0_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_508);
-      if (v_507) {
-         _fx_free_LN14C_form__cexp_t(&v_507);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_530);
+      if (v_529) {
+         _fx_free_LN14C_form__cexp_t(&v_529);
       }
-      if (v_506) {
-         _fx_free_LN15C_form__cstmt_t(&v_506);
-      }
-      if (v_505) {
-         _fx_free_N15C_form__cstmt_t(&v_505);
-      }
-      if (call_mktup_0) {
-         _fx_free_N14C_form__cexp_t(&call_mktup_0);
-      }
-      if (v_504) {
-         _fx_free_LN14C_form__cexp_t(&v_504);
-      }
-      if (v_503) {
-         _fx_free_LN14C_form__cexp_t(&v_503);
-      }
-      if (v_502) {
-         _fx_free_N14C_form__cexp_t(&v_502);
-      }
-      if (v_501) {
-         _fx_free_LN14C_form__cexp_t(&v_501);
-      }
-      if (ccode_83) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_83);
-      }
-      if (t_exp_0) {
-         _fx_free_N14C_form__cexp_t(&t_exp_0);
-      }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_500);
-      if (ccode_82) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_82);
-      }
-      if (cargs_3) {
-         _fx_free_LN14C_form__cexp_t(&cargs_3);
-      }
-      FX_FREE_STR(&prefix_2);
-      if (args_10) {
-         _fx_free_LN14K_form__atom_t(&args_10);
-      }
-      _fx_free_T2LN14K_form__atom_tS(&v_499);
-      goto _fx_endmatch_55;
-   }
-   if (tag_0 == 16) {
-      fx_str_t v_515 = {0};
-      fx_str_t fp_prefix_0 = {0};
-      _fx_N14C_form__cexp_t f_exp_4 = 0;
-      _fx_N14C_form__cexp_t v_516 = 0;
-      _fx_LN14C_form__cexp_t v_517 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_518 = {0};
-      _fx_N14C_form__cexp_t e0_1 = 0;
-      _fx_R16Ast__val_flags_t v_519 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_520 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_521 = {0};
-      _fx_N14C_form__cexp_t fp_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_85 = 0;
-      _fx_LN14C_form__cexp_t cargs_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_86 = 0;
-      _fx_LN14K_form__atom_t args_11 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_522 = {0};
-      _fx_N14C_form__cexp_t fp_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_87 = 0;
-      _fx_LN14C_form__cexp_t v_523 = 0;
-      _fx_N14C_form__cexp_t v_524 = 0;
-      _fx_LN14C_form__cexp_t v_525 = 0;
-      _fx_LN14C_form__cexp_t v_526 = 0;
-      _fx_N14C_form__cexp_t call_mkclo_0 = 0;
-      _fx_N15C_form__cstmt_t v_527 = 0;
-      _fx_LN15C_form__cstmt_t v_528 = 0;
-      _fx_T4R9Ast__id_tR9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_9 = &kexp_0->u.KExpMkClosure;
-      _fx_LN14K_form__atom_t args_12 = vcase_9->t2;
-      _fx_R9Ast__id_t* f_4 = &vcase_9->t1;
-      _fx_R9Ast__id_t* make_fp_0 = &vcase_9->t0;
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(f_4, &v_515, 0), _fx_catch_115);
-      fx_str_t slit_133 = FX_MAKE_STR("_fp");
-      {
-         const fx_str_t strs_29[] = { v_515, slit_133 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_29, 2, &fp_prefix_0), _fx_catch_115);
-      }
-      bool t_10;
-      if (args_12 == 0) {
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(make_fp_0, &_fx_g9Ast__noid, &t_10, 0), _fx_catch_115);
-      }
-      else {
-         t_10 = false;
-      }
-      if (t_10) {
-         _fx_R9Ast__id_t fp_id_0;
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &fp_prefix_0, &fp_id_0, 0), _fx_catch_115);
-         FX_CALL(
-            _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               f_4, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_115);
-         FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(f_4, &kloc_0, &f_exp_4, 0),
-            _fx_catch_115);
-         FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_516, 0), _fx_catch_115);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_516, 0, true, &v_517), _fx_catch_115);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(f_exp_4, v_517, false, &v_517), _fx_catch_115);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_518);
-         FX_CALL(
-            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_517, &v_518, &e0_1),
-            _fx_catch_115);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_519, 0), _fx_catch_115);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_1, &v_520);
-         fx_str_t slit_134 = FX_MAKE_STR("");
-         FX_CALL(
-            _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &fp_id_0, ctyp_0, &v_519, &slit_134, &v_520, ccode_0, &kloc_0, &v_521, 0), _fx_catch_115);
-         FX_COPY_PTR(v_521.t0, &fp_exp_0);
-         FX_COPY_PTR(v_521.t1, &ccode_85);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, fp_exp_0, ccode_85, &v_1);
-      }
-      else {
-         FX_COPY_PTR(ccode_0, &ccode_86);
-         FX_COPY_PTR(args_12, &args_11);
-         _fx_LN14K_form__atom_t lst_8 = args_11;
-         for (; lst_8; lst_8 = lst_8->tl) {
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_529 = {0};
-            _fx_N14C_form__cexp_t ca_2 = 0;
-            _fx_LN15C_form__cstmt_t ccode1_7 = 0;
-            _fx_N14C_form__cexp_t ca_3 = 0;
-            _fx_LN14C_form__cexp_t v_530 = 0;
-            _fx_N14K_form__atom_t* a_3 = &lst_8->hd;
-            FX_CALL(
-               atom2cexp_0.fp(a_3, ccode_86, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_529, atom2cexp_0.fcv), _fx_catch_114);
-            FX_COPY_PTR(v_529.t0, &ca_2);
-            FX_COPY_PTR(v_529.t1, &ccode1_7);
-            FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(ca_2, &kloc_0, &ca_3, 0),
-               _fx_catch_114);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_3, cargs_4, true, &v_530), _fx_catch_114);
-            _fx_free_LN14C_form__cexp_t(&cargs_4);
-            FX_COPY_PTR(v_530, &cargs_4);
-            _fx_free_LN15C_form__cstmt_t(&ccode_86);
-            FX_COPY_PTR(ccode1_7, &ccode_86);
-
-         _fx_catch_114: ;
-            if (v_530) {
-               _fx_free_LN14C_form__cexp_t(&v_530);
-            }
-            if (ca_3) {
-               _fx_free_N14C_form__cexp_t(&ca_3);
-            }
-            if (ccode1_7) {
-               _fx_free_LN15C_form__cstmt_t(&ccode1_7);
-            }
-            if (ca_2) {
-               _fx_free_N14C_form__cexp_t(&ca_2);
-            }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_529);
-            FX_CHECK_EXN(_fx_catch_115);
-         }
-         FX_CALL(
-            _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &fp_prefix_0, ctyp_0, ccode_86, &kloc_0, block_stack_ref_0, km_idx_0, &v_522, 0), _fx_catch_115);
-         FX_COPY_PTR(v_522.t0, &fp_exp_1);
-         FX_COPY_PTR(v_522.t1, &ccode_87);
-         FX_CALL(
-            _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               make_fp_0, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_115);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_4, &v_523, 0), _fx_catch_115);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(fp_exp_1, &v_524, 0), _fx_catch_115);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_524, 0, true, &v_525), _fx_catch_115);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_523, v_525, &v_526, 0),
-            _fx_catch_115);
-         FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(make_fp_0,
-               v_526, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mkclo_0, 0), _fx_catch_115);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mkclo_0, &v_527), _fx_catch_115);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_527, ccode_87, true, &v_528), _fx_catch_115);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, fp_exp_1, v_528, &v_1);
-      }
-
-   _fx_catch_115: ;
       if (v_528) {
          _fx_free_LN15C_form__cstmt_t(&v_528);
       }
       if (v_527) {
          _fx_free_N15C_form__cstmt_t(&v_527);
       }
-      if (call_mkclo_0) {
-         _fx_free_N14C_form__cexp_t(&call_mkclo_0);
+      if (call_mktup_0) {
+         _fx_free_N14C_form__cexp_t(&call_mktup_0);
       }
       if (v_526) {
          _fx_free_LN14C_form__cexp_t(&v_526);
@@ -26826,133 +26861,304 @@ static int
       if (v_523) {
          _fx_free_LN14C_form__cexp_t(&v_523);
       }
+      if (ccode_88) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_88);
+      }
+      if (t_exp_0) {
+         _fx_free_N14C_form__cexp_t(&t_exp_0);
+      }
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_522);
       if (ccode_87) {
          _fx_free_LN15C_form__cstmt_t(&ccode_87);
+      }
+      if (cargs_3) {
+         _fx_free_LN14C_form__cexp_t(&cargs_3);
+      }
+      FX_FREE_STR(&prefix_2);
+      if (args_10) {
+         _fx_free_LN14K_form__atom_t(&args_10);
+      }
+      _fx_free_T2LN14K_form__atom_tS(&v_521);
+      goto _fx_endmatch_58;
+   }
+   if (tag_0 == 16) {
+      fx_str_t v_537 = {0};
+      fx_str_t fp_prefix_0 = {0};
+      _fx_N14C_form__cexp_t f_exp_4 = 0;
+      _fx_N14C_form__cexp_t v_538 = 0;
+      _fx_LN14C_form__cexp_t v_539 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_540 = {0};
+      _fx_N14C_form__cexp_t e0_1 = 0;
+      _fx_R16Ast__val_flags_t v_541 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_542 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_543 = {0};
+      _fx_N14C_form__cexp_t fp_exp_0 = 0;
+      _fx_LN15C_form__cstmt_t ccode_90 = 0;
+      _fx_LN14C_form__cexp_t cargs_4 = 0;
+      _fx_LN15C_form__cstmt_t ccode_91 = 0;
+      _fx_LN14K_form__atom_t args_11 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_544 = {0};
+      _fx_N14C_form__cexp_t fp_exp_1 = 0;
+      _fx_LN15C_form__cstmt_t ccode_92 = 0;
+      _fx_LN14C_form__cexp_t v_545 = 0;
+      _fx_N14C_form__cexp_t v_546 = 0;
+      _fx_LN14C_form__cexp_t v_547 = 0;
+      _fx_LN14C_form__cexp_t v_548 = 0;
+      _fx_N14C_form__cexp_t call_mkclo_0 = 0;
+      _fx_N15C_form__cstmt_t v_549 = 0;
+      _fx_LN15C_form__cstmt_t v_550 = 0;
+      _fx_T4R9Ast__id_tR9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_9 = &kexp_0->u.KExpMkClosure;
+      _fx_LN14K_form__atom_t args_12 = vcase_9->t2;
+      _fx_R9Ast__id_t* f_4 = &vcase_9->t1;
+      _fx_R9Ast__id_t* make_fp_0 = &vcase_9->t0;
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(f_4, &v_537, 0), _fx_catch_122);
+      fx_str_t slit_134 = FX_MAKE_STR("_fp");
+      {
+         const fx_str_t strs_29[] = { v_537, slit_134 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_29, 2, &fp_prefix_0), _fx_catch_122);
+      }
+      bool t_10;
+      if (args_12 == 0) {
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(make_fp_0, &_fx_g9Ast__noid, &t_10, 0), _fx_catch_122);
+      }
+      else {
+         t_10 = false;
+      }
+      if (t_10) {
+         _fx_R9Ast__id_t fp_id_0;
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &fp_prefix_0, &fp_id_0, 0), _fx_catch_122);
+         FX_CALL(
+            _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
+               f_4, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_122);
+         FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(f_4, &kloc_0, &f_exp_4, 0),
+            _fx_catch_122);
+         FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_538, 0), _fx_catch_122);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_538, 0, true, &v_539), _fx_catch_122);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(f_exp_4, v_539, false, &v_539), _fx_catch_122);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_540);
+         FX_CALL(
+            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_539, &v_540, &e0_1),
+            _fx_catch_122);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_541, 0), _fx_catch_122);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_1, &v_542);
+         fx_str_t slit_135 = FX_MAKE_STR("");
+         FX_CALL(
+            _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+               &fp_id_0, ctyp_0, &v_541, &slit_135, &v_542, ccode_0, &kloc_0, &v_543, 0), _fx_catch_122);
+         FX_COPY_PTR(v_543.t0, &fp_exp_0);
+         FX_COPY_PTR(v_543.t1, &ccode_90);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, fp_exp_0, ccode_90, &v_1);
+      }
+      else {
+         FX_COPY_PTR(ccode_0, &ccode_91);
+         FX_COPY_PTR(args_12, &args_11);
+         _fx_LN14K_form__atom_t lst_8 = args_11;
+         for (; lst_8; lst_8 = lst_8->tl) {
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_551 = {0};
+            _fx_N14C_form__cexp_t ca_2 = 0;
+            _fx_LN15C_form__cstmt_t ccode1_7 = 0;
+            _fx_N14C_form__cexp_t ca_3 = 0;
+            _fx_LN14C_form__cexp_t v_552 = 0;
+            _fx_N14K_form__atom_t* a_4 = &lst_8->hd;
+            FX_CALL(
+               atom2cexp_0.fp(a_4, ccode_91, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_551, atom2cexp_0.fcv), _fx_catch_121);
+            FX_COPY_PTR(v_551.t0, &ca_2);
+            FX_COPY_PTR(v_551.t1, &ccode1_7);
+            FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(ca_2, &kloc_0, &ca_3, 0),
+               _fx_catch_121);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_3, cargs_4, true, &v_552), _fx_catch_121);
+            _fx_free_LN14C_form__cexp_t(&cargs_4);
+            FX_COPY_PTR(v_552, &cargs_4);
+            _fx_free_LN15C_form__cstmt_t(&ccode_91);
+            FX_COPY_PTR(ccode1_7, &ccode_91);
+
+         _fx_catch_121: ;
+            if (v_552) {
+               _fx_free_LN14C_form__cexp_t(&v_552);
+            }
+            if (ca_3) {
+               _fx_free_N14C_form__cexp_t(&ca_3);
+            }
+            if (ccode1_7) {
+               _fx_free_LN15C_form__cstmt_t(&ccode1_7);
+            }
+            if (ca_2) {
+               _fx_free_N14C_form__cexp_t(&ca_2);
+            }
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_551);
+            FX_CHECK_EXN(_fx_catch_122);
+         }
+         FX_CALL(
+            _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+               dstexp_r_0, &fp_prefix_0, ctyp_0, ccode_91, &kloc_0, block_stack_ref_0, km_idx_0, &v_544, 0), _fx_catch_122);
+         FX_COPY_PTR(v_544.t0, &fp_exp_1);
+         FX_COPY_PTR(v_544.t1, &ccode_92);
+         FX_CALL(
+            _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
+               make_fp_0, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_122);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_4, &v_545, 0), _fx_catch_122);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(fp_exp_1, &v_546, 0), _fx_catch_122);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_546, 0, true, &v_547), _fx_catch_122);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_545, v_547, &v_548, 0),
+            _fx_catch_122);
+         FX_CALL(
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(make_fp_0,
+               v_548, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mkclo_0, 0), _fx_catch_122);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mkclo_0, &v_549), _fx_catch_122);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_549, ccode_92, true, &v_550), _fx_catch_122);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, fp_exp_1, v_550, &v_1);
+      }
+
+   _fx_catch_122: ;
+      if (v_550) {
+         _fx_free_LN15C_form__cstmt_t(&v_550);
+      }
+      if (v_549) {
+         _fx_free_N15C_form__cstmt_t(&v_549);
+      }
+      if (call_mkclo_0) {
+         _fx_free_N14C_form__cexp_t(&call_mkclo_0);
+      }
+      if (v_548) {
+         _fx_free_LN14C_form__cexp_t(&v_548);
+      }
+      if (v_547) {
+         _fx_free_LN14C_form__cexp_t(&v_547);
+      }
+      if (v_546) {
+         _fx_free_N14C_form__cexp_t(&v_546);
+      }
+      if (v_545) {
+         _fx_free_LN14C_form__cexp_t(&v_545);
+      }
+      if (ccode_92) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_92);
       }
       if (fp_exp_1) {
          _fx_free_N14C_form__cexp_t(&fp_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_522);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_544);
       if (args_11) {
          _fx_free_LN14K_form__atom_t(&args_11);
       }
-      if (ccode_86) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_86);
+      if (ccode_91) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_91);
       }
       if (cargs_4) {
          _fx_free_LN14C_form__cexp_t(&cargs_4);
       }
-      if (ccode_85) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_85);
+      if (ccode_90) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_90);
       }
       if (fp_exp_0) {
          _fx_free_N14C_form__cexp_t(&fp_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_521);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_520);
-      _fx_free_R16Ast__val_flags_t(&v_519);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_543);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_542);
+      _fx_free_R16Ast__val_flags_t(&v_541);
       if (e0_1) {
          _fx_free_N14C_form__cexp_t(&e0_1);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_518);
-      if (v_517) {
-         _fx_free_LN14C_form__cexp_t(&v_517);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_540);
+      if (v_539) {
+         _fx_free_LN14C_form__cexp_t(&v_539);
       }
-      if (v_516) {
-         _fx_free_N14C_form__cexp_t(&v_516);
+      if (v_538) {
+         _fx_free_N14C_form__cexp_t(&v_538);
       }
       if (f_exp_4) {
          _fx_free_N14C_form__cexp_t(&f_exp_4);
       }
       FX_FREE_STR(&fp_prefix_0);
-      FX_FREE_STR(&v_515);
-      goto _fx_endmatch_55;
+      FX_FREE_STR(&v_537);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 17) {
       _fx_LLT2BN14K_form__atom_t arows_0 = 0;
-      _fx_T2iN14C_form__ctyp_t v_531 = {0};
+      _fx_T2iN14C_form__ctyp_t v_553 = {0};
       _fx_N14C_form__ctyp_t elem_ctyp_2 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_532 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_554 = {0};
       _fx_N14C_form__cexp_t arr_exp_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_88 = 0;
-      _fx_N14C_form__ctyp_t v_533 = 0;
+      _fx_LN15C_form__cstmt_t ccode_93 = 0;
+      _fx_N14C_form__ctyp_t v_555 = 0;
       _fx_N14C_form__cexp_t scalars_exp_0 = 0;
       _fx_LN14C_form__cexp_t scalars_data_0 = 0;
       _fx_LN14C_form__cexp_t tags_data_0 = 0;
       _fx_LN14C_form__cexp_t arr_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_89 = 0;
+      _fx_LN15C_form__cstmt_t ccode_94 = 0;
       _fx_LLT2BN14K_form__atom_t arows_1 = 0;
-      _fx_LN14C_form__cexp_t v_534 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_535 = {0};
+      _fx_LN14C_form__cexp_t v_556 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_557 = {0};
       _fx_LN15C_form__cstmt_t sub_ccode_2 = 0;
-      _fx_N14C_form__cexp_t v_536 = 0;
-      _fx_LN14C_form__cexp_t v_537 = 0;
-      _fx_LN14C_form__cexp_t v_538 = 0;
+      _fx_N14C_form__cexp_t v_558 = 0;
+      _fx_LN14C_form__cexp_t v_559 = 0;
+      _fx_LN14C_form__cexp_t v_560 = 0;
       _fx_LN14C_form__cexp_t tags_data_1 = 0;
-      _fx_N14C_form__ctyp_t v_539 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_540 = {0};
+      _fx_N14C_form__ctyp_t v_561 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_562 = {0};
       _fx_N14C_form__cexp_t tags_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_3 = 0;
-      _fx_LN14C_form__cexp_t v_541 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_542 = {0};
+      _fx_LN14C_form__cexp_t v_563 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_564 = {0};
       _fx_N14C_form__cexp_t arr_data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_4 = 0;
-      _fx_N14C_form__cexp_t v_543 = 0;
-      _fx_LN14C_form__cexp_t v_544 = 0;
+      _fx_N14C_form__cexp_t v_565 = 0;
+      _fx_LN14C_form__cexp_t v_566 = 0;
       _fx_N14C_form__cexp_t sizeof_elem_exp_0 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_545 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_567 = {0};
       _fx_N14C_form__cexp_t free_f_exp_0 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_546 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_568 = {0};
       _fx_N14C_form__cexp_t copy_f_exp_0 = 0;
-      _fx_N14C_form__cexp_t v_547 = 0;
-      _fx_N14C_form__cexp_t v_548 = 0;
-      _fx_LN14C_form__cexp_t v_549 = 0;
+      _fx_N14C_form__cexp_t v_569 = 0;
+      _fx_N14C_form__cexp_t v_570 = 0;
+      _fx_LN14C_form__cexp_t v_571 = 0;
       _fx_N14C_form__cexp_t call_mkarr_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_5 = 0;
-      _fx_N15C_form__cstmt_t v_550 = 0;
-      _fx_LN15C_form__cstmt_t ccode_90 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_551 = {0};
+      _fx_N15C_form__cstmt_t v_572 = 0;
+      _fx_LN15C_form__cstmt_t ccode_95 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_573 = {0};
       _fx_N14C_form__cexp_t arr_exp_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_91 = 0;
-      _fx_LT2BN14K_form__atom_t v_552 = 0;
+      _fx_LN15C_form__cstmt_t ccode_96 = 0;
+      _fx_LT2BN14K_form__atom_t v_574 = 0;
       _fx_Li shape_0 = 0;
-      _fx_Li v_553 = 0;
+      _fx_Li v_575 = 0;
       _fx_LN14C_form__cexp_t shape_1 = 0;
       _fx_LN14C_form__cexp_t data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_92 = 0;
+      _fx_LN15C_form__cstmt_t ccode_97 = 0;
       _fx_LLT2BN14K_form__atom_t arows_2 = 0;
-      _fx_LN19C_form__ctyp_attr_t v_554 = 0;
+      _fx_LN19C_form__ctyp_attr_t v_576 = 0;
       _fx_N14C_form__ctyp_t shape_ctyp_0 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_555 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_577 = {0};
       _fx_N14C_form__cexp_t shape_arr_0 = 0;
-      _fx_R16Ast__val_flags_t v_556 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_557 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_558 = {0};
+      _fx_R16Ast__val_flags_t v_578 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_579 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_580 = {0};
       _fx_N14C_form__cexp_t shape_exp_0 = 0;
       _fx_LN15C_form__cstmt_t ccode__0 = 0;
-      _fx_LN14C_form__cexp_t v_559 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_560 = {0};
+      _fx_LN14C_form__cexp_t v_581 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_582 = {0};
       _fx_N14C_form__cexp_t data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t glob_data_ccode__0 = 0;
       _fx_R17C_form__cdefval_t data_cv_0 = {0};
       _fx_R16Ast__val_flags_t data_flags_0 = {0};
-      _fx_R16Ast__val_flags_t v_561 = {0};
-      _fx_R17C_form__cdefval_t v_562 = {0};
-      _fx_N15C_form__cinfo_t v_563 = {0};
-      _fx_Ta3N14C_form__cexp_t v_564 = {0};
+      _fx_R16Ast__val_flags_t v_583 = {0};
+      _fx_R17C_form__cdefval_t v_584 = {0};
+      _fx_N15C_form__cinfo_t v_585 = {0};
+      _fx_Ta3N14C_form__cexp_t v_586 = {0};
       _fx_N14C_form__cexp_t sizeof_elem_exp_1 = 0;
       _fx_N14C_form__cexp_t free_f_exp_1 = 0;
       _fx_N14C_form__cexp_t copy_f_exp_1 = 0;
-      _fx_N14C_form__cexp_t v_565 = 0;
-      _fx_N14C_form__cexp_t v_566 = 0;
-      _fx_LN14C_form__cexp_t v_567 = 0;
+      _fx_N14C_form__cexp_t v_587 = 0;
+      _fx_N14C_form__cexp_t v_588 = 0;
+      _fx_LN14C_form__cexp_t v_589 = 0;
       _fx_N14C_form__cexp_t call_mkarr_1 = 0;
       _fx_LN15C_form__cstmt_t ccode__1 = 0;
-      _fx_N15C_form__cstmt_t v_568 = 0;
-      _fx_LN15C_form__cstmt_t v_569 = 0;
-      _fx_LN14C_form__cexp_t v_570 = 0;
-      _fx_N14C_form__cexp_t v_571 = 0;
-      _fx_LN15C_form__cstmt_t ccode_93 = 0;
+      _fx_N15C_form__cstmt_t v_590 = 0;
+      _fx_LN15C_form__cstmt_t v_591 = 0;
+      _fx_LN14C_form__cexp_t v_592 = 0;
+      _fx_N14C_form__cexp_t v_593 = 0;
+      _fx_LN15C_form__cstmt_t ccode_98 = 0;
       _fx_T3BLLT2BN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_10 = &kexp_0->u.KExpMkArray;
       _fx_LLT2BN14K_form__atom_t arows_3 = vcase_10->t1;
       bool all_literals_0 = vcase_10->t0;
@@ -26968,20 +27174,20 @@ static int
             for (; lst_10; lst_10 = lst_10->tl) {
                _fx_T2BN14K_form__atom_t* __pat___0 = &lst_10->hd;
                if (__pat___0->t0) {
-                  __fold_result___1 = true; FX_BREAK(_fx_catch_116);
+                  __fold_result___1 = true; FX_BREAK(_fx_catch_123);
                }
 
-            _fx_catch_116: ;
+            _fx_catch_123: ;
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_117);
+               FX_CHECK_EXN(_fx_catch_124);
             }
             if (__fold_result___1) {
-               __fold_result___0 = true; FX_BREAK(_fx_catch_117);
+               __fold_result___0 = true; FX_BREAK(_fx_catch_124);
             }
 
-         _fx_catch_117: ;
+         _fx_catch_124: ;
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_133);
+            FX_CHECK_EXN(_fx_catch_140);
          }
          have_expanded_0 = __fold_result___0;
       }
@@ -26990,197 +27196,197 @@ static int
       }
       if (FX_REC_VARIANT_TAG(ctyp_0) == 19) {
          _fx_T2iN14C_form__ctyp_t* vcase_11 = &ctyp_0->u.CTypArray;
-         _fx_make_T2iN14C_form__ctyp_t(vcase_11->t0, vcase_11->t1, &v_531);
+         _fx_make_T2iN14C_form__ctyp_t(vcase_11->t0, vcase_11->t1, &v_553);
       }
       else {
-         fx_exn_t v_572 = {0};
-         fx_str_t slit_135 = FX_MAKE_STR("cgen: invalid output type of array construction expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_135, &v_572, 0), _fx_catch_118);
-         FX_THROW(&v_572, false, _fx_catch_118);
+         fx_exn_t v_594 = {0};
+         fx_str_t slit_136 = FX_MAKE_STR("cgen: invalid output type of array construction expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_136, &v_594, 0), _fx_catch_125);
+         FX_THROW(&v_594, false, _fx_catch_125);
 
-      _fx_catch_118: ;
-         fx_free_exn(&v_572);
+      _fx_catch_125: ;
+         fx_free_exn(&v_594);
       }
-      FX_CHECK_EXN(_fx_catch_133);
-      int_ dims_0 = v_531.t0;
-      FX_COPY_PTR(v_531.t1, &elem_ctyp_2);
+      FX_CHECK_EXN(_fx_catch_140);
+      int_ dims_0 = v_553.t0;
+      FX_COPY_PTR(v_553.t1, &elem_ctyp_2);
       if (have_expanded_0) {
-         fx_str_t slit_136 = FX_MAKE_STR("arr");
+         fx_str_t slit_137 = FX_MAKE_STR("arr");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_136, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_532, 0), _fx_catch_133);
-         FX_COPY_PTR(v_532.t0, &arr_exp_3);
-         FX_COPY_PTR(v_532.t1, &ccode_88);
+               dstexp_r_0, &slit_137, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_554, 0), _fx_catch_140);
+         FX_COPY_PTR(v_554.t0, &arr_exp_3);
+         FX_COPY_PTR(v_554.t1, &ccode_93);
          _fx_R9Ast__id_t scalars_id_0;
-         fx_str_t slit_137 = FX_MAKE_STR("scalars");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_137, &scalars_id_0, 0), _fx_catch_133);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_2, &v_533, 0), _fx_catch_133);
+         fx_str_t slit_138 = FX_MAKE_STR("scalars");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_138, &scalars_id_0, 0), _fx_catch_140);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_2, &v_555, 0), _fx_catch_140);
          FX_CALL(
-            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_0, v_533,
-               &kloc_0, &scalars_exp_0, 0), _fx_catch_133);
+            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_0, v_555,
+               &kloc_0, &scalars_exp_0, 0), _fx_catch_140);
          int_ nscalars_0 = 0;
-         FX_COPY_PTR(ccode_88, &ccode_89);
+         FX_COPY_PTR(ccode_93, &ccode_94);
          FX_COPY_PTR(arows_3, &arows_1);
          _fx_LLT2BN14K_form__atom_t lst_11 = arows_1;
          for (; lst_11; lst_11 = lst_11->tl) {
-            _fx_N14C_form__cexp_t v_573 = 0;
-            _fx_LN14C_form__cexp_t v_574 = 0;
+            _fx_N14C_form__cexp_t v_595 = 0;
+            _fx_LN14C_form__cexp_t v_596 = 0;
             _fx_LT2BN14K_form__atom_t arow_1 = lst_11->hd;
             _fx_LT2BN14K_form__atom_t lst_12 = arow_1;
             for (; lst_12; lst_12 = lst_12->tl) {
-               _fx_N14K_form__atom_t a_4 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_575 = {0};
+               _fx_N14K_form__atom_t a_5 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_597 = {0};
                _fx_N14C_form__cexp_t e_10 = 0;
                _fx_LN15C_form__cstmt_t ccode1_8 = 0;
                _fx_N14K_form__ktyp_t elem_ktyp_0 = 0;
-               _fx_N14K_form__ktyp_t v_576 = 0;
-               _fx_T2iN14C_form__cexp_t v_577 = {0};
+               _fx_N14K_form__ktyp_t v_598 = 0;
+               _fx_T2iN14C_form__cexp_t v_599 = {0};
                _fx_N14C_form__cexp_t elem_ptr_0 = 0;
-               _fx_N14C_form__cexp_t v_578 = 0;
-               _fx_LN14C_form__cexp_t v_579 = 0;
-               _fx_LN14C_form__cexp_t v_580 = 0;
-               _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_581 = {0};
+               _fx_N14C_form__cexp_t v_600 = 0;
+               _fx_LN14C_form__cexp_t v_601 = 0;
+               _fx_LN14C_form__cexp_t v_602 = 0;
+               _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_603 = {0};
                _fx_LN14C_form__cexp_t scalars_data1_0 = 0;
                _fx_N14C_form__cexp_t arr_data_elem_0 = 0;
-               _fx_N14C_form__cexp_t v_582 = 0;
-               _fx_LN14C_form__cexp_t v_583 = 0;
-               _fx_LN14C_form__cexp_t v_584 = 0;
+               _fx_N14C_form__cexp_t v_604 = 0;
+               _fx_LN14C_form__cexp_t v_605 = 0;
+               _fx_LN14C_form__cexp_t v_606 = 0;
                _fx_T2BN14K_form__atom_t* __pat___1 = &lst_12->hd;
-               _fx_copy_N14K_form__atom_t(&__pat___1->t1, &a_4);
+               _fx_copy_N14K_form__atom_t(&__pat___1->t1, &a_5);
                FX_CALL(
-                  atom2cexp_0.fp(&a_4, ccode_89, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                     km_idx_0, &v_575, atom2cexp_0.fcv), _fx_catch_124);
-               FX_COPY_PTR(v_575.t0, &e_10);
-               FX_COPY_PTR(v_575.t1, &ccode1_8);
-               _fx_free_LN15C_form__cstmt_t(&ccode_89);
-               FX_COPY_PTR(ccode1_8, &ccode_89);
+                  atom2cexp_0.fp(&a_5, ccode_94, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                     km_idx_0, &v_597, atom2cexp_0.fcv), _fx_catch_131);
+               FX_COPY_PTR(v_597.t0, &e_10);
+               FX_COPY_PTR(v_597.t1, &ccode1_8);
+               _fx_free_LN15C_form__cstmt_t(&ccode_94);
+               FX_COPY_PTR(ccode1_8, &ccode_94);
                if (__pat___1->t0) {
                   FX_CALL(
-                     _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_4, &kloc_0, &elem_ktyp_0,
-                        0), _fx_catch_124);
+                     _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_5, &kloc_0, &elem_ktyp_0,
+                        0), _fx_catch_131);
                   FX_CALL(
-                     _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_0, &kloc_0, &v_576,
-                        0), _fx_catch_124);
-                  int tag_14 = FX_REC_VARIANT_TAG(v_576);
+                     _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_0, &kloc_0, &v_598,
+                        0), _fx_catch_131);
+                  int tag_14 = FX_REC_VARIANT_TAG(v_598);
                   if (tag_14 == 17) {
-                     _fx_N14C_form__cexp_t v_585 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_585, 0), _fx_catch_119);
-                     _fx_make_T2iN14C_form__cexp_t(v_576->u.KTypArray.t0, v_585, &v_577);
+                     _fx_N14C_form__cexp_t v_607 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_607, 0), _fx_catch_126);
+                     _fx_make_T2iN14C_form__cexp_t(v_598->u.KTypArray.t0, v_607, &v_599);
 
-                  _fx_catch_119: ;
-                     if (v_585) {
-                        _fx_free_N14C_form__cexp_t(&v_585);
+                  _fx_catch_126: ;
+                     if (v_607) {
+                        _fx_free_N14C_form__cexp_t(&v_607);
                      }
                   }
                   else if (tag_14 == 20) {
-                     _fx_make_T2iN14C_form__cexp_t(100, e_10, &v_577);
+                     _fx_make_T2iN14C_form__cexp_t(100, e_10, &v_599);
                   }
                   else if (tag_14 == 18) {
-                     _fx_N14C_form__cexp_t v_586 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_586, 0), _fx_catch_120);
-                     _fx_make_T2iN14C_form__cexp_t(110, v_586, &v_577);
+                     _fx_N14C_form__cexp_t v_608 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_608, 0), _fx_catch_127);
+                     _fx_make_T2iN14C_form__cexp_t(110, v_608, &v_599);
 
-                  _fx_catch_120: ;
-                     if (v_586) {
-                        _fx_free_N14C_form__cexp_t(&v_586);
+                  _fx_catch_127: ;
+                     if (v_608) {
+                        _fx_free_N14C_form__cexp_t(&v_608);
                      }
                   }
                   else {
-                     fx_str_t v_587 = {0};
-                     fx_str_t v_588 = {0};
-                     fx_str_t v_589 = {0};
-                     fx_exn_t v_590 = {0};
-                     FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_4, &v_587, 0), _fx_catch_121);
-                     FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_587, &v_588, 0), _fx_catch_121);
-                     fx_str_t slit_138 = FX_MAKE_STR("cgen: the expanded structure ");
-                     fx_str_t slit_139 = FX_MAKE_STR(" is not an array, rrbvec or list");
+                     fx_str_t v_609 = {0};
+                     fx_str_t v_610 = {0};
+                     fx_str_t v_611 = {0};
+                     fx_exn_t v_612 = {0};
+                     FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_5, &v_609, 0), _fx_catch_128);
+                     FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_609, &v_610, 0), _fx_catch_128);
+                     fx_str_t slit_139 = FX_MAKE_STR("cgen: the expanded structure ");
+                     fx_str_t slit_140 = FX_MAKE_STR(" is not an array, rrbvec or list");
                      {
-                        const fx_str_t strs_30[] = { slit_138, v_588, slit_139 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_30, 3, &v_589), _fx_catch_121);
+                        const fx_str_t strs_30[] = { slit_139, v_610, slit_140 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_30, 3, &v_611), _fx_catch_128);
                      }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_589, &v_590, 0), _fx_catch_121);
-                     FX_THROW(&v_590, false, _fx_catch_121);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_611, &v_612, 0), _fx_catch_128);
+                     FX_THROW(&v_612, false, _fx_catch_128);
 
-                  _fx_catch_121: ;
-                     fx_free_exn(&v_590);
-                     FX_FREE_STR(&v_589);
-                     FX_FREE_STR(&v_588);
-                     FX_FREE_STR(&v_587);
+                  _fx_catch_128: ;
+                     fx_free_exn(&v_612);
+                     FX_FREE_STR(&v_611);
+                     FX_FREE_STR(&v_610);
+                     FX_FREE_STR(&v_609);
                   }
-                  FX_CHECK_EXN(_fx_catch_124);
-                  int_ tag_15 = v_577.t0;
-                  FX_COPY_PTR(v_577.t1, &elem_ptr_0);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_15, &kloc_0, &v_578, 0),
-                     _fx_catch_124);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_578, tags_data_0, true, &v_579), _fx_catch_124);
+                  FX_CHECK_EXN(_fx_catch_131);
+                  int_ tag_15 = v_599.t0;
+                  FX_COPY_PTR(v_599.t1, &elem_ptr_0);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_15, &kloc_0, &v_600, 0),
+                     _fx_catch_131);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_600, tags_data_0, true, &v_601), _fx_catch_131);
                   _fx_free_LN14C_form__cexp_t(&tags_data_0);
-                  FX_COPY_PTR(v_579, &tags_data_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_0, arr_data_0, true, &v_580), _fx_catch_124);
+                  FX_COPY_PTR(v_601, &tags_data_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_0, arr_data_0, true, &v_602), _fx_catch_131);
                   _fx_free_LN14C_form__cexp_t(&arr_data_0);
-                  FX_COPY_PTR(v_580, &arr_data_0);
+                  FX_COPY_PTR(v_602, &arr_data_0);
                }
                else {
                   if (FX_REC_VARIANT_TAG(e_10) == 1) {
-                     _fx_N14C_form__cexp_t v_591 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_591, 0), _fx_catch_122);
-                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0, scalars_data_0, v_591, &v_581);
+                     _fx_N14C_form__cexp_t v_613 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_613, 0), _fx_catch_129);
+                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0, scalars_data_0, v_613, &v_603);
 
-                  _fx_catch_122: ;
-                     if (v_591) {
-                        _fx_free_N14C_form__cexp_t(&v_591);
+                  _fx_catch_129: ;
+                     if (v_613) {
+                        _fx_free_N14C_form__cexp_t(&v_613);
                      }
                   }
                   else {
-                     _fx_LN14C_form__cexp_t v_592 = 0;
-                     _fx_N14C_form__cexp_t v_593 = 0;
-                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_594 = {0};
-                     _fx_N14C_form__cexp_t v_595 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(e_10, scalars_data_0, true, &v_592), _fx_catch_123);
-                     FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_0, &kloc_0, &v_593, 0),
-                        _fx_catch_123);
-                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_594);
+                     _fx_LN14C_form__cexp_t v_614 = 0;
+                     _fx_N14C_form__cexp_t v_615 = 0;
+                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_616 = {0};
+                     _fx_N14C_form__cexp_t v_617 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(e_10, scalars_data_0, true, &v_614), _fx_catch_130);
+                     FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_0, &kloc_0, &v_615, 0),
+                        _fx_catch_130);
+                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_616);
                      FX_CALL(
                         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g18C_gen_code__COpAdd, scalars_exp_0, v_593, &v_594, &v_595), _fx_catch_123);
-                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0 + 1, v_592, v_595, &v_581);
+                           &_fx_g18C_gen_code__COpAdd, scalars_exp_0, v_615, &v_616, &v_617), _fx_catch_130);
+                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0 + 1, v_614, v_617, &v_603);
 
-                  _fx_catch_123: ;
-                     if (v_595) {
-                        _fx_free_N14C_form__cexp_t(&v_595);
+                  _fx_catch_130: ;
+                     if (v_617) {
+                        _fx_free_N14C_form__cexp_t(&v_617);
                      }
-                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_594);
-                     if (v_593) {
-                        _fx_free_N14C_form__cexp_t(&v_593);
+                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_616);
+                     if (v_615) {
+                        _fx_free_N14C_form__cexp_t(&v_615);
                      }
-                     if (v_592) {
-                        _fx_free_LN14C_form__cexp_t(&v_592);
+                     if (v_614) {
+                        _fx_free_LN14C_form__cexp_t(&v_614);
                      }
                   }
-                  FX_CHECK_EXN(_fx_catch_124);
-                  int_ nscalars1_0 = v_581.t0;
-                  FX_COPY_PTR(v_581.t1, &scalars_data1_0);
-                  FX_COPY_PTR(v_581.t2, &arr_data_elem_0);
+                  FX_CHECK_EXN(_fx_catch_131);
+                  int_ nscalars1_0 = v_603.t0;
+                  FX_COPY_PTR(v_603.t1, &scalars_data1_0);
+                  FX_COPY_PTR(v_603.t2, &arr_data_elem_0);
                   nscalars_0 = nscalars1_0;
                   _fx_free_LN14C_form__cexp_t(&scalars_data_0);
                   FX_COPY_PTR(scalars_data1_0, &scalars_data_0);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_582, 0), _fx_catch_124);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_582, tags_data_0, true, &v_583), _fx_catch_124);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_604, 0), _fx_catch_131);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_604, tags_data_0, true, &v_605), _fx_catch_131);
                   _fx_free_LN14C_form__cexp_t(&tags_data_0);
-                  FX_COPY_PTR(v_583, &tags_data_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_elem_0, arr_data_0, true, &v_584), _fx_catch_124);
+                  FX_COPY_PTR(v_605, &tags_data_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_elem_0, arr_data_0, true, &v_606), _fx_catch_131);
                   _fx_free_LN14C_form__cexp_t(&arr_data_0);
-                  FX_COPY_PTR(v_584, &arr_data_0);
+                  FX_COPY_PTR(v_606, &arr_data_0);
                }
 
-            _fx_catch_124: ;
-               if (v_584) {
-                  _fx_free_LN14C_form__cexp_t(&v_584);
+            _fx_catch_131: ;
+               if (v_606) {
+                  _fx_free_LN14C_form__cexp_t(&v_606);
                }
-               if (v_583) {
-                  _fx_free_LN14C_form__cexp_t(&v_583);
+               if (v_605) {
+                  _fx_free_LN14C_form__cexp_t(&v_605);
                }
-               if (v_582) {
-                  _fx_free_N14C_form__cexp_t(&v_582);
+               if (v_604) {
+                  _fx_free_N14C_form__cexp_t(&v_604);
                }
                if (arr_data_elem_0) {
                   _fx_free_N14C_form__cexp_t(&arr_data_elem_0);
@@ -27188,22 +27394,22 @@ static int
                if (scalars_data1_0) {
                   _fx_free_LN14C_form__cexp_t(&scalars_data1_0);
                }
-               _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_581);
-               if (v_580) {
-                  _fx_free_LN14C_form__cexp_t(&v_580);
+               _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_603);
+               if (v_602) {
+                  _fx_free_LN14C_form__cexp_t(&v_602);
                }
-               if (v_579) {
-                  _fx_free_LN14C_form__cexp_t(&v_579);
+               if (v_601) {
+                  _fx_free_LN14C_form__cexp_t(&v_601);
                }
-               if (v_578) {
-                  _fx_free_N14C_form__cexp_t(&v_578);
+               if (v_600) {
+                  _fx_free_N14C_form__cexp_t(&v_600);
                }
                if (elem_ptr_0) {
                   _fx_free_N14C_form__cexp_t(&elem_ptr_0);
                }
-               _fx_free_T2iN14C_form__cexp_t(&v_577);
-               if (v_576) {
-                  _fx_free_N14K_form__ktyp_t(&v_576);
+               _fx_free_T2iN14C_form__cexp_t(&v_599);
+               if (v_598) {
+                  _fx_free_N14K_form__ktyp_t(&v_598);
                }
                if (elem_ktyp_0) {
                   _fx_free_N14K_form__ktyp_t(&elem_ktyp_0);
@@ -27214,179 +27420,179 @@ static int
                if (e_10) {
                   _fx_free_N14C_form__cexp_t(&e_10);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_575);
-               _fx_free_N14K_form__atom_t(&a_4);
-               FX_CHECK_EXN(_fx_catch_125);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_597);
+               _fx_free_N14K_form__atom_t(&a_5);
+               FX_CHECK_EXN(_fx_catch_132);
             }
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(127, &kloc_0, &v_573, 0), _fx_catch_125);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_573, tags_data_0, true, &v_574), _fx_catch_125);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(127, &kloc_0, &v_595, 0), _fx_catch_132);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_595, tags_data_0, true, &v_596), _fx_catch_132);
             _fx_free_LN14C_form__cexp_t(&tags_data_0);
-            FX_COPY_PTR(v_574, &tags_data_0);
+            FX_COPY_PTR(v_596, &tags_data_0);
 
-         _fx_catch_125: ;
-            if (v_574) {
-               _fx_free_LN14C_form__cexp_t(&v_574);
+         _fx_catch_132: ;
+            if (v_596) {
+               _fx_free_LN14C_form__cexp_t(&v_596);
             }
-            if (v_573) {
-               _fx_free_N14C_form__cexp_t(&v_573);
+            if (v_595) {
+               _fx_free_N14C_form__cexp_t(&v_595);
             }
-            FX_CHECK_EXN(_fx_catch_133);
+            FX_CHECK_EXN(_fx_catch_140);
          }
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_0, &v_534, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_0, &v_556, 0), _fx_catch_140);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &scalars_id_0, elem_ctyp_2, v_534, 0, &kloc_0, &v_535, 0), _fx_catch_133);
-         FX_COPY_PTR(v_535.t1, &sub_ccode_2);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_536, 0), _fx_catch_133);
-         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_0, &v_537, 0), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_536, v_537, true, &v_538), _fx_catch_133);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_538, &tags_data_1, 0), _fx_catch_133);
-         _fx_R9Ast__id_t v_596;
-         fx_str_t slit_140 = FX_MAKE_STR("tags");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_140, &v_596, 0), _fx_catch_133);
-         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_539), _fx_catch_133);
+               &scalars_id_0, elem_ctyp_2, v_556, 0, &kloc_0, &v_557, 0), _fx_catch_140);
+         FX_COPY_PTR(v_557.t1, &sub_ccode_2);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_558, 0), _fx_catch_140);
+         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_0, &v_559, 0), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_558, v_559, true, &v_560), _fx_catch_140);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_560, &tags_data_1, 0), _fx_catch_140);
+         _fx_R9Ast__id_t v_618;
+         fx_str_t slit_141 = FX_MAKE_STR("tags");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_141, &v_618, 0), _fx_catch_140);
+         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_561), _fx_catch_140);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_596, v_539, tags_data_1, sub_ccode_2, &kloc_0, &v_540, 0), _fx_catch_133);
-         FX_COPY_PTR(v_540.t0, &tags_exp_0);
-         FX_COPY_PTR(v_540.t1, &sub_ccode_3);
-         _fx_R9Ast__id_t v_597;
-         fx_str_t slit_141 = FX_MAKE_STR("parts");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_141, &v_597, 0), _fx_catch_133);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(arr_data_0, &v_541, 0), _fx_catch_133);
+               &v_618, v_561, tags_data_1, sub_ccode_2, &kloc_0, &v_562, 0), _fx_catch_140);
+         FX_COPY_PTR(v_562.t0, &tags_exp_0);
+         FX_COPY_PTR(v_562.t1, &sub_ccode_3);
+         _fx_R9Ast__id_t v_619;
+         fx_str_t slit_142 = FX_MAKE_STR("parts");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_142, &v_619, 0), _fx_catch_140);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(arr_data_0, &v_563, 0), _fx_catch_140);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_597, _fx_g23C_form__std_CTypVoidPtr, v_541, sub_ccode_3, &kloc_0, &v_542, 0), _fx_catch_133);
-         FX_COPY_PTR(v_542.t0, &arr_data_exp_0);
-         FX_COPY_PTR(v_542.t1, &sub_ccode_4);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2, &kloc_0, &v_543),
-            _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_543, 0, true, &v_544), _fx_catch_133);
+               &v_619, _fx_g23C_form__std_CTypVoidPtr, v_563, sub_ccode_3, &kloc_0, &v_564, 0), _fx_catch_140);
+         FX_COPY_PTR(v_564.t0, &arr_data_exp_0);
+         FX_COPY_PTR(v_564.t1, &sub_ccode_4);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2, &kloc_0, &v_565),
+            _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_565, 0, true, &v_566), _fx_catch_140);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g18C_form__std_sizeof, v_544, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_0, 0),
-            _fx_catch_133);
+               &_fx_g18C_form__std_sizeof, v_566, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_0, 0),
+            _fx_catch_140);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
-               false, &kloc_0, &v_545, 0), _fx_catch_133);
-         _fx_Nt6option1N14C_form__cexp_t* v_598 = &v_545.t1;
-         if (v_598->tag == 2) {
+               false, &kloc_0, &v_567, 0), _fx_catch_140);
+         _fx_Nt6option1N14C_form__cexp_t* v_620 = &v_567.t1;
+         if (v_620->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_598->u.Some,
-                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_0), _fx_catch_126);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_620->u.Some,
+                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_0), _fx_catch_133);
 
-         _fx_catch_126: ;
+         _fx_catch_133: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_0, 0), _fx_catch_127);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_0, 0), _fx_catch_134);
 
-         _fx_catch_127: ;
+         _fx_catch_134: ;
          }
-         FX_CHECK_EXN(_fx_catch_133);
+         FX_CHECK_EXN(_fx_catch_140);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
-               false, &kloc_0, &v_546, 0), _fx_catch_133);
-         _fx_Nt6option1N14C_form__cexp_t* v_599 = &v_546.t1;
-         if (v_599->tag == 2) {
+               false, &kloc_0, &v_568, 0), _fx_catch_140);
+         _fx_Nt6option1N14C_form__cexp_t* v_621 = &v_568.t1;
+         if (v_621->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_599->u.Some,
-                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_0), _fx_catch_128);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_621->u.Some,
+                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_0), _fx_catch_135);
 
-         _fx_catch_128: ;
+         _fx_catch_135: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_0, 0), _fx_catch_129);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_0, 0), _fx_catch_136);
 
-         _fx_catch_129: ;
+         _fx_catch_136: ;
          }
-         FX_CHECK_EXN(_fx_catch_133);
-         _fx_R9Ast__id_t v_600;
-         fx_str_t slit_142 = FX_MAKE_STR("fx_compose_arr");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_142, &v_600, 0), _fx_catch_133);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_0, &kloc_0, &v_547, 0), _fx_catch_133);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_3, &v_548, 0), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_548, 0, true, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_exp_0, v_549, false, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_0, v_549, false, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_0, v_549, false, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_0, v_549, false, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_0, v_549, false, &v_549), _fx_catch_133);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_547, v_549, false, &v_549), _fx_catch_133);
+         FX_CHECK_EXN(_fx_catch_140);
+         _fx_R9Ast__id_t v_622;
+         fx_str_t slit_143 = FX_MAKE_STR("fx_compose_arr");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_143, &v_622, 0), _fx_catch_140);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_0, &kloc_0, &v_569, 0), _fx_catch_140);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_3, &v_570, 0), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_570, 0, true, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_exp_0, v_571, false, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_0, v_571, false, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_0, v_571, false, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_0, v_571, false, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_0, v_571, false, &v_571), _fx_catch_140);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_569, v_571, false, &v_571), _fx_catch_140);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_600, v_549,
-               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_0, 0), _fx_catch_133);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_622, v_571,
+               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_0, 0), _fx_catch_140);
          FX_CALL(
             _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-               call_mkarr_0, sub_ccode_4, &kloc_0, block_stack_ref_0, &sub_ccode_5, 0), _fx_catch_133);
+               call_mkarr_0, sub_ccode_4, &kloc_0, block_stack_ref_0, &sub_ccode_5, 0), _fx_catch_140);
          FX_CALL(
-            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_5, &kloc_0, &v_550, 0),
-            _fx_catch_133);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_550, ccode_89, true, &ccode_90), _fx_catch_133);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_3, ccode_90, &v_1);
+            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_5, &kloc_0, &v_572, 0),
+            _fx_catch_140);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_572, ccode_94, true, &ccode_95), _fx_catch_140);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_3, ccode_95, &v_1);
       }
       else {
-         fx_str_t slit_143 = FX_MAKE_STR("arr");
+         fx_str_t slit_144 = FX_MAKE_STR("arr");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_143, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_551, 0), _fx_catch_133);
-         FX_COPY_PTR(v_551.t0, &arr_exp_4);
-         FX_COPY_PTR(v_551.t1, &ccode_91);
+               dstexp_r_0, &slit_144, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_573, 0), _fx_catch_140);
+         FX_COPY_PTR(v_573.t0, &arr_exp_4);
+         FX_COPY_PTR(v_573.t1, &ccode_96);
          int_ nrows_0;
-         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LLT2BN14K_form__atom_t(arows_3, &nrows_0, 0), _fx_catch_133);
-         FX_CALL(_fx_M10C_gen_codeFM2hdLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(arows_3, &v_552, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LLT2BN14K_form__atom_t(arows_3, &nrows_0, 0), _fx_catch_140);
+         FX_CALL(_fx_M10C_gen_codeFM2hdLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(arows_3, &v_574, 0), _fx_catch_140);
          int_ ncols_0;
-         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2BN14K_form__atom_t(v_552, &ncols_0, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2BN14K_form__atom_t(v_574, &ncols_0, 0), _fx_catch_140);
          if (nrows_0 > 1) {
-            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &v_553), _fx_catch_133);
-            FX_CALL(_fx_cons_Li(nrows_0, v_553, true, &shape_0), _fx_catch_133);
+            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &v_575), _fx_catch_140);
+            FX_CALL(_fx_cons_Li(nrows_0, v_575, true, &shape_0), _fx_catch_140);
          }
          else {
-            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &shape_0), _fx_catch_133);
+            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &shape_0), _fx_catch_140);
          }
          _fx_LN14C_form__cexp_t lstend_0 = 0;
          _fx_Li lst_13 = shape_0;
          for (; lst_13; lst_13 = lst_13->tl) {
             _fx_N14C_form__cexp_t res_18 = 0;
             int_ i_5 = lst_13->hd;
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(i_5, &kloc_0, &res_18, 0), _fx_catch_130);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(i_5, &kloc_0, &res_18, 0), _fx_catch_137);
             _fx_LN14C_form__cexp_t node_0 = 0;
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_18, 0, false, &node_0), _fx_catch_130);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_18, 0, false, &node_0), _fx_catch_137);
             FX_LIST_APPEND(shape_1, lstend_0, node_0);
 
-         _fx_catch_130: ;
+         _fx_catch_137: ;
             if (res_18) {
                _fx_free_N14C_form__cexp_t(&res_18);
             }
-            FX_CHECK_EXN(_fx_catch_133);
+            FX_CHECK_EXN(_fx_catch_140);
          }
-         FX_COPY_PTR(ccode_91, &ccode_92);
+         FX_COPY_PTR(ccode_96, &ccode_97);
          FX_COPY_PTR(arows_3, &arows_2);
          _fx_LLT2BN14K_form__atom_t lst_14 = arows_2;
          for (; lst_14; lst_14 = lst_14->tl) {
             _fx_LT2BN14K_form__atom_t arow_2 = lst_14->hd;
             _fx_LT2BN14K_form__atom_t lst_15 = arow_2;
             for (; lst_15; lst_15 = lst_15->tl) {
-               _fx_N14K_form__atom_t a_5 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_601 = {0};
+               _fx_N14K_form__atom_t a_6 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_623 = {0};
                _fx_N14C_form__cexp_t e_11 = 0;
                _fx_LN15C_form__cstmt_t ccode1_9 = 0;
-               _fx_LN14C_form__cexp_t v_602 = 0;
+               _fx_LN14C_form__cexp_t v_624 = 0;
                _fx_T2BN14K_form__atom_t* __pat___2 = &lst_15->hd;
-               _fx_copy_N14K_form__atom_t(&__pat___2->t1, &a_5);
+               _fx_copy_N14K_form__atom_t(&__pat___2->t1, &a_6);
                FX_CALL(
-                  atom2cexp_0.fp(&a_5, ccode_92, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                     km_idx_0, &v_601, atom2cexp_0.fcv), _fx_catch_131);
-               FX_COPY_PTR(v_601.t0, &e_11);
-               FX_COPY_PTR(v_601.t1, &ccode1_9);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(e_11, data_0, true, &v_602), _fx_catch_131);
+                  atom2cexp_0.fp(&a_6, ccode_97, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                     km_idx_0, &v_623, atom2cexp_0.fcv), _fx_catch_138);
+               FX_COPY_PTR(v_623.t0, &e_11);
+               FX_COPY_PTR(v_623.t1, &ccode1_9);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(e_11, data_0, true, &v_624), _fx_catch_138);
                _fx_free_LN14C_form__cexp_t(&data_0);
-               FX_COPY_PTR(v_602, &data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_92);
-               FX_COPY_PTR(ccode1_9, &ccode_92);
+               FX_COPY_PTR(v_624, &data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_97);
+               FX_COPY_PTR(ccode1_9, &ccode_97);
 
-            _fx_catch_131: ;
-               if (v_602) {
-                  _fx_free_LN14C_form__cexp_t(&v_602);
+            _fx_catch_138: ;
+               if (v_624) {
+                  _fx_free_LN14C_form__cexp_t(&v_624);
                }
                if (ccode1_9) {
                   _fx_free_LN15C_form__cstmt_t(&ccode1_9);
@@ -27394,112 +27600,112 @@ static int
                if (e_11) {
                   _fx_free_N14C_form__cexp_t(&e_11);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_601);
-               _fx_free_N14K_form__atom_t(&a_5);
-               FX_CHECK_EXN(_fx_catch_132);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_623);
+               _fx_free_N14K_form__atom_t(&a_6);
+               FX_CHECK_EXN(_fx_catch_139);
             }
 
-         _fx_catch_132: ;
-            FX_CHECK_EXN(_fx_catch_133);
+         _fx_catch_139: ;
+            FX_CHECK_EXN(_fx_catch_140);
          }
          if (all_literals_0) {
             int_ dims_1;
-            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14C_form__cexp_t(shape_1, &dims_1, 0), _fx_catch_133);
-            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_554), _fx_catch_133);
+            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14C_form__cexp_t(shape_1, &dims_1, 0), _fx_catch_140);
+            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_576), _fx_catch_140);
             FX_CALL(
-               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_554,
-                  _fx_g19C_gen_code__CTypInt, &shape_ctyp_0), _fx_catch_133);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(shape_ctyp_0, &kloc_0, &v_555);
+               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_576,
+                  _fx_g19C_gen_code__CTypInt, &shape_ctyp_0), _fx_catch_140);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(shape_ctyp_0, &kloc_0, &v_577);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(shape_1, &v_555,
-                  &shape_arr_0), _fx_catch_133);
-            _fx_R9Ast__id_t v_603;
-            fx_str_t slit_144 = FX_MAKE_STR("shape");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_144, &v_603, 0), _fx_catch_133);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_556, 0), _fx_catch_133);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(shape_arr_0, &v_557);
-            fx_str_t slit_145 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(shape_1, &v_577,
+                  &shape_arr_0), _fx_catch_140);
+            _fx_R9Ast__id_t v_625;
+            fx_str_t slit_145 = FX_MAKE_STR("shape");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_145, &v_625, 0), _fx_catch_140);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_578, 0), _fx_catch_140);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(shape_arr_0, &v_579);
+            fx_str_t slit_146 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_603, shape_ctyp_0, &v_556, &slit_145, &v_557, 0, &kloc_0, &v_558, 0), _fx_catch_133);
-            FX_COPY_PTR(v_558.t0, &shape_exp_0);
-            FX_COPY_PTR(v_558.t1, &ccode__0);
+                  &v_625, shape_ctyp_0, &v_578, &slit_146, &v_579, 0, &kloc_0, &v_580, 0), _fx_catch_140);
+            FX_COPY_PTR(v_580.t0, &shape_exp_0);
+            FX_COPY_PTR(v_580.t1, &ccode__0);
             _fx_R9Ast__id_t data_id_0;
-            fx_str_t slit_146 = FX_MAKE_STR("data");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_146, &data_id_0, 0), _fx_catch_133);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_559, 0), _fx_catch_133);
+            fx_str_t slit_147 = FX_MAKE_STR("data");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_147, &data_id_0, 0), _fx_catch_140);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_581, 0), _fx_catch_140);
             FX_CALL(
                _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &data_id_0, elem_ctyp_2, v_559, *glob_data_ccode_0, &kloc_0, &v_560, 0), _fx_catch_133);
-            FX_COPY_PTR(v_560.t0, &data_exp_0);
-            FX_COPY_PTR(v_560.t1, &glob_data_ccode__0);
+                  &data_id_0, elem_ctyp_2, v_581, *glob_data_ccode_0, &kloc_0, &v_582, 0), _fx_catch_140);
+            FX_COPY_PTR(v_582.t0, &data_exp_0);
+            FX_COPY_PTR(v_582.t1, &glob_data_ccode__0);
             FX_CALL(_fx_M6C_formFM8get_cvalRM9cdefval_t2R9Ast__id_tR10Ast__loc_t(&data_id_0, &kloc_0, &data_cv_0, 0),
-               _fx_catch_133);
+               _fx_catch_140);
             _fx_copy_R16Ast__val_flags_t(&data_cv_0.cv_flags, &data_flags_0);
             _fx_make_R16Ast__val_flags_t(data_flags_0.val_flag_arg, data_flags_0.val_flag_mutable, data_flags_0.val_flag_temp,
                data_flags_0.val_flag_tempref, true, data_flags_0.val_flag_subarray, data_flags_0.val_flag_instance,
-               &data_flags_0.val_flag_method, data_flags_0.val_flag_ctor, data_flags_0.val_flag_global, &v_561);
-            _fx_make_R17C_form__cdefval_t(&data_cv_0.cv_name, data_cv_0.cv_typ, &data_cv_0.cv_cname, &v_561, &data_cv_0.cv_loc,
-               &v_562);
-            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&v_562, &v_563);
-            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(&data_id_0, &v_563, 0), _fx_catch_133);
+               &data_flags_0.val_flag_method, data_flags_0.val_flag_ctor, data_flags_0.val_flag_global, &v_583);
+            _fx_make_R17C_form__cdefval_t(&data_cv_0.cv_name, data_cv_0.cv_typ, &data_cv_0.cv_cname, &v_583, &data_cv_0.cv_loc,
+               &v_584);
+            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&v_584, &v_585);
+            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(&data_id_0, &v_585, 0), _fx_catch_140);
             _fx_free_LN15C_form__cstmt_t(glob_data_ccode_0);
             FX_COPY_PTR(glob_data_ccode__0, glob_data_ccode_0);
             FX_CALL(
                _fx_M10C_gen_codeFM23get_elem_size_free_copyTa3N14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2,
-                  &kloc_0, &v_564, 0), _fx_catch_133);
-            FX_COPY_PTR(v_564.t0, &sizeof_elem_exp_1);
-            FX_COPY_PTR(v_564.t1, &free_f_exp_1);
-            FX_COPY_PTR(v_564.t2, &copy_f_exp_1);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_1, &kloc_0, &v_565, 0), _fx_catch_133);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_4, &v_566, 0), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_566, 0, true, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(data_exp_0, v_567, false, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_1, v_567, false, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_1, v_567, false, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_1, v_567, false, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(shape_exp_0, v_567, false, &v_567), _fx_catch_133);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_565, v_567, false, &v_567), _fx_catch_133);
+                  &kloc_0, &v_586, 0), _fx_catch_140);
+            FX_COPY_PTR(v_586.t0, &sizeof_elem_exp_1);
+            FX_COPY_PTR(v_586.t1, &free_f_exp_1);
+            FX_COPY_PTR(v_586.t2, &copy_f_exp_1);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_1, &kloc_0, &v_587, 0), _fx_catch_140);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_4, &v_588, 0), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_588, 0, true, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(data_exp_0, v_589, false, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_1, v_589, false, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_1, v_589, false, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_1, v_589, false, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(shape_exp_0, v_589, false, &v_589), _fx_catch_140);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_587, v_589, false, &v_589), _fx_catch_140);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g23C_form__std_fx_make_arr, v_567, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_1, 0),
-               _fx_catch_133);
+                  &_fx_g23C_form__std_fx_make_arr, v_589, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_1, 0),
+               _fx_catch_140);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_mkarr_1, ccode__0, &kloc_0, block_stack_ref_0, &ccode__1, 0), _fx_catch_133);
+                  call_mkarr_1, ccode__0, &kloc_0, block_stack_ref_0, &ccode__1, 0), _fx_catch_140);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode__1, &kloc_0, &v_568, 0),
-               _fx_catch_133);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_568, ccode_92, true, &v_569), _fx_catch_133);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, v_569, &v_1);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode__1, &kloc_0, &v_590, 0),
+               _fx_catch_140);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_590, ccode_97, true, &v_591), _fx_catch_140);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, v_591, &v_1);
          }
          else {
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_570, 0), _fx_catch_133);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_592, 0), _fx_catch_140);
             FX_CALL(
                _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0,
-                  block_stack_ref_0, &v_571, 0), _fx_catch_133);
+                  block_stack_ref_0, &v_593, 0), _fx_catch_140);
             FX_CALL(
                _fx_M10C_gen_codeFM18make_make_arr_callLN15C_form__cstmt_t7N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_ti(
-                  arr_exp_4, shape_1, v_570, ccode_92, v_571, &kloc_0, km_idx_0, &ccode_93, 0), _fx_catch_133);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, ccode_93, &v_1);
+                  arr_exp_4, shape_1, v_592, ccode_97, v_593, &kloc_0, km_idx_0, &ccode_98, 0), _fx_catch_140);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, ccode_98, &v_1);
          }
       }
 
-   _fx_catch_133: ;
-      if (ccode_93) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_93);
+   _fx_catch_140: ;
+      if (ccode_98) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_98);
       }
-      if (v_571) {
-         _fx_free_N14C_form__cexp_t(&v_571);
+      if (v_593) {
+         _fx_free_N14C_form__cexp_t(&v_593);
       }
-      if (v_570) {
-         _fx_free_LN14C_form__cexp_t(&v_570);
+      if (v_592) {
+         _fx_free_LN14C_form__cexp_t(&v_592);
       }
-      if (v_569) {
-         _fx_free_LN15C_form__cstmt_t(&v_569);
+      if (v_591) {
+         _fx_free_LN15C_form__cstmt_t(&v_591);
       }
-      if (v_568) {
-         _fx_free_N15C_form__cstmt_t(&v_568);
+      if (v_590) {
+         _fx_free_N15C_form__cstmt_t(&v_590);
       }
       if (ccode__1) {
          _fx_free_LN15C_form__cstmt_t(&ccode__1);
@@ -27507,14 +27713,14 @@ static int
       if (call_mkarr_1) {
          _fx_free_N14C_form__cexp_t(&call_mkarr_1);
       }
-      if (v_567) {
-         _fx_free_LN14C_form__cexp_t(&v_567);
+      if (v_589) {
+         _fx_free_LN14C_form__cexp_t(&v_589);
       }
-      if (v_566) {
-         _fx_free_N14C_form__cexp_t(&v_566);
+      if (v_588) {
+         _fx_free_N14C_form__cexp_t(&v_588);
       }
-      if (v_565) {
-         _fx_free_N14C_form__cexp_t(&v_565);
+      if (v_587) {
+         _fx_free_N14C_form__cexp_t(&v_587);
       }
       if (copy_f_exp_1) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_1);
@@ -27525,10 +27731,10 @@ static int
       if (sizeof_elem_exp_1) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_1);
       }
-      _fx_free_Ta3N14C_form__cexp_t(&v_564);
-      _fx_free_N15C_form__cinfo_t(&v_563);
-      _fx_free_R17C_form__cdefval_t(&v_562);
-      _fx_free_R16Ast__val_flags_t(&v_561);
+      _fx_free_Ta3N14C_form__cexp_t(&v_586);
+      _fx_free_N15C_form__cinfo_t(&v_585);
+      _fx_free_R17C_form__cdefval_t(&v_584);
+      _fx_free_R16Ast__val_flags_t(&v_583);
       _fx_free_R16Ast__val_flags_t(&data_flags_0);
       _fx_free_R17C_form__cdefval_t(&data_cv_0);
       if (glob_data_ccode__0) {
@@ -27537,9 +27743,9 @@ static int
       if (data_exp_0) {
          _fx_free_N14C_form__cexp_t(&data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_560);
-      if (v_559) {
-         _fx_free_LN14C_form__cexp_t(&v_559);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_582);
+      if (v_581) {
+         _fx_free_LN14C_form__cexp_t(&v_581);
       }
       if (ccode__0) {
          _fx_free_LN15C_form__cstmt_t(&ccode__0);
@@ -27547,22 +27753,22 @@ static int
       if (shape_exp_0) {
          _fx_free_N14C_form__cexp_t(&shape_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_558);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_557);
-      _fx_free_R16Ast__val_flags_t(&v_556);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_580);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_579);
+      _fx_free_R16Ast__val_flags_t(&v_578);
       if (shape_arr_0) {
          _fx_free_N14C_form__cexp_t(&shape_arr_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_555);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_577);
       if (shape_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&shape_ctyp_0);
       }
-      FX_FREE_LIST_SIMPLE(&v_554);
+      FX_FREE_LIST_SIMPLE(&v_576);
       if (arows_2) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_2);
       }
-      if (ccode_92) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_92);
+      if (ccode_97) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_97);
       }
       if (data_0) {
          _fx_free_LN14C_form__cexp_t(&data_0);
@@ -27570,23 +27776,23 @@ static int
       if (shape_1) {
          _fx_free_LN14C_form__cexp_t(&shape_1);
       }
-      FX_FREE_LIST_SIMPLE(&v_553);
+      FX_FREE_LIST_SIMPLE(&v_575);
       FX_FREE_LIST_SIMPLE(&shape_0);
-      if (v_552) {
-         _fx_free_LT2BN14K_form__atom_t(&v_552);
+      if (v_574) {
+         _fx_free_LT2BN14K_form__atom_t(&v_574);
       }
-      if (ccode_91) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_91);
+      if (ccode_96) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_96);
       }
       if (arr_exp_4) {
          _fx_free_N14C_form__cexp_t(&arr_exp_4);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_551);
-      if (ccode_90) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_90);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_573);
+      if (ccode_95) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_95);
       }
-      if (v_550) {
-         _fx_free_N15C_form__cstmt_t(&v_550);
+      if (v_572) {
+         _fx_free_N15C_form__cstmt_t(&v_572);
       }
       if (sub_ccode_5) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_5);
@@ -27594,31 +27800,31 @@ static int
       if (call_mkarr_0) {
          _fx_free_N14C_form__cexp_t(&call_mkarr_0);
       }
-      if (v_549) {
-         _fx_free_LN14C_form__cexp_t(&v_549);
+      if (v_571) {
+         _fx_free_LN14C_form__cexp_t(&v_571);
       }
-      if (v_548) {
-         _fx_free_N14C_form__cexp_t(&v_548);
+      if (v_570) {
+         _fx_free_N14C_form__cexp_t(&v_570);
       }
-      if (v_547) {
-         _fx_free_N14C_form__cexp_t(&v_547);
+      if (v_569) {
+         _fx_free_N14C_form__cexp_t(&v_569);
       }
       if (copy_f_exp_0) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_0);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_546);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_568);
       if (free_f_exp_0) {
          _fx_free_N14C_form__cexp_t(&free_f_exp_0);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_545);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_567);
       if (sizeof_elem_exp_0) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_0);
       }
-      if (v_544) {
-         _fx_free_LN14C_form__cexp_t(&v_544);
+      if (v_566) {
+         _fx_free_LN14C_form__cexp_t(&v_566);
       }
-      if (v_543) {
-         _fx_free_N14C_form__cexp_t(&v_543);
+      if (v_565) {
+         _fx_free_N14C_form__cexp_t(&v_565);
       }
       if (sub_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_4);
@@ -27626,9 +27832,9 @@ static int
       if (arr_data_exp_0) {
          _fx_free_N14C_form__cexp_t(&arr_data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_542);
-      if (v_541) {
-         _fx_free_LN14C_form__cexp_t(&v_541);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_564);
+      if (v_563) {
+         _fx_free_LN14C_form__cexp_t(&v_563);
       }
       if (sub_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_3);
@@ -27636,34 +27842,34 @@ static int
       if (tags_exp_0) {
          _fx_free_N14C_form__cexp_t(&tags_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_540);
-      if (v_539) {
-         _fx_free_N14C_form__ctyp_t(&v_539);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_562);
+      if (v_561) {
+         _fx_free_N14C_form__ctyp_t(&v_561);
       }
       if (tags_data_1) {
          _fx_free_LN14C_form__cexp_t(&tags_data_1);
       }
-      if (v_538) {
-         _fx_free_LN14C_form__cexp_t(&v_538);
+      if (v_560) {
+         _fx_free_LN14C_form__cexp_t(&v_560);
       }
-      if (v_537) {
-         _fx_free_LN14C_form__cexp_t(&v_537);
+      if (v_559) {
+         _fx_free_LN14C_form__cexp_t(&v_559);
       }
-      if (v_536) {
-         _fx_free_N14C_form__cexp_t(&v_536);
+      if (v_558) {
+         _fx_free_N14C_form__cexp_t(&v_558);
       }
       if (sub_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_535);
-      if (v_534) {
-         _fx_free_LN14C_form__cexp_t(&v_534);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_557);
+      if (v_556) {
+         _fx_free_LN14C_form__cexp_t(&v_556);
       }
       if (arows_1) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_1);
       }
-      if (ccode_89) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_89);
+      if (ccode_94) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_94);
       }
       if (arr_data_0) {
          _fx_free_LN14C_form__cexp_t(&arr_data_0);
@@ -27677,79 +27883,79 @@ static int
       if (scalars_exp_0) {
          _fx_free_N14C_form__cexp_t(&scalars_exp_0);
       }
-      if (v_533) {
-         _fx_free_N14C_form__ctyp_t(&v_533);
+      if (v_555) {
+         _fx_free_N14C_form__ctyp_t(&v_555);
       }
-      if (ccode_88) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_88);
+      if (ccode_93) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_93);
       }
       if (arr_exp_3) {
          _fx_free_N14C_form__cexp_t(&arr_exp_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_532);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_554);
       if (elem_ctyp_2) {
          _fx_free_N14C_form__ctyp_t(&elem_ctyp_2);
       }
-      _fx_free_T2iN14C_form__ctyp_t(&v_531);
+      _fx_free_T2iN14C_form__ctyp_t(&v_553);
       if (arows_0) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 18) {
       _fx_LT2BN14K_form__atom_t elems_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_604 = {0};
-      _fx_N14C_form__cexp_t vec_exp_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_94 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_626 = {0};
+      _fx_N14C_form__cexp_t vec_exp_3 = 0;
+      _fx_LN15C_form__cstmt_t ccode_99 = 0;
       _fx_N14C_form__ctyp_t elem_ctyp_3 = 0;
-      _fx_N14C_form__ctyp_t v_605 = 0;
+      _fx_N14C_form__ctyp_t v_627 = 0;
       _fx_N14C_form__cexp_t scalars_exp_1 = 0;
       _fx_LN14C_form__cexp_t scalars_data_1 = 0;
       _fx_LN14C_form__cexp_t tags_data_2 = 0;
       _fx_LN14C_form__cexp_t vec_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_95 = 0;
+      _fx_LN15C_form__cstmt_t ccode_100 = 0;
       _fx_LT2BN14K_form__atom_t elems_1 = 0;
       _fx_LN14C_form__cexp_t scalars_data_2 = 0;
       _fx_LN14C_form__cexp_t tags_data_3 = 0;
       _fx_LN14C_form__cexp_t vec_data_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_96 = 0;
-      _fx_LN14C_form__cexp_t v_606 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_607 = {0};
+      _fx_LN15C_form__cstmt_t ccode_101 = 0;
+      _fx_LN14C_form__cexp_t v_628 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_629 = {0};
       _fx_LN15C_form__cstmt_t sub_ccode_6 = 0;
-      _fx_N14C_form__cexp_t v_608 = 0;
-      _fx_LN14C_form__cexp_t v_609 = 0;
-      _fx_LN14C_form__cexp_t v_610 = 0;
+      _fx_N14C_form__cexp_t v_630 = 0;
+      _fx_LN14C_form__cexp_t v_631 = 0;
+      _fx_LN14C_form__cexp_t v_632 = 0;
       _fx_LN14C_form__cexp_t tags_data_4 = 0;
-      _fx_N14C_form__ctyp_t v_611 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_612 = {0};
+      _fx_N14C_form__ctyp_t v_633 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_634 = {0};
       _fx_N14C_form__cexp_t tags_exp_1 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_7 = 0;
-      _fx_LN14C_form__cexp_t v_613 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_614 = {0};
+      _fx_LN14C_form__cexp_t v_635 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_636 = {0};
       _fx_N14C_form__cexp_t vec_data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_8 = 0;
-      _fx_N14C_form__cexp_t v_615 = 0;
-      _fx_LN14C_form__cexp_t v_616 = 0;
+      _fx_N14C_form__cexp_t v_637 = 0;
+      _fx_LN14C_form__cexp_t v_638 = 0;
       _fx_N14C_form__cexp_t sizeof_elem_exp_2 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_617 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_639 = {0};
       _fx_N14C_form__cexp_t free_f_exp_2 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_618 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_640 = {0};
       _fx_N14C_form__cexp_t copy_f_exp_2 = 0;
-      _fx_N14C_form__cexp_t v_619 = 0;
-      _fx_LN14C_form__cexp_t v_620 = 0;
+      _fx_N14C_form__cexp_t v_641 = 0;
+      _fx_LN14C_form__cexp_t v_642 = 0;
       _fx_N14C_form__cexp_t call_mkvec_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_9 = 0;
-      _fx_N15C_form__cstmt_t v_621 = 0;
-      _fx_LN15C_form__cstmt_t ccode_97 = 0;
+      _fx_N15C_form__cstmt_t v_643 = 0;
+      _fx_LN15C_form__cstmt_t ccode_102 = 0;
       _fx_LN14C_form__cexp_t data_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_98 = 0;
+      _fx_LN15C_form__cstmt_t ccode_103 = 0;
       _fx_LT2BN14K_form__atom_t elems_2 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_622 = {0};
-      _fx_N14C_form__cexp_t vec_exp_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_99 = 0;
-      _fx_LN14C_form__cexp_t v_623 = 0;
-      _fx_N14C_form__cexp_t v_624 = 0;
-      _fx_LN15C_form__cstmt_t ccode_100 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_644 = {0};
+      _fx_N14C_form__cexp_t vec_exp_4 = 0;
+      _fx_LN15C_form__cstmt_t ccode_104 = 0;
+      _fx_LN14C_form__cexp_t v_645 = 0;
+      _fx_N14C_form__cexp_t v_646 = 0;
+      _fx_LN15C_form__cstmt_t ccode_105 = 0;
       _fx_LT2BN14K_form__atom_t elems_3 = kexp_0->u.KExpMkVector.t0;
       bool __fold_result___2 = false;
       FX_COPY_PTR(elems_3, &elems_0);
@@ -27757,200 +27963,200 @@ static int
       for (; lst_16; lst_16 = lst_16->tl) {
          _fx_T2BN14K_form__atom_t* __pat___3 = &lst_16->hd;
          if (__pat___3->t0) {
-            __fold_result___2 = true; FX_BREAK(_fx_catch_134);
+            __fold_result___2 = true; FX_BREAK(_fx_catch_141);
          }
 
-      _fx_catch_134: ;
+      _fx_catch_141: ;
          FX_CHECK_BREAK();
-         FX_CHECK_EXN(_fx_catch_147);
+         FX_CHECK_EXN(_fx_catch_154);
       }
       bool have_expanded_1 = __fold_result___2;
       if (have_expanded_1) {
-         fx_str_t slit_147 = FX_MAKE_STR("vec");
+         fx_str_t slit_148 = FX_MAKE_STR("vec");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_147, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_604, 0), _fx_catch_147);
-         FX_COPY_PTR(v_604.t0, &vec_exp_2);
-         FX_COPY_PTR(v_604.t1, &ccode_94);
+               dstexp_r_0, &slit_148, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_626, 0), _fx_catch_154);
+         FX_COPY_PTR(v_626.t0, &vec_exp_3);
+         FX_COPY_PTR(v_626.t1, &ccode_99);
          if (FX_REC_VARIANT_TAG(ctyp_0) == 20) {
             FX_COPY_PTR(ctyp_0->u.CTypRRBVec, &elem_ctyp_3);
          }
          else {
-            fx_exn_t v_625 = {0};
-            fx_str_t slit_148 = FX_MAKE_STR("cgen: invalid output type of rrbvec construction expression");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_148, &v_625, 0), _fx_catch_135);
-            FX_THROW(&v_625, false, _fx_catch_135);
+            fx_exn_t v_647 = {0};
+            fx_str_t slit_149 = FX_MAKE_STR("cgen: invalid output type of rrbvec construction expression");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_149, &v_647, 0), _fx_catch_142);
+            FX_THROW(&v_647, false, _fx_catch_142);
 
-         _fx_catch_135: ;
-            fx_free_exn(&v_625);
+         _fx_catch_142: ;
+            fx_free_exn(&v_647);
          }
-         FX_CHECK_EXN(_fx_catch_147);
+         FX_CHECK_EXN(_fx_catch_154);
          _fx_R9Ast__id_t scalars_id_1;
-         fx_str_t slit_149 = FX_MAKE_STR("scalars");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_149, &scalars_id_1, 0), _fx_catch_147);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_3, &v_605, 0), _fx_catch_147);
+         fx_str_t slit_150 = FX_MAKE_STR("scalars");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_150, &scalars_id_1, 0), _fx_catch_154);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_3, &v_627, 0), _fx_catch_154);
          FX_CALL(
-            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_1, v_605,
-               &kloc_0, &scalars_exp_1, 0), _fx_catch_147);
+            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_1, v_627,
+               &kloc_0, &scalars_exp_1, 0), _fx_catch_154);
          int_ nscalars_1 = 0;
-         FX_COPY_PTR(ccode_94, &ccode_95);
+         FX_COPY_PTR(ccode_99, &ccode_100);
          FX_COPY_PTR(elems_3, &elems_1);
          _fx_LT2BN14K_form__atom_t lst_17 = elems_1;
          for (; lst_17; lst_17 = lst_17->tl) {
-            _fx_N14K_form__atom_t a_6 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_626 = {0};
+            _fx_N14K_form__atom_t a_7 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_648 = {0};
             _fx_N14C_form__cexp_t e_12 = 0;
             _fx_LN15C_form__cstmt_t ccode1_10 = 0;
             _fx_N14K_form__ktyp_t elem_ktyp_1 = 0;
-            _fx_N14K_form__ktyp_t v_627 = 0;
-            _fx_T2iN14C_form__cexp_t v_628 = {0};
+            _fx_N14K_form__ktyp_t v_649 = 0;
+            _fx_T2iN14C_form__cexp_t v_650 = {0};
             _fx_N14C_form__cexp_t elem_ptr_1 = 0;
-            _fx_N14C_form__cexp_t v_629 = 0;
-            _fx_LN14C_form__cexp_t v_630 = 0;
-            _fx_LN14C_form__cexp_t v_631 = 0;
-            _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_632 = {0};
+            _fx_N14C_form__cexp_t v_651 = 0;
+            _fx_LN14C_form__cexp_t v_652 = 0;
+            _fx_LN14C_form__cexp_t v_653 = 0;
+            _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_654 = {0};
             _fx_LN14C_form__cexp_t scalars_data1_1 = 0;
             _fx_N14C_form__cexp_t vec_data_elem_0 = 0;
-            _fx_N14C_form__cexp_t v_633 = 0;
-            _fx_LN14C_form__cexp_t v_634 = 0;
-            _fx_LN14C_form__cexp_t v_635 = 0;
+            _fx_N14C_form__cexp_t v_655 = 0;
+            _fx_LN14C_form__cexp_t v_656 = 0;
+            _fx_LN14C_form__cexp_t v_657 = 0;
             _fx_T2BN14K_form__atom_t* __pat___4 = &lst_17->hd;
-            _fx_copy_N14K_form__atom_t(&__pat___4->t1, &a_6);
+            _fx_copy_N14K_form__atom_t(&__pat___4->t1, &a_7);
             FX_CALL(
-               atom2cexp_0.fp(&a_6, ccode_95, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_626, atom2cexp_0.fcv), _fx_catch_141);
-            FX_COPY_PTR(v_626.t0, &e_12);
-            FX_COPY_PTR(v_626.t1, &ccode1_10);
+               atom2cexp_0.fp(&a_7, ccode_100, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_648, atom2cexp_0.fcv), _fx_catch_148);
+            FX_COPY_PTR(v_648.t0, &e_12);
+            FX_COPY_PTR(v_648.t1, &ccode1_10);
             if (__pat___4->t0) {
                FX_CALL(
-                  _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_6, &kloc_0, &elem_ktyp_1, 0),
-                  _fx_catch_141);
+                  _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_7, &kloc_0, &elem_ktyp_1, 0),
+                  _fx_catch_148);
                FX_CALL(
-                  _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_1, &kloc_0, &v_627, 0),
-                  _fx_catch_141);
-               int tag_16 = FX_REC_VARIANT_TAG(v_627);
+                  _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_1, &kloc_0, &v_649, 0),
+                  _fx_catch_148);
+               int tag_16 = FX_REC_VARIANT_TAG(v_649);
                if (tag_16 == 17) {
-                  _fx_N14C_form__cexp_t v_636 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_636, 0), _fx_catch_136);
-                  _fx_make_T2iN14C_form__cexp_t(v_627->u.KTypArray.t0, v_636, &v_628);
+                  _fx_N14C_form__cexp_t v_658 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_658, 0), _fx_catch_143);
+                  _fx_make_T2iN14C_form__cexp_t(v_649->u.KTypArray.t0, v_658, &v_650);
 
-               _fx_catch_136: ;
-                  if (v_636) {
-                     _fx_free_N14C_form__cexp_t(&v_636);
+               _fx_catch_143: ;
+                  if (v_658) {
+                     _fx_free_N14C_form__cexp_t(&v_658);
                   }
                }
                else if (tag_16 == 20) {
-                  _fx_make_T2iN14C_form__cexp_t(100, e_12, &v_628);
+                  _fx_make_T2iN14C_form__cexp_t(100, e_12, &v_650);
                }
                else if (tag_16 == 18) {
-                  _fx_N14C_form__cexp_t v_637 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_637, 0), _fx_catch_137);
-                  _fx_make_T2iN14C_form__cexp_t(110, v_637, &v_628);
+                  _fx_N14C_form__cexp_t v_659 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_659, 0), _fx_catch_144);
+                  _fx_make_T2iN14C_form__cexp_t(110, v_659, &v_650);
 
-               _fx_catch_137: ;
-                  if (v_637) {
-                     _fx_free_N14C_form__cexp_t(&v_637);
+               _fx_catch_144: ;
+                  if (v_659) {
+                     _fx_free_N14C_form__cexp_t(&v_659);
                   }
                }
                else {
-                  fx_str_t v_638 = {0};
-                  fx_str_t v_639 = {0};
-                  fx_str_t v_640 = {0};
-                  fx_exn_t v_641 = {0};
-                  FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_6, &v_638, 0), _fx_catch_138);
-                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_638, &v_639, 0), _fx_catch_138);
-                  fx_str_t slit_150 = FX_MAKE_STR("cgen: the expanded structure ");
-                  fx_str_t slit_151 = FX_MAKE_STR(" is not an array, rrbvec or list");
+                  fx_str_t v_660 = {0};
+                  fx_str_t v_661 = {0};
+                  fx_str_t v_662 = {0};
+                  fx_exn_t v_663 = {0};
+                  FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_7, &v_660, 0), _fx_catch_145);
+                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_660, &v_661, 0), _fx_catch_145);
+                  fx_str_t slit_151 = FX_MAKE_STR("cgen: the expanded structure ");
+                  fx_str_t slit_152 = FX_MAKE_STR(" is not an array, rrbvec or list");
                   {
-                     const fx_str_t strs_31[] = { slit_150, v_639, slit_151 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_31, 3, &v_640), _fx_catch_138);
+                     const fx_str_t strs_31[] = { slit_151, v_661, slit_152 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_31, 3, &v_662), _fx_catch_145);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_640, &v_641, 0), _fx_catch_138);
-                  FX_THROW(&v_641, false, _fx_catch_138);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_662, &v_663, 0), _fx_catch_145);
+                  FX_THROW(&v_663, false, _fx_catch_145);
 
-               _fx_catch_138: ;
-                  fx_free_exn(&v_641);
-                  FX_FREE_STR(&v_640);
-                  FX_FREE_STR(&v_639);
-                  FX_FREE_STR(&v_638);
+               _fx_catch_145: ;
+                  fx_free_exn(&v_663);
+                  FX_FREE_STR(&v_662);
+                  FX_FREE_STR(&v_661);
+                  FX_FREE_STR(&v_660);
                }
-               FX_CHECK_EXN(_fx_catch_141);
-               int_ tag_17 = v_628.t0;
-               FX_COPY_PTR(v_628.t1, &elem_ptr_1);
-               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_17, &kloc_0, &v_629, 0), _fx_catch_141);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_629, tags_data_2, true, &v_630), _fx_catch_141);
+               FX_CHECK_EXN(_fx_catch_148);
+               int_ tag_17 = v_650.t0;
+               FX_COPY_PTR(v_650.t1, &elem_ptr_1);
+               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_17, &kloc_0, &v_651, 0), _fx_catch_148);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_651, tags_data_2, true, &v_652), _fx_catch_148);
                _fx_free_LN14C_form__cexp_t(&tags_data_2);
-               FX_COPY_PTR(v_630, &tags_data_2);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_1, vec_data_0, true, &v_631), _fx_catch_141);
+               FX_COPY_PTR(v_652, &tags_data_2);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_1, vec_data_0, true, &v_653), _fx_catch_148);
                _fx_free_LN14C_form__cexp_t(&vec_data_0);
-               FX_COPY_PTR(v_631, &vec_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_95);
-               FX_COPY_PTR(ccode1_10, &ccode_95);
+               FX_COPY_PTR(v_653, &vec_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_100);
+               FX_COPY_PTR(ccode1_10, &ccode_100);
             }
             else {
                if (FX_REC_VARIANT_TAG(e_12) == 1) {
-                  _fx_N14C_form__cexp_t v_642 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_642, 0), _fx_catch_139);
-                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1, scalars_data_1, v_642, &v_632);
+                  _fx_N14C_form__cexp_t v_664 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_664, 0), _fx_catch_146);
+                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1, scalars_data_1, v_664, &v_654);
 
-               _fx_catch_139: ;
-                  if (v_642) {
-                     _fx_free_N14C_form__cexp_t(&v_642);
+               _fx_catch_146: ;
+                  if (v_664) {
+                     _fx_free_N14C_form__cexp_t(&v_664);
                   }
                }
                else {
-                  _fx_LN14C_form__cexp_t v_643 = 0;
-                  _fx_N14C_form__cexp_t v_644 = 0;
-                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_645 = {0};
-                  _fx_N14C_form__cexp_t v_646 = 0;
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(e_12, scalars_data_1, true, &v_643), _fx_catch_140);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_1, &kloc_0, &v_644, 0),
-                     _fx_catch_140);
-                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_645);
+                  _fx_LN14C_form__cexp_t v_665 = 0;
+                  _fx_N14C_form__cexp_t v_666 = 0;
+                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_667 = {0};
+                  _fx_N14C_form__cexp_t v_668 = 0;
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(e_12, scalars_data_1, true, &v_665), _fx_catch_147);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_1, &kloc_0, &v_666, 0),
+                     _fx_catch_147);
+                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_667);
                   FX_CALL(
                      _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g18C_gen_code__COpAdd, scalars_exp_1, v_644, &v_645, &v_646), _fx_catch_140);
-                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1 + 1, v_643, v_646, &v_632);
+                        &_fx_g18C_gen_code__COpAdd, scalars_exp_1, v_666, &v_667, &v_668), _fx_catch_147);
+                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1 + 1, v_665, v_668, &v_654);
 
-               _fx_catch_140: ;
-                  if (v_646) {
-                     _fx_free_N14C_form__cexp_t(&v_646);
+               _fx_catch_147: ;
+                  if (v_668) {
+                     _fx_free_N14C_form__cexp_t(&v_668);
                   }
-                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_645);
-                  if (v_644) {
-                     _fx_free_N14C_form__cexp_t(&v_644);
+                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_667);
+                  if (v_666) {
+                     _fx_free_N14C_form__cexp_t(&v_666);
                   }
-                  if (v_643) {
-                     _fx_free_LN14C_form__cexp_t(&v_643);
+                  if (v_665) {
+                     _fx_free_LN14C_form__cexp_t(&v_665);
                   }
                }
-               FX_CHECK_EXN(_fx_catch_141);
-               int_ nscalars1_1 = v_632.t0;
-               FX_COPY_PTR(v_632.t1, &scalars_data1_1);
-               FX_COPY_PTR(v_632.t2, &vec_data_elem_0);
+               FX_CHECK_EXN(_fx_catch_148);
+               int_ nscalars1_1 = v_654.t0;
+               FX_COPY_PTR(v_654.t1, &scalars_data1_1);
+               FX_COPY_PTR(v_654.t2, &vec_data_elem_0);
                nscalars_1 = nscalars1_1;
                _fx_free_LN14C_form__cexp_t(&scalars_data_1);
                FX_COPY_PTR(scalars_data1_1, &scalars_data_1);
-               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_633, 0), _fx_catch_141);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_633, tags_data_2, true, &v_634), _fx_catch_141);
+               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_655, 0), _fx_catch_148);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_655, tags_data_2, true, &v_656), _fx_catch_148);
                _fx_free_LN14C_form__cexp_t(&tags_data_2);
-               FX_COPY_PTR(v_634, &tags_data_2);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_elem_0, vec_data_0, true, &v_635), _fx_catch_141);
+               FX_COPY_PTR(v_656, &tags_data_2);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_elem_0, vec_data_0, true, &v_657), _fx_catch_148);
                _fx_free_LN14C_form__cexp_t(&vec_data_0);
-               FX_COPY_PTR(v_635, &vec_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_95);
-               FX_COPY_PTR(ccode1_10, &ccode_95);
+               FX_COPY_PTR(v_657, &vec_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_100);
+               FX_COPY_PTR(ccode1_10, &ccode_100);
             }
 
-         _fx_catch_141: ;
-            if (v_635) {
-               _fx_free_LN14C_form__cexp_t(&v_635);
+         _fx_catch_148: ;
+            if (v_657) {
+               _fx_free_LN14C_form__cexp_t(&v_657);
             }
-            if (v_634) {
-               _fx_free_LN14C_form__cexp_t(&v_634);
+            if (v_656) {
+               _fx_free_LN14C_form__cexp_t(&v_656);
             }
-            if (v_633) {
-               _fx_free_N14C_form__cexp_t(&v_633);
+            if (v_655) {
+               _fx_free_N14C_form__cexp_t(&v_655);
             }
             if (vec_data_elem_0) {
                _fx_free_N14C_form__cexp_t(&vec_data_elem_0);
@@ -27958,22 +28164,22 @@ static int
             if (scalars_data1_1) {
                _fx_free_LN14C_form__cexp_t(&scalars_data1_1);
             }
-            _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_632);
-            if (v_631) {
-               _fx_free_LN14C_form__cexp_t(&v_631);
+            _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_654);
+            if (v_653) {
+               _fx_free_LN14C_form__cexp_t(&v_653);
             }
-            if (v_630) {
-               _fx_free_LN14C_form__cexp_t(&v_630);
+            if (v_652) {
+               _fx_free_LN14C_form__cexp_t(&v_652);
             }
-            if (v_629) {
-               _fx_free_N14C_form__cexp_t(&v_629);
+            if (v_651) {
+               _fx_free_N14C_form__cexp_t(&v_651);
             }
             if (elem_ptr_1) {
                _fx_free_N14C_form__cexp_t(&elem_ptr_1);
             }
-            _fx_free_T2iN14C_form__cexp_t(&v_628);
-            if (v_627) {
-               _fx_free_N14K_form__ktyp_t(&v_627);
+            _fx_free_T2iN14C_form__cexp_t(&v_650);
+            if (v_649) {
+               _fx_free_N14K_form__ktyp_t(&v_649);
             }
             if (elem_ktyp_1) {
                _fx_free_N14K_form__ktyp_t(&elem_ktyp_1);
@@ -27984,130 +28190,130 @@ static int
             if (e_12) {
                _fx_free_N14C_form__cexp_t(&e_12);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_626);
-            _fx_free_N14K_form__atom_t(&a_6);
-            FX_CHECK_EXN(_fx_catch_147);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_648);
+            _fx_free_N14K_form__atom_t(&a_7);
+            FX_CHECK_EXN(_fx_catch_154);
          }
          FX_COPY_PTR(scalars_data_1, &scalars_data_2);
          FX_COPY_PTR(tags_data_2, &tags_data_3);
          FX_COPY_PTR(vec_data_0, &vec_data_1);
-         FX_COPY_PTR(ccode_95, &ccode_96);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_2, &v_606, 0), _fx_catch_147);
+         FX_COPY_PTR(ccode_100, &ccode_101);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_2, &v_628, 0), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &scalars_id_1, elem_ctyp_3, v_606, 0, &kloc_0, &v_607, 0), _fx_catch_147);
-         FX_COPY_PTR(v_607.t1, &sub_ccode_6);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_608, 0), _fx_catch_147);
-         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_3, &v_609, 0), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_608, v_609, true, &v_610), _fx_catch_147);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_610, &tags_data_4, 0), _fx_catch_147);
-         _fx_R9Ast__id_t v_647;
-         fx_str_t slit_152 = FX_MAKE_STR("tags");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_152, &v_647, 0), _fx_catch_147);
-         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_611), _fx_catch_147);
+               &scalars_id_1, elem_ctyp_3, v_628, 0, &kloc_0, &v_629, 0), _fx_catch_154);
+         FX_COPY_PTR(v_629.t1, &sub_ccode_6);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_630, 0), _fx_catch_154);
+         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_3, &v_631, 0), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_630, v_631, true, &v_632), _fx_catch_154);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_632, &tags_data_4, 0), _fx_catch_154);
+         _fx_R9Ast__id_t v_669;
+         fx_str_t slit_153 = FX_MAKE_STR("tags");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_153, &v_669, 0), _fx_catch_154);
+         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_633), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_647, v_611, tags_data_4, sub_ccode_6, &kloc_0, &v_612, 0), _fx_catch_147);
-         FX_COPY_PTR(v_612.t0, &tags_exp_1);
-         FX_COPY_PTR(v_612.t1, &sub_ccode_7);
-         _fx_R9Ast__id_t v_648;
-         fx_str_t slit_153 = FX_MAKE_STR("parts");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_153, &v_648, 0), _fx_catch_147);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(vec_data_1, &v_613, 0), _fx_catch_147);
+               &v_669, v_633, tags_data_4, sub_ccode_6, &kloc_0, &v_634, 0), _fx_catch_154);
+         FX_COPY_PTR(v_634.t0, &tags_exp_1);
+         FX_COPY_PTR(v_634.t1, &sub_ccode_7);
+         _fx_R9Ast__id_t v_670;
+         fx_str_t slit_154 = FX_MAKE_STR("parts");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_154, &v_670, 0), _fx_catch_154);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(vec_data_1, &v_635, 0), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_648, _fx_g23C_form__std_CTypVoidPtr, v_613, sub_ccode_7, &kloc_0, &v_614, 0), _fx_catch_147);
-         FX_COPY_PTR(v_614.t0, &vec_data_exp_0);
-         FX_COPY_PTR(v_614.t1, &sub_ccode_8);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_3, &kloc_0, &v_615),
-            _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_615, 0, true, &v_616), _fx_catch_147);
+               &v_670, _fx_g23C_form__std_CTypVoidPtr, v_635, sub_ccode_7, &kloc_0, &v_636, 0), _fx_catch_154);
+         FX_COPY_PTR(v_636.t0, &vec_data_exp_0);
+         FX_COPY_PTR(v_636.t1, &sub_ccode_8);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_3, &kloc_0, &v_637),
+            _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_637, 0, true, &v_638), _fx_catch_154);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g18C_form__std_sizeof, v_616, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_2, 0),
-            _fx_catch_147);
+               &_fx_g18C_form__std_sizeof, v_638, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_2, 0),
+            _fx_catch_154);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_3, true,
-               false, &kloc_0, &v_617, 0), _fx_catch_147);
-         _fx_Nt6option1N14C_form__cexp_t* v_649 = &v_617.t1;
-         if (v_649->tag == 2) {
+               false, &kloc_0, &v_639, 0), _fx_catch_154);
+         _fx_Nt6option1N14C_form__cexp_t* v_671 = &v_639.t1;
+         if (v_671->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_649->u.Some,
-                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_2), _fx_catch_142);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_671->u.Some,
+                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_2), _fx_catch_149);
 
-         _fx_catch_142: ;
+         _fx_catch_149: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_2, 0), _fx_catch_143);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_2, 0), _fx_catch_150);
 
-         _fx_catch_143: ;
+         _fx_catch_150: ;
          }
-         FX_CHECK_EXN(_fx_catch_147);
+         FX_CHECK_EXN(_fx_catch_154);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_3, true,
-               false, &kloc_0, &v_618, 0), _fx_catch_147);
-         _fx_Nt6option1N14C_form__cexp_t* v_650 = &v_618.t1;
-         if (v_650->tag == 2) {
+               false, &kloc_0, &v_640, 0), _fx_catch_154);
+         _fx_Nt6option1N14C_form__cexp_t* v_672 = &v_640.t1;
+         if (v_672->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_650->u.Some,
-                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_2), _fx_catch_144);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_672->u.Some,
+                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_2), _fx_catch_151);
 
-         _fx_catch_144: ;
+         _fx_catch_151: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_2, 0), _fx_catch_145);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_2, 0), _fx_catch_152);
 
-         _fx_catch_145: ;
+         _fx_catch_152: ;
          }
-         FX_CHECK_EXN(_fx_catch_147);
-         _fx_R9Ast__id_t v_651;
-         fx_str_t slit_154 = FX_MAKE_STR("fx_compose_vec");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_154, &v_651, 0), _fx_catch_147);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(vec_exp_2, &v_619, 0), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_619, 0, true, &v_620), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_exp_0, v_620, false, &v_620), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_1, v_620, false, &v_620), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_2, v_620, false, &v_620), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_2, v_620, false, &v_620), _fx_catch_147);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_2, v_620, false, &v_620), _fx_catch_147);
+         FX_CHECK_EXN(_fx_catch_154);
+         _fx_R9Ast__id_t v_673;
+         fx_str_t slit_155 = FX_MAKE_STR("fx_compose_vec");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_155, &v_673, 0), _fx_catch_154);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(vec_exp_3, &v_641, 0), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_641, 0, true, &v_642), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_exp_0, v_642, false, &v_642), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_1, v_642, false, &v_642), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_2, v_642, false, &v_642), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_2, v_642, false, &v_642), _fx_catch_154);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_2, v_642, false, &v_642), _fx_catch_154);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_651, v_620,
-               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkvec_0, 0), _fx_catch_147);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_673, v_642,
+               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkvec_0, 0), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-               call_mkvec_0, sub_ccode_8, &kloc_0, block_stack_ref_0, &sub_ccode_9, 0), _fx_catch_147);
+               call_mkvec_0, sub_ccode_8, &kloc_0, block_stack_ref_0, &sub_ccode_9, 0), _fx_catch_154);
          FX_CALL(
-            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_9, &kloc_0, &v_621, 0),
-            _fx_catch_147);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_621, ccode_96, true, &ccode_97), _fx_catch_147);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_2, ccode_97, &v_1);
+            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_9, &kloc_0, &v_643, 0),
+            _fx_catch_154);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_643, ccode_101, true, &ccode_102), _fx_catch_154);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_3, ccode_102, &v_1);
       }
       else {
-         FX_COPY_PTR(ccode_0, &ccode_98);
+         FX_COPY_PTR(ccode_0, &ccode_103);
          FX_COPY_PTR(elems_3, &elems_2);
          _fx_LT2BN14K_form__atom_t lst_18 = elems_2;
          for (; lst_18; lst_18 = lst_18->tl) {
-            _fx_N14K_form__atom_t a_7 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_652 = {0};
+            _fx_N14K_form__atom_t a_8 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_674 = {0};
             _fx_N14C_form__cexp_t e_13 = 0;
             _fx_LN15C_form__cstmt_t ccode1_11 = 0;
-            _fx_LN14C_form__cexp_t v_653 = 0;
+            _fx_LN14C_form__cexp_t v_675 = 0;
             _fx_T2BN14K_form__atom_t* __pat___5 = &lst_18->hd;
-            _fx_copy_N14K_form__atom_t(&__pat___5->t1, &a_7);
+            _fx_copy_N14K_form__atom_t(&__pat___5->t1, &a_8);
             FX_CALL(
-               atom2cexp_0.fp(&a_7, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_652, atom2cexp_0.fcv), _fx_catch_146);
-            FX_COPY_PTR(v_652.t0, &e_13);
-            FX_COPY_PTR(v_652.t1, &ccode1_11);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_13, data_1, true, &v_653), _fx_catch_146);
+               atom2cexp_0.fp(&a_8, ccode_103, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_674, atom2cexp_0.fcv), _fx_catch_153);
+            FX_COPY_PTR(v_674.t0, &e_13);
+            FX_COPY_PTR(v_674.t1, &ccode1_11);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_13, data_1, true, &v_675), _fx_catch_153);
             _fx_free_LN14C_form__cexp_t(&data_1);
-            FX_COPY_PTR(v_653, &data_1);
-            _fx_free_LN15C_form__cstmt_t(&ccode_98);
-            FX_COPY_PTR(ccode1_11, &ccode_98);
+            FX_COPY_PTR(v_675, &data_1);
+            _fx_free_LN15C_form__cstmt_t(&ccode_103);
+            FX_COPY_PTR(ccode1_11, &ccode_103);
 
-         _fx_catch_146: ;
-            if (v_653) {
-               _fx_free_LN14C_form__cexp_t(&v_653);
+         _fx_catch_153: ;
+            if (v_675) {
+               _fx_free_LN14C_form__cexp_t(&v_675);
             }
             if (ccode1_11) {
                _fx_free_LN15C_form__cstmt_t(&ccode1_11);
@@ -28115,57 +28321,57 @@ static int
             if (e_13) {
                _fx_free_N14C_form__cexp_t(&e_13);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_652);
-            _fx_free_N14K_form__atom_t(&a_7);
-            FX_CHECK_EXN(_fx_catch_147);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_674);
+            _fx_free_N14K_form__atom_t(&a_8);
+            FX_CHECK_EXN(_fx_catch_154);
          }
-         fx_str_t slit_155 = FX_MAKE_STR("vec");
+         fx_str_t slit_156 = FX_MAKE_STR("vec");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_155, ctyp_0, ccode_98, &kloc_0, block_stack_ref_0, km_idx_0, &v_622, 0), _fx_catch_147);
-         FX_COPY_PTR(v_622.t0, &vec_exp_3);
-         FX_COPY_PTR(v_622.t1, &ccode_99);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_1, &v_623, 0), _fx_catch_147);
+               dstexp_r_0, &slit_156, ctyp_0, ccode_103, &kloc_0, block_stack_ref_0, km_idx_0, &v_644, 0), _fx_catch_154);
+         FX_COPY_PTR(v_644.t0, &vec_exp_4);
+         FX_COPY_PTR(v_644.t1, &ccode_104);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_1, &v_645, 0), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &v_624, 0), _fx_catch_147);
+               &v_646, 0), _fx_catch_154);
          FX_CALL(
             _fx_M10C_gen_codeFM18make_make_vec_callLN15C_form__cstmt_t6N14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_ti(
-               vec_exp_3, v_623, ccode_99, v_624, &kloc_0, km_idx_0, &ccode_100, 0), _fx_catch_147);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_3, ccode_100, &v_1);
+               vec_exp_4, v_645, ccode_104, v_646, &kloc_0, km_idx_0, &ccode_105, 0), _fx_catch_154);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_4, ccode_105, &v_1);
       }
 
-   _fx_catch_147: ;
-      if (ccode_100) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_100);
+   _fx_catch_154: ;
+      if (ccode_105) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_105);
       }
-      if (v_624) {
-         _fx_free_N14C_form__cexp_t(&v_624);
+      if (v_646) {
+         _fx_free_N14C_form__cexp_t(&v_646);
       }
-      if (v_623) {
-         _fx_free_LN14C_form__cexp_t(&v_623);
+      if (v_645) {
+         _fx_free_LN14C_form__cexp_t(&v_645);
       }
-      if (ccode_99) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_99);
+      if (ccode_104) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_104);
       }
-      if (vec_exp_3) {
-         _fx_free_N14C_form__cexp_t(&vec_exp_3);
+      if (vec_exp_4) {
+         _fx_free_N14C_form__cexp_t(&vec_exp_4);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_622);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_644);
       if (elems_2) {
          _fx_free_LT2BN14K_form__atom_t(&elems_2);
       }
-      if (ccode_98) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_98);
+      if (ccode_103) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_103);
       }
       if (data_1) {
          _fx_free_LN14C_form__cexp_t(&data_1);
       }
-      if (ccode_97) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_97);
+      if (ccode_102) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_102);
       }
-      if (v_621) {
-         _fx_free_N15C_form__cstmt_t(&v_621);
+      if (v_643) {
+         _fx_free_N15C_form__cstmt_t(&v_643);
       }
       if (sub_ccode_9) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_9);
@@ -28173,28 +28379,28 @@ static int
       if (call_mkvec_0) {
          _fx_free_N14C_form__cexp_t(&call_mkvec_0);
       }
-      if (v_620) {
-         _fx_free_LN14C_form__cexp_t(&v_620);
+      if (v_642) {
+         _fx_free_LN14C_form__cexp_t(&v_642);
       }
-      if (v_619) {
-         _fx_free_N14C_form__cexp_t(&v_619);
+      if (v_641) {
+         _fx_free_N14C_form__cexp_t(&v_641);
       }
       if (copy_f_exp_2) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_2);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_618);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_640);
       if (free_f_exp_2) {
          _fx_free_N14C_form__cexp_t(&free_f_exp_2);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_617);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_639);
       if (sizeof_elem_exp_2) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_2);
       }
-      if (v_616) {
-         _fx_free_LN14C_form__cexp_t(&v_616);
+      if (v_638) {
+         _fx_free_LN14C_form__cexp_t(&v_638);
       }
-      if (v_615) {
-         _fx_free_N14C_form__cexp_t(&v_615);
+      if (v_637) {
+         _fx_free_N14C_form__cexp_t(&v_637);
       }
       if (sub_ccode_8) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_8);
@@ -28202,9 +28408,9 @@ static int
       if (vec_data_exp_0) {
          _fx_free_N14C_form__cexp_t(&vec_data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_614);
-      if (v_613) {
-         _fx_free_LN14C_form__cexp_t(&v_613);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_636);
+      if (v_635) {
+         _fx_free_LN14C_form__cexp_t(&v_635);
       }
       if (sub_ccode_7) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_7);
@@ -28212,31 +28418,31 @@ static int
       if (tags_exp_1) {
          _fx_free_N14C_form__cexp_t(&tags_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_612);
-      if (v_611) {
-         _fx_free_N14C_form__ctyp_t(&v_611);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_634);
+      if (v_633) {
+         _fx_free_N14C_form__ctyp_t(&v_633);
       }
       if (tags_data_4) {
          _fx_free_LN14C_form__cexp_t(&tags_data_4);
       }
-      if (v_610) {
-         _fx_free_LN14C_form__cexp_t(&v_610);
+      if (v_632) {
+         _fx_free_LN14C_form__cexp_t(&v_632);
       }
-      if (v_609) {
-         _fx_free_LN14C_form__cexp_t(&v_609);
+      if (v_631) {
+         _fx_free_LN14C_form__cexp_t(&v_631);
       }
-      if (v_608) {
-         _fx_free_N14C_form__cexp_t(&v_608);
+      if (v_630) {
+         _fx_free_N14C_form__cexp_t(&v_630);
       }
       if (sub_ccode_6) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_6);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_607);
-      if (v_606) {
-         _fx_free_LN14C_form__cexp_t(&v_606);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_629);
+      if (v_628) {
+         _fx_free_LN14C_form__cexp_t(&v_628);
       }
-      if (ccode_96) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_96);
+      if (ccode_101) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_101);
       }
       if (vec_data_1) {
          _fx_free_LN14C_form__cexp_t(&vec_data_1);
@@ -28250,8 +28456,8 @@ static int
       if (elems_1) {
          _fx_free_LT2BN14K_form__atom_t(&elems_1);
       }
-      if (ccode_95) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_95);
+      if (ccode_100) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_100);
       }
       if (vec_data_0) {
          _fx_free_LN14C_form__cexp_t(&vec_data_0);
@@ -28265,29 +28471,29 @@ static int
       if (scalars_exp_1) {
          _fx_free_N14C_form__cexp_t(&scalars_exp_1);
       }
-      if (v_605) {
-         _fx_free_N14C_form__ctyp_t(&v_605);
+      if (v_627) {
+         _fx_free_N14C_form__ctyp_t(&v_627);
       }
       if (elem_ctyp_3) {
          _fx_free_N14C_form__ctyp_t(&elem_ctyp_3);
       }
-      if (ccode_94) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_94);
+      if (ccode_99) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_99);
       }
-      if (vec_exp_2) {
-         _fx_free_N14C_form__cexp_t(&vec_exp_2);
+      if (vec_exp_3) {
+         _fx_free_N14C_form__cexp_t(&vec_exp_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_604);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_626);
       if (elems_0) {
          _fx_free_LT2BN14K_form__atom_t(&elems_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 19) {
-      fx_exn_t v_654 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_655 = {0};
+      fx_exn_t v_676 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_677 = {0};
       _fx_N14C_form__cexp_t arr_exp_5 = 0;
-      _fx_LN15C_form__cstmt_t ccode_101 = 0;
+      _fx_LN15C_form__cstmt_t ccode_106 = 0;
       _fx_N14C_form__cexp_t lbl_7 = 0;
       _fx_N14C_form__ctyp_t arr_ctyp_0 = 0;
       _fx_T5N14K_form__atom_tN13Ast__border_tN18Ast__interpolate_tLN13K_form__dom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_12 =
@@ -28295,1343 +28501,1343 @@ static int
       _fx_LN13K_form__dom_t idxs_1 = vcase_12->t3;
       _fx_N13Ast__border_t* border_0 = &vcase_12->t1;
       if (vcase_12->t2.tag != 1) {
-         fx_str_t slit_156 = FX_MAKE_STR("cgen: inter-element interpolation is not supported yet");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_156, &v_654, 0), _fx_catch_207);
-         FX_THROW(&v_654, false, _fx_catch_207);
+         fx_str_t slit_157 = FX_MAKE_STR("cgen: inter-element interpolation is not supported yet");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_157, &v_676, 0), _fx_catch_214);
+         FX_THROW(&v_676, false, _fx_catch_214);
       }
-      FX_CALL(atom2cexp__0.fp(&vcase_12->t0, false, ccode_0, &kloc_0, &v_655, atom2cexp__0.fcv), _fx_catch_207);
-      FX_COPY_PTR(v_655.t0, &arr_exp_5);
-      FX_COPY_PTR(v_655.t1, &ccode_101);
+      FX_CALL(atom2cexp__0.fp(&vcase_12->t0, false, ccode_0, &kloc_0, &v_677, atom2cexp__0.fcv), _fx_catch_214);
+      FX_COPY_PTR(v_677.t0, &arr_exp_5);
+      FX_COPY_PTR(v_677.t1, &ccode_106);
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_7, 0), _fx_catch_207);
-      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(arr_exp_5, &arr_ctyp_0, 0), _fx_catch_207);
+            &lbl_7, 0), _fx_catch_214);
+      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(arr_exp_5, &arr_ctyp_0, 0), _fx_catch_214);
       int tag_18 = FX_REC_VARIANT_TAG(arr_ctyp_0);
       if (tag_18 == 12) {
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_656 = &idxs_1->hd;
-               if (v_656->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_657 = {0};
+               _fx_N13K_form__dom_t* v_678 = &idxs_1->hd;
+               if (v_678->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_679 = {0};
                   _fx_N14C_form__cexp_t i_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_102 = 0;
-                  _fx_LN14C_form__cexp_t v_658 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_107 = 0;
+                  _fx_LN14C_form__cexp_t v_680 = 0;
                   _fx_N14C_form__cexp_t get_elem_exp_1 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&v_656->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_657, atom2cexp_0.fcv), _fx_catch_148);
-                  FX_COPY_PTR(v_657.t0, &i_exp_2);
-                  FX_COPY_PTR(v_657.t1, &ccode_102);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_2, 0, true, &v_658), _fx_catch_148);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_658, false, &v_658), _fx_catch_148);
+                     atom2cexp_0.fp(&v_678->u.DomainFast, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_679, atom2cexp_0.fcv), _fx_catch_155);
+                  FX_COPY_PTR(v_679.t0, &i_exp_2);
+                  FX_COPY_PTR(v_679.t1, &ccode_107);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_2, 0, true, &v_680), _fx_catch_155);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_680, false, &v_680), _fx_catch_155);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g23C_form__std_FX_STR_ELEM, v_658, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &get_elem_exp_1, 0),
-                     _fx_catch_148);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_1, ccode_102, &v_1);
+                        &_fx_g23C_form__std_FX_STR_ELEM, v_680, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &get_elem_exp_1, 0),
+                     _fx_catch_155);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_1, ccode_107, &v_1);
 
-               _fx_catch_148: ;
+               _fx_catch_155: ;
                   if (get_elem_exp_1) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_1);
                   }
-                  if (v_658) {
-                     _fx_free_LN14C_form__cexp_t(&v_658);
+                  if (v_680) {
+                     _fx_free_LN14C_form__cexp_t(&v_680);
                   }
-                  if (ccode_102) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_102);
+                  if (ccode_107) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_107);
                   }
                   if (i_exp_2) {
                      _fx_free_N14C_form__cexp_t(&i_exp_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_657);
-                  goto _fx_endmatch_19;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_679);
+                  goto _fx_endmatch_22;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_659 = &idxs_1->hd;
-               if (v_659->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_660 = {0};
+               _fx_N13K_form__dom_t* v_681 = &idxs_1->hd;
+               if (v_681->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_682 = {0};
                   _fx_N14C_form__cexp_t i_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_103 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_661 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_108 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_683 = {0};
                   _fx_N14C_form__cexp_t get_elem_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_104 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_659->u.DomainElem, true, ccode_101, &kloc_0, &v_660, atom2cexp__0.fcv),
-                     _fx_catch_153);
-                  FX_COPY_PTR(v_660.t0, &i_exp_3);
-                  FX_COPY_PTR(v_660.t1, &ccode_103);
+                  _fx_LN15C_form__cstmt_t ccode_109 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_681->u.DomainElem, true, ccode_106, &kloc_0, &v_682, atom2cexp__0.fcv),
+                     _fx_catch_160);
+                  FX_COPY_PTR(v_682.t0, &i_exp_3);
+                  FX_COPY_PTR(v_682.t1, &ccode_108);
                   int tag_19 = border_0->tag;
                   if (tag_19 == 1) {
-                     _fx_LN14C_form__cexp_t v_662 = 0;
+                     _fx_LN14C_form__cexp_t v_684 = 0;
                      _fx_N14C_form__cexp_t chk_exp_0 = 0;
-                     _fx_LN14C_form__cexp_t v_663 = 0;
-                     _fx_N14C_form__cexp_t v_664 = 0;
-                     _fx_N15C_form__cstmt_t v_665 = 0;
-                     _fx_LN15C_form__cstmt_t v_666 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_662), _fx_catch_149);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, v_662, false, &v_662), _fx_catch_149);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_662, false, &v_662), _fx_catch_149);
+                     _fx_LN14C_form__cexp_t v_685 = 0;
+                     _fx_N14C_form__cexp_t v_686 = 0;
+                     _fx_N15C_form__cstmt_t v_687 = 0;
+                     _fx_LN15C_form__cstmt_t v_688 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_684), _fx_catch_156);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, v_684, false, &v_684), _fx_catch_156);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_684, false, &v_684), _fx_catch_156);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g25C_form__std_FX_STR_CHKIDX, v_662, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_0, 0),
-                        _fx_catch_149);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_663), _fx_catch_149);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_663, false, &v_663), _fx_catch_149);
+                           &_fx_g25C_form__std_FX_STR_CHKIDX, v_684, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_0, 0),
+                        _fx_catch_156);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_685), _fx_catch_156);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_685, false, &v_685), _fx_catch_156);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g23C_form__std_FX_STR_ELEM, v_663, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_664, 0),
-                        _fx_catch_149);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_0, &v_665), _fx_catch_149);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_665, ccode_103, true, &v_666), _fx_catch_149);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_664, v_666, &v_661);
+                           &_fx_g23C_form__std_FX_STR_ELEM, v_685, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_686, 0),
+                        _fx_catch_156);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_0, &v_687), _fx_catch_156);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_687, ccode_108, true, &v_688), _fx_catch_156);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_686, v_688, &v_683);
 
-                  _fx_catch_149: ;
-                     if (v_666) {
-                        _fx_free_LN15C_form__cstmt_t(&v_666);
+                  _fx_catch_156: ;
+                     if (v_688) {
+                        _fx_free_LN15C_form__cstmt_t(&v_688);
                      }
-                     if (v_665) {
-                        _fx_free_N15C_form__cstmt_t(&v_665);
+                     if (v_687) {
+                        _fx_free_N15C_form__cstmt_t(&v_687);
                      }
-                     if (v_664) {
-                        _fx_free_N14C_form__cexp_t(&v_664);
+                     if (v_686) {
+                        _fx_free_N14C_form__cexp_t(&v_686);
                      }
-                     if (v_663) {
-                        _fx_free_LN14C_form__cexp_t(&v_663);
+                     if (v_685) {
+                        _fx_free_LN14C_form__cexp_t(&v_685);
                      }
                      if (chk_exp_0) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_0);
                      }
-                     if (v_662) {
-                        _fx_free_LN14C_form__cexp_t(&v_662);
+                     if (v_684) {
+                        _fx_free_LN14C_form__cexp_t(&v_684);
                      }
                   }
                   else if (tag_19 == 2) {
-                     _fx_LN14C_form__cexp_t v_667 = 0;
-                     _fx_N14C_form__cexp_t v_668 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_667), _fx_catch_150);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_667, false, &v_667), _fx_catch_150);
+                     _fx_LN14C_form__cexp_t v_689 = 0;
+                     _fx_N14C_form__cexp_t v_690 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_689), _fx_catch_157);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_689, false, &v_689), _fx_catch_157);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_CLIP, v_667, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_668, 0),
-                        _fx_catch_150);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_668, ccode_103, &v_661);
+                           &_fx_g28C_form__std_FX_STR_ELEM_CLIP, v_689, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_690, 0),
+                        _fx_catch_157);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_690, ccode_108, &v_683);
 
-                  _fx_catch_150: ;
-                     if (v_668) {
-                        _fx_free_N14C_form__cexp_t(&v_668);
+                  _fx_catch_157: ;
+                     if (v_690) {
+                        _fx_free_N14C_form__cexp_t(&v_690);
                      }
-                     if (v_667) {
-                        _fx_free_LN14C_form__cexp_t(&v_667);
+                     if (v_689) {
+                        _fx_free_LN14C_form__cexp_t(&v_689);
                      }
                   }
                   else if (tag_19 == 3) {
-                     _fx_LN14C_form__cexp_t v_669 = 0;
-                     _fx_N14C_form__cexp_t v_670 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_669), _fx_catch_151);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_669, false, &v_669), _fx_catch_151);
+                     _fx_LN14C_form__cexp_t v_691 = 0;
+                     _fx_N14C_form__cexp_t v_692 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_691), _fx_catch_158);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_691, false, &v_691), _fx_catch_158);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_WRAP, v_669, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_670, 0),
-                        _fx_catch_151);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_670, ccode_103, &v_661);
+                           &_fx_g28C_form__std_FX_STR_ELEM_WRAP, v_691, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_692, 0),
+                        _fx_catch_158);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_692, ccode_108, &v_683);
 
-                  _fx_catch_151: ;
-                     if (v_670) {
-                        _fx_free_N14C_form__cexp_t(&v_670);
+                  _fx_catch_158: ;
+                     if (v_692) {
+                        _fx_free_N14C_form__cexp_t(&v_692);
                      }
-                     if (v_669) {
-                        _fx_free_LN14C_form__cexp_t(&v_669);
+                     if (v_691) {
+                        _fx_free_LN14C_form__cexp_t(&v_691);
                      }
                   }
                   else if (tag_19 == 4) {
-                     _fx_LN14C_form__cexp_t v_671 = 0;
-                     _fx_N14C_form__cexp_t v_672 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_671), _fx_catch_152);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_671, false, &v_671), _fx_catch_152);
+                     _fx_LN14C_form__cexp_t v_693 = 0;
+                     _fx_N14C_form__cexp_t v_694 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_693), _fx_catch_159);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_693, false, &v_693), _fx_catch_159);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_ZERO, v_671, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_672, 0),
-                        _fx_catch_152);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_672, ccode_103, &v_661);
+                           &_fx_g28C_form__std_FX_STR_ELEM_ZERO, v_693, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_694, 0),
+                        _fx_catch_159);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_694, ccode_108, &v_683);
 
-                  _fx_catch_152: ;
-                     if (v_672) {
-                        _fx_free_N14C_form__cexp_t(&v_672);
+                  _fx_catch_159: ;
+                     if (v_694) {
+                        _fx_free_N14C_form__cexp_t(&v_694);
                      }
-                     if (v_671) {
-                        _fx_free_LN14C_form__cexp_t(&v_671);
+                     if (v_693) {
+                        _fx_free_LN14C_form__cexp_t(&v_693);
                      }
                   }
                   else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_153);
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_160);
                   }
-                  FX_CHECK_EXN(_fx_catch_153);
-                  FX_COPY_PTR(v_661.t0, &get_elem_exp_2);
-                  FX_COPY_PTR(v_661.t1, &ccode_104);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_2, ccode_104, &v_1);
+                  FX_CHECK_EXN(_fx_catch_160);
+                  FX_COPY_PTR(v_683.t0, &get_elem_exp_2);
+                  FX_COPY_PTR(v_683.t1, &ccode_109);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_2, ccode_109, &v_1);
 
-               _fx_catch_153: ;
-                  if (ccode_104) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_104);
+               _fx_catch_160: ;
+                  if (ccode_109) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_109);
                   }
                   if (get_elem_exp_2) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_661);
-                  if (ccode_103) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_103);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_683);
+                  if (ccode_108) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_108);
                   }
                   if (i_exp_3) {
                      _fx_free_N14C_form__cexp_t(&i_exp_3);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_660);
-                  goto _fx_endmatch_19;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_682);
+                  goto _fx_endmatch_22;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_673 = &idxs_1->hd;
-               if (v_673->tag == 3) {
-                  fx_exn_t v_674 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_675 = {0};
-                  _fx_N14C_form__cexp_t a_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_105 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_676 = {0};
-                  _fx_N14C_form__cexp_t b_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_106 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_677 = {0};
-                  _fx_N14C_form__cexp_t delta_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_107 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_678 = {0};
-                  _fx_N14C_form__cexp_t substr_exp_0 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_108 = 0;
-                  _fx_N14C_form__cexp_t v_679 = 0;
-                  _fx_N14C_form__cexp_t v_680 = 0;
-                  _fx_N14C_form__cexp_t v_681 = 0;
-                  _fx_LN14C_form__cexp_t v_682 = 0;
-                  _fx_N14C_form__cexp_t call_substr_0 = 0;
-                  _fx_LN15C_form__cstmt_t v_683 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_13 = &v_673->u.DomainRange;
-                  _fx_N14K_form__atom_t* b_0 = &vcase_13->t1;
-                  _fx_N14K_form__atom_t* a_8 = &vcase_13->t0;
-                  if (border_0->tag != 1) {
-                     fx_str_t slit_157 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_157, &v_674, 0), _fx_catch_158);
-                     FX_THROW(&v_674, false, _fx_catch_158);
-                  }
-                  if (a_8->tag == 2) {
-                     if (a_8->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_684 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_685 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_684, 0),
-                           _fx_catch_154);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_684, ccode_101, &v_685);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_685, &v_675);
-
-                     _fx_catch_154: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_685);
-                        if (v_684) {
-                           _fx_free_N14C_form__cexp_t(&v_684);
-                        }
-                        goto _fx_endmatch_17;
-                     }
-                  }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_686 = {0};
-                  FX_CALL(
-                     atom2cexp_0.fp(a_8, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_686, atom2cexp_0.fcv), _fx_catch_155);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_686, &v_675);
-
-               _fx_catch_155: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_686);
-
-               _fx_endmatch_17: ;
-                  FX_CHECK_EXN(_fx_catch_158);
-                  int_ mask_0 = v_675.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_687 = &v_675.t1;
-                  FX_COPY_PTR(v_687->t0, &a_exp_1);
-                  FX_COPY_PTR(v_687->t1, &ccode_105);
-                  if (b_0->tag == 2) {
-                     if (b_0->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_688 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_689 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_688, 0),
-                           _fx_catch_156);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_688, ccode_105, &v_689);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_0, &v_689, &v_676);
-
-                     _fx_catch_156: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_689);
-                        if (v_688) {
-                           _fx_free_N14C_form__cexp_t(&v_688);
-                        }
-                        goto _fx_endmatch_18;
-                     }
-                  }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_690 = {0};
-                  FX_CALL(
-                     atom2cexp_0.fp(b_0, ccode_105, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_690, atom2cexp_0.fcv), _fx_catch_157);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_0, &v_690, &v_676);
-
-               _fx_catch_157: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_690);
-
-               _fx_endmatch_18: ;
-                  FX_CHECK_EXN(_fx_catch_158);
-                  int_ mask_1 = v_676.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_691 = &v_676.t1;
-                  FX_COPY_PTR(v_691->t0, &b_exp_1);
-                  FX_COPY_PTR(v_691->t1, &ccode_106);
-                  FX_CALL(
-                     atom2cexp_0.fp(&vcase_13->t2, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_677, atom2cexp_0.fcv), _fx_catch_158);
-                  FX_COPY_PTR(v_677.t0, &delta_exp_1);
-                  FX_COPY_PTR(v_677.t1, &ccode_107);
-                  fx_str_t slit_158 = FX_MAKE_STR("substr");
-                  FX_CALL(
-                     _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_158, ctyp_0, ccode_107, &kloc_0, block_stack_ref_0, km_idx_0, &v_678, 0),
-                     _fx_catch_158);
-                  FX_COPY_PTR(v_678.t0, &substr_exp_0);
-                  FX_COPY_PTR(v_678.t1, &ccode_108);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_679, 0),
-                     _fx_catch_158);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_1, &kloc_0, &v_680, 0),
-                     _fx_catch_158);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(substr_exp_0, &v_681, 0),
-                     _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_681, 0, true, &v_682), _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_680, v_682, false, &v_682), _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_1, v_682, false, &v_682), _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_1, v_682, false, &v_682), _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_1, v_682, false, &v_682), _fx_catch_158);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_679, v_682, false, &v_682), _fx_catch_158);
-                  FX_CALL(
-                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g21C_form__std_fx_substr, v_682, _fx_g22C_gen_code__CTypString, &kloc_0, &call_substr_0, 0),
-                     _fx_catch_158);
-                  FX_CALL(
-                     _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_substr_0, ccode_108, &kloc_0, block_stack_ref_0, &v_683, 0), _fx_catch_158);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, substr_exp_0, v_683, &v_1);
-
-               _fx_catch_158: ;
-                  if (v_683) {
-                     _fx_free_LN15C_form__cstmt_t(&v_683);
-                  }
-                  if (call_substr_0) {
-                     _fx_free_N14C_form__cexp_t(&call_substr_0);
-                  }
-                  if (v_682) {
-                     _fx_free_LN14C_form__cexp_t(&v_682);
-                  }
-                  if (v_681) {
-                     _fx_free_N14C_form__cexp_t(&v_681);
-                  }
-                  if (v_680) {
-                     _fx_free_N14C_form__cexp_t(&v_680);
-                  }
-                  if (v_679) {
-                     _fx_free_N14C_form__cexp_t(&v_679);
-                  }
-                  if (ccode_108) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_108);
-                  }
-                  if (substr_exp_0) {
-                     _fx_free_N14C_form__cexp_t(&substr_exp_0);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_678);
-                  if (ccode_107) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_107);
-                  }
-                  if (delta_exp_1) {
-                     _fx_free_N14C_form__cexp_t(&delta_exp_1);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_677);
-                  if (ccode_106) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_106);
-                  }
-                  if (b_exp_1) {
-                     _fx_free_N14C_form__cexp_t(&b_exp_1);
-                  }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_676);
-                  if (ccode_105) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_105);
-                  }
-                  if (a_exp_1) {
-                     _fx_free_N14C_form__cexp_t(&a_exp_1);
-                  }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_675);
-                  fx_free_exn(&v_674);
-                  goto _fx_endmatch_19;
-               }
-            }
-         }
-         fx_exn_t v_692 = {0};
-         fx_str_t slit_159 =
-            FX_MAKE_STR("cgen: unexpected index type when accessing string (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_159, &v_692, 0), _fx_catch_159);
-         FX_THROW(&v_692, false, _fx_catch_159);
-
-      _fx_catch_159: ;
-         fx_free_exn(&v_692);
-
-      _fx_endmatch_19: ;
-         FX_CHECK_EXN(_fx_catch_160);
-
-      _fx_catch_160: ;
-      }
-      else if (tag_18 == 20) {
-         if (idxs_1 != 0) {
-            if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_693 = &idxs_1->hd;
-               if (v_693->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_694 = {0};
-                  _fx_N14C_form__cexp_t i_exp_4 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_109 = 0;
-                  _fx_N14C_form__cexp_t v_695 = 0;
-                  _fx_LN14C_form__cexp_t v_696 = 0;
-                  _fx_N14C_form__cexp_t get_elem_exp_3 = 0;
-                  FX_CALL(
-                     atom2cexp_0.fp(&v_693->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_694, atom2cexp_0.fcv), _fx_catch_161);
-                  FX_COPY_PTR(v_694.t0, &i_exp_4);
-                  FX_COPY_PTR(v_694.t1, &ccode_109);
-                  _fx_R9Ast__id_t v_697;
-                  fx_str_t slit_160 = FX_MAKE_STR("FX_RRB_ELEM");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_160, &v_697, 0), _fx_catch_161);
-                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_695),
-                     _fx_catch_161);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_4, 0, true, &v_696), _fx_catch_161);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_696, false, &v_696), _fx_catch_161);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_695, v_696, false, &v_696), _fx_catch_161);
-                  FX_CALL(
-                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_697, v_696, ctyp_0, &kloc_0, &get_elem_exp_3, 0), _fx_catch_161);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_3, ccode_109, &v_1);
-
-               _fx_catch_161: ;
-                  if (get_elem_exp_3) {
-                     _fx_free_N14C_form__cexp_t(&get_elem_exp_3);
-                  }
-                  if (v_696) {
-                     _fx_free_LN14C_form__cexp_t(&v_696);
-                  }
-                  if (v_695) {
-                     _fx_free_N14C_form__cexp_t(&v_695);
-                  }
-                  if (ccode_109) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_109);
-                  }
-                  if (i_exp_4) {
-                     _fx_free_N14C_form__cexp_t(&i_exp_4);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_694);
-                  goto _fx_endmatch_24;
-               }
-            }
-         }
-         if (idxs_1 != 0) {
-            if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_698 = &idxs_1->hd;
-               if (v_698->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_699 = {0};
-                  _fx_N14C_form__cexp_t i_exp_5 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_110 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_700 = {0};
-                  _fx_N14C_form__cexp_t get_elem_exp_4 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_111 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_698->u.DomainElem, true, ccode_101, &kloc_0, &v_699, atom2cexp__0.fcv),
-                     _fx_catch_166);
-                  FX_COPY_PTR(v_699.t0, &i_exp_5);
-                  FX_COPY_PTR(v_699.t1, &ccode_110);
-                  int tag_20 = border_0->tag;
-                  if (tag_20 == 1) {
-                     _fx_LN14C_form__cexp_t v_701 = 0;
-                     _fx_N14C_form__cexp_t chk_exp_1 = 0;
-                     _fx_N14C_form__cexp_t v_702 = 0;
-                     _fx_LN14C_form__cexp_t v_703 = 0;
-                     _fx_N14C_form__cexp_t get_elem_exp_5 = 0;
-                     _fx_N15C_form__cstmt_t v_704 = 0;
-                     _fx_LN15C_form__cstmt_t v_705 = 0;
-                     _fx_R9Ast__id_t v_706;
-                     fx_str_t slit_161 = FX_MAKE_STR("FX_RRB_CHKIDX");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_161, &v_706, 0), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_701), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, v_701, false, &v_701), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_701, false, &v_701), _fx_catch_162);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_706, v_701, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_1, 0), _fx_catch_162);
-                     _fx_R9Ast__id_t v_707;
-                     fx_str_t slit_162 = FX_MAKE_STR("FX_RRB_ELEM");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_162, &v_707, 0), _fx_catch_162);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_702),
-                        _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_703), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_703, false, &v_703), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_702, v_703, false, &v_703), _fx_catch_162);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_707, v_703, ctyp_0, &kloc_0, &get_elem_exp_5, 0), _fx_catch_162);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_1, &v_704), _fx_catch_162);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_704, ccode_110, true, &v_705), _fx_catch_162);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_5, v_705, &v_700);
-
-                  _fx_catch_162: ;
-                     if (v_705) {
-                        _fx_free_LN15C_form__cstmt_t(&v_705);
-                     }
-                     if (v_704) {
-                        _fx_free_N15C_form__cstmt_t(&v_704);
-                     }
-                     if (get_elem_exp_5) {
-                        _fx_free_N14C_form__cexp_t(&get_elem_exp_5);
-                     }
-                     if (v_703) {
-                        _fx_free_LN14C_form__cexp_t(&v_703);
-                     }
-                     if (v_702) {
-                        _fx_free_N14C_form__cexp_t(&v_702);
-                     }
-                     if (chk_exp_1) {
-                        _fx_free_N14C_form__cexp_t(&chk_exp_1);
-                     }
-                     if (v_701) {
-                        _fx_free_LN14C_form__cexp_t(&v_701);
-                     }
-                  }
-                  else if (tag_20 == 2) {
-                     _fx_N14C_form__cexp_t v_708 = 0;
-                     _fx_LN14C_form__cexp_t v_709 = 0;
-                     _fx_N14C_form__cexp_t get_elem_exp_6 = 0;
-                     _fx_R9Ast__id_t v_710;
-                     fx_str_t slit_163 = FX_MAKE_STR("FX_RRB_ELEM_CLIP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_163, &v_710, 0), _fx_catch_163);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_708),
-                        _fx_catch_163);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_709), _fx_catch_163);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_709, false, &v_709), _fx_catch_163);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_708, v_709, false, &v_709), _fx_catch_163);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_710, v_709, ctyp_0, &kloc_0, &get_elem_exp_6, 0), _fx_catch_163);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_6, ccode_110, &v_700);
-
-                  _fx_catch_163: ;
-                     if (get_elem_exp_6) {
-                        _fx_free_N14C_form__cexp_t(&get_elem_exp_6);
-                     }
-                     if (v_709) {
-                        _fx_free_LN14C_form__cexp_t(&v_709);
-                     }
-                     if (v_708) {
-                        _fx_free_N14C_form__cexp_t(&v_708);
-                     }
-                  }
-                  else if (tag_20 == 3) {
-                     _fx_N14C_form__cexp_t v_711 = 0;
-                     _fx_LN14C_form__cexp_t v_712 = 0;
-                     _fx_N14C_form__cexp_t get_elem_exp_7 = 0;
-                     _fx_R9Ast__id_t v_713;
-                     fx_str_t slit_164 = FX_MAKE_STR("FX_RRB_ELEM_WRAP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_164, &v_713, 0), _fx_catch_164);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_711),
-                        _fx_catch_164);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_712), _fx_catch_164);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_712, false, &v_712), _fx_catch_164);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_711, v_712, false, &v_712), _fx_catch_164);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_713, v_712, ctyp_0, &kloc_0, &get_elem_exp_7, 0), _fx_catch_164);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_7, ccode_110, &v_700);
-
-                  _fx_catch_164: ;
-                     if (get_elem_exp_7) {
-                        _fx_free_N14C_form__cexp_t(&get_elem_exp_7);
-                     }
-                     if (v_712) {
-                        _fx_free_LN14C_form__cexp_t(&v_712);
-                     }
-                     if (v_711) {
-                        _fx_free_N14C_form__cexp_t(&v_711);
-                     }
-                  }
-                  else if (tag_20 == 4) {
-                     _fx_N14C_form__cexp_t v_714 = 0;
-                     _fx_LN14C_form__cexp_t v_715 = 0;
-                     _fx_N14C_form__cexp_t get_elem_exp_8 = 0;
-                     _fx_R9Ast__id_t v_716;
-                     fx_str_t slit_165 = FX_MAKE_STR("FX_RRB_ELEM_ZERO");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_165, &v_716, 0), _fx_catch_165);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_714),
-                        _fx_catch_165);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_715), _fx_catch_165);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_715, false, &v_715), _fx_catch_165);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_714, v_715, false, &v_715), _fx_catch_165);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_716, v_715, ctyp_0, &kloc_0, &get_elem_exp_8, 0), _fx_catch_165);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_8, ccode_110, &v_700);
-
-                  _fx_catch_165: ;
-                     if (get_elem_exp_8) {
-                        _fx_free_N14C_form__cexp_t(&get_elem_exp_8);
-                     }
-                     if (v_715) {
-                        _fx_free_LN14C_form__cexp_t(&v_715);
-                     }
-                     if (v_714) {
-                        _fx_free_N14C_form__cexp_t(&v_714);
-                     }
-                  }
-                  else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_166);
-                  }
-                  FX_CHECK_EXN(_fx_catch_166);
-                  FX_COPY_PTR(v_700.t0, &get_elem_exp_4);
-                  FX_COPY_PTR(v_700.t1, &ccode_111);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_4, ccode_111, &v_1);
-
-               _fx_catch_166: ;
-                  if (ccode_111) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_111);
-                  }
-                  if (get_elem_exp_4) {
-                     _fx_free_N14C_form__cexp_t(&get_elem_exp_4);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_700);
-                  if (ccode_110) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_110);
-                  }
-                  if (i_exp_5) {
-                     _fx_free_N14C_form__cexp_t(&i_exp_5);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_699);
-                  goto _fx_endmatch_24;
-               }
-            }
-         }
-         if (idxs_1 != 0) {
-            if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_717 = &idxs_1->hd;
-               if (v_717->tag == 3) {
-                  fx_exn_t v_718 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_719 = {0};
+               _fx_N13K_form__dom_t* v_695 = &idxs_1->hd;
+               if (v_695->tag == 3) {
+                  fx_exn_t v_696 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_697 = {0};
                   _fx_N14C_form__cexp_t a_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_112 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_720 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_110 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_698 = {0};
                   _fx_N14C_form__cexp_t b_exp_2 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_111 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_699 = {0};
+                  _fx_N14C_form__cexp_t delta_exp_2 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_112 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_700 = {0};
+                  _fx_N14C_form__cexp_t substr_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode_113 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_721 = {0};
-                  _fx_N14C_form__cexp_t slice_exp_0 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_114 = 0;
-                  _fx_N14C_form__cexp_t v_722 = 0;
-                  _fx_N14C_form__cexp_t v_723 = 0;
-                  _fx_N14C_form__cexp_t v_724 = 0;
-                  _fx_N14C_form__cexp_t v_725 = 0;
-                  _fx_LN14C_form__cexp_t v_726 = 0;
-                  _fx_N14C_form__cexp_t call_slice_0 = 0;
-                  _fx_LN15C_form__cstmt_t v_727 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_14 = &v_717->u.DomainRange;
-                  _fx_N14K_form__atom_t* delta_0 = &vcase_14->t2;
-                  _fx_N14K_form__atom_t* b_1 = &vcase_14->t1;
-                  _fx_N14K_form__atom_t* a_9 = &vcase_14->t0;
+                  _fx_N14C_form__cexp_t v_701 = 0;
+                  _fx_N14C_form__cexp_t v_702 = 0;
+                  _fx_N14C_form__cexp_t v_703 = 0;
+                  _fx_LN14C_form__cexp_t v_704 = 0;
+                  _fx_N14C_form__cexp_t call_substr_0 = 0;
+                  _fx_LN15C_form__cstmt_t v_705 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_13 = &v_695->u.DomainRange;
+                  _fx_N14K_form__atom_t* b_1 = &vcase_13->t1;
+                  _fx_N14K_form__atom_t* a_9 = &vcase_13->t0;
                   if (border_0->tag != 1) {
-                     fx_str_t slit_166 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_166, &v_718, 0), _fx_catch_172);
-                     FX_THROW(&v_718, false, _fx_catch_172);
+                     fx_str_t slit_158 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_158, &v_696, 0), _fx_catch_165);
+                     FX_THROW(&v_696, false, _fx_catch_165);
                   }
                   if (a_9->tag == 2) {
                      if (a_9->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_728 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_729 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_728, 0),
-                           _fx_catch_167);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_728, ccode_101, &v_729);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_729, &v_719);
+                        _fx_N14C_form__cexp_t v_706 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_707 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_706, 0),
+                           _fx_catch_161);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_706, ccode_106, &v_707);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_707, &v_697);
 
-                     _fx_catch_167: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_729);
-                        if (v_728) {
-                           _fx_free_N14C_form__cexp_t(&v_728);
+                     _fx_catch_161: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_707);
+                        if (v_706) {
+                           _fx_free_N14C_form__cexp_t(&v_706);
                         }
                         goto _fx_endmatch_20;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_730 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_708 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(a_9, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_730, atom2cexp_0.fcv), _fx_catch_168);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_730, &v_719);
+                     atom2cexp_0.fp(a_9, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_708, atom2cexp_0.fcv), _fx_catch_162);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_708, &v_697);
 
-               _fx_catch_168: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_730);
+               _fx_catch_162: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_708);
 
                _fx_endmatch_20: ;
-                  FX_CHECK_EXN(_fx_catch_172);
-                  int_ mask_2 = v_719.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_731 = &v_719.t1;
-                  FX_COPY_PTR(v_731->t0, &a_exp_2);
-                  FX_COPY_PTR(v_731->t1, &ccode_112);
+                  FX_CHECK_EXN(_fx_catch_165);
+                  int_ mask_2 = v_697.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_709 = &v_697.t1;
+                  FX_COPY_PTR(v_709->t0, &a_exp_2);
+                  FX_COPY_PTR(v_709->t1, &ccode_110);
                   if (b_1->tag == 2) {
                      if (b_1->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_732 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_733 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_732, 0),
-                           _fx_catch_169);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_732, ccode_112, &v_733);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_2, &v_733, &v_720);
+                        _fx_N14C_form__cexp_t v_710 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_711 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_710, 0),
+                           _fx_catch_163);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_710, ccode_110, &v_711);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_2, &v_711, &v_698);
 
-                     _fx_catch_169: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_733);
-                        if (v_732) {
-                           _fx_free_N14C_form__cexp_t(&v_732);
+                     _fx_catch_163: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_711);
+                        if (v_710) {
+                           _fx_free_N14C_form__cexp_t(&v_710);
                         }
                         goto _fx_endmatch_21;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_734 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_712 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(b_1, ccode_112, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_734, atom2cexp_0.fcv), _fx_catch_170);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_2, &v_734, &v_720);
+                     atom2cexp_0.fp(b_1, ccode_110, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_712, atom2cexp_0.fcv), _fx_catch_164);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_2, &v_712, &v_698);
 
-               _fx_catch_170: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_734);
+               _fx_catch_164: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_712);
 
                _fx_endmatch_21: ;
-                  FX_CHECK_EXN(_fx_catch_172);
-                  int_ mask_3 = v_720.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_735 = &v_720.t1;
-                  FX_COPY_PTR(v_735->t0, &b_exp_2);
-                  FX_COPY_PTR(v_735->t1, &ccode_113);
-                  int tag_21 = delta_0->tag;
-                  int_ delta_1;
+                  FX_CHECK_EXN(_fx_catch_165);
+                  int_ mask_3 = v_698.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_713 = &v_698.t1;
+                  FX_COPY_PTR(v_713->t0, &b_exp_2);
+                  FX_COPY_PTR(v_713->t1, &ccode_111);
+                  FX_CALL(
+                     atom2cexp_0.fp(&vcase_13->t2, ccode_111, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_699, atom2cexp_0.fcv), _fx_catch_165);
+                  FX_COPY_PTR(v_699.t0, &delta_exp_2);
+                  FX_COPY_PTR(v_699.t1, &ccode_112);
+                  fx_str_t slit_159 = FX_MAKE_STR("substr");
+                  FX_CALL(
+                     _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+                        dstexp_r_0, &slit_159, ctyp_0, ccode_112, &kloc_0, block_stack_ref_0, km_idx_0, &v_700, 0),
+                     _fx_catch_165);
+                  FX_COPY_PTR(v_700.t0, &substr_exp_0);
+                  FX_COPY_PTR(v_700.t1, &ccode_113);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_701, 0),
+                     _fx_catch_165);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_3, &kloc_0, &v_702, 0),
+                     _fx_catch_165);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(substr_exp_0, &v_703, 0),
+                     _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_703, 0, true, &v_704), _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_702, v_704, false, &v_704), _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_2, v_704, false, &v_704), _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_2, v_704, false, &v_704), _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_2, v_704, false, &v_704), _fx_catch_165);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_701, v_704, false, &v_704), _fx_catch_165);
+                  FX_CALL(
+                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                        &_fx_g21C_form__std_fx_substr, v_704, _fx_g22C_gen_code__CTypString, &kloc_0, &call_substr_0, 0),
+                     _fx_catch_165);
+                  FX_CALL(
+                     _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+                        call_substr_0, ccode_113, &kloc_0, block_stack_ref_0, &v_705, 0), _fx_catch_165);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, substr_exp_0, v_705, &v_1);
+
+               _fx_catch_165: ;
+                  if (v_705) {
+                     _fx_free_LN15C_form__cstmt_t(&v_705);
+                  }
+                  if (call_substr_0) {
+                     _fx_free_N14C_form__cexp_t(&call_substr_0);
+                  }
+                  if (v_704) {
+                     _fx_free_LN14C_form__cexp_t(&v_704);
+                  }
+                  if (v_703) {
+                     _fx_free_N14C_form__cexp_t(&v_703);
+                  }
+                  if (v_702) {
+                     _fx_free_N14C_form__cexp_t(&v_702);
+                  }
+                  if (v_701) {
+                     _fx_free_N14C_form__cexp_t(&v_701);
+                  }
+                  if (ccode_113) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_113);
+                  }
+                  if (substr_exp_0) {
+                     _fx_free_N14C_form__cexp_t(&substr_exp_0);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_700);
+                  if (ccode_112) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_112);
+                  }
+                  if (delta_exp_2) {
+                     _fx_free_N14C_form__cexp_t(&delta_exp_2);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_699);
+                  if (ccode_111) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_111);
+                  }
+                  if (b_exp_2) {
+                     _fx_free_N14C_form__cexp_t(&b_exp_2);
+                  }
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_698);
+                  if (ccode_110) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_110);
+                  }
+                  if (a_exp_2) {
+                     _fx_free_N14C_form__cexp_t(&a_exp_2);
+                  }
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_697);
+                  fx_free_exn(&v_696);
+                  goto _fx_endmatch_22;
+               }
+            }
+         }
+         fx_exn_t v_714 = {0};
+         fx_str_t slit_160 =
+            FX_MAKE_STR("cgen: unexpected index type when accessing string (should be a single scalar index or range)");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_160, &v_714, 0), _fx_catch_166);
+         FX_THROW(&v_714, false, _fx_catch_166);
+
+      _fx_catch_166: ;
+         fx_free_exn(&v_714);
+
+      _fx_endmatch_22: ;
+         FX_CHECK_EXN(_fx_catch_167);
+
+      _fx_catch_167: ;
+      }
+      else if (tag_18 == 20) {
+         if (idxs_1 != 0) {
+            if (idxs_1->tl == 0) {
+               _fx_N13K_form__dom_t* v_715 = &idxs_1->hd;
+               if (v_715->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_716 = {0};
+                  _fx_N14C_form__cexp_t i_exp_4 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_114 = 0;
+                  _fx_N14C_form__cexp_t v_717 = 0;
+                  _fx_LN14C_form__cexp_t v_718 = 0;
+                  _fx_N14C_form__cexp_t get_elem_exp_3 = 0;
+                  FX_CALL(
+                     atom2cexp_0.fp(&v_715->u.DomainFast, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_716, atom2cexp_0.fcv), _fx_catch_168);
+                  FX_COPY_PTR(v_716.t0, &i_exp_4);
+                  FX_COPY_PTR(v_716.t1, &ccode_114);
+                  _fx_R9Ast__id_t v_719;
+                  fx_str_t slit_161 = FX_MAKE_STR("FX_RRB_ELEM");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_161, &v_719, 0), _fx_catch_168);
+                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_717),
+                     _fx_catch_168);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_4, 0, true, &v_718), _fx_catch_168);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_718, false, &v_718), _fx_catch_168);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_717, v_718, false, &v_718), _fx_catch_168);
+                  FX_CALL(
+                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                        &v_719, v_718, ctyp_0, &kloc_0, &get_elem_exp_3, 0), _fx_catch_168);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_3, ccode_114, &v_1);
+
+               _fx_catch_168: ;
+                  if (get_elem_exp_3) {
+                     _fx_free_N14C_form__cexp_t(&get_elem_exp_3);
+                  }
+                  if (v_718) {
+                     _fx_free_LN14C_form__cexp_t(&v_718);
+                  }
+                  if (v_717) {
+                     _fx_free_N14C_form__cexp_t(&v_717);
+                  }
+                  if (ccode_114) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_114);
+                  }
+                  if (i_exp_4) {
+                     _fx_free_N14C_form__cexp_t(&i_exp_4);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_716);
+                  goto _fx_endmatch_27;
+               }
+            }
+         }
+         if (idxs_1 != 0) {
+            if (idxs_1->tl == 0) {
+               _fx_N13K_form__dom_t* v_720 = &idxs_1->hd;
+               if (v_720->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_721 = {0};
+                  _fx_N14C_form__cexp_t i_exp_5 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_115 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_722 = {0};
+                  _fx_N14C_form__cexp_t get_elem_exp_4 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_116 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_720->u.DomainElem, true, ccode_106, &kloc_0, &v_721, atom2cexp__0.fcv),
+                     _fx_catch_173);
+                  FX_COPY_PTR(v_721.t0, &i_exp_5);
+                  FX_COPY_PTR(v_721.t1, &ccode_115);
+                  int tag_20 = border_0->tag;
+                  if (tag_20 == 1) {
+                     _fx_LN14C_form__cexp_t v_723 = 0;
+                     _fx_N14C_form__cexp_t chk_exp_1 = 0;
+                     _fx_N14C_form__cexp_t v_724 = 0;
+                     _fx_LN14C_form__cexp_t v_725 = 0;
+                     _fx_N14C_form__cexp_t get_elem_exp_5 = 0;
+                     _fx_N15C_form__cstmt_t v_726 = 0;
+                     _fx_LN15C_form__cstmt_t v_727 = 0;
+                     _fx_R9Ast__id_t v_728;
+                     fx_str_t slit_162 = FX_MAKE_STR("FX_RRB_CHKIDX");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_162, &v_728, 0), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_723), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, v_723, false, &v_723), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_723, false, &v_723), _fx_catch_169);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_728, v_723, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_1, 0), _fx_catch_169);
+                     _fx_R9Ast__id_t v_729;
+                     fx_str_t slit_163 = FX_MAKE_STR("FX_RRB_ELEM");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_163, &v_729, 0), _fx_catch_169);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_724),
+                        _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_725), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_725, false, &v_725), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_724, v_725, false, &v_725), _fx_catch_169);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_729, v_725, ctyp_0, &kloc_0, &get_elem_exp_5, 0), _fx_catch_169);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_1, &v_726), _fx_catch_169);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_726, ccode_115, true, &v_727), _fx_catch_169);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_5, v_727, &v_722);
+
+                  _fx_catch_169: ;
+                     if (v_727) {
+                        _fx_free_LN15C_form__cstmt_t(&v_727);
+                     }
+                     if (v_726) {
+                        _fx_free_N15C_form__cstmt_t(&v_726);
+                     }
+                     if (get_elem_exp_5) {
+                        _fx_free_N14C_form__cexp_t(&get_elem_exp_5);
+                     }
+                     if (v_725) {
+                        _fx_free_LN14C_form__cexp_t(&v_725);
+                     }
+                     if (v_724) {
+                        _fx_free_N14C_form__cexp_t(&v_724);
+                     }
+                     if (chk_exp_1) {
+                        _fx_free_N14C_form__cexp_t(&chk_exp_1);
+                     }
+                     if (v_723) {
+                        _fx_free_LN14C_form__cexp_t(&v_723);
+                     }
+                  }
+                  else if (tag_20 == 2) {
+                     _fx_N14C_form__cexp_t v_730 = 0;
+                     _fx_LN14C_form__cexp_t v_731 = 0;
+                     _fx_N14C_form__cexp_t get_elem_exp_6 = 0;
+                     _fx_R9Ast__id_t v_732;
+                     fx_str_t slit_164 = FX_MAKE_STR("FX_RRB_ELEM_CLIP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_164, &v_732, 0), _fx_catch_170);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_730),
+                        _fx_catch_170);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_731), _fx_catch_170);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_731, false, &v_731), _fx_catch_170);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_730, v_731, false, &v_731), _fx_catch_170);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_732, v_731, ctyp_0, &kloc_0, &get_elem_exp_6, 0), _fx_catch_170);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_6, ccode_115, &v_722);
+
+                  _fx_catch_170: ;
+                     if (get_elem_exp_6) {
+                        _fx_free_N14C_form__cexp_t(&get_elem_exp_6);
+                     }
+                     if (v_731) {
+                        _fx_free_LN14C_form__cexp_t(&v_731);
+                     }
+                     if (v_730) {
+                        _fx_free_N14C_form__cexp_t(&v_730);
+                     }
+                  }
+                  else if (tag_20 == 3) {
+                     _fx_N14C_form__cexp_t v_733 = 0;
+                     _fx_LN14C_form__cexp_t v_734 = 0;
+                     _fx_N14C_form__cexp_t get_elem_exp_7 = 0;
+                     _fx_R9Ast__id_t v_735;
+                     fx_str_t slit_165 = FX_MAKE_STR("FX_RRB_ELEM_WRAP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_165, &v_735, 0), _fx_catch_171);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_733),
+                        _fx_catch_171);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_734), _fx_catch_171);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_734, false, &v_734), _fx_catch_171);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_733, v_734, false, &v_734), _fx_catch_171);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_735, v_734, ctyp_0, &kloc_0, &get_elem_exp_7, 0), _fx_catch_171);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_7, ccode_115, &v_722);
+
+                  _fx_catch_171: ;
+                     if (get_elem_exp_7) {
+                        _fx_free_N14C_form__cexp_t(&get_elem_exp_7);
+                     }
+                     if (v_734) {
+                        _fx_free_LN14C_form__cexp_t(&v_734);
+                     }
+                     if (v_733) {
+                        _fx_free_N14C_form__cexp_t(&v_733);
+                     }
+                  }
+                  else if (tag_20 == 4) {
+                     _fx_N14C_form__cexp_t v_736 = 0;
+                     _fx_LN14C_form__cexp_t v_737 = 0;
+                     _fx_N14C_form__cexp_t get_elem_exp_8 = 0;
+                     _fx_R9Ast__id_t v_738;
+                     fx_str_t slit_166 = FX_MAKE_STR("FX_RRB_ELEM_ZERO");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_166, &v_738, 0), _fx_catch_172);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_736),
+                        _fx_catch_172);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_737), _fx_catch_172);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_737, false, &v_737), _fx_catch_172);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_736, v_737, false, &v_737), _fx_catch_172);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_738, v_737, ctyp_0, &kloc_0, &get_elem_exp_8, 0), _fx_catch_172);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_8, ccode_115, &v_722);
+
+                  _fx_catch_172: ;
+                     if (get_elem_exp_8) {
+                        _fx_free_N14C_form__cexp_t(&get_elem_exp_8);
+                     }
+                     if (v_737) {
+                        _fx_free_LN14C_form__cexp_t(&v_737);
+                     }
+                     if (v_736) {
+                        _fx_free_N14C_form__cexp_t(&v_736);
+                     }
+                  }
+                  else {
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_173);
+                  }
+                  FX_CHECK_EXN(_fx_catch_173);
+                  FX_COPY_PTR(v_722.t0, &get_elem_exp_4);
+                  FX_COPY_PTR(v_722.t1, &ccode_116);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_4, ccode_116, &v_1);
+
+               _fx_catch_173: ;
+                  if (ccode_116) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_116);
+                  }
+                  if (get_elem_exp_4) {
+                     _fx_free_N14C_form__cexp_t(&get_elem_exp_4);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_722);
+                  if (ccode_115) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_115);
+                  }
+                  if (i_exp_5) {
+                     _fx_free_N14C_form__cexp_t(&i_exp_5);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_721);
+                  goto _fx_endmatch_27;
+               }
+            }
+         }
+         if (idxs_1 != 0) {
+            if (idxs_1->tl == 0) {
+               _fx_N13K_form__dom_t* v_739 = &idxs_1->hd;
+               if (v_739->tag == 3) {
+                  fx_exn_t v_740 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_741 = {0};
+                  _fx_N14C_form__cexp_t a_exp_3 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_117 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_742 = {0};
+                  _fx_N14C_form__cexp_t b_exp_3 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_118 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_743 = {0};
+                  _fx_N14C_form__cexp_t slice_exp_0 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_119 = 0;
+                  _fx_N14C_form__cexp_t v_744 = 0;
+                  _fx_N14C_form__cexp_t v_745 = 0;
+                  _fx_N14C_form__cexp_t v_746 = 0;
+                  _fx_N14C_form__cexp_t v_747 = 0;
+                  _fx_LN14C_form__cexp_t v_748 = 0;
+                  _fx_N14C_form__cexp_t call_slice_0 = 0;
+                  _fx_LN15C_form__cstmt_t v_749 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_14 = &v_739->u.DomainRange;
+                  _fx_N14K_form__atom_t* delta_1 = &vcase_14->t2;
+                  _fx_N14K_form__atom_t* b_2 = &vcase_14->t1;
+                  _fx_N14K_form__atom_t* a_10 = &vcase_14->t0;
+                  if (border_0->tag != 1) {
+                     fx_str_t slit_167 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_167, &v_740, 0), _fx_catch_179);
+                     FX_THROW(&v_740, false, _fx_catch_179);
+                  }
+                  if (a_10->tag == 2) {
+                     if (a_10->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_750 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_751 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_750, 0),
+                           _fx_catch_174);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_750, ccode_106, &v_751);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_751, &v_741);
+
+                     _fx_catch_174: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_751);
+                        if (v_750) {
+                           _fx_free_N14C_form__cexp_t(&v_750);
+                        }
+                        goto _fx_endmatch_23;
+                     }
+                  }
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_752 = {0};
+                  FX_CALL(
+                     atom2cexp_0.fp(a_10, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_752, atom2cexp_0.fcv), _fx_catch_175);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_752, &v_741);
+
+               _fx_catch_175: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_752);
+
+               _fx_endmatch_23: ;
+                  FX_CHECK_EXN(_fx_catch_179);
+                  int_ mask_4 = v_741.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_753 = &v_741.t1;
+                  FX_COPY_PTR(v_753->t0, &a_exp_3);
+                  FX_COPY_PTR(v_753->t1, &ccode_117);
+                  if (b_2->tag == 2) {
+                     if (b_2->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_754 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_755 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_754, 0),
+                           _fx_catch_176);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_754, ccode_117, &v_755);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_4, &v_755, &v_742);
+
+                     _fx_catch_176: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_755);
+                        if (v_754) {
+                           _fx_free_N14C_form__cexp_t(&v_754);
+                        }
+                        goto _fx_endmatch_24;
+                     }
+                  }
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_756 = {0};
+                  FX_CALL(
+                     atom2cexp_0.fp(b_2, ccode_117, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_756, atom2cexp_0.fcv), _fx_catch_177);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_4, &v_756, &v_742);
+
+               _fx_catch_177: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_756);
+
+               _fx_endmatch_24: ;
+                  FX_CHECK_EXN(_fx_catch_179);
+                  int_ mask_5 = v_742.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_757 = &v_742.t1;
+                  FX_COPY_PTR(v_757->t0, &b_exp_3);
+                  FX_COPY_PTR(v_757->t1, &ccode_118);
+                  int tag_21 = delta_1->tag;
+                  int_ delta_2;
                   bool res_19;
                   if (tag_21 == 2) {
-                     if (delta_0->u.AtomLit.tag == 8) {
-                        res_19 = true; goto _fx_endmatch_22;
+                     if (delta_1->u.AtomLit.tag == 8) {
+                        res_19 = true; goto _fx_endmatch_25;
                      }
                   }
                   if (tag_21 == 2) {
-                     _fx_N14K_form__klit_t* v_736 = &delta_0->u.AtomLit;
-                     if (v_736->tag == 1) {
-                        if (v_736->u.KLitInt == 1LL) {
-                           res_19 = true; goto _fx_endmatch_22;
+                     _fx_N14K_form__klit_t* v_758 = &delta_1->u.AtomLit;
+                     if (v_758->tag == 1) {
+                        if (v_758->u.KLitInt == 1LL) {
+                           res_19 = true; goto _fx_endmatch_25;
                         }
                      }
                   }
                   res_19 = false;
 
-               _fx_endmatch_22: ;
-                  FX_CHECK_EXN(_fx_catch_172);
+               _fx_endmatch_25: ;
+                  FX_CHECK_EXN(_fx_catch_179);
                   if (res_19) {
-                     delta_1 = 1; goto _fx_endmatch_23;
+                     delta_2 = 1; goto _fx_endmatch_26;
                   }
                   if (tag_21 == 2) {
-                     _fx_N14K_form__klit_t* v_737 = &delta_0->u.AtomLit;
-                     if (v_737->tag == 1) {
-                        if (v_737->u.KLitInt == -1LL) {
-                           delta_1 = -1; goto _fx_endmatch_23;
+                     _fx_N14K_form__klit_t* v_759 = &delta_1->u.AtomLit;
+                     if (v_759->tag == 1) {
+                        if (v_759->u.KLitInt == -1LL) {
+                           delta_2 = -1; goto _fx_endmatch_26;
                         }
                      }
                   }
-                  fx_exn_t v_738 = {0};
-                  fx_str_t slit_167 = FX_MAKE_STR("cgen: rrbvec slicing only supports stride == ±1");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_167, &v_738, 0), _fx_catch_171);
-                  FX_THROW(&v_738, false, _fx_catch_171);
+                  fx_exn_t v_760 = {0};
+                  fx_str_t slit_168 = FX_MAKE_STR("cgen: rrbvec slicing only supports stride == ±1");
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_168, &v_760, 0), _fx_catch_178);
+                  FX_THROW(&v_760, false, _fx_catch_178);
 
-               _fx_catch_171: ;
-                  fx_free_exn(&v_738);
+               _fx_catch_178: ;
+                  fx_free_exn(&v_760);
 
-               _fx_endmatch_23: ;
-                  FX_CHECK_EXN(_fx_catch_172);
-                  fx_str_t slit_168 = FX_MAKE_STR("slice");
+               _fx_endmatch_26: ;
+                  FX_CHECK_EXN(_fx_catch_179);
+                  fx_str_t slit_169 = FX_MAKE_STR("slice");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_168, ctyp_0, ccode_113, &kloc_0, block_stack_ref_0, km_idx_0, &v_721, 0),
-                     _fx_catch_172);
-                  FX_COPY_PTR(v_721.t0, &slice_exp_0);
-                  FX_COPY_PTR(v_721.t1, &ccode_114);
-                  _fx_R9Ast__id_t v_739;
-                  fx_str_t slit_169 = FX_MAKE_STR("fx_rrb_slice");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_169, &v_739, 0), _fx_catch_172);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_722, 0),
-                     _fx_catch_172);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(delta_1, &kloc_0, &v_723, 0),
-                     _fx_catch_172);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_3, &kloc_0, &v_724, 0),
-                     _fx_catch_172);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_0, &v_725, 0),
-                     _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_725, 0, true, &v_726), _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_724, v_726, false, &v_726), _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_723, v_726, false, &v_726), _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_2, v_726, false, &v_726), _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_2, v_726, false, &v_726), _fx_catch_172);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_722, v_726, false, &v_726), _fx_catch_172);
+                        dstexp_r_0, &slit_169, ctyp_0, ccode_118, &kloc_0, block_stack_ref_0, km_idx_0, &v_743, 0),
+                     _fx_catch_179);
+                  FX_COPY_PTR(v_743.t0, &slice_exp_0);
+                  FX_COPY_PTR(v_743.t1, &ccode_119);
+                  _fx_R9Ast__id_t v_761;
+                  fx_str_t slit_170 = FX_MAKE_STR("fx_rrb_slice");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_170, &v_761, 0), _fx_catch_179);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_744, 0),
+                     _fx_catch_179);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(delta_2, &kloc_0, &v_745, 0),
+                     _fx_catch_179);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_5, &kloc_0, &v_746, 0),
+                     _fx_catch_179);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_0, &v_747, 0),
+                     _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_747, 0, true, &v_748), _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_746, v_748, false, &v_748), _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_745, v_748, false, &v_748), _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_3, v_748, false, &v_748), _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_3, v_748, false, &v_748), _fx_catch_179);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_744, v_748, false, &v_748), _fx_catch_179);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_739, v_726, ctyp_0, &kloc_0, &call_slice_0, 0), _fx_catch_172);
+                        &v_761, v_748, ctyp_0, &kloc_0, &call_slice_0, 0), _fx_catch_179);
                   FX_CALL(
                      _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_slice_0, ccode_114, &kloc_0, block_stack_ref_0, &v_727, 0), _fx_catch_172);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_0, v_727, &v_1);
+                        call_slice_0, ccode_119, &kloc_0, block_stack_ref_0, &v_749, 0), _fx_catch_179);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_0, v_749, &v_1);
 
-               _fx_catch_172: ;
-                  if (v_727) {
-                     _fx_free_LN15C_form__cstmt_t(&v_727);
+               _fx_catch_179: ;
+                  if (v_749) {
+                     _fx_free_LN15C_form__cstmt_t(&v_749);
                   }
                   if (call_slice_0) {
                      _fx_free_N14C_form__cexp_t(&call_slice_0);
                   }
-                  if (v_726) {
-                     _fx_free_LN14C_form__cexp_t(&v_726);
+                  if (v_748) {
+                     _fx_free_LN14C_form__cexp_t(&v_748);
                   }
-                  if (v_725) {
-                     _fx_free_N14C_form__cexp_t(&v_725);
+                  if (v_747) {
+                     _fx_free_N14C_form__cexp_t(&v_747);
                   }
-                  if (v_724) {
-                     _fx_free_N14C_form__cexp_t(&v_724);
+                  if (v_746) {
+                     _fx_free_N14C_form__cexp_t(&v_746);
                   }
-                  if (v_723) {
-                     _fx_free_N14C_form__cexp_t(&v_723);
+                  if (v_745) {
+                     _fx_free_N14C_form__cexp_t(&v_745);
                   }
-                  if (v_722) {
-                     _fx_free_N14C_form__cexp_t(&v_722);
+                  if (v_744) {
+                     _fx_free_N14C_form__cexp_t(&v_744);
                   }
-                  if (ccode_114) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_114);
+                  if (ccode_119) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_119);
                   }
                   if (slice_exp_0) {
                      _fx_free_N14C_form__cexp_t(&slice_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_721);
-                  if (ccode_113) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_113);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_743);
+                  if (ccode_118) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_118);
                   }
-                  if (b_exp_2) {
-                     _fx_free_N14C_form__cexp_t(&b_exp_2);
+                  if (b_exp_3) {
+                     _fx_free_N14C_form__cexp_t(&b_exp_3);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_720);
-                  if (ccode_112) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_112);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_742);
+                  if (ccode_117) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_117);
                   }
-                  if (a_exp_2) {
-                     _fx_free_N14C_form__cexp_t(&a_exp_2);
+                  if (a_exp_3) {
+                     _fx_free_N14C_form__cexp_t(&a_exp_3);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_719);
-                  fx_free_exn(&v_718);
-                  goto _fx_endmatch_24;
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_741);
+                  fx_free_exn(&v_740);
+                  goto _fx_endmatch_27;
                }
             }
          }
-         fx_exn_t v_740 = {0};
-         fx_str_t slit_170 =
+         fx_exn_t v_762 = {0};
+         fx_str_t slit_171 =
             FX_MAKE_STR("cgen: unexpected index type when accessing rrbvec (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_170, &v_740, 0), _fx_catch_173);
-         FX_THROW(&v_740, false, _fx_catch_173);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_171, &v_762, 0), _fx_catch_180);
+         FX_THROW(&v_762, false, _fx_catch_180);
 
-      _fx_catch_173: ;
-         fx_free_exn(&v_740);
+      _fx_catch_180: ;
+         fx_free_exn(&v_762);
 
-      _fx_endmatch_24: ;
-         FX_CHECK_EXN(_fx_catch_174);
+      _fx_endmatch_27: ;
+         FX_CHECK_EXN(_fx_catch_181);
 
-      _fx_catch_174: ;
+      _fx_catch_181: ;
       }
       else if (tag_18 == 21) {
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_741 = &idxs_1->hd;
-               if (v_741->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_742 = {0};
+               _fx_N13K_form__dom_t* v_763 = &idxs_1->hd;
+               if (v_763->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_764 = {0};
                   _fx_N14C_form__cexp_t i_exp_6 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_115 = 0;
-                  _fx_N14C_form__cexp_t v_743 = 0;
-                  _fx_LN14C_form__cexp_t v_744 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_120 = 0;
+                  _fx_N14C_form__cexp_t v_765 = 0;
+                  _fx_LN14C_form__cexp_t v_766 = 0;
                   _fx_N14C_form__cexp_t get_elem_exp_9 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&v_741->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_742, atom2cexp_0.fcv), _fx_catch_175);
-                  FX_COPY_PTR(v_742.t0, &i_exp_6);
-                  FX_COPY_PTR(v_742.t1, &ccode_115);
-                  _fx_R9Ast__id_t v_745;
-                  fx_str_t slit_171 = FX_MAKE_STR("FX_VEC_ELEM");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_171, &v_745, 0), _fx_catch_175);
-                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_743),
-                     _fx_catch_175);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_6, 0, true, &v_744), _fx_catch_175);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_744, false, &v_744), _fx_catch_175);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_743, v_744, false, &v_744), _fx_catch_175);
+                     atom2cexp_0.fp(&v_763->u.DomainFast, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_764, atom2cexp_0.fcv), _fx_catch_182);
+                  FX_COPY_PTR(v_764.t0, &i_exp_6);
+                  FX_COPY_PTR(v_764.t1, &ccode_120);
+                  _fx_R9Ast__id_t v_767;
+                  fx_str_t slit_172 = FX_MAKE_STR("FX_VEC_ELEM");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_172, &v_767, 0), _fx_catch_182);
+                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_765),
+                     _fx_catch_182);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_6, 0, true, &v_766), _fx_catch_182);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_766, false, &v_766), _fx_catch_182);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_765, v_766, false, &v_766), _fx_catch_182);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_745, v_744, ctyp_0, &kloc_0, &get_elem_exp_9, 0), _fx_catch_175);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_9, ccode_115, &v_1);
+                        &v_767, v_766, ctyp_0, &kloc_0, &get_elem_exp_9, 0), _fx_catch_182);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_9, ccode_120, &v_1);
 
-               _fx_catch_175: ;
+               _fx_catch_182: ;
                   if (get_elem_exp_9) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_9);
                   }
-                  if (v_744) {
-                     _fx_free_LN14C_form__cexp_t(&v_744);
+                  if (v_766) {
+                     _fx_free_LN14C_form__cexp_t(&v_766);
                   }
-                  if (v_743) {
-                     _fx_free_N14C_form__cexp_t(&v_743);
+                  if (v_765) {
+                     _fx_free_N14C_form__cexp_t(&v_765);
                   }
-                  if (ccode_115) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_115);
+                  if (ccode_120) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_120);
                   }
                   if (i_exp_6) {
                      _fx_free_N14C_form__cexp_t(&i_exp_6);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_742);
-                  goto _fx_endmatch_28;
-               }
-            }
-         }
-         if (idxs_1 != 0) {
-            if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_746 = &idxs_1->hd;
-               if (v_746->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_747 = {0};
-                  _fx_N14C_form__cexp_t i_exp_7 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_116 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_748 = {0};
-                  _fx_N14C_form__cexp_t get_elem_exp_10 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_117 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_746->u.DomainElem, true, ccode_101, &kloc_0, &v_747, atom2cexp__0.fcv),
-                     _fx_catch_180);
-                  FX_COPY_PTR(v_747.t0, &i_exp_7);
-                  FX_COPY_PTR(v_747.t1, &ccode_116);
-                  int tag_22 = border_0->tag;
-                  if (tag_22 == 1) {
-                     _fx_LN14C_form__cexp_t v_749 = 0;
-                     _fx_N14C_form__cexp_t chk_exp_2 = 0;
-                     _fx_N14C_form__cexp_t v_750 = 0;
-                     _fx_LN14C_form__cexp_t v_751 = 0;
-                     _fx_N14C_form__cexp_t get_elem_exp_11 = 0;
-                     _fx_N15C_form__cstmt_t v_752 = 0;
-                     _fx_LN15C_form__cstmt_t v_753 = 0;
-                     _fx_R9Ast__id_t v_754;
-                     fx_str_t slit_172 = FX_MAKE_STR("FX_VEC_CHKIDX");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_172, &v_754, 0), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_749), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, v_749, false, &v_749), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_749, false, &v_749), _fx_catch_176);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_754, v_749, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_2, 0), _fx_catch_176);
-                     _fx_R9Ast__id_t v_755;
-                     fx_str_t slit_173 = FX_MAKE_STR("FX_VEC_ELEM");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_173, &v_755, 0), _fx_catch_176);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_750),
-                        _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_751), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_751, false, &v_751), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_750, v_751, false, &v_751), _fx_catch_176);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_755, v_751, ctyp_0, &kloc_0, &get_elem_exp_11, 0), _fx_catch_176);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_2, &v_752), _fx_catch_176);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_752, ccode_116, true, &v_753), _fx_catch_176);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_11, v_753, &v_748);
-
-                  _fx_catch_176: ;
-                     if (v_753) {
-                        _fx_free_LN15C_form__cstmt_t(&v_753);
-                     }
-                     if (v_752) {
-                        _fx_free_N15C_form__cstmt_t(&v_752);
-                     }
-                     if (get_elem_exp_11) {
-                        _fx_free_N14C_form__cexp_t(&get_elem_exp_11);
-                     }
-                     if (v_751) {
-                        _fx_free_LN14C_form__cexp_t(&v_751);
-                     }
-                     if (v_750) {
-                        _fx_free_N14C_form__cexp_t(&v_750);
-                     }
-                     if (chk_exp_2) {
-                        _fx_free_N14C_form__cexp_t(&chk_exp_2);
-                     }
-                     if (v_749) {
-                        _fx_free_LN14C_form__cexp_t(&v_749);
-                     }
-                  }
-                  else if (tag_22 == 2) {
-                     _fx_N14C_form__cexp_t v_756 = 0;
-                     _fx_LN14C_form__cexp_t v_757 = 0;
-                     _fx_N14C_form__cexp_t v_758 = 0;
-                     _fx_R9Ast__id_t v_759;
-                     fx_str_t slit_174 = FX_MAKE_STR("FX_VEC_ELEM_CLIP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_174, &v_759, 0), _fx_catch_177);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_756),
-                        _fx_catch_177);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_757), _fx_catch_177);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_757, false, &v_757), _fx_catch_177);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_756, v_757, false, &v_757), _fx_catch_177);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_759, v_757, ctyp_0, &kloc_0, &v_758, 0), _fx_catch_177);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_758, ccode_116, &v_748);
-
-                  _fx_catch_177: ;
-                     if (v_758) {
-                        _fx_free_N14C_form__cexp_t(&v_758);
-                     }
-                     if (v_757) {
-                        _fx_free_LN14C_form__cexp_t(&v_757);
-                     }
-                     if (v_756) {
-                        _fx_free_N14C_form__cexp_t(&v_756);
-                     }
-                  }
-                  else if (tag_22 == 3) {
-                     _fx_N14C_form__cexp_t v_760 = 0;
-                     _fx_LN14C_form__cexp_t v_761 = 0;
-                     _fx_N14C_form__cexp_t v_762 = 0;
-                     _fx_R9Ast__id_t v_763;
-                     fx_str_t slit_175 = FX_MAKE_STR("FX_VEC_ELEM_WRAP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_175, &v_763, 0), _fx_catch_178);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_760),
-                        _fx_catch_178);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_761), _fx_catch_178);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_761, false, &v_761), _fx_catch_178);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_760, v_761, false, &v_761), _fx_catch_178);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_763, v_761, ctyp_0, &kloc_0, &v_762, 0), _fx_catch_178);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_762, ccode_116, &v_748);
-
-                  _fx_catch_178: ;
-                     if (v_762) {
-                        _fx_free_N14C_form__cexp_t(&v_762);
-                     }
-                     if (v_761) {
-                        _fx_free_LN14C_form__cexp_t(&v_761);
-                     }
-                     if (v_760) {
-                        _fx_free_N14C_form__cexp_t(&v_760);
-                     }
-                  }
-                  else if (tag_22 == 4) {
-                     _fx_N14C_form__cexp_t v_764 = 0;
-                     _fx_LN14C_form__cexp_t v_765 = 0;
-                     _fx_N14C_form__cexp_t v_766 = 0;
-                     _fx_R9Ast__id_t v_767;
-                     fx_str_t slit_176 = FX_MAKE_STR("FX_VEC_ELEM_ZERO");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_176, &v_767, 0), _fx_catch_179);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_764),
-                        _fx_catch_179);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_765), _fx_catch_179);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_765, false, &v_765), _fx_catch_179);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_764, v_765, false, &v_765), _fx_catch_179);
-                     FX_CALL(
-                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_767, v_765, ctyp_0, &kloc_0, &v_766, 0), _fx_catch_179);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_766, ccode_116, &v_748);
-
-                  _fx_catch_179: ;
-                     if (v_766) {
-                        _fx_free_N14C_form__cexp_t(&v_766);
-                     }
-                     if (v_765) {
-                        _fx_free_LN14C_form__cexp_t(&v_765);
-                     }
-                     if (v_764) {
-                        _fx_free_N14C_form__cexp_t(&v_764);
-                     }
-                  }
-                  else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_180);
-                  }
-                  FX_CHECK_EXN(_fx_catch_180);
-                  FX_COPY_PTR(v_748.t0, &get_elem_exp_10);
-                  FX_COPY_PTR(v_748.t1, &ccode_117);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_10, ccode_117, &v_1);
-
-               _fx_catch_180: ;
-                  if (ccode_117) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_117);
-                  }
-                  if (get_elem_exp_10) {
-                     _fx_free_N14C_form__cexp_t(&get_elem_exp_10);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_748);
-                  if (ccode_116) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_116);
-                  }
-                  if (i_exp_7) {
-                     _fx_free_N14C_form__cexp_t(&i_exp_7);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_747);
-                  goto _fx_endmatch_28;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_764);
+                  goto _fx_endmatch_31;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
                _fx_N13K_form__dom_t* v_768 = &idxs_1->hd;
-               if (v_768->tag == 3) {
-                  fx_exn_t v_769 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_770 = {0};
-                  _fx_N14C_form__cexp_t a_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_118 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_771 = {0};
-                  _fx_N14C_form__cexp_t b_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_119 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_772 = {0};
-                  _fx_N14C_form__cexp_t delta_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_120 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_773 = {0};
-                  _fx_N14C_form__cexp_t slice_exp_1 = 0;
+               if (v_768->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_769 = {0};
+                  _fx_N14C_form__cexp_t i_exp_7 = 0;
                   _fx_LN15C_form__cstmt_t ccode_121 = 0;
-                  _fx_N14C_form__cexp_t v_774 = 0;
-                  _fx_N14C_form__cexp_t v_775 = 0;
-                  _fx_LN14C_form__cexp_t v_776 = 0;
-                  _fx_N14C_form__cexp_t call_slice_1 = 0;
-                  _fx_LN15C_form__cstmt_t v_777 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_15 = &v_768->u.DomainRange;
-                  _fx_N14K_form__atom_t* delta_2 = &vcase_15->t2;
-                  _fx_N14K_form__atom_t* b_2 = &vcase_15->t1;
-                  _fx_N14K_form__atom_t* a_10 = &vcase_15->t0;
-                  if (border_0->tag != 1) {
-                     fx_str_t slit_177 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported for vectors");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_177, &v_769, 0), _fx_catch_187);
-                     FX_THROW(&v_769, false, _fx_catch_187);
-                  }
-                  if (a_10->tag == 2) {
-                     if (a_10->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_778 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_779 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_778, 0),
-                           _fx_catch_181);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_778, ccode_101, &v_779);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_779, &v_770);
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_770 = {0};
+                  _fx_N14C_form__cexp_t get_elem_exp_10 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_122 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_768->u.DomainElem, true, ccode_106, &kloc_0, &v_769, atom2cexp__0.fcv),
+                     _fx_catch_187);
+                  FX_COPY_PTR(v_769.t0, &i_exp_7);
+                  FX_COPY_PTR(v_769.t1, &ccode_121);
+                  int tag_22 = border_0->tag;
+                  if (tag_22 == 1) {
+                     _fx_LN14C_form__cexp_t v_771 = 0;
+                     _fx_N14C_form__cexp_t chk_exp_2 = 0;
+                     _fx_N14C_form__cexp_t v_772 = 0;
+                     _fx_LN14C_form__cexp_t v_773 = 0;
+                     _fx_N14C_form__cexp_t get_elem_exp_11 = 0;
+                     _fx_N15C_form__cstmt_t v_774 = 0;
+                     _fx_LN15C_form__cstmt_t v_775 = 0;
+                     _fx_R9Ast__id_t v_776;
+                     fx_str_t slit_173 = FX_MAKE_STR("FX_VEC_CHKIDX");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_173, &v_776, 0), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_771), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, v_771, false, &v_771), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_771, false, &v_771), _fx_catch_183);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_776, v_771, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_2, 0), _fx_catch_183);
+                     _fx_R9Ast__id_t v_777;
+                     fx_str_t slit_174 = FX_MAKE_STR("FX_VEC_ELEM");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_174, &v_777, 0), _fx_catch_183);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_772),
+                        _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_773), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_773, false, &v_773), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_772, v_773, false, &v_773), _fx_catch_183);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_777, v_773, ctyp_0, &kloc_0, &get_elem_exp_11, 0), _fx_catch_183);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_2, &v_774), _fx_catch_183);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_774, ccode_121, true, &v_775), _fx_catch_183);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_11, v_775, &v_770);
 
-                     _fx_catch_181: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_779);
-                        if (v_778) {
-                           _fx_free_N14C_form__cexp_t(&v_778);
-                        }
-                        goto _fx_endmatch_25;
+                  _fx_catch_183: ;
+                     if (v_775) {
+                        _fx_free_LN15C_form__cstmt_t(&v_775);
+                     }
+                     if (v_774) {
+                        _fx_free_N15C_form__cstmt_t(&v_774);
+                     }
+                     if (get_elem_exp_11) {
+                        _fx_free_N14C_form__cexp_t(&get_elem_exp_11);
+                     }
+                     if (v_773) {
+                        _fx_free_LN14C_form__cexp_t(&v_773);
+                     }
+                     if (v_772) {
+                        _fx_free_N14C_form__cexp_t(&v_772);
+                     }
+                     if (chk_exp_2) {
+                        _fx_free_N14C_form__cexp_t(&chk_exp_2);
+                     }
+                     if (v_771) {
+                        _fx_free_LN14C_form__cexp_t(&v_771);
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_780 = {0};
-                  FX_CALL(
-                     atom2cexp_0.fp(a_10, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_780, atom2cexp_0.fcv), _fx_catch_182);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_780, &v_770);
+                  else if (tag_22 == 2) {
+                     _fx_N14C_form__cexp_t v_778 = 0;
+                     _fx_LN14C_form__cexp_t v_779 = 0;
+                     _fx_N14C_form__cexp_t v_780 = 0;
+                     _fx_R9Ast__id_t v_781;
+                     fx_str_t slit_175 = FX_MAKE_STR("FX_VEC_ELEM_CLIP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_175, &v_781, 0), _fx_catch_184);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_778),
+                        _fx_catch_184);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_779), _fx_catch_184);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_779, false, &v_779), _fx_catch_184);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_778, v_779, false, &v_779), _fx_catch_184);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_781, v_779, ctyp_0, &kloc_0, &v_780, 0), _fx_catch_184);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_780, ccode_121, &v_770);
 
-               _fx_catch_182: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_780);
-
-               _fx_endmatch_25: ;
-                  FX_CHECK_EXN(_fx_catch_187);
-                  int_ mask_4 = v_770.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_781 = &v_770.t1;
-                  FX_COPY_PTR(v_781->t0, &a_exp_3);
-                  FX_COPY_PTR(v_781->t1, &ccode_118);
-                  if (b_2->tag == 2) {
-                     if (b_2->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_782 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_783 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_782, 0),
-                           _fx_catch_183);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_782, ccode_118, &v_783);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_4, &v_783, &v_771);
-
-                     _fx_catch_183: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_783);
-                        if (v_782) {
-                           _fx_free_N14C_form__cexp_t(&v_782);
-                        }
-                        goto _fx_endmatch_26;
+                  _fx_catch_184: ;
+                     if (v_780) {
+                        _fx_free_N14C_form__cexp_t(&v_780);
+                     }
+                     if (v_779) {
+                        _fx_free_LN14C_form__cexp_t(&v_779);
+                     }
+                     if (v_778) {
+                        _fx_free_N14C_form__cexp_t(&v_778);
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_784 = {0};
-                  FX_CALL(
-                     atom2cexp_0.fp(b_2, ccode_118, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_784, atom2cexp_0.fcv), _fx_catch_184);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_4, &v_784, &v_771);
+                  else if (tag_22 == 3) {
+                     _fx_N14C_form__cexp_t v_782 = 0;
+                     _fx_LN14C_form__cexp_t v_783 = 0;
+                     _fx_N14C_form__cexp_t v_784 = 0;
+                     _fx_R9Ast__id_t v_785;
+                     fx_str_t slit_176 = FX_MAKE_STR("FX_VEC_ELEM_WRAP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_176, &v_785, 0), _fx_catch_185);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_782),
+                        _fx_catch_185);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_783), _fx_catch_185);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_783, false, &v_783), _fx_catch_185);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_782, v_783, false, &v_783), _fx_catch_185);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_785, v_783, ctyp_0, &kloc_0, &v_784, 0), _fx_catch_185);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_784, ccode_121, &v_770);
 
-               _fx_catch_184: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_784);
-
-               _fx_endmatch_26: ;
-                  FX_CHECK_EXN(_fx_catch_187);
-                  int_ mask_5 = v_771.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_785 = &v_771.t1;
-                  FX_COPY_PTR(v_785->t0, &b_exp_3);
-                  FX_COPY_PTR(v_785->t1, &ccode_119);
-                  if (delta_2->tag == 2) {
-                     if (delta_2->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_786 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_786, 0),
-                           _fx_catch_185);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_786, ccode_119, &v_772);
-
-                     _fx_catch_185: ;
-                        if (v_786) {
-                           _fx_free_N14C_form__cexp_t(&v_786);
-                        }
-                        goto _fx_endmatch_27;
+                  _fx_catch_185: ;
+                     if (v_784) {
+                        _fx_free_N14C_form__cexp_t(&v_784);
+                     }
+                     if (v_783) {
+                        _fx_free_LN14C_form__cexp_t(&v_783);
+                     }
+                     if (v_782) {
+                        _fx_free_N14C_form__cexp_t(&v_782);
                      }
                   }
-                  FX_CALL(
-                     atom2cexp_0.fp(delta_2, ccode_119, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_772, atom2cexp_0.fcv), _fx_catch_186);
+                  else if (tag_22 == 4) {
+                     _fx_N14C_form__cexp_t v_786 = 0;
+                     _fx_LN14C_form__cexp_t v_787 = 0;
+                     _fx_N14C_form__cexp_t v_788 = 0;
+                     _fx_R9Ast__id_t v_789;
+                     fx_str_t slit_177 = FX_MAKE_STR("FX_VEC_ELEM_ZERO");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_177, &v_789, 0), _fx_catch_186);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_786),
+                        _fx_catch_186);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_787), _fx_catch_186);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_787, false, &v_787), _fx_catch_186);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_786, v_787, false, &v_787), _fx_catch_186);
+                     FX_CALL(
+                        _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                           &v_789, v_787, ctyp_0, &kloc_0, &v_788, 0), _fx_catch_186);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_788, ccode_121, &v_770);
 
-               _fx_catch_186: ;
-
-               _fx_endmatch_27: ;
+                  _fx_catch_186: ;
+                     if (v_788) {
+                        _fx_free_N14C_form__cexp_t(&v_788);
+                     }
+                     if (v_787) {
+                        _fx_free_LN14C_form__cexp_t(&v_787);
+                     }
+                     if (v_786) {
+                        _fx_free_N14C_form__cexp_t(&v_786);
+                     }
+                  }
+                  else {
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_187);
+                  }
                   FX_CHECK_EXN(_fx_catch_187);
-                  FX_COPY_PTR(v_772.t0, &delta_exp_2);
-                  FX_COPY_PTR(v_772.t1, &ccode_120);
-                  fx_str_t slit_178 = FX_MAKE_STR("slice");
-                  FX_CALL(
-                     _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_178, ctyp_0, ccode_120, &kloc_0, block_stack_ref_0, km_idx_0, &v_773, 0),
-                     _fx_catch_187);
-                  FX_COPY_PTR(v_773.t0, &slice_exp_1);
-                  FX_COPY_PTR(v_773.t1, &ccode_121);
-                  _fx_R9Ast__id_t v_787;
-                  fx_str_t slit_179 = FX_MAKE_STR("fx_vec_slice");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_179, &v_787, 0), _fx_catch_187);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_5, &kloc_0, &v_774, 0),
-                     _fx_catch_187);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_1, &v_775, 0),
-                     _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_775, 0, true, &v_776), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_774, v_776, false, &v_776), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_2, v_776, false, &v_776), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_3, v_776, false, &v_776), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_3, v_776, false, &v_776), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_776, false, &v_776), _fx_catch_187);
-                  FX_CALL(
-                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_787, v_776, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_slice_1, 0), _fx_catch_187);
-                  FX_CALL(
-                     _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_slice_1, ccode_121, &kloc_0, block_stack_ref_0, &v_777, 0), _fx_catch_187);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_1, v_777, &v_1);
+                  FX_COPY_PTR(v_770.t0, &get_elem_exp_10);
+                  FX_COPY_PTR(v_770.t1, &ccode_122);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_10, ccode_122, &v_1);
 
                _fx_catch_187: ;
-                  if (v_777) {
-                     _fx_free_LN15C_form__cstmt_t(&v_777);
+                  if (ccode_122) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_122);
+                  }
+                  if (get_elem_exp_10) {
+                     _fx_free_N14C_form__cexp_t(&get_elem_exp_10);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_770);
+                  if (ccode_121) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_121);
+                  }
+                  if (i_exp_7) {
+                     _fx_free_N14C_form__cexp_t(&i_exp_7);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_769);
+                  goto _fx_endmatch_31;
+               }
+            }
+         }
+         if (idxs_1 != 0) {
+            if (idxs_1->tl == 0) {
+               _fx_N13K_form__dom_t* v_790 = &idxs_1->hd;
+               if (v_790->tag == 3) {
+                  fx_exn_t v_791 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_792 = {0};
+                  _fx_N14C_form__cexp_t a_exp_4 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_123 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_793 = {0};
+                  _fx_N14C_form__cexp_t b_exp_4 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_124 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_794 = {0};
+                  _fx_N14C_form__cexp_t delta_exp_3 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_125 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_795 = {0};
+                  _fx_N14C_form__cexp_t slice_exp_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_126 = 0;
+                  _fx_N14C_form__cexp_t v_796 = 0;
+                  _fx_N14C_form__cexp_t v_797 = 0;
+                  _fx_LN14C_form__cexp_t v_798 = 0;
+                  _fx_N14C_form__cexp_t call_slice_1 = 0;
+                  _fx_LN15C_form__cstmt_t v_799 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_15 = &v_790->u.DomainRange;
+                  _fx_N14K_form__atom_t* delta_3 = &vcase_15->t2;
+                  _fx_N14K_form__atom_t* b_3 = &vcase_15->t1;
+                  _fx_N14K_form__atom_t* a_11 = &vcase_15->t0;
+                  if (border_0->tag != 1) {
+                     fx_str_t slit_178 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported for vectors");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_178, &v_791, 0), _fx_catch_194);
+                     FX_THROW(&v_791, false, _fx_catch_194);
+                  }
+                  if (a_11->tag == 2) {
+                     if (a_11->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_800 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_801 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_800, 0),
+                           _fx_catch_188);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_800, ccode_106, &v_801);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_801, &v_792);
+
+                     _fx_catch_188: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_801);
+                        if (v_800) {
+                           _fx_free_N14C_form__cexp_t(&v_800);
+                        }
+                        goto _fx_endmatch_28;
+                     }
+                  }
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_802 = {0};
+                  FX_CALL(
+                     atom2cexp_0.fp(a_11, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_802, atom2cexp_0.fcv), _fx_catch_189);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_802, &v_792);
+
+               _fx_catch_189: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_802);
+
+               _fx_endmatch_28: ;
+                  FX_CHECK_EXN(_fx_catch_194);
+                  int_ mask_6 = v_792.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_803 = &v_792.t1;
+                  FX_COPY_PTR(v_803->t0, &a_exp_4);
+                  FX_COPY_PTR(v_803->t1, &ccode_123);
+                  if (b_3->tag == 2) {
+                     if (b_3->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_804 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_805 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_804, 0),
+                           _fx_catch_190);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_804, ccode_123, &v_805);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_6, &v_805, &v_793);
+
+                     _fx_catch_190: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_805);
+                        if (v_804) {
+                           _fx_free_N14C_form__cexp_t(&v_804);
+                        }
+                        goto _fx_endmatch_29;
+                     }
+                  }
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_806 = {0};
+                  FX_CALL(
+                     atom2cexp_0.fp(b_3, ccode_123, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_806, atom2cexp_0.fcv), _fx_catch_191);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_6, &v_806, &v_793);
+
+               _fx_catch_191: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_806);
+
+               _fx_endmatch_29: ;
+                  FX_CHECK_EXN(_fx_catch_194);
+                  int_ mask_7 = v_793.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_807 = &v_793.t1;
+                  FX_COPY_PTR(v_807->t0, &b_exp_4);
+                  FX_COPY_PTR(v_807->t1, &ccode_124);
+                  if (delta_3->tag == 2) {
+                     if (delta_3->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_808 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_808, 0),
+                           _fx_catch_192);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_808, ccode_124, &v_794);
+
+                     _fx_catch_192: ;
+                        if (v_808) {
+                           _fx_free_N14C_form__cexp_t(&v_808);
+                        }
+                        goto _fx_endmatch_30;
+                     }
+                  }
+                  FX_CALL(
+                     atom2cexp_0.fp(delta_3, ccode_124, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_794, atom2cexp_0.fcv), _fx_catch_193);
+
+               _fx_catch_193: ;
+
+               _fx_endmatch_30: ;
+                  FX_CHECK_EXN(_fx_catch_194);
+                  FX_COPY_PTR(v_794.t0, &delta_exp_3);
+                  FX_COPY_PTR(v_794.t1, &ccode_125);
+                  fx_str_t slit_179 = FX_MAKE_STR("slice");
+                  FX_CALL(
+                     _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+                        dstexp_r_0, &slit_179, ctyp_0, ccode_125, &kloc_0, block_stack_ref_0, km_idx_0, &v_795, 0),
+                     _fx_catch_194);
+                  FX_COPY_PTR(v_795.t0, &slice_exp_1);
+                  FX_COPY_PTR(v_795.t1, &ccode_126);
+                  _fx_R9Ast__id_t v_809;
+                  fx_str_t slit_180 = FX_MAKE_STR("fx_vec_slice");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_180, &v_809, 0), _fx_catch_194);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_7, &kloc_0, &v_796, 0),
+                     _fx_catch_194);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_1, &v_797, 0),
+                     _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_797, 0, true, &v_798), _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_796, v_798, false, &v_798), _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_3, v_798, false, &v_798), _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_4, v_798, false, &v_798), _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_798, false, &v_798), _fx_catch_194);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_798, false, &v_798), _fx_catch_194);
+                  FX_CALL(
+                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                        &v_809, v_798, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_slice_1, 0), _fx_catch_194);
+                  FX_CALL(
+                     _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+                        call_slice_1, ccode_126, &kloc_0, block_stack_ref_0, &v_799, 0), _fx_catch_194);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_1, v_799, &v_1);
+
+               _fx_catch_194: ;
+                  if (v_799) {
+                     _fx_free_LN15C_form__cstmt_t(&v_799);
                   }
                   if (call_slice_1) {
                      _fx_free_N14C_form__cexp_t(&call_slice_1);
                   }
-                  if (v_776) {
-                     _fx_free_LN14C_form__cexp_t(&v_776);
+                  if (v_798) {
+                     _fx_free_LN14C_form__cexp_t(&v_798);
                   }
-                  if (v_775) {
-                     _fx_free_N14C_form__cexp_t(&v_775);
+                  if (v_797) {
+                     _fx_free_N14C_form__cexp_t(&v_797);
                   }
-                  if (v_774) {
-                     _fx_free_N14C_form__cexp_t(&v_774);
+                  if (v_796) {
+                     _fx_free_N14C_form__cexp_t(&v_796);
                   }
-                  if (ccode_121) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_121);
+                  if (ccode_126) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_126);
                   }
                   if (slice_exp_1) {
                      _fx_free_N14C_form__cexp_t(&slice_exp_1);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_773);
-                  if (ccode_120) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_120);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_795);
+                  if (ccode_125) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_125);
                   }
-                  if (delta_exp_2) {
-                     _fx_free_N14C_form__cexp_t(&delta_exp_2);
+                  if (delta_exp_3) {
+                     _fx_free_N14C_form__cexp_t(&delta_exp_3);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_772);
-                  if (ccode_119) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_119);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_794);
+                  if (ccode_124) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_124);
                   }
-                  if (b_exp_3) {
-                     _fx_free_N14C_form__cexp_t(&b_exp_3);
+                  if (b_exp_4) {
+                     _fx_free_N14C_form__cexp_t(&b_exp_4);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_771);
-                  if (ccode_118) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_118);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_793);
+                  if (ccode_123) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_123);
                   }
-                  if (a_exp_3) {
-                     _fx_free_N14C_form__cexp_t(&a_exp_3);
+                  if (a_exp_4) {
+                     _fx_free_N14C_form__cexp_t(&a_exp_4);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_770);
-                  fx_free_exn(&v_769);
-                  goto _fx_endmatch_28;
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_792);
+                  fx_free_exn(&v_791);
+                  goto _fx_endmatch_31;
                }
             }
          }
-         fx_exn_t v_788 = {0};
-         fx_str_t slit_180 =
+         fx_exn_t v_810 = {0};
+         fx_str_t slit_181 =
             FX_MAKE_STR("cgen: unexpected index type when accessing vector (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_180, &v_788, 0), _fx_catch_188);
-         FX_THROW(&v_788, false, _fx_catch_188);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_181, &v_810, 0), _fx_catch_195);
+         FX_THROW(&v_810, false, _fx_catch_195);
 
-      _fx_catch_188: ;
-         fx_free_exn(&v_788);
+      _fx_catch_195: ;
+         fx_free_exn(&v_810);
 
-      _fx_endmatch_28: ;
-         FX_CHECK_EXN(_fx_catch_189);
+      _fx_endmatch_31: ;
+         FX_CHECK_EXN(_fx_catch_196);
 
-      _fx_catch_189: ;
+      _fx_catch_196: ;
       }
       else if (tag_18 == 19) {
          _fx_LN13K_form__dom_t idxs_2 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_789 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_811 = {0};
          _fx_N14C_form__cexp_t subarr_exp_0 = 0;
-         _fx_N14C_form__cexp_t v_790 = 0;
-         _fx_N14C_form__cexp_t v_791 = 0;
-         _fx_LN14C_form__cexp_t v_792 = 0;
+         _fx_N14C_form__cexp_t v_812 = 0;
+         _fx_N14C_form__cexp_t v_813 = 0;
+         _fx_LN14C_form__cexp_t v_814 = 0;
          _fx_N14C_form__cexp_t call_flatten_0 = 0;
-         _fx_LN15C_form__cstmt_t v_793 = 0;
-         fx_exn_t v_794 = {0};
+         _fx_LN15C_form__cstmt_t v_815 = 0;
+         fx_exn_t v_816 = {0};
          _fx_LN14C_form__cexp_t range_data_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_122 = 0;
+         _fx_LN15C_form__cstmt_t ccode_127 = 0;
          _fx_LN13K_form__dom_t idxs_3 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_795 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_817 = {0};
          _fx_N14C_form__cexp_t subarr_exp_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_123 = 0;
-         _fx_LN19C_form__ctyp_attr_t v_796 = 0;
+         _fx_LN15C_form__cstmt_t ccode_128 = 0;
+         _fx_LN19C_form__ctyp_attr_t v_818 = 0;
          _fx_N14C_form__ctyp_t rdata_ctyp_0 = 0;
-         _fx_LN14C_form__cexp_t v_797 = 0;
-         _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_798 = {0};
+         _fx_LN14C_form__cexp_t v_819 = 0;
+         _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_820 = {0};
          _fx_N14C_form__cexp_t rdata_arr_0 = 0;
-         _fx_R16Ast__val_flags_t v_799 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_800 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_801 = {0};
+         _fx_R16Ast__val_flags_t v_821 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_822 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_823 = {0};
          _fx_N14C_form__cexp_t rdata_exp_0 = 0;
          _fx_LN15C_form__cstmt_t sub_ccode_10 = 0;
-         _fx_N14C_form__cexp_t v_802 = 0;
-         _fx_N14C_form__cexp_t v_803 = 0;
-         _fx_LN14C_form__cexp_t v_804 = 0;
+         _fx_N14C_form__cexp_t v_824 = 0;
+         _fx_N14C_form__cexp_t v_825 = 0;
+         _fx_LN14C_form__cexp_t v_826 = 0;
          _fx_N14C_form__cexp_t call_subarr_0 = 0;
          _fx_LN15C_form__cstmt_t sub_ccode_11 = 0;
-         _fx_N15C_form__cstmt_t v_805 = 0;
-         _fx_LN15C_form__cstmt_t ccode_124 = 0;
+         _fx_N15C_form__cstmt_t v_827 = 0;
+         _fx_LN15C_form__cstmt_t ccode_129 = 0;
          _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_0 = {0};
          _fx_LN14C_form__cexp_t i_exps_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_125 = 0;
+         _fx_LN15C_form__cstmt_t ccode_130 = 0;
          _fx_LN13K_form__dom_t idxs_4 = 0;
          _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_1 = {0};
-         _fx_LN15C_form__cstmt_t ccode_126 = 0;
+         _fx_LN15C_form__cstmt_t ccode_131 = 0;
          _fx_LR9Ast__id_t access_op_0 = 0;
-         _fx_N14C_form__cexp_t v_806 = 0;
-         _fx_LN14C_form__cexp_t v_807 = 0;
-         _fx_LN14C_form__cexp_t v_808 = 0;
-         _fx_N14C_form__ctyp_t v_809 = 0;
+         _fx_N14C_form__cexp_t v_828 = 0;
+         _fx_LN14C_form__cexp_t v_829 = 0;
+         _fx_LN14C_form__cexp_t v_830 = 0;
+         _fx_N14C_form__ctyp_t v_831 = 0;
          _fx_N14C_form__cexp_t get_elem_exp_12 = 0;
-         _fx_N14C_form__cexp_t v_810 = 0;
+         _fx_N14C_form__cexp_t v_832 = 0;
          bool __fold_result___3 = false;
          FX_COPY_PTR(idxs_1, &idxs_2);
          _fx_LN13K_form__dom_t lst_19 = idxs_2;
@@ -29644,14 +29850,14 @@ static int
             else {
                res_20 = false;
             }
-            FX_CHECK_EXN(_fx_catch_190);
+            FX_CHECK_EXN(_fx_catch_197);
             if (res_20) {
-               __fold_result___3 = true; FX_BREAK(_fx_catch_190);
+               __fold_result___3 = true; FX_BREAK(_fx_catch_197);
             }
 
-         _fx_catch_190: ;
+         _fx_catch_197: ;
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_205);
+            FX_CHECK_EXN(_fx_catch_212);
          }
          bool need_subarr_0 = __fold_result___3;
          bool need_flatten_0;
@@ -29659,19 +29865,19 @@ static int
             bool res_21;
             if (idxs_1 != 0) {
                if (idxs_1->tl == 0) {
-                  _fx_N13K_form__dom_t* v_811 = &idxs_1->hd;
-                  if (v_811->tag == 3) {
-                     _fx_Ta3N14K_form__atom_t* vcase_16 = &v_811->u.DomainRange;
-                     _fx_N14K_form__atom_t* v_812 = &vcase_16->t0;
-                     if (v_812->tag == 2) {
-                        _fx_N14K_form__atom_t* v_813 = &vcase_16->t1;
-                        if (v_813->tag == 2) {
-                           _fx_N14K_form__atom_t* v_814 = &vcase_16->t2;
-                           if (v_814->tag == 2) {
-                              if (v_812->u.AtomLit.tag == 8) {
-                                 if (v_813->u.AtomLit.tag == 8) {
-                                    if (v_814->u.AtomLit.tag == 8) {
-                                       res_21 = true; goto _fx_endmatch_29;
+                  _fx_N13K_form__dom_t* v_833 = &idxs_1->hd;
+                  if (v_833->tag == 3) {
+                     _fx_Ta3N14K_form__atom_t* vcase_16 = &v_833->u.DomainRange;
+                     _fx_N14K_form__atom_t* v_834 = &vcase_16->t0;
+                     if (v_834->tag == 2) {
+                        _fx_N14K_form__atom_t* v_835 = &vcase_16->t1;
+                        if (v_835->tag == 2) {
+                           _fx_N14K_form__atom_t* v_836 = &vcase_16->t2;
+                           if (v_836->tag == 2) {
+                              if (v_834->u.AtomLit.tag == 8) {
+                                 if (v_835->u.AtomLit.tag == 8) {
+                                    if (v_836->u.AtomLit.tag == 8) {
+                                       res_21 = true; goto _fx_endmatch_32;
                                     }
                                  }
                               }
@@ -29683,21 +29889,21 @@ static int
             }
             if (idxs_1 != 0) {
                if (idxs_1->tl == 0) {
-                  _fx_N13K_form__dom_t* v_815 = &idxs_1->hd;
-                  if (v_815->tag == 3) {
-                     _fx_Ta3N14K_form__atom_t* vcase_17 = &v_815->u.DomainRange;
-                     _fx_N14K_form__atom_t* v_816 = &vcase_17->t0;
-                     if (v_816->tag == 2) {
-                        _fx_N14K_form__atom_t* v_817 = &vcase_17->t1;
-                        if (v_817->tag == 2) {
-                           _fx_N14K_form__atom_t* v_818 = &vcase_17->t2;
-                           if (v_818->tag == 2) {
-                              if (v_816->u.AtomLit.tag == 8) {
-                                 if (v_817->u.AtomLit.tag == 8) {
-                                    _fx_N14K_form__klit_t* v_819 = &v_818->u.AtomLit;
-                                    if (v_819->tag == 1) {
-                                       if (v_819->u.KLitInt == 1LL) {
-                                          res_21 = true; goto _fx_endmatch_29;
+                  _fx_N13K_form__dom_t* v_837 = &idxs_1->hd;
+                  if (v_837->tag == 3) {
+                     _fx_Ta3N14K_form__atom_t* vcase_17 = &v_837->u.DomainRange;
+                     _fx_N14K_form__atom_t* v_838 = &vcase_17->t0;
+                     if (v_838->tag == 2) {
+                        _fx_N14K_form__atom_t* v_839 = &vcase_17->t1;
+                        if (v_839->tag == 2) {
+                           _fx_N14K_form__atom_t* v_840 = &vcase_17->t2;
+                           if (v_840->tag == 2) {
+                              if (v_838->u.AtomLit.tag == 8) {
+                                 if (v_839->u.AtomLit.tag == 8) {
+                                    _fx_N14K_form__klit_t* v_841 = &v_840->u.AtomLit;
+                                    if (v_841->tag == 1) {
+                                       if (v_841->u.KLitInt == 1LL) {
+                                          res_21 = true; goto _fx_endmatch_32;
                                        }
                                     }
                                  }
@@ -29710,77 +29916,77 @@ static int
             }
             res_21 = false;
 
-         _fx_endmatch_29: ;
-            FX_CHECK_EXN(_fx_catch_205);
+         _fx_endmatch_32: ;
+            FX_CHECK_EXN(_fx_catch_212);
             if (res_21) {
-               need_flatten_0 = true; goto _fx_endmatch_30;
+               need_flatten_0 = true; goto _fx_endmatch_33;
             }
             need_flatten_0 = false;
 
-         _fx_endmatch_30: ;
-            FX_CHECK_EXN(_fx_catch_205);
+         _fx_endmatch_33: ;
+            FX_CHECK_EXN(_fx_catch_212);
          }
          else {
             need_flatten_0 = false;
          }
          if (need_flatten_0) {
-            fx_str_t slit_181 = FX_MAKE_STR("arr");
+            fx_str_t slit_182 = FX_MAKE_STR("arr");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_181, ctyp_0, ccode_101, &kloc_0, block_stack_ref_0, km_idx_0, &v_789, 0), _fx_catch_205);
-            FX_COPY_PTR(v_789.t0, &subarr_exp_0);
-            _fx_R9Ast__id_t v_820;
-            fx_str_t slit_182 = FX_MAKE_STR("fx_flatten_arr");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_182, &v_820, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_790, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_0, &v_791, 0), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_791, 0, true, &v_792), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_790, v_792, false, &v_792), _fx_catch_205);
+                  dstexp_r_0, &slit_182, ctyp_0, ccode_106, &kloc_0, block_stack_ref_0, km_idx_0, &v_811, 0), _fx_catch_212);
+            FX_COPY_PTR(v_811.t0, &subarr_exp_0);
+            _fx_R9Ast__id_t v_842;
+            fx_str_t slit_183 = FX_MAKE_STR("fx_flatten_arr");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_183, &v_842, 0), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_812, 0), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_0, &v_813, 0), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_813, 0, true, &v_814), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_812, v_814, false, &v_814), _fx_catch_212);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_820,
-                  v_792, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_flatten_0, 0), _fx_catch_205);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_842,
+                  v_814, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_flatten_0, 0), _fx_catch_212);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_flatten_0, ccode_101, &kloc_0, block_stack_ref_0, &v_793, 0), _fx_catch_205);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_0, v_793, &v_1);
+                  call_flatten_0, ccode_106, &kloc_0, block_stack_ref_0, &v_815, 0), _fx_catch_212);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_0, v_815, &v_1);
          }
          else if (need_subarr_0) {
             if (border_0->tag != 1) {
-               fx_str_t slit_183 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_183, &v_794, 0), _fx_catch_205);
-               FX_THROW(&v_794, false, _fx_catch_205);
+               fx_str_t slit_184 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_184, &v_816, 0), _fx_catch_212);
+               FX_THROW(&v_816, false, _fx_catch_212);
             }
-            FX_COPY_PTR(ccode_101, &ccode_122);
+            FX_COPY_PTR(ccode_106, &ccode_127);
             FX_COPY_PTR(idxs_1, &idxs_3);
             _fx_LN13K_form__dom_t lst_20 = idxs_3;
             for (; lst_20; lst_20 = lst_20->tl) {
                _fx_N13K_form__dom_t* d_1 = &lst_20->hd;
                int tag_23 = d_1->tag;
                if (tag_23 == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_821 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_843 = {0};
                   _fx_N14C_form__cexp_t i_exp_8 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_12 = 0;
-                  _fx_N14C_form__cexp_t v_822 = 0;
-                  _fx_LN14C_form__cexp_t v_823 = 0;
+                  _fx_N14C_form__cexp_t v_844 = 0;
+                  _fx_LN14C_form__cexp_t v_845 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_1->u.DomainElem, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_821, atom2cexp_0.fcv), _fx_catch_191);
-                  FX_COPY_PTR(v_821.t0, &i_exp_8);
-                  FX_COPY_PTR(v_821.t1, &ccode1_12);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_822, 0), _fx_catch_191);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_822, range_data_0, true, &v_823), _fx_catch_191);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_8, v_823, false, &v_823), _fx_catch_191);
+                     atom2cexp_0.fp(&d_1->u.DomainElem, ccode_127, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_843, atom2cexp_0.fcv), _fx_catch_198);
+                  FX_COPY_PTR(v_843.t0, &i_exp_8);
+                  FX_COPY_PTR(v_843.t1, &ccode1_12);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_844, 0), _fx_catch_198);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_844, range_data_0, true, &v_845), _fx_catch_198);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_8, v_845, false, &v_845), _fx_catch_198);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_823, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
-                  FX_COPY_PTR(ccode1_12, &ccode_122);
+                  FX_COPY_PTR(v_845, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_127);
+                  FX_COPY_PTR(ccode1_12, &ccode_127);
 
-               _fx_catch_191: ;
-                  if (v_823) {
-                     _fx_free_LN14C_form__cexp_t(&v_823);
+               _fx_catch_198: ;
+                  if (v_845) {
+                     _fx_free_LN14C_form__cexp_t(&v_845);
                   }
-                  if (v_822) {
-                     _fx_free_N14C_form__cexp_t(&v_822);
+                  if (v_844) {
+                     _fx_free_N14C_form__cexp_t(&v_844);
                   }
                   if (ccode1_12) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_12);
@@ -29788,33 +29994,33 @@ static int
                   if (i_exp_8) {
                      _fx_free_N14C_form__cexp_t(&i_exp_8);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_821);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_843);
                }
                else if (tag_23 == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_824 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_846 = {0};
                   _fx_N14C_form__cexp_t i_exp_9 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_13 = 0;
-                  _fx_N14C_form__cexp_t v_825 = 0;
-                  _fx_LN14C_form__cexp_t v_826 = 0;
+                  _fx_N14C_form__cexp_t v_847 = 0;
+                  _fx_LN14C_form__cexp_t v_848 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_1->u.DomainFast, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_824, atom2cexp_0.fcv), _fx_catch_192);
-                  FX_COPY_PTR(v_824.t0, &i_exp_9);
-                  FX_COPY_PTR(v_824.t1, &ccode1_13);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_825, 0), _fx_catch_192);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_825, range_data_0, true, &v_826), _fx_catch_192);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_9, v_826, false, &v_826), _fx_catch_192);
+                     atom2cexp_0.fp(&d_1->u.DomainFast, ccode_127, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_846, atom2cexp_0.fcv), _fx_catch_199);
+                  FX_COPY_PTR(v_846.t0, &i_exp_9);
+                  FX_COPY_PTR(v_846.t1, &ccode1_13);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_847, 0), _fx_catch_199);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_847, range_data_0, true, &v_848), _fx_catch_199);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_9, v_848, false, &v_848), _fx_catch_199);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_826, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
-                  FX_COPY_PTR(ccode1_13, &ccode_122);
+                  FX_COPY_PTR(v_848, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_127);
+                  FX_COPY_PTR(ccode1_13, &ccode_127);
 
-               _fx_catch_192: ;
-                  if (v_826) {
-                     _fx_free_LN14C_form__cexp_t(&v_826);
+               _fx_catch_199: ;
+                  if (v_848) {
+                     _fx_free_LN14C_form__cexp_t(&v_848);
                   }
-                  if (v_825) {
-                     _fx_free_N14C_form__cexp_t(&v_825);
+                  if (v_847) {
+                     _fx_free_N14C_form__cexp_t(&v_847);
                   }
                   if (ccode1_13) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_13);
@@ -29822,122 +30028,122 @@ static int
                   if (i_exp_9) {
                      _fx_free_N14C_form__cexp_t(&i_exp_9);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_824);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_846);
                }
                else if (tag_23 == 3) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_827 = {0};
-                  _fx_N14C_form__cexp_t a_exp_4 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_849 = {0};
+                  _fx_N14C_form__cexp_t a_exp_5 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_14 = 0;
-                  _fx_T2LN14C_form__cexp_tLN15C_form__cstmt_t v_828 = {0};
+                  _fx_T2LN14C_form__cexp_tLN15C_form__cstmt_t v_850 = {0};
                   _fx_LN14C_form__cexp_t range_delta_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_1 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_829 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_851 = {0};
                   _fx_N14C_form__cexp_t d_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode3_0 = 0;
-                  _fx_LN14C_form__cexp_t v_830 = 0;
-                  _fx_LN14C_form__cexp_t v_831 = 0;
+                  _fx_LN14C_form__cexp_t v_852 = 0;
+                  _fx_LN14C_form__cexp_t v_853 = 0;
                   _fx_Ta3N14K_form__atom_t* vcase_18 = &d_1->u.DomainRange;
-                  _fx_N14K_form__atom_t* b_3 = &vcase_18->t1;
-                  _fx_N14K_form__atom_t* a_11 = &vcase_18->t0;
-                  if (a_11->tag == 2) {
-                     if (a_11->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_832 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_832, 0),
-                           _fx_catch_193);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_832, ccode_122, &v_827);
+                  _fx_N14K_form__atom_t* b_4 = &vcase_18->t1;
+                  _fx_N14K_form__atom_t* a_12 = &vcase_18->t0;
+                  if (a_12->tag == 2) {
+                     if (a_12->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_854 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_854, 0),
+                           _fx_catch_200);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_854, ccode_127, &v_849);
 
-                     _fx_catch_193: ;
-                        if (v_832) {
-                           _fx_free_N14C_form__cexp_t(&v_832);
+                     _fx_catch_200: ;
+                        if (v_854) {
+                           _fx_free_N14C_form__cexp_t(&v_854);
                         }
-                        goto _fx_endmatch_31;
+                        goto _fx_endmatch_34;
                      }
                   }
                   FX_CALL(
-                     atom2cexp_0.fp(a_11, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_827, atom2cexp_0.fcv), _fx_catch_194);
+                     atom2cexp_0.fp(a_12, ccode_127, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_849, atom2cexp_0.fcv), _fx_catch_201);
 
-               _fx_catch_194: ;
+               _fx_catch_201: ;
 
-               _fx_endmatch_31: ;
-                  FX_CHECK_EXN(_fx_catch_197);
-                  FX_COPY_PTR(v_827.t0, &a_exp_4);
-                  FX_COPY_PTR(v_827.t1, &ccode1_14);
-                  if (b_3->tag == 2) {
-                     if (b_3->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_833 = 0;
-                        _fx_LN14C_form__cexp_t v_834 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(2, &kloc_0, &v_833, 0),
-                           _fx_catch_195);
-                        FX_CALL(_fx_cons_LN14C_form__cexp_t(v_833, 0, true, &v_834), _fx_catch_195);
-                        FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_834, false, &v_834), _fx_catch_195);
-                        _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_834, ccode1_14, &v_828);
+               _fx_endmatch_34: ;
+                  FX_CHECK_EXN(_fx_catch_204);
+                  FX_COPY_PTR(v_849.t0, &a_exp_5);
+                  FX_COPY_PTR(v_849.t1, &ccode1_14);
+                  if (b_4->tag == 2) {
+                     if (b_4->u.AtomLit.tag == 8) {
+                        _fx_N14C_form__cexp_t v_855 = 0;
+                        _fx_LN14C_form__cexp_t v_856 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(2, &kloc_0, &v_855, 0),
+                           _fx_catch_202);
+                        FX_CALL(_fx_cons_LN14C_form__cexp_t(v_855, 0, true, &v_856), _fx_catch_202);
+                        FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_5, v_856, false, &v_856), _fx_catch_202);
+                        _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_856, ccode1_14, &v_850);
 
-                     _fx_catch_195: ;
-                        if (v_834) {
-                           _fx_free_LN14C_form__cexp_t(&v_834);
+                     _fx_catch_202: ;
+                        if (v_856) {
+                           _fx_free_LN14C_form__cexp_t(&v_856);
                         }
-                        if (v_833) {
-                           _fx_free_N14C_form__cexp_t(&v_833);
+                        if (v_855) {
+                           _fx_free_N14C_form__cexp_t(&v_855);
                         }
-                        goto _fx_endmatch_32;
+                        goto _fx_endmatch_35;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_835 = {0};
-                  _fx_N14C_form__cexp_t b_exp_4 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_857 = {0};
+                  _fx_N14C_form__cexp_t b_exp_5 = 0;
                   _fx_LN15C_form__cstmt_t ccode__2 = 0;
-                  _fx_N14C_form__cexp_t v_836 = 0;
-                  _fx_LN14C_form__cexp_t v_837 = 0;
+                  _fx_N14C_form__cexp_t v_858 = 0;
+                  _fx_LN14C_form__cexp_t v_859 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(b_3, ccode1_14, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_835, atom2cexp_0.fcv), _fx_catch_196);
-                  FX_COPY_PTR(v_835.t0, &b_exp_4);
-                  FX_COPY_PTR(v_835.t1, &ccode__2);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_836, 0), _fx_catch_196);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_836, 0, true, &v_837), _fx_catch_196);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_837, false, &v_837), _fx_catch_196);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_4, v_837, false, &v_837), _fx_catch_196);
-                  _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_837, ccode__2, &v_828);
+                     atom2cexp_0.fp(b_4, ccode1_14, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_857, atom2cexp_0.fcv), _fx_catch_203);
+                  FX_COPY_PTR(v_857.t0, &b_exp_5);
+                  FX_COPY_PTR(v_857.t1, &ccode__2);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_858, 0), _fx_catch_203);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_858, 0, true, &v_859), _fx_catch_203);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_5, v_859, false, &v_859), _fx_catch_203);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_5, v_859, false, &v_859), _fx_catch_203);
+                  _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_859, ccode__2, &v_850);
 
-               _fx_catch_196: ;
-                  if (v_837) {
-                     _fx_free_LN14C_form__cexp_t(&v_837);
+               _fx_catch_203: ;
+                  if (v_859) {
+                     _fx_free_LN14C_form__cexp_t(&v_859);
                   }
-                  if (v_836) {
-                     _fx_free_N14C_form__cexp_t(&v_836);
+                  if (v_858) {
+                     _fx_free_N14C_form__cexp_t(&v_858);
                   }
                   if (ccode__2) {
                      _fx_free_LN15C_form__cstmt_t(&ccode__2);
                   }
-                  if (b_exp_4) {
-                     _fx_free_N14C_form__cexp_t(&b_exp_4);
+                  if (b_exp_5) {
+                     _fx_free_N14C_form__cexp_t(&b_exp_5);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_835);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_857);
 
-               _fx_endmatch_32: ;
-                  FX_CHECK_EXN(_fx_catch_197);
-                  FX_COPY_PTR(v_828.t0, &range_delta_0);
-                  FX_COPY_PTR(v_828.t1, &ccode2_1);
+               _fx_endmatch_35: ;
+                  FX_CHECK_EXN(_fx_catch_204);
+                  FX_COPY_PTR(v_850.t0, &range_delta_0);
+                  FX_COPY_PTR(v_850.t1, &ccode2_1);
                   FX_CALL(
                      atom2cexp_0.fp(&vcase_18->t2, ccode2_1, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_829, atom2cexp_0.fcv), _fx_catch_197);
-                  FX_COPY_PTR(v_829.t0, &d_exp_0);
-                  FX_COPY_PTR(v_829.t1, &ccode3_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(d_exp_0, range_delta_0, true, &v_830), _fx_catch_197);
+                        i2e_ref_0, km_idx_0, &v_851, atom2cexp_0.fcv), _fx_catch_204);
+                  FX_COPY_PTR(v_851.t0, &d_exp_0);
+                  FX_COPY_PTR(v_851.t1, &ccode3_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(d_exp_0, range_delta_0, true, &v_852), _fx_catch_204);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_830, range_data_0,
-                        &v_831, 0), _fx_catch_197);
+                     _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_852, range_data_0,
+                        &v_853, 0), _fx_catch_204);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_831, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
-                  FX_COPY_PTR(ccode3_0, &ccode_122);
+                  FX_COPY_PTR(v_853, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_127);
+                  FX_COPY_PTR(ccode3_0, &ccode_127);
 
-               _fx_catch_197: ;
-                  if (v_831) {
-                     _fx_free_LN14C_form__cexp_t(&v_831);
+               _fx_catch_204: ;
+                  if (v_853) {
+                     _fx_free_LN14C_form__cexp_t(&v_853);
                   }
-                  if (v_830) {
-                     _fx_free_LN14C_form__cexp_t(&v_830);
+                  if (v_852) {
+                     _fx_free_LN14C_form__cexp_t(&v_852);
                   }
                   if (ccode3_0) {
                      _fx_free_LN15C_form__cstmt_t(&ccode3_0);
@@ -29945,76 +30151,76 @@ static int
                   if (d_exp_0) {
                      _fx_free_N14C_form__cexp_t(&d_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_829);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_851);
                   if (ccode2_1) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_1);
                   }
                   if (range_delta_0) {
                      _fx_free_LN14C_form__cexp_t(&range_delta_0);
                   }
-                  _fx_free_T2LN14C_form__cexp_tLN15C_form__cstmt_t(&v_828);
+                  _fx_free_T2LN14C_form__cexp_tLN15C_form__cstmt_t(&v_850);
                   if (ccode1_14) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_14);
                   }
-                  if (a_exp_4) {
-                     _fx_free_N14C_form__cexp_t(&a_exp_4);
+                  if (a_exp_5) {
+                     _fx_free_N14C_form__cexp_t(&a_exp_5);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_827);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_849);
                }
                else {
-                  FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_198);
+                  FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_205);
                }
-               FX_CHECK_EXN(_fx_catch_198);
-
-            _fx_catch_198: ;
                FX_CHECK_EXN(_fx_catch_205);
+
+            _fx_catch_205: ;
+               FX_CHECK_EXN(_fx_catch_212);
             }
-            fx_str_t slit_184 = FX_MAKE_STR("arr");
+            fx_str_t slit_185 = FX_MAKE_STR("arr");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_184, ctyp_0, ccode_122, &kloc_0, block_stack_ref_0, km_idx_0, &v_795, 0), _fx_catch_205);
-            FX_COPY_PTR(v_795.t0, &subarr_exp_1);
-            FX_COPY_PTR(v_795.t1, &ccode_123);
-            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_796), _fx_catch_205);
+                  dstexp_r_0, &slit_185, ctyp_0, ccode_127, &kloc_0, block_stack_ref_0, km_idx_0, &v_817, 0), _fx_catch_212);
+            FX_COPY_PTR(v_817.t0, &subarr_exp_1);
+            FX_COPY_PTR(v_817.t1, &ccode_128);
+            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_818), _fx_catch_212);
             FX_CALL(
-               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_796,
-                  _fx_g19C_gen_code__CTypInt, &rdata_ctyp_0), _fx_catch_205);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(range_data_0, &v_797, 0), _fx_catch_205);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(rdata_ctyp_0, &kloc_0, &v_798);
+               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_818,
+                  _fx_g19C_gen_code__CTypInt, &rdata_ctyp_0), _fx_catch_212);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(range_data_0, &v_819, 0), _fx_catch_212);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(rdata_ctyp_0, &kloc_0, &v_820);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_797, &v_798,
-                  &rdata_arr_0), _fx_catch_205);
-            _fx_R9Ast__id_t v_838;
-            fx_str_t slit_185 = FX_MAKE_STR("ranges");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_185, &v_838, 0), _fx_catch_205);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_799, 0), _fx_catch_205);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(rdata_arr_0, &v_800);
-            fx_str_t slit_186 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_819, &v_820,
+                  &rdata_arr_0), _fx_catch_212);
+            _fx_R9Ast__id_t v_860;
+            fx_str_t slit_186 = FX_MAKE_STR("ranges");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_186, &v_860, 0), _fx_catch_212);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_821, 0), _fx_catch_212);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(rdata_arr_0, &v_822);
+            fx_str_t slit_187 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_838, rdata_ctyp_0, &v_799, &slit_186, &v_800, 0, &kloc_0, &v_801, 0), _fx_catch_205);
-            FX_COPY_PTR(v_801.t0, &rdata_exp_0);
-            FX_COPY_PTR(v_801.t1, &sub_ccode_10);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_802, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_1, &v_803, 0), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_803, 0, true, &v_804), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(rdata_exp_0, v_804, false, &v_804), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_802, v_804, false, &v_804), _fx_catch_205);
+                  &v_860, rdata_ctyp_0, &v_821, &slit_187, &v_822, 0, &kloc_0, &v_823, 0), _fx_catch_212);
+            FX_COPY_PTR(v_823.t0, &rdata_exp_0);
+            FX_COPY_PTR(v_823.t1, &sub_ccode_10);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_824, 0), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_1, &v_825, 0), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_825, 0, true, &v_826), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(rdata_exp_0, v_826, false, &v_826), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_824, v_826, false, &v_826), _fx_catch_212);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g21C_form__std_fx_subarr, v_804, _fx_g19C_gen_code__CTypInt, &kloc_0, &call_subarr_0, 0), _fx_catch_205);
+                  &_fx_g21C_form__std_fx_subarr, v_826, _fx_g19C_gen_code__CTypInt, &kloc_0, &call_subarr_0, 0), _fx_catch_212);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_subarr_0, sub_ccode_10, &kloc_0, block_stack_ref_0, &sub_ccode_11, 0), _fx_catch_205);
+                  call_subarr_0, sub_ccode_10, &kloc_0, block_stack_ref_0, &sub_ccode_11, 0), _fx_catch_212);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_11, &kloc_0, &v_805, 0),
-               _fx_catch_205);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_805, ccode_123, true, &ccode_124), _fx_catch_205);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_1, ccode_124, &v_1);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_11, &kloc_0, &v_827, 0),
+               _fx_catch_212);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_827, ccode_128, true, &ccode_129), _fx_catch_212);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_1, ccode_129, &v_1);
          }
          else {
             _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &chk_exp_opt_0);
-            FX_COPY_PTR(ccode_101, &ccode_125);
+            FX_COPY_PTR(ccode_106, &ccode_130);
             int_ dim_0 = 0;
             FX_COPY_PTR(idxs_1, &idxs_4);
             _fx_LN13K_form__dom_t lst_21 = idxs_4;
@@ -30031,28 +30237,28 @@ static int
                   else {
                      _fx_copy_N13K_form__dom_t(d_3, &d_2);
                   }
-                  FX_CHECK_EXN(_fx_catch_203);
+                  FX_CHECK_EXN(_fx_catch_210);
                }
                int tag_24 = d_2.tag;
                if (tag_24 == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_839 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_861 = {0};
                   _fx_N14C_form__cexp_t i_exp_10 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_15 = 0;
-                  _fx_LN14C_form__cexp_t v_840 = 0;
+                  _fx_LN14C_form__cexp_t v_862 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_2.u.DomainFast, ccode_125, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_839, atom2cexp_0.fcv), _fx_catch_199);
-                  FX_COPY_PTR(v_839.t0, &i_exp_10);
-                  FX_COPY_PTR(v_839.t1, &ccode1_15);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_10, i_exps_2, true, &v_840), _fx_catch_199);
+                     atom2cexp_0.fp(&d_2.u.DomainFast, ccode_130, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_861, atom2cexp_0.fcv), _fx_catch_206);
+                  FX_COPY_PTR(v_861.t0, &i_exp_10);
+                  FX_COPY_PTR(v_861.t1, &ccode1_15);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_10, i_exps_2, true, &v_862), _fx_catch_206);
                   _fx_free_LN14C_form__cexp_t(&i_exps_2);
-                  FX_COPY_PTR(v_840, &i_exps_2);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_125);
-                  FX_COPY_PTR(ccode1_15, &ccode_125);
+                  FX_COPY_PTR(v_862, &i_exps_2);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_130);
+                  FX_COPY_PTR(ccode1_15, &ccode_130);
 
-               _fx_catch_199: ;
-                  if (v_840) {
-                     _fx_free_LN14C_form__cexp_t(&v_840);
+               _fx_catch_206: ;
+                  if (v_862) {
+                     _fx_free_LN14C_form__cexp_t(&v_862);
                   }
                   if (ccode1_15) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_15);
@@ -30060,74 +30266,74 @@ static int
                   if (i_exp_10) {
                      _fx_free_N14C_form__cexp_t(&i_exp_10);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_839);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_861);
                }
                else if (tag_24 == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_841 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_863 = {0};
                   _fx_N14C_form__cexp_t i_exp_11 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_16 = 0;
-                  _fx_N14C_form__cexp_t v_842 = 0;
-                  _fx_LN14C_form__cexp_t v_843 = 0;
+                  _fx_N14C_form__cexp_t v_864 = 0;
+                  _fx_LN14C_form__cexp_t v_865 = 0;
                   _fx_N14C_form__cexp_t chk_exp1_0 = 0;
                   _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_2 = {0};
-                  _fx_Nt6option1N14C_form__cexp_t v_844 = {0};
-                  _fx_LN14C_form__cexp_t v_845 = 0;
-                  FX_CALL(atom2cexp__0.fp(&d_2.u.DomainElem, true, ccode_125, &kloc_0, &v_841, atom2cexp__0.fcv),
-                     _fx_catch_201);
-                  FX_COPY_PTR(v_841.t0, &i_exp_11);
-                  FX_COPY_PTR(v_841.t1, &ccode1_16);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dim_0, &kloc_0, &v_842, 0),
-                     _fx_catch_201);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, 0, true, &v_843), _fx_catch_201);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_842, v_843, false, &v_843), _fx_catch_201);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_843, false, &v_843), _fx_catch_201);
+                  _fx_Nt6option1N14C_form__cexp_t v_866 = {0};
+                  _fx_LN14C_form__cexp_t v_867 = 0;
+                  FX_CALL(atom2cexp__0.fp(&d_2.u.DomainElem, true, ccode_130, &kloc_0, &v_863, atom2cexp__0.fcv),
+                     _fx_catch_208);
+                  FX_COPY_PTR(v_863.t0, &i_exp_11);
+                  FX_COPY_PTR(v_863.t1, &ccode1_16);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dim_0, &kloc_0, &v_864, 0),
+                     _fx_catch_208);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, 0, true, &v_865), _fx_catch_208);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_864, v_865, false, &v_865), _fx_catch_208);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_865, false, &v_865), _fx_catch_208);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g22C_form__std_FX_CHKIDX1, v_843, _fx_g20C_gen_code__CTypBool, &kloc_0, &chk_exp1_0, 0),
-                     _fx_catch_201);
+                        &_fx_g22C_form__std_FX_CHKIDX1, v_865, _fx_g20C_gen_code__CTypBool, &kloc_0, &chk_exp1_0, 0),
+                     _fx_catch_208);
                   _fx_copy_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0, &chk_exp_opt_2);
                   if (chk_exp_opt_2.tag == 2) {
-                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_846 = {0};
+                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_868 = {0};
                      _fx_N14C_form__cexp_t chk_exp_3 = 0;
-                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &kloc_0, &v_846);
+                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &kloc_0, &v_868);
                      FX_CALL(
                         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g23C_gen_code__COpLogicAnd, chk_exp_opt_2.u.Some, chk_exp1_0, &v_846, &chk_exp_3),
-                        _fx_catch_200);
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp_3, &v_844);
+                           &_fx_g23C_gen_code__COpLogicAnd, chk_exp_opt_2.u.Some, chk_exp1_0, &v_868, &chk_exp_3),
+                        _fx_catch_207);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp_3, &v_866);
 
-                  _fx_catch_200: ;
+                  _fx_catch_207: ;
                      if (chk_exp_3) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_3);
                      }
-                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_846);
+                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_868);
                   }
                   else {
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp1_0, &v_844);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp1_0, &v_866);
                   }
-                  FX_CHECK_EXN(_fx_catch_201);
+                  FX_CHECK_EXN(_fx_catch_208);
                   _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0);
-                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_844, &chk_exp_opt_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, i_exps_2, true, &v_845), _fx_catch_201);
+                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_866, &chk_exp_opt_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, i_exps_2, true, &v_867), _fx_catch_208);
                   _fx_free_LN14C_form__cexp_t(&i_exps_2);
-                  FX_COPY_PTR(v_845, &i_exps_2);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_125);
-                  FX_COPY_PTR(ccode1_16, &ccode_125);
+                  FX_COPY_PTR(v_867, &i_exps_2);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_130);
+                  FX_COPY_PTR(ccode1_16, &ccode_130);
 
-               _fx_catch_201: ;
-                  if (v_845) {
-                     _fx_free_LN14C_form__cexp_t(&v_845);
+               _fx_catch_208: ;
+                  if (v_867) {
+                     _fx_free_LN14C_form__cexp_t(&v_867);
                   }
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_844);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_866);
                   _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_2);
                   if (chk_exp1_0) {
                      _fx_free_N14C_form__cexp_t(&chk_exp1_0);
                   }
-                  if (v_843) {
-                     _fx_free_LN14C_form__cexp_t(&v_843);
+                  if (v_865) {
+                     _fx_free_LN14C_form__cexp_t(&v_865);
                   }
-                  if (v_842) {
-                     _fx_free_N14C_form__cexp_t(&v_842);
+                  if (v_864) {
+                     _fx_free_N14C_form__cexp_t(&v_864);
                   }
                   if (ccode1_16) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_16);
@@ -30135,54 +30341,54 @@ static int
                   if (i_exp_11) {
                      _fx_free_N14C_form__cexp_t(&i_exp_11);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_841);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_863);
                }
                else {
-                  fx_exn_t v_847 = {0};
-                  fx_str_t slit_187 = FX_MAKE_STR("cgen: unexpected index type");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_187, &v_847, 0), _fx_catch_202);
-                  FX_THROW(&v_847, false, _fx_catch_202);
+                  fx_exn_t v_869 = {0};
+                  fx_str_t slit_188 = FX_MAKE_STR("cgen: unexpected index type");
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_188, &v_869, 0), _fx_catch_209);
+                  FX_THROW(&v_869, false, _fx_catch_209);
 
-               _fx_catch_202: ;
-                  fx_free_exn(&v_847);
+               _fx_catch_209: ;
+                  fx_free_exn(&v_869);
                }
-               FX_CHECK_EXN(_fx_catch_203);
+               FX_CHECK_EXN(_fx_catch_210);
 
-            _fx_catch_203: ;
+            _fx_catch_210: ;
                _fx_free_N13K_form__dom_t(&d_2);
-               FX_CHECK_EXN(_fx_catch_205);
+               FX_CHECK_EXN(_fx_catch_212);
             }
             _fx_copy_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0, &chk_exp_opt_1);
             if (chk_exp_opt_1.tag == 2) {
-               _fx_LN14C_form__cexp_t v_848 = 0;
+               _fx_LN14C_form__cexp_t v_870 = 0;
                _fx_N14C_form__cexp_t call_chkidx_0 = 0;
-               _fx_N15C_form__cstmt_t v_849 = 0;
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_848), _fx_catch_204);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(chk_exp_opt_1.u.Some, v_848, false, &v_848), _fx_catch_204);
+               _fx_N15C_form__cstmt_t v_871 = 0;
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_870), _fx_catch_211);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(chk_exp_opt_1.u.Some, v_870, false, &v_870), _fx_catch_211);
                FX_CALL(
                   _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                     &_fx_g21C_form__std_FX_CHKIDX, v_848, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_chkidx_0, 0),
-                  _fx_catch_204);
-               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_chkidx_0, &v_849), _fx_catch_204);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_849, ccode_125, true, &ccode_126), _fx_catch_204);
+                     &_fx_g21C_form__std_FX_CHKIDX, v_870, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_chkidx_0, 0),
+                  _fx_catch_211);
+               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_chkidx_0, &v_871), _fx_catch_211);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_871, ccode_130, true, &ccode_131), _fx_catch_211);
 
-            _fx_catch_204: ;
-               if (v_849) {
-                  _fx_free_N15C_form__cstmt_t(&v_849);
+            _fx_catch_211: ;
+               if (v_871) {
+                  _fx_free_N15C_form__cstmt_t(&v_871);
                }
                if (call_chkidx_0) {
                   _fx_free_N14C_form__cexp_t(&call_chkidx_0);
                }
-               if (v_848) {
-                  _fx_free_LN14C_form__cexp_t(&v_848);
+               if (v_870) {
+                  _fx_free_LN14C_form__cexp_t(&v_870);
                }
             }
             else {
-               FX_COPY_PTR(ccode_125, &ccode_126);
+               FX_COPY_PTR(ccode_130, &ccode_131);
             }
-            FX_CHECK_EXN(_fx_catch_205);
+            FX_CHECK_EXN(_fx_catch_212);
             int_ ndims_2;
-            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN13K_form__dom_t(idxs_1, &ndims_2, 0), _fx_catch_205);
+            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN13K_form__dom_t(idxs_1, &ndims_2, 0), _fx_catch_212);
             int tag_25 = border_0->tag;
             if (tag_25 == 1) {
                FX_COPY_PTR(_fx_g21C_form__std_FX_PTR_xD, &access_op_0);
@@ -30197,63 +30403,63 @@ static int
                FX_COPY_PTR(_fx_g26C_form__std_FX_PTR_xD_ZERO, &access_op_0);
             }
             else {
-               FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_205);
+               FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_212);
             }
-            FX_CHECK_EXN(_fx_catch_205);
-            _fx_R9Ast__id_t v_850;
-            FX_CALL(_fx_M10C_gen_codeFM3nthR9Ast__id_t2LR9Ast__id_ti(access_op_0, ndims_2 - 1, &v_850, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_806),
-               _fx_catch_205);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(i_exps_2, &v_807, 0), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_807, true, &v_808), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_806, v_808, false, &v_808), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ctyp_0, &v_809, 0), _fx_catch_205);
+            FX_CHECK_EXN(_fx_catch_212);
+            _fx_R9Ast__id_t v_872;
+            FX_CALL(_fx_M10C_gen_codeFM3nthR9Ast__id_t2LR9Ast__id_ti(access_op_0, ndims_2 - 1, &v_872, 0), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_828),
+               _fx_catch_212);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(i_exps_2, &v_829, 0), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_829, true, &v_830), _fx_catch_212);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_828, v_830, false, &v_830), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ctyp_0, &v_831, 0), _fx_catch_212);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_850,
-                  v_808, v_809, &kloc_0, &get_elem_exp_12, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(get_elem_exp_12, &v_810, 0), _fx_catch_205);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_810, ccode_126, &v_1);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_872,
+                  v_830, v_831, &kloc_0, &get_elem_exp_12, 0), _fx_catch_212);
+            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(get_elem_exp_12, &v_832, 0), _fx_catch_212);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_832, ccode_131, &v_1);
          }
 
-      _fx_catch_205: ;
-         if (v_810) {
-            _fx_free_N14C_form__cexp_t(&v_810);
+      _fx_catch_212: ;
+         if (v_832) {
+            _fx_free_N14C_form__cexp_t(&v_832);
          }
          if (get_elem_exp_12) {
             _fx_free_N14C_form__cexp_t(&get_elem_exp_12);
          }
-         if (v_809) {
-            _fx_free_N14C_form__ctyp_t(&v_809);
+         if (v_831) {
+            _fx_free_N14C_form__ctyp_t(&v_831);
          }
-         if (v_808) {
-            _fx_free_LN14C_form__cexp_t(&v_808);
+         if (v_830) {
+            _fx_free_LN14C_form__cexp_t(&v_830);
          }
-         if (v_807) {
-            _fx_free_LN14C_form__cexp_t(&v_807);
+         if (v_829) {
+            _fx_free_LN14C_form__cexp_t(&v_829);
          }
-         if (v_806) {
-            _fx_free_N14C_form__cexp_t(&v_806);
+         if (v_828) {
+            _fx_free_N14C_form__cexp_t(&v_828);
          }
          FX_FREE_LIST_SIMPLE(&access_op_0);
-         if (ccode_126) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_126);
+         if (ccode_131) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_131);
          }
          _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_1);
          if (idxs_4) {
             _fx_free_LN13K_form__dom_t(&idxs_4);
          }
-         if (ccode_125) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_125);
+         if (ccode_130) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_130);
          }
          if (i_exps_2) {
             _fx_free_LN14C_form__cexp_t(&i_exps_2);
          }
          _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0);
-         if (ccode_124) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_124);
+         if (ccode_129) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_129);
          }
-         if (v_805) {
-            _fx_free_N15C_form__cstmt_t(&v_805);
+         if (v_827) {
+            _fx_free_N15C_form__cstmt_t(&v_827);
          }
          if (sub_ccode_11) {
             _fx_free_LN15C_form__cstmt_t(&sub_ccode_11);
@@ -30261,14 +30467,14 @@ static int
          if (call_subarr_0) {
             _fx_free_N14C_form__cexp_t(&call_subarr_0);
          }
-         if (v_804) {
-            _fx_free_LN14C_form__cexp_t(&v_804);
+         if (v_826) {
+            _fx_free_LN14C_form__cexp_t(&v_826);
          }
-         if (v_803) {
-            _fx_free_N14C_form__cexp_t(&v_803);
+         if (v_825) {
+            _fx_free_N14C_form__cexp_t(&v_825);
          }
-         if (v_802) {
-            _fx_free_N14C_form__cexp_t(&v_802);
+         if (v_824) {
+            _fx_free_N14C_form__cexp_t(&v_824);
          }
          if (sub_ccode_10) {
             _fx_free_LN15C_form__cstmt_t(&sub_ccode_10);
@@ -30276,119 +30482,119 @@ static int
          if (rdata_exp_0) {
             _fx_free_N14C_form__cexp_t(&rdata_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_801);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_800);
-         _fx_free_R16Ast__val_flags_t(&v_799);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_823);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_822);
+         _fx_free_R16Ast__val_flags_t(&v_821);
          if (rdata_arr_0) {
             _fx_free_N14C_form__cexp_t(&rdata_arr_0);
          }
-         _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_798);
-         if (v_797) {
-            _fx_free_LN14C_form__cexp_t(&v_797);
+         _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_820);
+         if (v_819) {
+            _fx_free_LN14C_form__cexp_t(&v_819);
          }
          if (rdata_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&rdata_ctyp_0);
          }
-         FX_FREE_LIST_SIMPLE(&v_796);
-         if (ccode_123) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_123);
+         FX_FREE_LIST_SIMPLE(&v_818);
+         if (ccode_128) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_128);
          }
          if (subarr_exp_1) {
             _fx_free_N14C_form__cexp_t(&subarr_exp_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_795);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_817);
          if (idxs_3) {
             _fx_free_LN13K_form__dom_t(&idxs_3);
          }
-         if (ccode_122) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_122);
+         if (ccode_127) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_127);
          }
          if (range_data_0) {
             _fx_free_LN14C_form__cexp_t(&range_data_0);
          }
-         fx_free_exn(&v_794);
-         if (v_793) {
-            _fx_free_LN15C_form__cstmt_t(&v_793);
+         fx_free_exn(&v_816);
+         if (v_815) {
+            _fx_free_LN15C_form__cstmt_t(&v_815);
          }
          if (call_flatten_0) {
             _fx_free_N14C_form__cexp_t(&call_flatten_0);
          }
-         if (v_792) {
-            _fx_free_LN14C_form__cexp_t(&v_792);
+         if (v_814) {
+            _fx_free_LN14C_form__cexp_t(&v_814);
          }
-         if (v_791) {
-            _fx_free_N14C_form__cexp_t(&v_791);
+         if (v_813) {
+            _fx_free_N14C_form__cexp_t(&v_813);
          }
-         if (v_790) {
-            _fx_free_N14C_form__cexp_t(&v_790);
+         if (v_812) {
+            _fx_free_N14C_form__cexp_t(&v_812);
          }
          if (subarr_exp_0) {
             _fx_free_N14C_form__cexp_t(&subarr_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_789);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_811);
          if (idxs_2) {
             _fx_free_LN13K_form__dom_t(&idxs_2);
          }
       }
       else {
-         fx_exn_t v_851 = {0};
-         fx_str_t slit_188 =
+         fx_exn_t v_873 = {0};
+         fx_str_t slit_189 =
             FX_MAKE_STR(
                "cgen: unknown/unsupported type of the container, it should be CTypArray _ or CTypRRBVec _ or CTypString");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_188, &v_851, 0), _fx_catch_206);
-         FX_THROW(&v_851, false, _fx_catch_206);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_189, &v_873, 0), _fx_catch_213);
+         FX_THROW(&v_873, false, _fx_catch_213);
 
-      _fx_catch_206: ;
-         fx_free_exn(&v_851);
+      _fx_catch_213: ;
+         fx_free_exn(&v_873);
       }
-      FX_CHECK_EXN(_fx_catch_207);
+      FX_CHECK_EXN(_fx_catch_214);
 
-   _fx_catch_207: ;
+   _fx_catch_214: ;
       if (arr_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&arr_ctyp_0);
       }
       if (lbl_7) {
          _fx_free_N14C_form__cexp_t(&lbl_7);
       }
-      if (ccode_101) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_101);
+      if (ccode_106) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_106);
       }
       if (arr_exp_5) {
          _fx_free_N14C_form__cexp_t(&arr_exp_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_655);
-      fx_free_exn(&v_654);
-      goto _fx_endmatch_55;
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_677);
+      fx_free_exn(&v_676);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 20) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_852 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_874 = {0};
       _fx_N14C_form__cexp_t ce1_7 = 0;
-      _fx_LN15C_form__cstmt_t ccode_127 = 0;
-      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_853 = {0};
+      _fx_LN15C_form__cstmt_t ccode_132 = 0;
+      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_875 = {0};
       _fx_N14C_form__cexp_t ce1_8 = 0;
       _fx_LT2R9Ast__id_tN14C_form__ctyp_t relems_0 = 0;
-      fx_str_t v_854 = {0};
-      fx_str_t v_855 = {0};
-      fx_str_t v_856 = {0};
-      fx_exn_t v_857 = {0};
-      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_858 = {0};
-      _fx_N14C_form__cexp_t v_859 = 0;
+      fx_str_t v_876 = {0};
+      fx_str_t v_877 = {0};
+      fx_str_t v_878 = {0};
+      fx_exn_t v_879 = {0};
+      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_880 = {0};
+      _fx_N14C_form__cexp_t v_881 = 0;
       _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_19 = &kexp_0->u.KExpMem;
       int_ n_1 = vcase_19->t1;
       FX_CALL(
          _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
             &vcase_19->t0, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-            km_idx_0, &v_852, 0), _fx_catch_208);
-      FX_COPY_PTR(v_852.t0, &ce1_7);
-      FX_COPY_PTR(v_852.t1, &ccode_127);
+            km_idx_0, &v_874, 0), _fx_catch_215);
+      FX_COPY_PTR(v_874.t0, &ce1_7);
+      FX_COPY_PTR(v_874.t1, &ccode_132);
       FX_CALL(
          _fx_M10C_gen_codeFM10get_structT4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti1N14C_form__cexp_t(ce1_7,
-            &v_853, 0), _fx_catch_208);
-      FX_COPY_PTR(v_853.t1, &ce1_8);
-      FX_COPY_PTR(v_853.t2, &relems_0);
-      int_ ofs_0 = v_853.t3;
+            &v_875, 0), _fx_catch_215);
+      FX_COPY_PTR(v_875.t1, &ce1_8);
+      FX_COPY_PTR(v_875.t2, &relems_0);
+      int_ ofs_0 = v_875.t3;
       int_ nelems_0;
-      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2R9Ast__id_tN14C_form__ctyp_t(relems_0, &nelems_0, 0), _fx_catch_208);
+      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2R9Ast__id_tN14C_form__ctyp_t(relems_0, &nelems_0, 0), _fx_catch_215);
       bool t_11;
       if (n_1 < 0) {
          t_11 = true;
@@ -30397,497 +30603,497 @@ static int
          t_11 = n_1 + ofs_0 >= nelems_0;
       }
       if (t_11) {
-         FX_CALL(_fx_F6stringS1i(n_1, &v_854, 0), _fx_catch_208);
-         FX_CALL(_fx_F6stringS1i(nelems_0, &v_855, 0), _fx_catch_208);
-         fx_str_t slit_189 = FX_MAKE_STR("cgen: the tuple/record element index ");
-         fx_str_t slit_190 = FX_MAKE_STR(" is out of range [0, ");
-         fx_str_t slit_191 = FX_MAKE_STR("]");
+         FX_CALL(_fx_F6stringS1i(n_1, &v_876, 0), _fx_catch_215);
+         FX_CALL(_fx_F6stringS1i(nelems_0, &v_877, 0), _fx_catch_215);
+         fx_str_t slit_190 = FX_MAKE_STR("cgen: the tuple/record element index ");
+         fx_str_t slit_191 = FX_MAKE_STR(" is out of range [0, ");
+         fx_str_t slit_192 = FX_MAKE_STR("]");
          {
-            const fx_str_t strs_32[] = { slit_189, v_854, slit_190, v_855, slit_191 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_856), _fx_catch_208);
+            const fx_str_t strs_32[] = { slit_190, v_876, slit_191, v_877, slit_192 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_878), _fx_catch_215);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_856, &v_857, 0), _fx_catch_208);
-         FX_THROW(&v_857, false, _fx_catch_208);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_878, &v_879, 0), _fx_catch_215);
+         FX_THROW(&v_879, false, _fx_catch_215);
       }
       FX_CALL(
-         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(relems_0, n_1 + ofs_0, &v_858,
-            0), _fx_catch_208);
-      _fx_R9Ast__id_t n_id_1 = v_858.t0;
+         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(relems_0, n_1 + ofs_0, &v_880,
+            0), _fx_catch_215);
+      _fx_R9Ast__id_t n_id_1 = v_880.t0;
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(ce1_8, &n_id_1, ctyp_0, &v_859,
-            0), _fx_catch_208);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_859, ccode_127, &v_1);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(ce1_8, &n_id_1, ctyp_0, &v_881,
+            0), _fx_catch_215);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_881, ccode_132, &v_1);
 
-   _fx_catch_208: ;
-      if (v_859) {
-         _fx_free_N14C_form__cexp_t(&v_859);
+   _fx_catch_215: ;
+      if (v_881) {
+         _fx_free_N14C_form__cexp_t(&v_881);
       }
-      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_858);
-      fx_free_exn(&v_857);
-      FX_FREE_STR(&v_856);
-      FX_FREE_STR(&v_855);
-      FX_FREE_STR(&v_854);
+      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_880);
+      fx_free_exn(&v_879);
+      FX_FREE_STR(&v_878);
+      FX_FREE_STR(&v_877);
+      FX_FREE_STR(&v_876);
       if (relems_0) {
          _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&relems_0);
       }
       if (ce1_8) {
          _fx_free_N14C_form__cexp_t(&ce1_8);
       }
-      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_853);
-      if (ccode_127) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_127);
+      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_875);
+      if (ccode_132) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_132);
       }
       if (ce1_7) {
          _fx_free_N14C_form__cexp_t(&ce1_7);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_852);
-      goto _fx_endmatch_55;
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_874);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 21) {
       _fx_N14K_form__ktyp_t ktyp_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_128 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_860 = {0};
-      _fx_N14C_form__cexp_t i_exp_12 = 0;
-      _fx_LN15C_form__cstmt_t ccode_129 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_861 = {0};
-      _fx_N14C_form__cexp_t e_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_130 = 0;
-      _fx_N14C_form__ctyp_t ctyp_2 = 0;
-      _fx_N14C_form__cexp_t v_862 = 0;
-      _fx_N14C_form__cexp_t v_863 = 0;
-      _fx_N14C_form__cexp_t v_864 = 0;
-      _fx_LN14C_form__cexp_t v_865 = 0;
-      _fx_N14C_form__cexp_t copy_arr_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_131 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_866 = {0};
-      _fx_N14C_form__cexp_t i_exp_13 = 0;
-      _fx_LN15C_form__cstmt_t ccode_132 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_867 = {0};
-      _fx_N14C_form__cexp_t a_exp_5 = 0;
       _fx_LN15C_form__cstmt_t ccode_133 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_882 = {0};
+      _fx_N14C_form__cexp_t i_exp_12 = 0;
+      _fx_LN15C_form__cstmt_t ccode_134 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_883 = {0};
+      _fx_N14C_form__cexp_t e_exp_0 = 0;
+      _fx_LN15C_form__cstmt_t ccode_135 = 0;
+      _fx_N14C_form__ctyp_t ctyp_2 = 0;
+      _fx_N14C_form__cexp_t v_884 = 0;
+      _fx_N14C_form__cexp_t v_885 = 0;
+      _fx_N14C_form__cexp_t v_886 = 0;
+      _fx_LN14C_form__cexp_t v_887 = 0;
+      _fx_N14C_form__cexp_t copy_arr_data_0 = 0;
+      _fx_LN15C_form__cstmt_t ccode_136 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_888 = {0};
+      _fx_N14C_form__cexp_t i_exp_13 = 0;
+      _fx_LN15C_form__cstmt_t ccode_137 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_889 = {0};
+      _fx_N14C_form__cexp_t a_exp_6 = 0;
+      _fx_LN15C_form__cstmt_t ccode_138 = 0;
       _fx_T3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t* vcase_20 = &kexp_0->u.KExpAssign;
-      _fx_N14K_form__atom_t* a_12 = &vcase_20->t1;
+      _fx_N14K_form__atom_t* a_13 = &vcase_20->t1;
       _fx_R9Ast__id_t* i_6 = &vcase_20->t0;
-      FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &ktyp_2, 0), _fx_catch_209);
-      _fx_R17K_form__ktprops_t v_868;
-      FX_CALL(_fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_2, &kloc_0, &v_868, 0),
-         _fx_catch_209);
-      bool ktp_complex_2 = v_868.ktp_complex;
+      FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &ktyp_2, 0), _fx_catch_216);
+      _fx_R17K_form__ktprops_t v_890;
+      FX_CALL(_fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_2, &kloc_0, &v_890, 0),
+         _fx_catch_216);
+      bool ktp_complex_2 = v_890.ktp_complex;
       if (ktp_complex_2) {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_6, true, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_860, 0), _fx_catch_209);
-         FX_COPY_PTR(v_860.t0, &i_exp_12);
-         FX_COPY_PTR(v_860.t1, &ccode_129);
-         FX_CALL(atom2cexp__0.fp(a_12, true, ccode_129, &kloc_0, &v_861, atom2cexp__0.fcv), _fx_catch_209);
-         FX_COPY_PTR(v_861.t0, &e_exp_0);
-         FX_COPY_PTR(v_861.t1, &ccode_130);
-         FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(i_exp_12, &ctyp_2, 0), _fx_catch_209);
-         bool v_869;
-         FX_CALL(_fx_M6K_formFM11is_subarrayB2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &v_869, 0), _fx_catch_209);
-         if (v_869) {
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_exp_0, &v_862, 0), _fx_catch_209);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_12, &v_863, 0), _fx_catch_209);
-            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(true, &kloc_0, &v_864, 0), _fx_catch_209);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_864, 0, true, &v_865), _fx_catch_209);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_863, v_865, false, &v_865), _fx_catch_209);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_862, v_865, false, &v_865), _fx_catch_209);
+               &v_882, 0), _fx_catch_216);
+         FX_COPY_PTR(v_882.t0, &i_exp_12);
+         FX_COPY_PTR(v_882.t1, &ccode_134);
+         FX_CALL(atom2cexp__0.fp(a_13, true, ccode_134, &kloc_0, &v_883, atom2cexp__0.fcv), _fx_catch_216);
+         FX_COPY_PTR(v_883.t0, &e_exp_0);
+         FX_COPY_PTR(v_883.t1, &ccode_135);
+         FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(i_exp_12, &ctyp_2, 0), _fx_catch_216);
+         bool v_891;
+         FX_CALL(_fx_M6K_formFM11is_subarrayB2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &v_891, 0), _fx_catch_216);
+         if (v_891) {
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_exp_0, &v_884, 0), _fx_catch_216);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_12, &v_885, 0), _fx_catch_216);
+            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(true, &kloc_0, &v_886, 0), _fx_catch_216);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_886, 0, true, &v_887), _fx_catch_216);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_885, v_887, false, &v_887), _fx_catch_216);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_884, v_887, false, &v_887), _fx_catch_216);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g28C_form__std_fx_copy_arr_data, v_865, _fx_g19C_gen_code__CTypInt, &kloc_0, &copy_arr_data_0, 0),
-               _fx_catch_209);
+                  &_fx_g28C_form__std_fx_copy_arr_data, v_887, _fx_g19C_gen_code__CTypInt, &kloc_0, &copy_arr_data_0, 0),
+               _fx_catch_216);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  copy_arr_data_0, ccode_130, &kloc_0, block_stack_ref_0, &ccode_128, 0), _fx_catch_209);
+                  copy_arr_data_0, ccode_135, &kloc_0, block_stack_ref_0, &ccode_133, 0), _fx_catch_216);
          }
          else {
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_free_codeLN15C_form__cstmt_t6N14C_form__cexp_tN14C_form__ctyp_tBBLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_exp_12, ctyp_2, true, false, ccode_130, &kloc_0, &ccode_131, 0), _fx_catch_209);
+                  i_exp_12, ctyp_2, true, false, ccode_135, &kloc_0, &ccode_136, 0), _fx_catch_216);
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  e_exp_0, i_exp_12, ctyp_2, ccode_131, &kloc_0, &ccode_128, 0), _fx_catch_209);
+                  e_exp_0, i_exp_12, ctyp_2, ccode_136, &kloc_0, &ccode_133, 0), _fx_catch_216);
          }
       }
       else {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_6, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_866, 0), _fx_catch_209);
-         FX_COPY_PTR(v_866.t0, &i_exp_13);
-         FX_COPY_PTR(v_866.t1, &ccode_132);
+               &v_888, 0), _fx_catch_216);
+         FX_COPY_PTR(v_888.t0, &i_exp_13);
+         FX_COPY_PTR(v_888.t1, &ccode_137);
          FX_CALL(
-            atom2cexp_0.fp(a_12, ccode_132, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_867, atom2cexp_0.fcv), _fx_catch_209);
-         FX_COPY_PTR(v_867.t0, &a_exp_5);
-         FX_COPY_PTR(v_867.t1, &ccode_133);
+            atom2cexp_0.fp(a_13, ccode_137, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_889, atom2cexp_0.fcv), _fx_catch_216);
+         FX_COPY_PTR(v_889.t0, &a_exp_6);
+         FX_COPY_PTR(v_889.t1, &ccode_138);
          FX_CALL(
             _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               a_exp_5, i_exp_13, ctyp_0, ccode_133, &kloc_0, &ccode_128, 0), _fx_catch_209);
+               a_exp_6, i_exp_13, ctyp_0, ccode_138, &kloc_0, &ccode_133, 0), _fx_catch_216);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_128, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_133, &v_1);
 
-   _fx_catch_209: ;
-      if (ccode_133) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_133);
+   _fx_catch_216: ;
+      if (ccode_138) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_138);
       }
-      if (a_exp_5) {
-         _fx_free_N14C_form__cexp_t(&a_exp_5);
+      if (a_exp_6) {
+         _fx_free_N14C_form__cexp_t(&a_exp_6);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_867);
-      if (ccode_132) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_132);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_889);
+      if (ccode_137) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_137);
       }
       if (i_exp_13) {
          _fx_free_N14C_form__cexp_t(&i_exp_13);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_866);
-      if (ccode_131) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_131);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_888);
+      if (ccode_136) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_136);
       }
       if (copy_arr_data_0) {
          _fx_free_N14C_form__cexp_t(&copy_arr_data_0);
       }
-      if (v_865) {
-         _fx_free_LN14C_form__cexp_t(&v_865);
+      if (v_887) {
+         _fx_free_LN14C_form__cexp_t(&v_887);
       }
-      if (v_864) {
-         _fx_free_N14C_form__cexp_t(&v_864);
-      }
-      if (v_863) {
-         _fx_free_N14C_form__cexp_t(&v_863);
-      }
-      if (v_862) {
-         _fx_free_N14C_form__cexp_t(&v_862);
-      }
-      if (ctyp_2) {
-         _fx_free_N14C_form__ctyp_t(&ctyp_2);
-      }
-      if (ccode_130) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_130);
-      }
-      if (e_exp_0) {
-         _fx_free_N14C_form__cexp_t(&e_exp_0);
-      }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_861);
-      if (ccode_129) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_129);
-      }
-      if (i_exp_12) {
-         _fx_free_N14C_form__cexp_t(&i_exp_12);
-      }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_860);
-      if (ccode_128) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_128);
-      }
-      if (ktyp_2) {
-         _fx_free_N14K_form__ktyp_t(&ktyp_2);
-      }
-      goto _fx_endmatch_55;
-   }
-   if (tag_0 == 22) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_870 = {0};
-      _fx_N14C_form__cexp_t dst_exp_14 = 0;
-      _fx_LN15C_form__cstmt_t ccode_134 = 0;
-      _fx_LN15C_form__cstmt_t ccode_135 = 0;
-      fx_str_t slit_192 = FX_MAKE_STR("res");
-      FX_CALL(
-         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_192, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_870, 0), _fx_catch_210);
-      FX_COPY_PTR(v_870.t0, &dst_exp_14);
-      FX_COPY_PTR(v_870.t1, &ccode_134);
-      FX_CALL(
-         process_cases_0.fp(kexp_0->u.KExpMatch.t0, dstexp_r_0, ccode_134, false, &kloc_0, block_stack_ref_0,
-            defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0,
-            i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0,
-            &ccode_135, process_cases_0.fcv), _fx_catch_210);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_14, ccode_135, &v_1);
-
-   _fx_catch_210: ;
-      if (ccode_135) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_135);
-      }
-      if (ccode_134) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_134);
-      }
-      if (dst_exp_14) {
-         _fx_free_N14C_form__cexp_t(&dst_exp_14);
-      }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_870);
-      goto _fx_endmatch_55;
-   }
-   if (tag_0 == 23) {
-      _fx_Ta2N14K_form__kexp_t v_871 = {0};
-      _fx_N14K_form__kexp_t pop_exn_0 = 0;
-      _fx_N14K_form__kexp_t catch_e_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_872 = {0};
-      _fx_N14C_form__cexp_t dst_exp_15 = 0;
-      _fx_LN15C_form__cstmt_t ccode_136 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_873 = {0};
-      _fx_LN15C_form__cstmt_t try_ccode_0 = 0;
-      _fx_rR23C_gen_code__block_ctx_t bctx_try_0 = 0;
-      _fx_LN15C_form__cstmt_t bctx_cleanup_1 = 0;
-      _fx_LN15C_form__cstmt_t bctx_prologue_1 = 0;
-      _fx_LN15C_form__cstmt_t epilogue_1 = 0;
-      _fx_N15C_form__cstmt_t v_874 = 0;
-      _fx_LN15C_form__cstmt_t v_875 = 0;
-      _fx_LN15C_form__cstmt_t v_876 = 0;
-      _fx_LN15C_form__cstmt_t v_877 = 0;
-      _fx_LN15C_form__cstmt_t ccode_137 = 0;
-      _fx_N14C_form__cexp_t fx_status_exp_1 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_878 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_879 = {0};
-      _fx_LN15C_form__cstmt_t catch_ccode_0 = 0;
-      _fx_N14C_form__cexp_t v_880 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_881 = {0};
-      _fx_N14C_form__cexp_t v_882 = 0;
-      _fx_N15C_form__cstmt_t v_883 = 0;
-      _fx_LN15C_form__cstmt_t catch_ccode_1 = 0;
-      _fx_LN15C_form__cstmt_t catch_ccode_2 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_884 = {0};
-      _fx_LN15C_form__cstmt_t catch_ccode_3 = 0;
-      _fx_N14C_form__cexp_t v_885 = 0;
-      _fx_N14C_form__cexp_t v_886 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_887 = {0};
-      _fx_N14C_form__cexp_t check_neg_status_0 = 0;
-      _fx_N15C_form__cstmt_t v_888 = 0;
-      _fx_N15C_form__cstmt_t v_889 = 0;
-      _fx_N15C_form__cstmt_t catch_clause_0 = 0;
-      _fx_LN15C_form__cstmt_t v_890 = 0;
-      _fx_T3N14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_21 = &kexp_0->u.KExpTryCatch;
-      _fx_N14K_form__kexp_t catch_e_1 = vcase_21->t1;
-      _fx_N14K_form__kexp_t try_e_0 = vcase_21->t0;
-      int tag_26 = FX_REC_VARIANT_TAG(catch_e_1);
-      if (tag_26 == 10) {
-         _fx_LN14K_form__kexp_t v_891 = catch_e_1->u.KExpSeq.t0;
-         if (v_891 != 0) {
-            _fx_N14K_form__kexp_t pop_exn_1 = v_891->hd;
-            if (FX_REC_VARIANT_TAG(pop_exn_1) == 31) {
-               _fx_N14K_form__kexp_t v_892 = pop_exn_1->u.KDefVal.t1;
-               if (FX_REC_VARIANT_TAG(v_892) == 8) {
-                  if (v_892->u.KExpIntrin.t0.tag == 1) {
-                     _fx_N14K_form__kexp_t v_893 = 0;
-                     FX_CALL(
-                        _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_891->tl, &kloc_0, &v_893,
-                           0), _fx_catch_211);
-                     _fx_make_Ta2N14K_form__kexp_t(pop_exn_1, v_893, &v_871);
-
-                  _fx_catch_211: ;
-                     if (v_893) {
-                        _fx_free_N14K_form__kexp_t(&v_893);
-                     }
-                     goto _fx_endmatch_33;
-                  }
-               }
-            }
-         }
-      }
-      if (tag_26 == 10) {
-         _fx_LN14K_form__kexp_t v_894 = catch_e_1->u.KExpSeq.t0;
-         if (v_894 != 0) {
-            _fx_N14K_form__kexp_t pop_exn_2 = v_894->hd;
-            if (FX_REC_VARIANT_TAG(pop_exn_2) == 8) {
-               if (pop_exn_2->u.KExpIntrin.t0.tag == 1) {
-                  _fx_N14K_form__kexp_t v_895 = 0;
-                  FX_CALL(
-                     _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_894->tl, &kloc_0, &v_895, 0),
-                     _fx_catch_212);
-                  _fx_make_Ta2N14K_form__kexp_t(pop_exn_2, v_895, &v_871);
-
-               _fx_catch_212: ;
-                  if (v_895) {
-                     _fx_free_N14K_form__kexp_t(&v_895);
-                  }
-                  goto _fx_endmatch_33;
-               }
-            }
-         }
-      }
-      fx_exn_t v_896 = {0};
-      fx_str_t slit_193 = FX_MAKE_STR("catch part in KExpTryCatch() should be a sequence starting with \'val x = pop_exn()\'");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_193, &v_896, 0), _fx_catch_213);
-      FX_THROW(&v_896, false, _fx_catch_213);
-
-   _fx_catch_213: ;
-      fx_free_exn(&v_896);
-
-   _fx_endmatch_33: ;
-      FX_CHECK_EXN(_fx_catch_215);
-      FX_COPY_PTR(v_871.t0, &pop_exn_0);
-      FX_COPY_PTR(v_871.t1, &catch_e_0);
-      fx_str_t slit_194 = FX_MAKE_STR("res");
-      FX_CALL(
-         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_194, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_872, 0), _fx_catch_215);
-      FX_COPY_PTR(v_872.t0, &dst_exp_15);
-      FX_COPY_PTR(v_872.t1, &ccode_136);
-      _fx_R10Ast__loc_t try_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(try_e_0, &try_loc_0, 0), _fx_catch_215);
-      _fx_R10Ast__loc_t try_end_loc_0;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&try_loc_0, &try_end_loc_0, 0), _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g25C_gen_code__BlockKind_Try, &try_loc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            try_e_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
-            fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_873, fx_fv), _fx_catch_215);
-      FX_COPY_PTR(v_873.t1, &try_ccode_0);
-      FX_CALL(
-         _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_try_0, 0), _fx_catch_215);
-      _fx_R23C_gen_code__block_ctx_t* v_897 = &bctx_try_0->data;
-      int_ bctx_label_used_1 = v_897->bctx_label_used;
-      _fx_R9Ast__id_t bctx_label_1 = v_897->bctx_label;
-      FX_COPY_PTR(v_897->bctx_cleanup, &bctx_cleanup_1);
-      FX_COPY_PTR(v_897->bctx_prologue, &bctx_prologue_1);
-      if (bctx_label_used_1 == 0) {
-         FX_COPY_PTR(bctx_cleanup_1, &epilogue_1);
-      }
-      else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_1, &try_end_loc_0, &v_874),
-            _fx_catch_215);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_874, 0, true, &v_875), _fx_catch_215);
-         FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_1, v_875,
-               &epilogue_1, 0), _fx_catch_215);
-      }
-      FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_prologue_1, ccode_136,
-            &v_876, 0), _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(try_ccode_0, v_876, &v_877, 0),
-         _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_1, v_877, &ccode_137,
-            0), _fx_catch_215);
-      FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&try_end_loc_0, block_stack_ref_0, 0),
-         _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0,
-            &fx_status_exp_1, 0), _fx_catch_215);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_878), _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            pop_exn_0, v_878, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
-            fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_879, fx_fv), _fx_catch_215);
-      FX_COPY_PTR(v_879.t1, &catch_ccode_0);
-      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_880, 0), _fx_catch_215);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypVoid, &try_end_loc_0, &v_881);
-      FX_CALL(
-         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g21C_gen_code__COpAssign, fx_status_exp_1, v_880, &v_881, &v_882), _fx_catch_215);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_882, &v_883), _fx_catch_215);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_883, catch_ccode_0, true, &catch_ccode_1), _fx_catch_215);
-      if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
-         FX_COPY_PTR(catch_ccode_1, &catch_ccode_2);
-      }
-      else {
-         FX_CALL(
-            _fx_M11C_gen_typesFM13gen_free_codeLN15C_form__cstmt_t6N14C_form__cexp_tN14C_form__ctyp_tBBLN15C_form__cstmt_tR10Ast__loc_t(
-               dst_exp_15, ctyp_0, true, true, catch_ccode_1, &try_end_loc_0, &catch_ccode_2, 0), _fx_catch_214);
-
-      _fx_catch_214: ;
-      }
-      FX_CHECK_EXN(_fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            catch_e_0, dstexp_r_0, catch_ccode_2, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
-            fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_884, fx_fv), _fx_catch_215);
-      FX_COPY_PTR(v_884.t1, &catch_ccode_3);
-      _fx_N17C_form__cbinary_t v_898;
-      _fx_M6C_formFM6COpCmpN17C_form__cbinary_t1N12Ast__cmpop_t(&_fx_g17C_gen_code__CmpLT, &v_898);
-      FX_CALL(
-         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0, &v_885, 0),
-         _fx_catch_215);
-      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_886, 0), _fx_catch_215);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &try_end_loc_0, &v_887);
-      FX_CALL(
-         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &v_898, v_885, v_886, &v_887, &check_neg_status_0), _fx_catch_215);
-      _fx_R10Ast__loc_t catch_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(catch_e_0, &catch_loc_0, 0), _fx_catch_215);
-      FX_CALL(
-         _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(catch_ccode_3, &catch_loc_0, &v_888, 0),
-         _fx_catch_215);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&try_end_loc_0, &v_889), _fx_catch_215);
-      FX_CALL(
-         _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            check_neg_status_0, v_888, v_889, &catch_loc_0, &catch_clause_0, 0), _fx_catch_215);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(catch_clause_0, ccode_137, true, &v_890), _fx_catch_215);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_15, v_890, &v_1);
-
-   _fx_catch_215: ;
-      if (v_890) {
-         _fx_free_LN15C_form__cstmt_t(&v_890);
-      }
-      if (catch_clause_0) {
-         _fx_free_N15C_form__cstmt_t(&catch_clause_0);
-      }
-      if (v_889) {
-         _fx_free_N15C_form__cstmt_t(&v_889);
-      }
-      if (v_888) {
-         _fx_free_N15C_form__cstmt_t(&v_888);
-      }
-      if (check_neg_status_0) {
-         _fx_free_N14C_form__cexp_t(&check_neg_status_0);
-      }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_887);
       if (v_886) {
          _fx_free_N14C_form__cexp_t(&v_886);
       }
       if (v_885) {
          _fx_free_N14C_form__cexp_t(&v_885);
       }
+      if (v_884) {
+         _fx_free_N14C_form__cexp_t(&v_884);
+      }
+      if (ctyp_2) {
+         _fx_free_N14C_form__ctyp_t(&ctyp_2);
+      }
+      if (ccode_135) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_135);
+      }
+      if (e_exp_0) {
+         _fx_free_N14C_form__cexp_t(&e_exp_0);
+      }
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_883);
+      if (ccode_134) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_134);
+      }
+      if (i_exp_12) {
+         _fx_free_N14C_form__cexp_t(&i_exp_12);
+      }
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_882);
+      if (ccode_133) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_133);
+      }
+      if (ktyp_2) {
+         _fx_free_N14K_form__ktyp_t(&ktyp_2);
+      }
+      goto _fx_endmatch_58;
+   }
+   if (tag_0 == 22) {
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_892 = {0};
+      _fx_N14C_form__cexp_t dst_exp_14 = 0;
+      _fx_LN15C_form__cstmt_t ccode_139 = 0;
+      _fx_LN15C_form__cstmt_t ccode_140 = 0;
+      fx_str_t slit_193 = FX_MAKE_STR("res");
+      FX_CALL(
+         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+            dstexp_r_0, &slit_193, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_892, 0), _fx_catch_217);
+      FX_COPY_PTR(v_892.t0, &dst_exp_14);
+      FX_COPY_PTR(v_892.t1, &ccode_139);
+      FX_CALL(
+         process_cases_0.fp(kexp_0->u.KExpMatch.t0, dstexp_r_0, ccode_139, false, &kloc_0, block_stack_ref_0,
+            defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0,
+            i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0,
+            &ccode_140, process_cases_0.fcv), _fx_catch_217);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_14, ccode_140, &v_1);
+
+   _fx_catch_217: ;
+      if (ccode_140) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_140);
+      }
+      if (ccode_139) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_139);
+      }
+      if (dst_exp_14) {
+         _fx_free_N14C_form__cexp_t(&dst_exp_14);
+      }
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_892);
+      goto _fx_endmatch_58;
+   }
+   if (tag_0 == 23) {
+      _fx_Ta2N14K_form__kexp_t v_893 = {0};
+      _fx_N14K_form__kexp_t pop_exn_0 = 0;
+      _fx_N14K_form__kexp_t catch_e_0 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_894 = {0};
+      _fx_N14C_form__cexp_t dst_exp_15 = 0;
+      _fx_LN15C_form__cstmt_t ccode_141 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_895 = {0};
+      _fx_LN15C_form__cstmt_t try_ccode_0 = 0;
+      _fx_rR23C_gen_code__block_ctx_t bctx_try_0 = 0;
+      _fx_LN15C_form__cstmt_t bctx_cleanup_1 = 0;
+      _fx_LN15C_form__cstmt_t bctx_prologue_1 = 0;
+      _fx_LN15C_form__cstmt_t epilogue_1 = 0;
+      _fx_N15C_form__cstmt_t v_896 = 0;
+      _fx_LN15C_form__cstmt_t v_897 = 0;
+      _fx_LN15C_form__cstmt_t v_898 = 0;
+      _fx_LN15C_form__cstmt_t v_899 = 0;
+      _fx_LN15C_form__cstmt_t ccode_142 = 0;
+      _fx_N14C_form__cexp_t fx_status_exp_1 = 0;
+      _fx_rNt6option1N14C_form__cexp_t v_900 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_901 = {0};
+      _fx_LN15C_form__cstmt_t catch_ccode_0 = 0;
+      _fx_N14C_form__cexp_t v_902 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_903 = {0};
+      _fx_N14C_form__cexp_t v_904 = 0;
+      _fx_N15C_form__cstmt_t v_905 = 0;
+      _fx_LN15C_form__cstmt_t catch_ccode_1 = 0;
+      _fx_LN15C_form__cstmt_t catch_ccode_2 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_906 = {0};
+      _fx_LN15C_form__cstmt_t catch_ccode_3 = 0;
+      _fx_N14C_form__cexp_t v_907 = 0;
+      _fx_N14C_form__cexp_t v_908 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_909 = {0};
+      _fx_N14C_form__cexp_t check_neg_status_0 = 0;
+      _fx_N15C_form__cstmt_t v_910 = 0;
+      _fx_N15C_form__cstmt_t v_911 = 0;
+      _fx_N15C_form__cstmt_t catch_clause_0 = 0;
+      _fx_LN15C_form__cstmt_t v_912 = 0;
+      _fx_T3N14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_21 = &kexp_0->u.KExpTryCatch;
+      _fx_N14K_form__kexp_t catch_e_1 = vcase_21->t1;
+      _fx_N14K_form__kexp_t try_e_0 = vcase_21->t0;
+      int tag_26 = FX_REC_VARIANT_TAG(catch_e_1);
+      if (tag_26 == 10) {
+         _fx_LN14K_form__kexp_t v_913 = catch_e_1->u.KExpSeq.t0;
+         if (v_913 != 0) {
+            _fx_N14K_form__kexp_t pop_exn_1 = v_913->hd;
+            if (FX_REC_VARIANT_TAG(pop_exn_1) == 31) {
+               _fx_N14K_form__kexp_t v_914 = pop_exn_1->u.KDefVal.t1;
+               if (FX_REC_VARIANT_TAG(v_914) == 8) {
+                  if (v_914->u.KExpIntrin.t0.tag == 1) {
+                     _fx_N14K_form__kexp_t v_915 = 0;
+                     FX_CALL(
+                        _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_913->tl, &kloc_0, &v_915,
+                           0), _fx_catch_218);
+                     _fx_make_Ta2N14K_form__kexp_t(pop_exn_1, v_915, &v_893);
+
+                  _fx_catch_218: ;
+                     if (v_915) {
+                        _fx_free_N14K_form__kexp_t(&v_915);
+                     }
+                     goto _fx_endmatch_36;
+                  }
+               }
+            }
+         }
+      }
+      if (tag_26 == 10) {
+         _fx_LN14K_form__kexp_t v_916 = catch_e_1->u.KExpSeq.t0;
+         if (v_916 != 0) {
+            _fx_N14K_form__kexp_t pop_exn_2 = v_916->hd;
+            if (FX_REC_VARIANT_TAG(pop_exn_2) == 8) {
+               if (pop_exn_2->u.KExpIntrin.t0.tag == 1) {
+                  _fx_N14K_form__kexp_t v_917 = 0;
+                  FX_CALL(
+                     _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_916->tl, &kloc_0, &v_917, 0),
+                     _fx_catch_219);
+                  _fx_make_Ta2N14K_form__kexp_t(pop_exn_2, v_917, &v_893);
+
+               _fx_catch_219: ;
+                  if (v_917) {
+                     _fx_free_N14K_form__kexp_t(&v_917);
+                  }
+                  goto _fx_endmatch_36;
+               }
+            }
+         }
+      }
+      fx_exn_t v_918 = {0};
+      fx_str_t slit_194 = FX_MAKE_STR("catch part in KExpTryCatch() should be a sequence starting with \'val x = pop_exn()\'");
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_194, &v_918, 0), _fx_catch_220);
+      FX_THROW(&v_918, false, _fx_catch_220);
+
+   _fx_catch_220: ;
+      fx_free_exn(&v_918);
+
+   _fx_endmatch_36: ;
+      FX_CHECK_EXN(_fx_catch_222);
+      FX_COPY_PTR(v_893.t0, &pop_exn_0);
+      FX_COPY_PTR(v_893.t1, &catch_e_0);
+      fx_str_t slit_195 = FX_MAKE_STR("res");
+      FX_CALL(
+         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+            dstexp_r_0, &slit_195, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_894, 0), _fx_catch_222);
+      FX_COPY_PTR(v_894.t0, &dst_exp_15);
+      FX_COPY_PTR(v_894.t1, &ccode_141);
+      _fx_R10Ast__loc_t try_loc_0;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(try_e_0, &try_loc_0, 0), _fx_catch_222);
+      _fx_R10Ast__loc_t try_end_loc_0;
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&try_loc_0, &try_end_loc_0, 0), _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
+            &_fx_g25C_gen_code__BlockKind_Try, &try_loc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
+            try_e_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
+            fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
+            top_inline_ccode_ref_0, u1vals_0, &v_895, fx_fv), _fx_catch_222);
+      FX_COPY_PTR(v_895.t1, &try_ccode_0);
+      FX_CALL(
+         _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
+            &bctx_try_0, 0), _fx_catch_222);
+      _fx_R23C_gen_code__block_ctx_t* v_919 = &bctx_try_0->data;
+      int_ bctx_label_used_1 = v_919->bctx_label_used;
+      _fx_R9Ast__id_t bctx_label_1 = v_919->bctx_label;
+      FX_COPY_PTR(v_919->bctx_cleanup, &bctx_cleanup_1);
+      FX_COPY_PTR(v_919->bctx_prologue, &bctx_prologue_1);
+      if (bctx_label_used_1 == 0) {
+         FX_COPY_PTR(bctx_cleanup_1, &epilogue_1);
+      }
+      else {
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_1, &try_end_loc_0, &v_896),
+            _fx_catch_222);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_896, 0, true, &v_897), _fx_catch_222);
+         FX_CALL(
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_1, v_897,
+               &epilogue_1, 0), _fx_catch_222);
+      }
+      FX_CALL(
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_prologue_1, ccode_141,
+            &v_898, 0), _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(try_ccode_0, v_898, &v_899, 0),
+         _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_1, v_899, &ccode_142,
+            0), _fx_catch_222);
+      FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&try_end_loc_0, block_stack_ref_0, 0),
+         _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0,
+            &fx_status_exp_1, 0), _fx_catch_222);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_900), _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
+            pop_exn_0, v_900, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
+            fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
+            top_inline_ccode_ref_0, u1vals_0, &v_901, fx_fv), _fx_catch_222);
+      FX_COPY_PTR(v_901.t1, &catch_ccode_0);
+      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_902, 0), _fx_catch_222);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypVoid, &try_end_loc_0, &v_903);
+      FX_CALL(
+         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
+            &_fx_g21C_gen_code__COpAssign, fx_status_exp_1, v_902, &v_903, &v_904), _fx_catch_222);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_904, &v_905), _fx_catch_222);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_905, catch_ccode_0, true, &catch_ccode_1), _fx_catch_222);
+      if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
+         FX_COPY_PTR(catch_ccode_1, &catch_ccode_2);
+      }
+      else {
+         FX_CALL(
+            _fx_M11C_gen_typesFM13gen_free_codeLN15C_form__cstmt_t6N14C_form__cexp_tN14C_form__ctyp_tBBLN15C_form__cstmt_tR10Ast__loc_t(
+               dst_exp_15, ctyp_0, true, true, catch_ccode_1, &try_end_loc_0, &catch_ccode_2, 0), _fx_catch_221);
+
+      _fx_catch_221: ;
+      }
+      FX_CHECK_EXN(_fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
+            catch_e_0, dstexp_r_0, catch_ccode_2, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_906, fx_fv), _fx_catch_222);
+      FX_COPY_PTR(v_906.t1, &catch_ccode_3);
+      _fx_N17C_form__cbinary_t v_920;
+      _fx_M6C_formFM6COpCmpN17C_form__cbinary_t1N12Ast__cmpop_t(&_fx_g17C_gen_code__CmpLT, &v_920);
+      FX_CALL(
+         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0, &v_907, 0),
+         _fx_catch_222);
+      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_908, 0), _fx_catch_222);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &try_end_loc_0, &v_909);
+      FX_CALL(
+         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
+            &v_920, v_907, v_908, &v_909, &check_neg_status_0), _fx_catch_222);
+      _fx_R10Ast__loc_t catch_loc_0;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(catch_e_0, &catch_loc_0, 0), _fx_catch_222);
+      FX_CALL(
+         _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(catch_ccode_3, &catch_loc_0, &v_910, 0),
+         _fx_catch_222);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&try_end_loc_0, &v_911), _fx_catch_222);
+      FX_CALL(
+         _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
+            check_neg_status_0, v_910, v_911, &catch_loc_0, &catch_clause_0, 0), _fx_catch_222);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(catch_clause_0, ccode_142, true, &v_912), _fx_catch_222);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_15, v_912, &v_1);
+
+   _fx_catch_222: ;
+      if (v_912) {
+         _fx_free_LN15C_form__cstmt_t(&v_912);
+      }
+      if (catch_clause_0) {
+         _fx_free_N15C_form__cstmt_t(&catch_clause_0);
+      }
+      if (v_911) {
+         _fx_free_N15C_form__cstmt_t(&v_911);
+      }
+      if (v_910) {
+         _fx_free_N15C_form__cstmt_t(&v_910);
+      }
+      if (check_neg_status_0) {
+         _fx_free_N14C_form__cexp_t(&check_neg_status_0);
+      }
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_909);
+      if (v_908) {
+         _fx_free_N14C_form__cexp_t(&v_908);
+      }
+      if (v_907) {
+         _fx_free_N14C_form__cexp_t(&v_907);
+      }
       if (catch_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_884);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_906);
       if (catch_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_2);
       }
       if (catch_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_1);
       }
-      if (v_883) {
-         _fx_free_N15C_form__cstmt_t(&v_883);
+      if (v_905) {
+         _fx_free_N15C_form__cstmt_t(&v_905);
       }
-      if (v_882) {
-         _fx_free_N14C_form__cexp_t(&v_882);
+      if (v_904) {
+         _fx_free_N14C_form__cexp_t(&v_904);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_881);
-      if (v_880) {
-         _fx_free_N14C_form__cexp_t(&v_880);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_903);
+      if (v_902) {
+         _fx_free_N14C_form__cexp_t(&v_902);
       }
       if (catch_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_879);
-      if (v_878) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_878);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_901);
+      if (v_900) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_900);
       }
       if (fx_status_exp_1) {
          _fx_free_N14C_form__cexp_t(&fx_status_exp_1);
       }
-      if (ccode_137) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_137);
+      if (ccode_142) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_142);
       }
-      if (v_877) {
-         _fx_free_LN15C_form__cstmt_t(&v_877);
+      if (v_899) {
+         _fx_free_LN15C_form__cstmt_t(&v_899);
       }
-      if (v_876) {
-         _fx_free_LN15C_form__cstmt_t(&v_876);
+      if (v_898) {
+         _fx_free_LN15C_form__cstmt_t(&v_898);
       }
-      if (v_875) {
-         _fx_free_LN15C_form__cstmt_t(&v_875);
+      if (v_897) {
+         _fx_free_LN15C_form__cstmt_t(&v_897);
       }
-      if (v_874) {
-         _fx_free_N15C_form__cstmt_t(&v_874);
+      if (v_896) {
+         _fx_free_N15C_form__cstmt_t(&v_896);
       }
       if (epilogue_1) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_1);
@@ -30904,252 +31110,252 @@ static int
       if (try_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&try_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_873);
-      if (ccode_136) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_136);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_895);
+      if (ccode_141) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_141);
       }
       if (dst_exp_15) {
          _fx_free_N14C_form__cexp_t(&dst_exp_15);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_872);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_894);
       if (catch_e_0) {
          _fx_free_N14K_form__kexp_t(&catch_e_0);
       }
       if (pop_exn_0) {
          _fx_free_N14K_form__kexp_t(&pop_exn_0);
       }
-      _fx_free_Ta2N14K_form__kexp_t(&v_871);
-      goto _fx_endmatch_55;
+      _fx_free_Ta2N14K_form__kexp_t(&v_893);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 24) {
       _fx_N14C_form__cexp_t lbl_8 = 0;
-      _fx_LN15C_form__cstmt_t ccode_138 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_899 = {0};
+      _fx_LN15C_form__cstmt_t ccode_143 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_921 = {0};
       _fx_N14C_form__cexp_t i_exp_14 = 0;
-      _fx_LN15C_form__cstmt_t ccode_139 = 0;
-      _fx_N14C_form__cexp_t v_900 = 0;
-      _fx_LN14C_form__cexp_t v_901 = 0;
+      _fx_LN15C_form__cstmt_t ccode_144 = 0;
+      _fx_N14C_form__cexp_t v_922 = 0;
+      _fx_LN14C_form__cexp_t v_923 = 0;
       _fx_N14C_form__cexp_t throw_exp_0 = 0;
-      _fx_N15C_form__cstmt_t v_902 = 0;
+      _fx_N15C_form__cstmt_t v_924 = 0;
       _fx_T3R9Ast__id_tBR10Ast__loc_t* vcase_22 = &kexp_0->u.KExpThrow;
       _fx_R9Ast__id_t* i_7 = &vcase_22->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_8, 0), _fx_catch_220);
+            &lbl_8, 0), _fx_catch_227);
       if (vcase_22->t1) {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_7, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_899, 0), _fx_catch_220);
-         FX_COPY_PTR(v_899.t0, &i_exp_14);
-         FX_COPY_PTR(v_899.t1, &ccode_139);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_14, &v_900, 0), _fx_catch_220);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_901), _fx_catch_220);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_900, v_901, false, &v_901), _fx_catch_220);
+               &v_921, 0), _fx_catch_227);
+         FX_COPY_PTR(v_921.t0, &i_exp_14);
+         FX_COPY_PTR(v_921.t1, &ccode_144);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_14, &v_922, 0), _fx_catch_227);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_923), _fx_catch_227);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_922, v_923, false, &v_923), _fx_catch_227);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g22C_form__std_FX_RETHROW, v_901, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_0, 0), _fx_catch_220);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_0, &v_902), _fx_catch_220);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_902, ccode_139, true, &ccode_138), _fx_catch_220);
+               &_fx_g22C_form__std_FX_RETHROW, v_923, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_0, 0), _fx_catch_227);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_0, &v_924), _fx_catch_227);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_924, ccode_144, true, &ccode_143), _fx_catch_227);
       }
       else {
-         _fx_Nt6option1R9Ast__id_t v_903;
+         _fx_Nt6option1R9Ast__id_t v_925;
          FX_CALL(
             _fx_M10C_gen_codeFM8find_optNt6option1R9Ast__id_t2Rt6Map__t2R9Ast__id_tR9Ast__id_tR9Ast__id_t(
-               &_fx_g23Ast__builtin_exceptions, i_7, &v_903, 0), _fx_catch_220);
-         if (v_903.tag == 2) {
-            fx_str_t v_904 = {0};
-            fx_str_t v_905 = {0};
+               &_fx_g23Ast__builtin_exceptions, i_7, &v_925, 0), _fx_catch_227);
+         if (v_925.tag == 2) {
+            fx_str_t v_926 = {0};
+            fx_str_t v_927 = {0};
             _fx_N14C_form__cexp_t i_exp_15 = 0;
-            _fx_LN14C_form__cexp_t v_906 = 0;
+            _fx_LN14C_form__cexp_t v_928 = 0;
             _fx_N14C_form__cexp_t throw_exp_1 = 0;
-            _fx_N15C_form__cstmt_t v_907 = 0;
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_7, &v_904, 0), _fx_catch_216);
-            fx_str_t slit_195 = FX_MAKE_STR("FX_EXN_");
+            _fx_N15C_form__cstmt_t v_929 = 0;
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_7, &v_926, 0), _fx_catch_223);
+            fx_str_t slit_196 = FX_MAKE_STR("FX_EXN_");
             {
-               const fx_str_t strs_33[] = { slit_195, v_904 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &v_905), _fx_catch_216);
+               const fx_str_t strs_33[] = { slit_196, v_926 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &v_927), _fx_catch_223);
             }
             _fx_R9Ast__id_t i_8;
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_905, &i_8, 0), _fx_catch_216);
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_927, &i_8, 0), _fx_catch_223);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&i_8,
-                  _fx_g20C_gen_code__CTypCInt, &kloc_0, &i_exp_15, 0), _fx_catch_216);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_906), _fx_catch_216);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_15, v_906, false, &v_906), _fx_catch_216);
+                  _fx_g20C_gen_code__CTypCInt, &kloc_0, &i_exp_15, 0), _fx_catch_223);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_928), _fx_catch_223);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_15, v_928, false, &v_928), _fx_catch_223);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g25C_form__std_FX_FAST_THROW, v_906, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_1, 0),
-               _fx_catch_216);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_1, &v_907), _fx_catch_216);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_907, ccode_0, true, &ccode_138), _fx_catch_216);
+                  &_fx_g25C_form__std_FX_FAST_THROW, v_928, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_1, 0),
+               _fx_catch_223);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_1, &v_929), _fx_catch_223);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_929, ccode_0, true, &ccode_143), _fx_catch_223);
 
-         _fx_catch_216: ;
-            if (v_907) {
-               _fx_free_N15C_form__cstmt_t(&v_907);
+         _fx_catch_223: ;
+            if (v_929) {
+               _fx_free_N15C_form__cstmt_t(&v_929);
             }
             if (throw_exp_1) {
                _fx_free_N14C_form__cexp_t(&throw_exp_1);
             }
-            if (v_906) {
-               _fx_free_LN14C_form__cexp_t(&v_906);
+            if (v_928) {
+               _fx_free_LN14C_form__cexp_t(&v_928);
             }
             if (i_exp_15) {
                _fx_free_N14C_form__cexp_t(&i_exp_15);
             }
-            FX_FREE_STR(&v_905);
-            FX_FREE_STR(&v_904);
+            FX_FREE_STR(&v_927);
+            FX_FREE_STR(&v_926);
          }
          else {
-            _fx_N15K_form__kinfo_t v_908 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_909 = {0};
+            _fx_N15K_form__kinfo_t v_930 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_931 = {0};
             _fx_N14C_form__cexp_t i_exp_16 = 0;
-            _fx_LN15C_form__cstmt_t ccode_140 = 0;
-            _fx_N14C_form__cexp_t v_910 = 0;
-            _fx_N14C_form__cexp_t v_911 = 0;
-            _fx_LN14C_form__cexp_t v_912 = 0;
+            _fx_LN15C_form__cstmt_t ccode_145 = 0;
+            _fx_N14C_form__cexp_t v_932 = 0;
+            _fx_N14C_form__cexp_t v_933 = 0;
+            _fx_LN14C_form__cexp_t v_934 = 0;
             _fx_N14C_form__cexp_t throw_exp_2 = 0;
-            _fx_N15C_form__cstmt_t v_913 = 0;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_7, &kloc_0, &v_908, 0), _fx_catch_219);
-            int tag_27 = v_908.tag;
+            _fx_N15C_form__cstmt_t v_935 = 0;
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_7, &kloc_0, &v_930, 0), _fx_catch_226);
+            int tag_27 = v_930.tag;
             bool move_f_0;
             if (tag_27 == 4) {
-               move_f_0 = false; goto _fx_endmatch_34;
+               move_f_0 = false; goto _fx_endmatch_37;
             }
             if (tag_27 == 2) {
-               if (FX_REC_VARIANT_TAG(v_908.u.KVal.kv_typ) == 22) {
+               if (FX_REC_VARIANT_TAG(v_930.u.KVal.kv_typ) == 22) {
                   FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_7, &move_f_0, 0),
-                     _fx_catch_217);
+                     _fx_catch_224);
 
-               _fx_catch_217: ;
-                  goto _fx_endmatch_34;
+               _fx_catch_224: ;
+                  goto _fx_endmatch_37;
                }
             }
-            fx_exn_t v_914 = {0};
-            fx_str_t slit_196 = FX_MAKE_STR("cgen: throw is applied to neither exception nor value of \'exn\' type");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_196, &v_914, 0), _fx_catch_218);
-            FX_THROW(&v_914, false, _fx_catch_218);
+            fx_exn_t v_936 = {0};
+            fx_str_t slit_197 = FX_MAKE_STR("cgen: throw is applied to neither exception nor value of \'exn\' type");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_197, &v_936, 0), _fx_catch_225);
+            FX_THROW(&v_936, false, _fx_catch_225);
 
-         _fx_catch_218: ;
-            fx_free_exn(&v_914);
+         _fx_catch_225: ;
+            fx_free_exn(&v_936);
 
-         _fx_endmatch_34: ;
-            FX_CHECK_EXN(_fx_catch_219);
+         _fx_endmatch_37: ;
+            FX_CHECK_EXN(_fx_catch_226);
             FX_CALL(
                _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                   i_7, move_f_0, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-                  &v_909, 0), _fx_catch_219);
-            FX_COPY_PTR(v_909.t0, &i_exp_16);
-            FX_COPY_PTR(v_909.t1, &ccode_140);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_16, &v_910, 0), _fx_catch_219);
-            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(move_f_0, &kloc_0, &v_911, 0), _fx_catch_219);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_912), _fx_catch_219);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_911, v_912, false, &v_912), _fx_catch_219);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_910, v_912, false, &v_912), _fx_catch_219);
+                  &v_931, 0), _fx_catch_226);
+            FX_COPY_PTR(v_931.t0, &i_exp_16);
+            FX_COPY_PTR(v_931.t1, &ccode_145);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_16, &v_932, 0), _fx_catch_226);
+            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(move_f_0, &kloc_0, &v_933, 0), _fx_catch_226);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_934), _fx_catch_226);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_933, v_934, false, &v_934), _fx_catch_226);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_932, v_934, false, &v_934), _fx_catch_226);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g20C_form__std_FX_THROW, v_912, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_2, 0), _fx_catch_219);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_2, &v_913), _fx_catch_219);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_913, ccode_140, true, &ccode_138), _fx_catch_219);
+                  &_fx_g20C_form__std_FX_THROW, v_934, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_2, 0), _fx_catch_226);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_2, &v_935), _fx_catch_226);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_935, ccode_145, true, &ccode_143), _fx_catch_226);
 
-         _fx_catch_219: ;
-            if (v_913) {
-               _fx_free_N15C_form__cstmt_t(&v_913);
+         _fx_catch_226: ;
+            if (v_935) {
+               _fx_free_N15C_form__cstmt_t(&v_935);
             }
             if (throw_exp_2) {
                _fx_free_N14C_form__cexp_t(&throw_exp_2);
             }
-            if (v_912) {
-               _fx_free_LN14C_form__cexp_t(&v_912);
+            if (v_934) {
+               _fx_free_LN14C_form__cexp_t(&v_934);
             }
-            if (v_911) {
-               _fx_free_N14C_form__cexp_t(&v_911);
+            if (v_933) {
+               _fx_free_N14C_form__cexp_t(&v_933);
             }
-            if (v_910) {
-               _fx_free_N14C_form__cexp_t(&v_910);
+            if (v_932) {
+               _fx_free_N14C_form__cexp_t(&v_932);
             }
-            if (ccode_140) {
-               _fx_free_LN15C_form__cstmt_t(&ccode_140);
+            if (ccode_145) {
+               _fx_free_LN15C_form__cstmt_t(&ccode_145);
             }
             if (i_exp_16) {
                _fx_free_N14C_form__cexp_t(&i_exp_16);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_909);
-            _fx_free_N15K_form__kinfo_t(&v_908);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_931);
+            _fx_free_N15K_form__kinfo_t(&v_930);
          }
-         FX_CHECK_EXN(_fx_catch_220);
+         FX_CHECK_EXN(_fx_catch_227);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_138, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_143, &v_1);
 
-   _fx_catch_220: ;
-      if (v_902) {
-         _fx_free_N15C_form__cstmt_t(&v_902);
+   _fx_catch_227: ;
+      if (v_924) {
+         _fx_free_N15C_form__cstmt_t(&v_924);
       }
       if (throw_exp_0) {
          _fx_free_N14C_form__cexp_t(&throw_exp_0);
       }
-      if (v_901) {
-         _fx_free_LN14C_form__cexp_t(&v_901);
+      if (v_923) {
+         _fx_free_LN14C_form__cexp_t(&v_923);
       }
-      if (v_900) {
-         _fx_free_N14C_form__cexp_t(&v_900);
+      if (v_922) {
+         _fx_free_N14C_form__cexp_t(&v_922);
       }
-      if (ccode_139) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_139);
+      if (ccode_144) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_144);
       }
       if (i_exp_14) {
          _fx_free_N14C_form__cexp_t(&i_exp_14);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_899);
-      if (ccode_138) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_138);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_921);
+      if (ccode_143) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_143);
       }
       if (lbl_8) {
          _fx_free_N14C_form__cexp_t(&lbl_8);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 25) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_915 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_937 = {0};
       _fx_N14C_form__cexp_t ce1_9 = 0;
-      _fx_LN15C_form__cstmt_t ccode_141 = 0;
+      _fx_LN15C_form__cstmt_t ccode_146 = 0;
       _fx_N14K_form__ktyp_t atyp_0 = 0;
       _fx_N14C_form__ctyp_t ctyp_3 = 0;
-      _fx_N14C_form__cexp_t v_916 = 0;
+      _fx_N14C_form__cexp_t v_938 = 0;
       _fx_T3N14K_form__atom_tN14K_form__ktyp_tR10Ast__loc_t* vcase_23 = &kexp_0->u.KExpCast;
       _fx_N14K_form__atom_t* a1_2 = &vcase_23->t0;
       FX_CALL(
          atom2cexp_0.fp(a1_2, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-            &v_915, atom2cexp_0.fcv), _fx_catch_230);
-      FX_COPY_PTR(v_915.t0, &ce1_9);
-      FX_COPY_PTR(v_915.t1, &ccode_141);
+            &v_937, atom2cexp_0.fcv), _fx_catch_237);
+      FX_COPY_PTR(v_937.t0, &ce1_9);
+      FX_COPY_PTR(v_937.t1, &ccode_146);
       FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(a1_2, &kloc_0, &atyp_0, 0),
-         _fx_catch_230);
+         _fx_catch_237);
       FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(vcase_23->t1, &kloc_0, &ctyp_3, 0),
-         _fx_catch_230);
+         _fx_catch_237);
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 32) {
-                  _fx_LN14C_form__cexp_t v_917 = 0;
-                  _fx_N14C_form__ctyp_t v_918 = 0;
-                  _fx_R9Ast__id_t v_919;
-                  fx_str_t slit_197 = FX_MAKE_STR("FX_F16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_197, &v_919, 0), _fx_catch_221);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_917), _fx_catch_221);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_918), _fx_catch_221);
+                  _fx_LN14C_form__cexp_t v_939 = 0;
+                  _fx_N14C_form__ctyp_t v_940 = 0;
+                  _fx_R9Ast__id_t v_941;
+                  fx_str_t slit_198 = FX_MAKE_STR("FX_F16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_198, &v_941, 0), _fx_catch_228);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_939), _fx_catch_228);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_940), _fx_catch_228);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_919, v_917, v_918, &kloc_0, &v_916, 0), _fx_catch_221);
+                        &v_941, v_939, v_940, &kloc_0, &v_938, 0), _fx_catch_228);
 
-               _fx_catch_221: ;
-                  if (v_918) {
-                     _fx_free_N14C_form__ctyp_t(&v_918);
+               _fx_catch_228: ;
+                  if (v_940) {
+                     _fx_free_N14C_form__ctyp_t(&v_940);
                   }
-                  if (v_917) {
-                     _fx_free_LN14C_form__cexp_t(&v_917);
+                  if (v_939) {
+                     _fx_free_LN14C_form__cexp_t(&v_939);
                   }
-                  goto _fx_endmatch_36;
+                  goto _fx_endmatch_39;
                }
             }
          }
@@ -31158,25 +31364,25 @@ static int
          if (atyp_0->u.KTypFloat == 17) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 32) {
-                  _fx_LN14C_form__cexp_t v_920 = 0;
-                  _fx_N14C_form__ctyp_t v_921 = 0;
-                  _fx_R9Ast__id_t v_922;
-                  fx_str_t slit_198 = FX_MAKE_STR("FX_BF16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_198, &v_922, 0), _fx_catch_222);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_920), _fx_catch_222);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_921), _fx_catch_222);
+                  _fx_LN14C_form__cexp_t v_942 = 0;
+                  _fx_N14C_form__ctyp_t v_943 = 0;
+                  _fx_R9Ast__id_t v_944;
+                  fx_str_t slit_199 = FX_MAKE_STR("FX_BF16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_199, &v_944, 0), _fx_catch_229);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_942), _fx_catch_229);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_943), _fx_catch_229);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_922, v_920, v_921, &kloc_0, &v_916, 0), _fx_catch_222);
+                        &v_944, v_942, v_943, &kloc_0, &v_938, 0), _fx_catch_229);
 
-               _fx_catch_222: ;
-                  if (v_921) {
-                     _fx_free_N14C_form__ctyp_t(&v_921);
+               _fx_catch_229: ;
+                  if (v_943) {
+                     _fx_free_N14C_form__ctyp_t(&v_943);
                   }
-                  if (v_920) {
-                     _fx_free_LN14C_form__cexp_t(&v_920);
+                  if (v_942) {
+                     _fx_free_LN14C_form__cexp_t(&v_942);
                   }
-                  goto _fx_endmatch_36;
+                  goto _fx_endmatch_39;
                }
             }
          }
@@ -31186,7 +31392,7 @@ static int
          if (atyp_0->u.KTypFloat == 16) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 16) {
-                  res_22 = true; goto _fx_endmatch_35;
+                  res_22 = true; goto _fx_endmatch_38;
                }
             }
          }
@@ -31195,61 +31401,61 @@ static int
          if (atyp_0->u.KTypFloat == 17) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 17) {
-                  res_22 = true; goto _fx_endmatch_35;
+                  res_22 = true; goto _fx_endmatch_38;
                }
             }
          }
       }
       res_22 = false;
 
-   _fx_endmatch_35: ;
-      FX_CHECK_EXN(_fx_catch_230);
+   _fx_endmatch_38: ;
+      FX_CHECK_EXN(_fx_catch_237);
       if (res_22) {
-         FX_COPY_PTR(ce1_9, &v_916); goto _fx_endmatch_36;
+         FX_COPY_PTR(ce1_9, &v_938); goto _fx_endmatch_39;
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 17) {
-                  _fx_LN14C_form__cexp_t v_923 = 0;
-                  _fx_N14C_form__ctyp_t v_924 = 0;
-                  _fx_N14C_form__cexp_t v_925 = 0;
-                  _fx_LN14C_form__cexp_t v_926 = 0;
-                  _fx_N14C_form__ctyp_t v_927 = 0;
-                  _fx_R9Ast__id_t v_928;
-                  fx_str_t slit_199 = FX_MAKE_STR("FX_F32TOBF16");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_199, &v_928, 0), _fx_catch_223);
-                  _fx_R9Ast__id_t v_929;
-                  fx_str_t slit_200 = FX_MAKE_STR("FX_F16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_200, &v_929, 0), _fx_catch_223);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_923), _fx_catch_223);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_924), _fx_catch_223);
+                  _fx_LN14C_form__cexp_t v_945 = 0;
+                  _fx_N14C_form__ctyp_t v_946 = 0;
+                  _fx_N14C_form__cexp_t v_947 = 0;
+                  _fx_LN14C_form__cexp_t v_948 = 0;
+                  _fx_N14C_form__ctyp_t v_949 = 0;
+                  _fx_R9Ast__id_t v_950;
+                  fx_str_t slit_200 = FX_MAKE_STR("FX_F32TOBF16");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_200, &v_950, 0), _fx_catch_230);
+                  _fx_R9Ast__id_t v_951;
+                  fx_str_t slit_201 = FX_MAKE_STR("FX_F16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_201, &v_951, 0), _fx_catch_230);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_945), _fx_catch_230);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_946), _fx_catch_230);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_929, v_923, v_924, &kloc_0, &v_925, 0), _fx_catch_223);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_925, 0, true, &v_926), _fx_catch_223);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_927), _fx_catch_223);
+                        &v_951, v_945, v_946, &kloc_0, &v_947, 0), _fx_catch_230);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_947, 0, true, &v_948), _fx_catch_230);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_949), _fx_catch_230);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_928, v_926, v_927, &kloc_0, &v_916, 0), _fx_catch_223);
+                        &v_950, v_948, v_949, &kloc_0, &v_938, 0), _fx_catch_230);
 
-               _fx_catch_223: ;
-                  if (v_927) {
-                     _fx_free_N14C_form__ctyp_t(&v_927);
+               _fx_catch_230: ;
+                  if (v_949) {
+                     _fx_free_N14C_form__ctyp_t(&v_949);
                   }
-                  if (v_926) {
-                     _fx_free_LN14C_form__cexp_t(&v_926);
+                  if (v_948) {
+                     _fx_free_LN14C_form__cexp_t(&v_948);
                   }
-                  if (v_925) {
-                     _fx_free_N14C_form__cexp_t(&v_925);
+                  if (v_947) {
+                     _fx_free_N14C_form__cexp_t(&v_947);
                   }
-                  if (v_924) {
-                     _fx_free_N14C_form__ctyp_t(&v_924);
+                  if (v_946) {
+                     _fx_free_N14C_form__ctyp_t(&v_946);
                   }
-                  if (v_923) {
-                     _fx_free_LN14C_form__cexp_t(&v_923);
+                  if (v_945) {
+                     _fx_free_LN14C_form__cexp_t(&v_945);
                   }
-                  goto _fx_endmatch_36;
+                  goto _fx_endmatch_39;
                }
             }
          }
@@ -31258,168 +31464,168 @@ static int
          if (atyp_0->u.KTypFloat == 17) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 16) {
-                  _fx_LN14C_form__cexp_t v_930 = 0;
-                  _fx_N14C_form__ctyp_t v_931 = 0;
-                  _fx_N14C_form__cexp_t v_932 = 0;
-                  _fx_LN14C_form__cexp_t v_933 = 0;
-                  _fx_N14C_form__ctyp_t v_934 = 0;
-                  _fx_R9Ast__id_t v_935;
-                  fx_str_t slit_201 = FX_MAKE_STR("FX_F32TOF16");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_201, &v_935, 0), _fx_catch_224);
-                  _fx_R9Ast__id_t v_936;
-                  fx_str_t slit_202 = FX_MAKE_STR("FX_BF16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_202, &v_936, 0), _fx_catch_224);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_930), _fx_catch_224);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_931), _fx_catch_224);
+                  _fx_LN14C_form__cexp_t v_952 = 0;
+                  _fx_N14C_form__ctyp_t v_953 = 0;
+                  _fx_N14C_form__cexp_t v_954 = 0;
+                  _fx_LN14C_form__cexp_t v_955 = 0;
+                  _fx_N14C_form__ctyp_t v_956 = 0;
+                  _fx_R9Ast__id_t v_957;
+                  fx_str_t slit_202 = FX_MAKE_STR("FX_F32TOF16");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_202, &v_957, 0), _fx_catch_231);
+                  _fx_R9Ast__id_t v_958;
+                  fx_str_t slit_203 = FX_MAKE_STR("FX_BF16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_203, &v_958, 0), _fx_catch_231);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_952), _fx_catch_231);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_953), _fx_catch_231);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_936, v_930, v_931, &kloc_0, &v_932, 0), _fx_catch_224);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_932, 0, true, &v_933), _fx_catch_224);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_934), _fx_catch_224);
+                        &v_958, v_952, v_953, &kloc_0, &v_954, 0), _fx_catch_231);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_954, 0, true, &v_955), _fx_catch_231);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_956), _fx_catch_231);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_935, v_933, v_934, &kloc_0, &v_916, 0), _fx_catch_224);
+                        &v_957, v_955, v_956, &kloc_0, &v_938, 0), _fx_catch_231);
 
-               _fx_catch_224: ;
-                  if (v_934) {
-                     _fx_free_N14C_form__ctyp_t(&v_934);
+               _fx_catch_231: ;
+                  if (v_956) {
+                     _fx_free_N14C_form__ctyp_t(&v_956);
                   }
-                  if (v_933) {
-                     _fx_free_LN14C_form__cexp_t(&v_933);
+                  if (v_955) {
+                     _fx_free_LN14C_form__cexp_t(&v_955);
                   }
-                  if (v_932) {
-                     _fx_free_N14C_form__cexp_t(&v_932);
+                  if (v_954) {
+                     _fx_free_N14C_form__cexp_t(&v_954);
                   }
-                  if (v_931) {
-                     _fx_free_N14C_form__ctyp_t(&v_931);
+                  if (v_953) {
+                     _fx_free_N14C_form__ctyp_t(&v_953);
                   }
-                  if (v_930) {
-                     _fx_free_LN14C_form__cexp_t(&v_930);
+                  if (v_952) {
+                     _fx_free_LN14C_form__cexp_t(&v_952);
                   }
-                  goto _fx_endmatch_36;
+                  goto _fx_endmatch_39;
                }
             }
          }
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
-            _fx_LN14C_form__cexp_t v_937 = 0;
-            _fx_N14C_form__ctyp_t v_938 = 0;
-            _fx_N14C_form__cexp_t v_939 = 0;
-            _fx_R9Ast__id_t v_940;
-            fx_str_t slit_203 = FX_MAKE_STR("FX_F16TOF32");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_203, &v_940, 0), _fx_catch_225);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_937), _fx_catch_225);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_938), _fx_catch_225);
+            _fx_LN14C_form__cexp_t v_959 = 0;
+            _fx_N14C_form__ctyp_t v_960 = 0;
+            _fx_N14C_form__cexp_t v_961 = 0;
+            _fx_R9Ast__id_t v_962;
+            fx_str_t slit_204 = FX_MAKE_STR("FX_F16TOF32");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_204, &v_962, 0), _fx_catch_232);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_959), _fx_catch_232);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_960), _fx_catch_232);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_940,
-                  v_937, v_938, &kloc_0, &v_939, 0), _fx_catch_225);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_962,
+                  v_959, v_960, &kloc_0, &v_961, 0), _fx_catch_232);
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_939, ctyp_3, &kloc_0,
-                  &v_916), _fx_catch_225);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_961, ctyp_3, &kloc_0,
+                  &v_938), _fx_catch_232);
 
-         _fx_catch_225: ;
-            if (v_939) {
-               _fx_free_N14C_form__cexp_t(&v_939);
+         _fx_catch_232: ;
+            if (v_961) {
+               _fx_free_N14C_form__cexp_t(&v_961);
             }
-            if (v_938) {
-               _fx_free_N14C_form__ctyp_t(&v_938);
+            if (v_960) {
+               _fx_free_N14C_form__ctyp_t(&v_960);
             }
-            if (v_937) {
-               _fx_free_LN14C_form__cexp_t(&v_937);
+            if (v_959) {
+               _fx_free_LN14C_form__cexp_t(&v_959);
             }
-            goto _fx_endmatch_36;
+            goto _fx_endmatch_39;
          }
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 17) {
-            _fx_LN14C_form__cexp_t v_941 = 0;
-            _fx_N14C_form__ctyp_t v_942 = 0;
-            _fx_N14C_form__cexp_t v_943 = 0;
-            _fx_R9Ast__id_t v_944;
-            fx_str_t slit_204 = FX_MAKE_STR("FX_BF16TOF32");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_204, &v_944, 0), _fx_catch_226);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_941), _fx_catch_226);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_942), _fx_catch_226);
+            _fx_LN14C_form__cexp_t v_963 = 0;
+            _fx_N14C_form__ctyp_t v_964 = 0;
+            _fx_N14C_form__cexp_t v_965 = 0;
+            _fx_R9Ast__id_t v_966;
+            fx_str_t slit_205 = FX_MAKE_STR("FX_BF16TOF32");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_205, &v_966, 0), _fx_catch_233);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_963), _fx_catch_233);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_964), _fx_catch_233);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_944,
-                  v_941, v_942, &kloc_0, &v_943, 0), _fx_catch_226);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_966,
+                  v_963, v_964, &kloc_0, &v_965, 0), _fx_catch_233);
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_943, ctyp_3, &kloc_0,
-                  &v_916), _fx_catch_226);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_965, ctyp_3, &kloc_0,
+                  &v_938), _fx_catch_233);
 
-         _fx_catch_226: ;
-            if (v_943) {
-               _fx_free_N14C_form__cexp_t(&v_943);
+         _fx_catch_233: ;
+            if (v_965) {
+               _fx_free_N14C_form__cexp_t(&v_965);
             }
-            if (v_942) {
-               _fx_free_N14C_form__ctyp_t(&v_942);
+            if (v_964) {
+               _fx_free_N14C_form__ctyp_t(&v_964);
             }
-            if (v_941) {
-               _fx_free_LN14C_form__cexp_t(&v_941);
+            if (v_963) {
+               _fx_free_LN14C_form__cexp_t(&v_963);
             }
-            goto _fx_endmatch_36;
+            goto _fx_endmatch_39;
          }
       }
       if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
          if (ctyp_3->u.CTypFloat == 16) {
-            _fx_LN14C_form__cexp_t v_945 = 0;
-            _fx_N14C_form__ctyp_t v_946 = 0;
-            _fx_R9Ast__id_t v_947;
-            fx_str_t slit_205 = FX_MAKE_STR("FX_F32TOF16");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_205, &v_947, 0), _fx_catch_227);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_945), _fx_catch_227);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_946), _fx_catch_227);
+            _fx_LN14C_form__cexp_t v_967 = 0;
+            _fx_N14C_form__ctyp_t v_968 = 0;
+            _fx_R9Ast__id_t v_969;
+            fx_str_t slit_206 = FX_MAKE_STR("FX_F32TOF16");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_206, &v_969, 0), _fx_catch_234);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_967), _fx_catch_234);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_968), _fx_catch_234);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_947,
-                  v_945, v_946, &kloc_0, &v_916, 0), _fx_catch_227);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_969,
+                  v_967, v_968, &kloc_0, &v_938, 0), _fx_catch_234);
 
-         _fx_catch_227: ;
-            if (v_946) {
-               _fx_free_N14C_form__ctyp_t(&v_946);
+         _fx_catch_234: ;
+            if (v_968) {
+               _fx_free_N14C_form__ctyp_t(&v_968);
             }
-            if (v_945) {
-               _fx_free_LN14C_form__cexp_t(&v_945);
+            if (v_967) {
+               _fx_free_LN14C_form__cexp_t(&v_967);
             }
-            goto _fx_endmatch_36;
+            goto _fx_endmatch_39;
          }
       }
       if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
          if (ctyp_3->u.CTypFloat == 17) {
-            _fx_LN14C_form__cexp_t v_948 = 0;
-            _fx_N14C_form__ctyp_t v_949 = 0;
-            _fx_R9Ast__id_t v_950;
-            fx_str_t slit_206 = FX_MAKE_STR("FX_F32TOBF16");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_206, &v_950, 0), _fx_catch_228);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_948), _fx_catch_228);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_949), _fx_catch_228);
+            _fx_LN14C_form__cexp_t v_970 = 0;
+            _fx_N14C_form__ctyp_t v_971 = 0;
+            _fx_R9Ast__id_t v_972;
+            fx_str_t slit_207 = FX_MAKE_STR("FX_F32TOBF16");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_207, &v_972, 0), _fx_catch_235);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_970), _fx_catch_235);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_971), _fx_catch_235);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_950,
-                  v_948, v_949, &kloc_0, &v_916, 0), _fx_catch_228);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_972,
+                  v_970, v_971, &kloc_0, &v_938, 0), _fx_catch_235);
 
-         _fx_catch_228: ;
-            if (v_949) {
-               _fx_free_N14C_form__ctyp_t(&v_949);
+         _fx_catch_235: ;
+            if (v_971) {
+               _fx_free_N14C_form__ctyp_t(&v_971);
             }
-            if (v_948) {
-               _fx_free_LN14C_form__cexp_t(&v_948);
+            if (v_970) {
+               _fx_free_LN14C_form__cexp_t(&v_970);
             }
-            goto _fx_endmatch_36;
+            goto _fx_endmatch_39;
          }
       }
       FX_CALL(
          _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(ce1_9, ctyp_3, &kloc_0,
-            &v_916), _fx_catch_229);
+            &v_938), _fx_catch_236);
 
-   _fx_catch_229: ;
+   _fx_catch_236: ;
 
-   _fx_endmatch_36: ;
-      FX_CHECK_EXN(_fx_catch_230);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_916, ccode_141, &v_1);
+   _fx_endmatch_39: ;
+      FX_CHECK_EXN(_fx_catch_237);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_938, ccode_146, &v_1);
 
-   _fx_catch_230: ;
-      if (v_916) {
-         _fx_free_N14C_form__cexp_t(&v_916);
+   _fx_catch_237: ;
+      if (v_938) {
+         _fx_free_N14C_form__cexp_t(&v_938);
       }
       if (ctyp_3) {
          _fx_free_N14C_form__ctyp_t(&ctyp_3);
@@ -31427,14 +31633,14 @@ static int
       if (atyp_0) {
          _fx_free_N14K_form__ktyp_t(&atyp_0);
       }
-      if (ccode_141) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_141);
+      if (ccode_146) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_146);
       }
       if (ce1_9) {
          _fx_free_N14C_form__cexp_t(&ce1_9);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_915);
-      goto _fx_endmatch_55;
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_937);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 26) {
       _fx_N14C_form__cexp_t map_lbl_0 = 0;
@@ -31443,66 +31649,66 @@ static int
       _fx_ri ndims_ref_0 = 0;
       _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t e_idoml_l_1 = 0;
       _fx_N14C_form__cexp_t glob_status_0 = 0;
-      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_951 = {0};
-      _fx_R16Ast__val_flags_t v_952 = {0};
-      _fx_N14C_form__cexp_t v_953 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_954 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_955 = {0};
+      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_973 = {0};
+      _fx_R16Ast__val_flags_t v_974 = {0};
+      _fx_N14C_form__cexp_t v_975 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_976 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_977 = {0};
       _fx_N14C_form__cexp_t par_status_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_142 = 0;
-      _fx_R16Ast__val_flags_t v_956 = {0};
-      _fx_N14C_form__cexp_t v_957 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_958 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_959 = {0};
+      _fx_LN15C_form__cstmt_t ccode_147 = 0;
+      _fx_R16Ast__val_flags_t v_978 = {0};
+      _fx_N14C_form__cexp_t v_979 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_980 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_981 = {0};
       _fx_N14C_form__cexp_t nested_status_0 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_0 = 0;
-      _fx_N14C_form__cexp_t v_960 = 0;
+      _fx_N14C_form__cexp_t v_982 = 0;
       _fx_N14C_form__cexp_t par_status_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_143 = 0;
+      _fx_LN15C_form__cstmt_t ccode_148 = 0;
       _fx_N14C_form__cexp_t nested_status_1 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_1 = 0;
-      _fx_N14K_form__ktyp_t v_961 = 0;
+      _fx_N14K_form__ktyp_t v_983 = 0;
       _fx_LN14K_form__ktyp_t coll_typs_0 = 0;
       _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t dst_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_144 = 0;
+      _fx_LN15C_form__cstmt_t ccode_149 = 0;
       _fx_LN15C_form__cstmt_t finalize_ccode_0 = 0;
       _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t dst_data_1 = 0;
       _fx_FPTa2LN15C_form__cstmt_t36LN15C_form__cstmt_tiLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14C_form__cexp_tLN14C_form__cexp_trLrR23C_gen_code__block_ctx_tLN15C_form__cstmt_trNt10Hashset__t1R9Ast__id_tLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_tN15Ast__for_make_tLSR10Ast__loc_trrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tBR10Ast__loc_tiN14C_form__cexp_tLN12Ast__scope_trLN15C_form__cstmt_triBBBN14C_form__cexp_tiN14C_form__cexp_tBrirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_tB
          form_map_0 = {0};
-      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_962 = {0};
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_963 = 0;
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_964 = 0;
-      _fx_Ta2LN15C_form__cstmt_t v_965 = {0};
+      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_984 = {0};
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_985 = 0;
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_986 = 0;
+      _fx_Ta2LN15C_form__cstmt_t v_987 = {0};
       _fx_LN15C_form__cstmt_t pre_map_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_1 = 0;
-      _fx_LN14C_form__cexp_t v_966 = 0;
+      _fx_LN14C_form__cexp_t v_988 = 0;
       _fx_N14C_form__cexp_t update_exn_parallel_0 = 0;
-      _fx_N15C_form__cstmt_t v_967 = 0;
+      _fx_N15C_form__cstmt_t v_989 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_2 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_3 = 0;
       _fx_LN14C_form__cexp_t cargs_5 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_968 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_990 = {0};
       _fx_N14C_form__cexp_t t_exp_2 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_4 = 0;
-      _fx_N14C_form__cexp_t v_969 = 0;
-      _fx_LN14C_form__cexp_t v_970 = 0;
-      _fx_LN14C_form__cexp_t v_971 = 0;
+      _fx_N14C_form__cexp_t v_991 = 0;
+      _fx_LN14C_form__cexp_t v_992 = 0;
+      _fx_LN14C_form__cexp_t v_993 = 0;
       _fx_N14C_form__cexp_t call_mktup_1 = 0;
-      _fx_N15C_form__cstmt_t v_972 = 0;
-      _fx_LN15C_form__cstmt_t v_973 = 0;
-      _fx_LN15C_form__cstmt_t v_974 = 0;
+      _fx_N15C_form__cstmt_t v_994 = 0;
+      _fx_LN15C_form__cstmt_t v_995 = 0;
+      _fx_LN15C_form__cstmt_t v_996 = 0;
       _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
          vcase_24 = &kexp_0->u.KExpMap;
       _fx_R16Ast__for_flags_t* flags_0 = &vcase_24->t2;
       _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t e_idoml_l_2 = vcase_24->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &map_lbl_0, 0), _fx_catch_246);
+            &map_lbl_0, 0), _fx_catch_253);
       _fx_R10Ast__loc_t for_loc_0;
-      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_0, 0), _fx_catch_246);
+      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_0, 0), _fx_catch_253);
       _fx_R10Ast__loc_t end_for_loc_0;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_0, 0), _fx_catch_246);
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_0, 0), _fx_catch_253);
       _fx_N15Ast__for_make_t for_flag_make_0 = flags_0->for_flag_make;
       bool need_make_array_0 = for_flag_make_0.tag == 2;
       bool need_make_vec_0 = for_flag_make_0.tag == 5;
@@ -31517,13 +31723,13 @@ static int
       int_ nfors_0;
       FX_CALL(
          _fx_M10C_gen_codeFM8length1_i1LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(e_idoml_l_2, &nfors_0, 0),
-         _fx_catch_246);
+         _fx_catch_253);
       bool pre_alloc_array_0;
       if (!need_make_array_0) {
          pre_alloc_array_0 = false;
       }
       else {
-         FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(256, &decl_inside_for_0, 0), _fx_catch_246);
+         FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(256, &decl_inside_for_0, 0), _fx_catch_253);
          bool __fold_result___4 = true;
          FX_COPY_PTR(e_idoml_l_2, &e_idoml_l_0);
          _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t lst_22 = e_idoml_l_0;
@@ -31531,26 +31737,26 @@ static int
             _fx_N14K_form__kexp_t e_14 = 0;
             _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_0 = 0;
             _fx_LR9Ast__id_t idxl_0 = 0;
-            _fx_LN14K_form__kexp_t v_975 = 0;
-            _fx_Nt10Hashset__t1R9Ast__id_t v_976 = 0;
+            _fx_LN14K_form__kexp_t v_997 = 0;
+            _fx_Nt10Hashset__t1R9Ast__id_t v_998 = 0;
             _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t* __pat___6 = &lst_22->hd;
             FX_COPY_PTR(__pat___6->t0, &e_14);
             FX_COPY_PTR(__pat___6->t1, &idoml_0);
             FX_COPY_PTR(__pat___6->t2, &idxl_0);
-            FX_CALL(_fx_cons_LN14K_form__kexp_t(e_14, 0, true, &v_975), _fx_catch_235);
-            FX_CALL(_fx_M6K_formFM8declaredNt10Hashset__t1R9Ast__id_t2LN14K_form__kexp_ti(v_975, 256, &v_976, 0),
-               _fx_catch_235);
+            FX_CALL(_fx_cons_LN14K_form__kexp_t(e_14, 0, true, &v_997), _fx_catch_242);
+            FX_CALL(_fx_M6K_formFM8declaredNt10Hashset__t1R9Ast__id_t2LN14K_form__kexp_ti(v_997, 256, &v_998, 0),
+               _fx_catch_242);
             FX_CALL(
-               _fx_M10C_gen_codeFM5unionv2Nt10Hashset__t1R9Ast__id_tNt10Hashset__t1R9Ast__id_t(decl_inside_for_0, v_976, 0),
-               _fx_catch_235);
+               _fx_M10C_gen_codeFM5unionv2Nt10Hashset__t1R9Ast__id_tNt10Hashset__t1R9Ast__id_t(decl_inside_for_0, v_998, 0),
+               _fx_catch_242);
             _fx_LR9Ast__id_t lst_23 = idxl_0;
             for (; lst_23; lst_23 = lst_23->tl) {
                _fx_R9Ast__id_t* i_9 = &lst_23->hd;
                FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, i_9, 0),
-                  _fx_catch_231);
+                  _fx_catch_238);
 
-            _fx_catch_231: ;
-               FX_CHECK_EXN(_fx_catch_235);
+            _fx_catch_238: ;
+               FX_CHECK_EXN(_fx_catch_242);
             }
             bool __fold_result___5 = true;
             _fx_LT2R9Ast__id_tN13K_form__dom_t lst_24 = idoml_0;
@@ -31560,20 +31766,20 @@ static int
                _fx_R9Ast__id_t i_10 = __pat___7->t0;
                _fx_copy_N13K_form__dom_t(&__pat___7->t1, &dom_0);
                FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, &i_10, 0),
-                  _fx_catch_234);
+                  _fx_catch_241);
                int tag_28 = dom_0.tag;
-               bool v_977;
+               bool v_999;
                if (tag_28 == 1) {
-                  _fx_N14K_form__atom_t* v_978 = &dom_0.u.DomainElem;
-                  if (v_978->tag == 1) {
-                     _fx_R17K_form__kdefval_t v_979 = {0};
+                  _fx_N14K_form__atom_t* v_1000 = &dom_0.u.DomainElem;
+                  if (v_1000->tag == 1) {
+                     _fx_R17K_form__kdefval_t v_1001 = {0};
                      _fx_R16Ast__val_flags_t kv_flags_0 = {0};
                      _fx_N14K_form__ktyp_t kv_typ_0 = 0;
-                     _fx_R9Ast__id_t* col_0 = &v_978->u.AtomId;
-                     FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(col_0, &kloc_0, &v_979, 0),
-                        _fx_catch_232);
-                     _fx_copy_R16Ast__val_flags_t(&v_979.kv_flags, &kv_flags_0);
-                     FX_COPY_PTR(v_979.kv_typ, &kv_typ_0);
+                     _fx_R9Ast__id_t* col_0 = &v_1000->u.AtomId;
+                     FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(col_0, &kloc_0, &v_1001, 0),
+                        _fx_catch_239);
+                     _fx_copy_R16Ast__val_flags_t(&v_1001.kv_flags, &kv_flags_0);
+                     FX_COPY_PTR(v_1001.kv_typ, &kv_typ_0);
                      bool t_12;
                      if (!kv_flags_0.val_flag_mutable) {
                         int tag_29 = FX_REC_VARIANT_TAG(kv_typ_0);
@@ -31587,43 +31793,43 @@ static int
                         else {
                            res_23 = false;
                         }
-                        FX_CHECK_EXN(_fx_catch_232);
+                        FX_CHECK_EXN(_fx_catch_239);
                         if (res_23) {
-                           t_12 = true; goto _fx_endmatch_37;
+                           t_12 = true; goto _fx_endmatch_40;
                         }
                         t_12 = false;
 
-                     _fx_endmatch_37: ;
-                        FX_CHECK_EXN(_fx_catch_232);
+                     _fx_endmatch_40: ;
+                        FX_CHECK_EXN(_fx_catch_239);
                      }
                      else {
                         t_12 = false;
                      }
                      if (t_12) {
-                        bool v_980;
+                        bool v_1002;
                         FX_CALL(
-                           _fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, col_0, &v_980, 0),
-                           _fx_catch_232);
-                        v_977 = !v_980;
+                           _fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, col_0, &v_1002, 0),
+                           _fx_catch_239);
+                        v_999 = !v_1002;
                      }
                      else {
-                        v_977 = false;
+                        v_999 = false;
                      }
 
-                  _fx_catch_232: ;
+                  _fx_catch_239: ;
                      if (kv_typ_0) {
                         _fx_free_N14K_form__ktyp_t(&kv_typ_0);
                      }
                      _fx_free_R16Ast__val_flags_t(&kv_flags_0);
-                     _fx_free_R17K_form__kdefval_t(&v_979);
-                     goto _fx_endmatch_38;
+                     _fx_free_R17K_form__kdefval_t(&v_1001);
+                     goto _fx_endmatch_41;
                   }
                }
                if (tag_28 == 1) {
-                  _fx_N14K_form__atom_t* v_981 = &dom_0.u.DomainElem;
-                  if (v_981->tag == 2) {
-                     if (v_981->u.AtomLit.tag == 5) {
-                        v_977 = true; goto _fx_endmatch_38;
+                  _fx_N14K_form__atom_t* v_1003 = &dom_0.u.DomainElem;
+                  if (v_1003->tag == 2) {
+                     if (v_1003->u.AtomLit.tag == 5) {
+                        v_999 = true; goto _fx_endmatch_41;
                      }
                   }
                }
@@ -31632,12 +31838,12 @@ static int
                   bool res_24;
                   FX_CALL(
                      _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                        &vcase_25->t0, decl_inside_for_0, &kloc_0, &res_24, 0), _fx_catch_233);
+                        &vcase_25->t0, decl_inside_for_0, &kloc_0, &res_24, 0), _fx_catch_240);
                   bool t_13;
                   if (res_24) {
                      FX_CALL(
                         _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                           &vcase_25->t1, decl_inside_for_0, &kloc_0, &t_13, 0), _fx_catch_233);
+                           &vcase_25->t1, decl_inside_for_0, &kloc_0, &t_13, 0), _fx_catch_240);
                   }
                   else {
                      t_13 = false;
@@ -31645,38 +31851,38 @@ static int
                   if (t_13) {
                      FX_CALL(
                         _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                           &vcase_25->t2, decl_inside_for_0, &kloc_0, &v_977, 0), _fx_catch_233);
+                           &vcase_25->t2, decl_inside_for_0, &kloc_0, &v_999, 0), _fx_catch_240);
                   }
                   else {
-                     v_977 = false;
+                     v_999 = false;
                   }
 
-               _fx_catch_233: ;
-                  goto _fx_endmatch_38;
+               _fx_catch_240: ;
+                  goto _fx_endmatch_41;
                }
-               v_977 = false;
+               v_999 = false;
 
-            _fx_endmatch_38: ;
-               FX_CHECK_EXN(_fx_catch_234);
-               if (!v_977) {
-                  __fold_result___5 = false; FX_BREAK(_fx_catch_234);
+            _fx_endmatch_41: ;
+               FX_CHECK_EXN(_fx_catch_241);
+               if (!v_999) {
+                  __fold_result___5 = false; FX_BREAK(_fx_catch_241);
                }
 
-            _fx_catch_234: ;
+            _fx_catch_241: ;
                _fx_free_N13K_form__dom_t(&dom_0);
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_235);
+               FX_CHECK_EXN(_fx_catch_242);
             }
             if (!__fold_result___5) {
-               __fold_result___4 = false; FX_BREAK(_fx_catch_235);
+               __fold_result___4 = false; FX_BREAK(_fx_catch_242);
             }
 
-         _fx_catch_235: ;
-            if (v_976) {
-               _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_976);
+         _fx_catch_242: ;
+            if (v_998) {
+               _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_998);
             }
-            if (v_975) {
-               _fx_free_LN14K_form__kexp_t(&v_975);
+            if (v_997) {
+               _fx_free_LN14K_form__kexp_t(&v_997);
             }
             FX_FREE_LIST_SIMPLE(&idxl_0);
             if (idoml_0) {
@@ -31686,11 +31892,11 @@ static int
                _fx_free_N14K_form__kexp_t(&e_14);
             }
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_246);
+            FX_CHECK_EXN(_fx_catch_253);
          }
          pre_alloc_array_0 = __fold_result___4;
       }
-      FX_CALL(_fx_make_ri(0, &ndims_ref_0), _fx_catch_246);
+      FX_CALL(_fx_make_ri(0, &ndims_ref_0), _fx_catch_253);
       int_* ndims_3 = &ndims_ref_0->data;
       int_ for_idx_0 = 0;
       FX_COPY_PTR(e_idoml_l_2, &e_idoml_l_1);
@@ -31702,14 +31908,14 @@ static int
          int_ ndims_i_0;
          FX_CALL(
             _fx_M10C_gen_codeFM17compute_for_ndimsi4iiLT2R9Ast__id_tN13K_form__dom_tR10Ast__loc_t(for_idx_0, nfors_0, idoml_1,
-               &for_loc_0, &ndims_i_0, 0), _fx_catch_236);
+               &for_loc_0, &ndims_i_0, 0), _fx_catch_243);
          *ndims_3 = *ndims_3 + ndims_i_0;
 
-      _fx_catch_236: ;
+      _fx_catch_243: ;
          if (idoml_1) {
             _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idoml_1);
          }
-         FX_CHECK_EXN(_fx_catch_246);
+         FX_CHECK_EXN(_fx_catch_253);
       }
       bool is_parallel_map_0;
       if (pre_alloc_array_0) {
@@ -31720,208 +31926,208 @@ static int
       }
       FX_CALL(
          _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(fx_status__0,
-            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_0, 0), _fx_catch_246);
+            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_0, 0), _fx_catch_253);
       if (is_parallel_map_0) {
-         _fx_R9Ast__id_t v_982;
-         fx_str_t slit_207 = FX_MAKE_STR("par_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_207, &v_982, 0), _fx_catch_246);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_952, 0), _fx_catch_246);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_953, 0), _fx_catch_246);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_953, &v_954);
-         fx_str_t slit_208 = FX_MAKE_STR("");
+         _fx_R9Ast__id_t v_1004;
+         fx_str_t slit_208 = FX_MAKE_STR("par_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_208, &v_1004, 0), _fx_catch_253);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_974, 0), _fx_catch_253);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_975, 0), _fx_catch_253);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_975, &v_976);
+         fx_str_t slit_209 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_982, _fx_g20C_gen_code__CTypCInt, &v_952, &slit_208, &v_954, ccode_0, &kloc_0, &v_955, 0), _fx_catch_246);
-         FX_COPY_PTR(v_955.t0, &par_status_0);
-         FX_COPY_PTR(v_955.t1, &ccode_142);
-         _fx_R9Ast__id_t v_983;
-         fx_str_t slit_209 = FX_MAKE_STR("status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_209, &v_983, 0), _fx_catch_246);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_956, 0), _fx_catch_246);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_957, 0), _fx_catch_246);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_957, &v_958);
-         fx_str_t slit_210 = FX_MAKE_STR("fx_status");
+               &v_1004, _fx_g20C_gen_code__CTypCInt, &v_974, &slit_209, &v_976, ccode_0, &kloc_0, &v_977, 0), _fx_catch_253);
+         FX_COPY_PTR(v_977.t0, &par_status_0);
+         FX_COPY_PTR(v_977.t1, &ccode_147);
+         _fx_R9Ast__id_t v_1005;
+         fx_str_t slit_210 = FX_MAKE_STR("status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_210, &v_1005, 0), _fx_catch_253);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_978, 0), _fx_catch_253);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_979, 0), _fx_catch_253);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_979, &v_980);
+         fx_str_t slit_211 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_983, _fx_g20C_gen_code__CTypCInt, &v_956, &slit_210, &v_958, 0, &kloc_0, &v_959, 0), _fx_catch_246);
-         FX_COPY_PTR(v_959.t0, &nested_status_0);
-         FX_COPY_PTR(v_959.t1, &decl_nested_status_0);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_0, ccode_142,
-            nested_status_0, decl_nested_status_0, &v_951);
+               &v_1005, _fx_g20C_gen_code__CTypCInt, &v_978, &slit_211, &v_980, 0, &kloc_0, &v_981, 0), _fx_catch_253);
+         FX_COPY_PTR(v_981.t0, &nested_status_0);
+         FX_COPY_PTR(v_981.t1, &decl_nested_status_0);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_0, ccode_147,
+            nested_status_0, decl_nested_status_0, &v_973);
       }
       else {
-         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_960, 0), _fx_catch_246);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_960, ccode_0, glob_status_0, 0,
-            &v_951);
+         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_982, 0), _fx_catch_253);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_982, ccode_0, glob_status_0, 0,
+            &v_973);
       }
-      FX_COPY_PTR(v_951.t0, &par_status_1);
-      FX_COPY_PTR(v_951.t1, &ccode_143);
-      FX_COPY_PTR(v_951.t2, &nested_status_1);
-      FX_COPY_PTR(v_951.t3, &decl_nested_status_1);
-      FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &for_loc_0, &v_961, 0),
-         _fx_catch_246);
+      FX_COPY_PTR(v_973.t0, &par_status_1);
+      FX_COPY_PTR(v_973.t1, &ccode_148);
+      FX_COPY_PTR(v_973.t2, &nested_status_1);
+      FX_COPY_PTR(v_973.t3, &decl_nested_status_1);
+      FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &for_loc_0, &v_983, 0),
+         _fx_catch_253);
       if (unzip_mode_0 == false) {
-         FX_CALL(_fx_cons_LN14K_form__ktyp_t(ktyp_0, 0, true, &coll_typs_0), _fx_catch_237);
+         FX_CALL(_fx_cons_LN14K_form__ktyp_t(ktyp_0, 0, true, &coll_typs_0), _fx_catch_244);
 
-      _fx_catch_237: ;
-         goto _fx_endmatch_39;
+      _fx_catch_244: ;
+         goto _fx_endmatch_42;
       }
       if (unzip_mode_0 == true) {
-         if (FX_REC_VARIANT_TAG(v_961) == 14) {
-            FX_COPY_PTR(v_961->u.KTypTuple, &coll_typs_0); goto _fx_endmatch_39;
+         if (FX_REC_VARIANT_TAG(v_983) == 14) {
+            FX_COPY_PTR(v_983->u.KTypTuple, &coll_typs_0); goto _fx_endmatch_42;
          }
       }
-      fx_exn_t v_984 = {0};
-      fx_str_t slit_211 = FX_MAKE_STR("cgen: the result of @unzip comprehension should be a tuple");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_211, &v_984, 0), _fx_catch_238);
-      FX_THROW(&v_984, false, _fx_catch_238);
+      fx_exn_t v_1006 = {0};
+      fx_str_t slit_212 = FX_MAKE_STR("cgen: the result of @unzip comprehension should be a tuple");
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_212, &v_1006, 0), _fx_catch_245);
+      FX_THROW(&v_1006, false, _fx_catch_245);
 
-   _fx_catch_238: ;
-      fx_free_exn(&v_984);
+   _fx_catch_245: ;
+      fx_free_exn(&v_1006);
 
-   _fx_endmatch_39: ;
-      FX_CHECK_EXN(_fx_catch_246);
-      FX_COPY_PTR(ccode_143, &ccode_144);
+   _fx_endmatch_42: ;
+      FX_CHECK_EXN(_fx_catch_253);
+      FX_COPY_PTR(ccode_148, &ccode_149);
       _fx_LN14K_form__ktyp_t lst_26 = coll_typs_0;
       for (; lst_26; lst_26 = lst_26->tl) {
          _fx_N14C_form__ctyp_t coll_ctyp_0 = 0;
-         _fx_N14K_form__ktyp_t v_985 = 0;
+         _fx_N14K_form__ktyp_t v_1007 = 0;
          _fx_N14K_form__ktyp_t coll_typ_0 = lst_26->hd;
          FX_CALL(
             _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &coll_ctyp_0,
-               0), _fx_catch_244);
-         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &v_985, 0),
-            _fx_catch_244);
+               0), _fx_catch_251);
+         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &v_1007, 0),
+            _fx_catch_251);
          if (for_flag_make_0.tag == 5) {
-            if (FX_REC_VARIANT_TAG(v_985) == 19) {
+            if (FX_REC_VARIANT_TAG(v_1007) == 19) {
                if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 21) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_986 = {0};
-                  _fx_R16Ast__val_flags_t v_987 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1008 = {0};
+                  _fx_R16Ast__val_flags_t v_1009 = {0};
                   _fx_N14C_form__cexp_t dst_exp_16 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_17 = 0;
-                  _fx_N14C_form__ctyp_t v_988 = 0;
-                  _fx_R16Ast__val_flags_t v_989 = {0};
-                  _fx_N14C_form__cexp_t v_990 = 0;
-                  _fx_Nt6option1N14C_form__cexp_t v_991 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_992 = {0};
+                  _fx_N14C_form__ctyp_t v_1010 = 0;
+                  _fx_R16Ast__val_flags_t v_1011 = {0};
+                  _fx_N14C_form__cexp_t v_1012 = 0;
+                  _fx_Nt6option1N14C_form__cexp_t v_1013 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1014 = {0};
                   _fx_N14C_form__cexp_t dst_ptr_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_2 = 0;
-                  _fx_N14C_form__cexp_t v_993 = 0;
-                  _fx_N14C_form__ctyp_t v_994 = 0;
+                  _fx_N14C_form__cexp_t v_1015 = 0;
+                  _fx_N14C_form__ctyp_t v_1016 = 0;
                   _fx_N14C_form__cexp_t base_0 = 0;
-                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_995 = {0};
+                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1017 = {0};
                   _fx_N14C_form__cexp_t nwritten_0 = 0;
-                  _fx_N14C_form__cexp_t v_996 = 0;
+                  _fx_N14C_form__cexp_t v_1018 = 0;
                   _fx_N14C_form__cexp_t set_size_0 = 0;
-                  _fx_N14C_form__cexp_t v_997 = 0;
-                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_998 = {0};
-                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_999 = 0;
-                  _fx_N15C_form__cstmt_t v_1000 = 0;
-                  _fx_LN15C_form__cstmt_t v_1001 = 0;
+                  _fx_N14C_form__cexp_t v_1019 = 0;
+                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1020 = {0};
+                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1021 = 0;
+                  _fx_N15C_form__cstmt_t v_1022 = 0;
+                  _fx_LN15C_form__cstmt_t v_1023 = 0;
                   _fx_N14C_form__ctyp_t elemtyp_0 = coll_ctyp_0->u.CTypVector;
                   if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_1002;
-                     fx_str_t slit_212 = FX_MAKE_STR("vec");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_212, &v_1002, 0), _fx_catch_239);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_987, 0), _fx_catch_239);
+                     _fx_R9Ast__id_t v_1024;
+                     fx_str_t slit_213 = FX_MAKE_STR("vec");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_213, &v_1024, 0), _fx_catch_246);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1009, 0), _fx_catch_246);
                      FX_CALL(
                         _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_1002, coll_ctyp_0, &v_987, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
-                           &v_986, 0), _fx_catch_239);
+                           &v_1024, coll_ctyp_0, &v_1009, &_fx_g18C_gen_code__None2_, ccode_149, &for_loc_0, block_stack_ref_0,
+                           &v_1008, 0), _fx_catch_246);
                   }
                   else {
-                     fx_str_t slit_213 = FX_MAKE_STR("vec");
+                     fx_str_t slit_214 = FX_MAKE_STR("vec");
                      FX_CALL(
                         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_213, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_986, 0),
-                        _fx_catch_239);
+                           dstexp_r_0, &slit_214, coll_ctyp_0, ccode_149, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1008, 0),
+                        _fx_catch_246);
                   }
-                  FX_COPY_PTR(v_986.t0, &dst_exp_16);
-                  FX_COPY_PTR(v_986.t1, &ccode1_17);
-                  _fx_R9Ast__id_t v_1003;
-                  fx_str_t slit_214 = FX_MAKE_STR("dstptr");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_214, &v_1003, 0), _fx_catch_239);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_988, 0), _fx_catch_239);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_989, 0), _fx_catch_239);
-                  FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_990, 0), _fx_catch_239);
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_990, &v_991);
-                  fx_str_t slit_215 = FX_MAKE_STR("");
+                  FX_COPY_PTR(v_1008.t0, &dst_exp_16);
+                  FX_COPY_PTR(v_1008.t1, &ccode1_17);
+                  _fx_R9Ast__id_t v_1025;
+                  fx_str_t slit_215 = FX_MAKE_STR("dstptr");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_215, &v_1025, 0), _fx_catch_246);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_1010, 0), _fx_catch_246);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1011, 0), _fx_catch_246);
+                  FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1012, 0), _fx_catch_246);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1012, &v_1013);
+                  fx_str_t slit_216 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_1003, v_988, &v_989, &slit_215, &v_991, ccode1_17, &for_loc_0, &v_992, 0), _fx_catch_239);
-                  FX_COPY_PTR(v_992.t0, &dst_ptr_0);
-                  FX_COPY_PTR(v_992.t1, &ccode2_2);
-                  _fx_R9Ast__id_t v_1004;
-                  fx_str_t slit_216 = FX_MAKE_STR("data");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_216, &v_1004, 0), _fx_catch_239);
+                        &v_1025, v_1010, &v_1011, &slit_216, &v_1013, ccode1_17, &for_loc_0, &v_1014, 0), _fx_catch_246);
+                  FX_COPY_PTR(v_1014.t0, &dst_ptr_0);
+                  FX_COPY_PTR(v_1014.t1, &ccode2_2);
+                  _fx_R9Ast__id_t v_1026;
+                  fx_str_t slit_217 = FX_MAKE_STR("data");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_217, &v_1026, 0), _fx_catch_246);
                   FX_CALL(
                      _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
-                        &v_1004, _fx_g23C_form__std_CTypVoidPtr, &v_993, 0), _fx_catch_239);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_994, 0), _fx_catch_239);
+                        &v_1026, _fx_g23C_form__std_CTypVoidPtr, &v_1015, 0), _fx_catch_246);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_1016, 0), _fx_catch_246);
                   FX_CALL(
-                     _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_993, v_994,
-                        &for_loc_0, &base_0), _fx_catch_239);
-                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g19C_gen_code__CTypInt, &for_loc_0, &v_995);
+                     _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_1015, v_1016,
+                        &for_loc_0, &base_0), _fx_catch_246);
+                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g19C_gen_code__CTypInt, &for_loc_0, &v_1017);
                   FX_CALL(
                      _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g18C_gen_code__COpSub, dst_ptr_0, base_0, &v_995, &nwritten_0), _fx_catch_239);
-                  _fx_R9Ast__id_t v_1005;
-                  fx_str_t slit_217 = FX_MAKE_STR("size");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_217, &v_1005, 0), _fx_catch_239);
+                        &_fx_g18C_gen_code__COpSub, dst_ptr_0, base_0, &v_1017, &nwritten_0), _fx_catch_246);
+                  _fx_R9Ast__id_t v_1027;
+                  fx_str_t slit_218 = FX_MAKE_STR("size");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_218, &v_1027, 0), _fx_catch_246);
                   FX_CALL(
                      _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
-                        &v_1005, _fx_g19C_gen_code__CTypInt, &v_996, 0), _fx_catch_239);
+                        &v_1027, _fx_g19C_gen_code__CTypInt, &v_1018, 0), _fx_catch_246);
                   FX_CALL(
-                     _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_996, nwritten_0,
-                        &set_size_0, 0), _fx_catch_239);
-                  FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_997, 0), _fx_catch_239);
+                     _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1018, nwritten_0,
+                        &set_size_0, 0), _fx_catch_246);
+                  FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1019, 0), _fx_catch_246);
                   _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                     elemtyp_0, dst_exp_16, dst_ptr_0, v_997, &v_998);
+                     elemtyp_0, dst_exp_16, dst_ptr_0, v_1019, &v_1020);
                   FX_CALL(
-                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_998,
-                        dst_data_0, true, &v_999), _fx_catch_239);
+                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1020,
+                        dst_data_0, true, &v_1021), _fx_catch_246);
                   _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
                      &dst_data_0);
-                  FX_COPY_PTR(v_999, &dst_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_144);
-                  FX_COPY_PTR(ccode2_2, &ccode_144);
-                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(set_size_0, &v_1000), _fx_catch_239);
-                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1000, finalize_ccode_0, true, &v_1001), _fx_catch_239);
+                  FX_COPY_PTR(v_1021, &dst_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_149);
+                  FX_COPY_PTR(ccode2_2, &ccode_149);
+                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(set_size_0, &v_1022), _fx_catch_246);
+                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1022, finalize_ccode_0, true, &v_1023), _fx_catch_246);
                   _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
-                  FX_COPY_PTR(v_1001, &finalize_ccode_0);
+                  FX_COPY_PTR(v_1023, &finalize_ccode_0);
 
-               _fx_catch_239: ;
-                  if (v_1001) {
-                     _fx_free_LN15C_form__cstmt_t(&v_1001);
+               _fx_catch_246: ;
+                  if (v_1023) {
+                     _fx_free_LN15C_form__cstmt_t(&v_1023);
                   }
-                  if (v_1000) {
-                     _fx_free_N15C_form__cstmt_t(&v_1000);
+                  if (v_1022) {
+                     _fx_free_N15C_form__cstmt_t(&v_1022);
                   }
-                  if (v_999) {
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_999);
+                  if (v_1021) {
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1021);
                   }
-                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_998);
-                  if (v_997) {
-                     _fx_free_N14C_form__cexp_t(&v_997);
+                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1020);
+                  if (v_1019) {
+                     _fx_free_N14C_form__cexp_t(&v_1019);
                   }
                   if (set_size_0) {
                      _fx_free_N14C_form__cexp_t(&set_size_0);
                   }
-                  if (v_996) {
-                     _fx_free_N14C_form__cexp_t(&v_996);
+                  if (v_1018) {
+                     _fx_free_N14C_form__cexp_t(&v_1018);
                   }
                   if (nwritten_0) {
                      _fx_free_N14C_form__cexp_t(&nwritten_0);
                   }
-                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_995);
+                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1017);
                   if (base_0) {
                      _fx_free_N14C_form__cexp_t(&base_0);
                   }
-                  if (v_994) {
-                     _fx_free_N14C_form__ctyp_t(&v_994);
+                  if (v_1016) {
+                     _fx_free_N14C_form__ctyp_t(&v_1016);
                   }
-                  if (v_993) {
-                     _fx_free_N14C_form__cexp_t(&v_993);
+                  if (v_1015) {
+                     _fx_free_N14C_form__cexp_t(&v_1015);
                   }
                   if (ccode2_2) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_2);
@@ -31929,137 +32135,7 @@ static int
                   if (dst_ptr_0) {
                      _fx_free_N14C_form__cexp_t(&dst_ptr_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_992);
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_991);
-                  if (v_990) {
-                     _fx_free_N14C_form__cexp_t(&v_990);
-                  }
-                  _fx_free_R16Ast__val_flags_t(&v_989);
-                  if (v_988) {
-                     _fx_free_N14C_form__ctyp_t(&v_988);
-                  }
-                  if (ccode1_17) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode1_17);
-                  }
-                  if (dst_exp_16) {
-                     _fx_free_N14C_form__cexp_t(&dst_exp_16);
-                  }
-                  _fx_free_R16Ast__val_flags_t(&v_987);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_986);
-                  goto _fx_endmatch_40;
-               }
-            }
-         }
-         if (for_flag_make_0.tag == 2) {
-            if (FX_REC_VARIANT_TAG(v_985) == 17) {
-               if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 19) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1006 = {0};
-                  _fx_R16Ast__val_flags_t v_1007 = {0};
-                  _fx_N14C_form__cexp_t dst_exp_17 = 0;
-                  _fx_LN15C_form__cstmt_t ccode1_18 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1008 = {0};
-                  _fx_N14C_form__cexp_t v_1009 = 0;
-                  _fx_N14C_form__ctyp_t v_1010 = 0;
-                  _fx_R16Ast__val_flags_t v_1011 = {0};
-                  _fx_N14C_form__cexp_t v_1012 = 0;
-                  _fx_Nt6option1N14C_form__cexp_t v_1013 = {0};
-                  _fx_N14C_form__cexp_t dst_ptr_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode2_3 = 0;
-                  fx_str_t v_1014 = {0};
-                  fx_str_t v_1015 = {0};
-                  fx_str_t v_1016 = {0};
-                  fx_exn_t v_1017 = {0};
-                  _fx_N14C_form__cexp_t v_1018 = 0;
-                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1019 = {0};
-                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1020 = 0;
-                  _fx_T2iN14C_form__ctyp_t* vcase_26 = &coll_ctyp_0->u.CTypArray;
-                  _fx_N14C_form__ctyp_t elemtyp_1 = vcase_26->t1;
-                  int_ nd_0 = vcase_26->t0;
-                  if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_1021;
-                     fx_str_t slit_218 = FX_MAKE_STR("arr");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_218, &v_1021, 0), _fx_catch_240);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1007, 0), _fx_catch_240);
-                     FX_CALL(
-                        _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_1021, coll_ctyp_0, &v_1007, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
-                           &v_1006, 0), _fx_catch_240);
-                  }
-                  else {
-                     fx_str_t slit_219 = FX_MAKE_STR("arr");
-                     FX_CALL(
-                        _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_219, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1006, 0),
-                        _fx_catch_240);
-                  }
-                  FX_COPY_PTR(v_1006.t0, &dst_exp_17);
-                  FX_COPY_PTR(v_1006.t1, &ccode1_18);
-                  if (is_parallel_map_0) {
-                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1009, 0), _fx_catch_240);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1009, ccode1_18, &v_1008);
-                  }
-                  else {
-                     _fx_R9Ast__id_t v_1022;
-                     fx_str_t slit_220 = FX_MAKE_STR("dstptr");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_220, &v_1022, 0), _fx_catch_240);
-                     FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_1, &v_1010, 0), _fx_catch_240);
-                     FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1011, 0), _fx_catch_240);
-                     FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1012, 0),
-                        _fx_catch_240);
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1012, &v_1013);
-                     fx_str_t slit_221 = FX_MAKE_STR("");
-                     FX_CALL(
-                        _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                           &v_1022, v_1010, &v_1011, &slit_221, &v_1013, ccode1_18, &for_loc_0, &v_1008, 0), _fx_catch_240);
-                  }
-                  FX_COPY_PTR(v_1008.t0, &dst_ptr_1);
-                  FX_COPY_PTR(v_1008.t1, &ccode2_3);
-                  if (nd_0 != *ndims_3) {
-                     FX_CALL(_fx_F6stringS1i(*ndims_3, &v_1014, 0), _fx_catch_240);
-                     FX_CALL(_fx_F6stringS1i(nd_0, &v_1015, 0), _fx_catch_240);
-                     fx_str_t slit_222 = FX_MAKE_STR("cgen: invalid dimensionaly of array comprehension result (computed: ");
-                     fx_str_t slit_223 = FX_MAKE_STR(", expected: ");
-                     fx_str_t slit_224 = FX_MAKE_STR(")");
-                     {
-                        const fx_str_t strs_34[] = { slit_222, v_1014, slit_223, v_1015, slit_224 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_34, 5, &v_1016), _fx_catch_240);
-                     }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1016, &v_1017, 0), _fx_catch_240);
-                     FX_THROW(&v_1017, false, _fx_catch_240);
-                  }
-                  else {
-                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1018, 0),
-                        _fx_catch_240);
-                     _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                        coll_ctyp_0, elemtyp_1, dst_exp_17, dst_ptr_1, v_1018, &v_1019);
-                     FX_CALL(
-                        _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                           &v_1019, dst_data_0, true, &v_1020), _fx_catch_240);
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                        &dst_data_0);
-                     FX_COPY_PTR(v_1020, &dst_data_0);
-                     _fx_free_LN15C_form__cstmt_t(&ccode_144);
-                     FX_COPY_PTR(ccode2_3, &ccode_144);
-                  }
-
-               _fx_catch_240: ;
-                  if (v_1020) {
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1020);
-                  }
-                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1019);
-                  if (v_1018) {
-                     _fx_free_N14C_form__cexp_t(&v_1018);
-                  }
-                  fx_free_exn(&v_1017);
-                  FX_FREE_STR(&v_1016);
-                  FX_FREE_STR(&v_1015);
-                  FX_FREE_STR(&v_1014);
-                  if (ccode2_3) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode2_3);
-                  }
-                  if (dst_ptr_1) {
-                     _fx_free_N14C_form__cexp_t(&dst_ptr_1);
-                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1014);
                   _fx_free_Nt6option1N14C_form__cexp_t(&v_1013);
                   if (v_1012) {
                      _fx_free_N14C_form__cexp_t(&v_1012);
@@ -32068,160 +32144,290 @@ static int
                   if (v_1010) {
                      _fx_free_N14C_form__ctyp_t(&v_1010);
                   }
-                  if (v_1009) {
-                     _fx_free_N14C_form__cexp_t(&v_1009);
+                  if (ccode1_17) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode1_17);
                   }
+                  if (dst_exp_16) {
+                     _fx_free_N14C_form__cexp_t(&dst_exp_16);
+                  }
+                  _fx_free_R16Ast__val_flags_t(&v_1009);
                   _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1008);
+                  goto _fx_endmatch_43;
+               }
+            }
+         }
+         if (for_flag_make_0.tag == 2) {
+            if (FX_REC_VARIANT_TAG(v_1007) == 17) {
+               if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 19) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1028 = {0};
+                  _fx_R16Ast__val_flags_t v_1029 = {0};
+                  _fx_N14C_form__cexp_t dst_exp_17 = 0;
+                  _fx_LN15C_form__cstmt_t ccode1_18 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1030 = {0};
+                  _fx_N14C_form__cexp_t v_1031 = 0;
+                  _fx_N14C_form__ctyp_t v_1032 = 0;
+                  _fx_R16Ast__val_flags_t v_1033 = {0};
+                  _fx_N14C_form__cexp_t v_1034 = 0;
+                  _fx_Nt6option1N14C_form__cexp_t v_1035 = {0};
+                  _fx_N14C_form__cexp_t dst_ptr_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode2_3 = 0;
+                  fx_str_t v_1036 = {0};
+                  fx_str_t v_1037 = {0};
+                  fx_str_t v_1038 = {0};
+                  fx_exn_t v_1039 = {0};
+                  _fx_N14C_form__cexp_t v_1040 = 0;
+                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1041 = {0};
+                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1042 = 0;
+                  _fx_T2iN14C_form__ctyp_t* vcase_26 = &coll_ctyp_0->u.CTypArray;
+                  _fx_N14C_form__ctyp_t elemtyp_1 = vcase_26->t1;
+                  int_ nd_0 = vcase_26->t0;
+                  if (unzip_mode_0) {
+                     _fx_R9Ast__id_t v_1043;
+                     fx_str_t slit_219 = FX_MAKE_STR("arr");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_219, &v_1043, 0), _fx_catch_247);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1029, 0), _fx_catch_247);
+                     FX_CALL(
+                        _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+                           &v_1043, coll_ctyp_0, &v_1029, &_fx_g18C_gen_code__None2_, ccode_149, &for_loc_0, block_stack_ref_0,
+                           &v_1028, 0), _fx_catch_247);
+                  }
+                  else {
+                     fx_str_t slit_220 = FX_MAKE_STR("arr");
+                     FX_CALL(
+                        _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+                           dstexp_r_0, &slit_220, coll_ctyp_0, ccode_149, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1028, 0),
+                        _fx_catch_247);
+                  }
+                  FX_COPY_PTR(v_1028.t0, &dst_exp_17);
+                  FX_COPY_PTR(v_1028.t1, &ccode1_18);
+                  if (is_parallel_map_0) {
+                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1031, 0), _fx_catch_247);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1031, ccode1_18, &v_1030);
+                  }
+                  else {
+                     _fx_R9Ast__id_t v_1044;
+                     fx_str_t slit_221 = FX_MAKE_STR("dstptr");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_221, &v_1044, 0), _fx_catch_247);
+                     FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_1, &v_1032, 0), _fx_catch_247);
+                     FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1033, 0), _fx_catch_247);
+                     FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1034, 0),
+                        _fx_catch_247);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1034, &v_1035);
+                     fx_str_t slit_222 = FX_MAKE_STR("");
+                     FX_CALL(
+                        _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+                           &v_1044, v_1032, &v_1033, &slit_222, &v_1035, ccode1_18, &for_loc_0, &v_1030, 0), _fx_catch_247);
+                  }
+                  FX_COPY_PTR(v_1030.t0, &dst_ptr_1);
+                  FX_COPY_PTR(v_1030.t1, &ccode2_3);
+                  if (nd_0 != *ndims_3) {
+                     FX_CALL(_fx_F6stringS1i(*ndims_3, &v_1036, 0), _fx_catch_247);
+                     FX_CALL(_fx_F6stringS1i(nd_0, &v_1037, 0), _fx_catch_247);
+                     fx_str_t slit_223 = FX_MAKE_STR("cgen: invalid dimensionaly of array comprehension result (computed: ");
+                     fx_str_t slit_224 = FX_MAKE_STR(", expected: ");
+                     fx_str_t slit_225 = FX_MAKE_STR(")");
+                     {
+                        const fx_str_t strs_34[] = { slit_223, v_1036, slit_224, v_1037, slit_225 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_34, 5, &v_1038), _fx_catch_247);
+                     }
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1038, &v_1039, 0), _fx_catch_247);
+                     FX_THROW(&v_1039, false, _fx_catch_247);
+                  }
+                  else {
+                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1040, 0),
+                        _fx_catch_247);
+                     _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                        coll_ctyp_0, elemtyp_1, dst_exp_17, dst_ptr_1, v_1040, &v_1041);
+                     FX_CALL(
+                        _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                           &v_1041, dst_data_0, true, &v_1042), _fx_catch_247);
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                        &dst_data_0);
+                     FX_COPY_PTR(v_1042, &dst_data_0);
+                     _fx_free_LN15C_form__cstmt_t(&ccode_149);
+                     FX_COPY_PTR(ccode2_3, &ccode_149);
+                  }
+
+               _fx_catch_247: ;
+                  if (v_1042) {
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1042);
+                  }
+                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1041);
+                  if (v_1040) {
+                     _fx_free_N14C_form__cexp_t(&v_1040);
+                  }
+                  fx_free_exn(&v_1039);
+                  FX_FREE_STR(&v_1038);
+                  FX_FREE_STR(&v_1037);
+                  FX_FREE_STR(&v_1036);
+                  if (ccode2_3) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode2_3);
+                  }
+                  if (dst_ptr_1) {
+                     _fx_free_N14C_form__cexp_t(&dst_ptr_1);
+                  }
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1035);
+                  if (v_1034) {
+                     _fx_free_N14C_form__cexp_t(&v_1034);
+                  }
+                  _fx_free_R16Ast__val_flags_t(&v_1033);
+                  if (v_1032) {
+                     _fx_free_N14C_form__ctyp_t(&v_1032);
+                  }
+                  if (v_1031) {
+                     _fx_free_N14C_form__cexp_t(&v_1031);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1030);
                   if (ccode1_18) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_18);
                   }
                   if (dst_exp_17) {
                      _fx_free_N14C_form__cexp_t(&dst_exp_17);
                   }
-                  _fx_free_R16Ast__val_flags_t(&v_1007);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1006);
-                  goto _fx_endmatch_40;
+                  _fx_free_R16Ast__val_flags_t(&v_1029);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1028);
+                  goto _fx_endmatch_43;
                }
             }
          }
          if (for_flag_make_0.tag == 4) {
-            if (FX_REC_VARIANT_TAG(v_985) == 18) {
+            if (FX_REC_VARIANT_TAG(v_1007) == 18) {
                if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 20) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1023 = {0};
-                  _fx_R16Ast__val_flags_t v_1024 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1045 = {0};
+                  _fx_R16Ast__val_flags_t v_1046 = {0};
                   _fx_N14C_form__cexp_t dst_exp_18 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_19 = 0;
-                  _fx_Ta3N14C_form__cexp_t v_1025 = {0};
+                  _fx_Ta3N14C_form__cexp_t v_1047 = {0};
                   _fx_N14C_form__cexp_t sizeof_elem_exp_3 = 0;
                   _fx_N14C_form__cexp_t free_f_exp_3 = 0;
                   _fx_N14C_form__cexp_t copy_f_exp_3 = 0;
                   _fx_N14C_form__ctyp_t iter_t_0 = 0;
-                  _fx_R16Ast__val_flags_t v_1026 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1027 = {0};
+                  _fx_R16Ast__val_flags_t v_1048 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1049 = {0};
                   _fx_N14C_form__cexp_t iter_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_4 = 0;
-                  _fx_N14C_form__cexp_t v_1028 = 0;
-                  _fx_LN14C_form__cexp_t v_1029 = 0;
+                  _fx_N14C_form__cexp_t v_1050 = 0;
+                  _fx_LN14C_form__cexp_t v_1051 = 0;
                   _fx_N14C_form__cexp_t call_start_write_0 = 0;
-                  _fx_N14C_form__ctyp_t v_1030 = 0;
-                  _fx_R16Ast__val_flags_t v_1031 = {0};
-                  _fx_Nt6option1N14C_form__cexp_t v_1032 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1033 = {0};
+                  _fx_N14C_form__ctyp_t v_1052 = 0;
+                  _fx_R16Ast__val_flags_t v_1053 = {0};
+                  _fx_Nt6option1N14C_form__cexp_t v_1054 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1055 = {0};
                   _fx_N14C_form__cexp_t dst_ptr_2 = 0;
                   _fx_LN15C_form__cstmt_t ccode3_1 = 0;
-                  _fx_LN14C_form__cexp_t v_1034 = 0;
+                  _fx_LN14C_form__cexp_t v_1056 = 0;
                   _fx_N14C_form__cexp_t call_end_write_0 = 0;
-                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1035 = {0};
-                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1036 = 0;
-                  _fx_N15C_form__cstmt_t v_1037 = 0;
-                  _fx_LN15C_form__cstmt_t v_1038 = 0;
+                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1057 = {0};
+                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1058 = 0;
+                  _fx_N15C_form__cstmt_t v_1059 = 0;
+                  _fx_LN15C_form__cstmt_t v_1060 = 0;
                   _fx_N14C_form__ctyp_t elemtyp_2 = coll_ctyp_0->u.CTypRRBVec;
                   if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_1039;
-                     fx_str_t slit_225 = FX_MAKE_STR("vec");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_225, &v_1039, 0), _fx_catch_241);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1024, 0), _fx_catch_241);
+                     _fx_R9Ast__id_t v_1061;
+                     fx_str_t slit_226 = FX_MAKE_STR("vec");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_226, &v_1061, 0), _fx_catch_248);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1046, 0), _fx_catch_248);
                      FX_CALL(
                         _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_1039, coll_ctyp_0, &v_1024, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
-                           &v_1023, 0), _fx_catch_241);
+                           &v_1061, coll_ctyp_0, &v_1046, &_fx_g18C_gen_code__None2_, ccode_149, &for_loc_0, block_stack_ref_0,
+                           &v_1045, 0), _fx_catch_248);
                   }
                   else {
-                     fx_str_t slit_226 = FX_MAKE_STR("vec");
+                     fx_str_t slit_227 = FX_MAKE_STR("vec");
                      FX_CALL(
                         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_226, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1023, 0),
-                        _fx_catch_241);
+                           dstexp_r_0, &slit_227, coll_ctyp_0, ccode_149, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1045, 0),
+                        _fx_catch_248);
                   }
-                  FX_COPY_PTR(v_1023.t0, &dst_exp_18);
-                  FX_COPY_PTR(v_1023.t1, &ccode1_19);
+                  FX_COPY_PTR(v_1045.t0, &dst_exp_18);
+                  FX_COPY_PTR(v_1045.t1, &ccode1_19);
                   FX_CALL(
                      _fx_M10C_gen_codeFM23get_elem_size_free_copyTa3N14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2,
-                        &for_loc_0, &v_1025, 0), _fx_catch_241);
-                  FX_COPY_PTR(v_1025.t0, &sizeof_elem_exp_3);
-                  FX_COPY_PTR(v_1025.t1, &free_f_exp_3);
-                  FX_COPY_PTR(v_1025.t2, &copy_f_exp_3);
-                  _fx_R9Ast__id_t v_1040;
-                  fx_str_t slit_227 = FX_MAKE_STR("fx_rrbiter_t");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_227, &v_1040, 0), _fx_catch_241);
-                  FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1040, &iter_t_0), _fx_catch_241);
-                  _fx_R9Ast__id_t v_1041;
-                  fx_str_t slit_228 = FX_MAKE_STR("iter");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_228, &v_1041, 0), _fx_catch_241);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1026, 0), _fx_catch_241);
-                  fx_str_t slit_229 = FX_MAKE_STR("");
+                        &for_loc_0, &v_1047, 0), _fx_catch_248);
+                  FX_COPY_PTR(v_1047.t0, &sizeof_elem_exp_3);
+                  FX_COPY_PTR(v_1047.t1, &free_f_exp_3);
+                  FX_COPY_PTR(v_1047.t2, &copy_f_exp_3);
+                  _fx_R9Ast__id_t v_1062;
+                  fx_str_t slit_228 = FX_MAKE_STR("fx_rrbiter_t");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_228, &v_1062, 0), _fx_catch_248);
+                  FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1062, &iter_t_0), _fx_catch_248);
+                  _fx_R9Ast__id_t v_1063;
+                  fx_str_t slit_229 = FX_MAKE_STR("iter");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_229, &v_1063, 0), _fx_catch_248);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1048, 0), _fx_catch_248);
+                  fx_str_t slit_230 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_1041, iter_t_0, &v_1026, &slit_229, &_fx_g18C_gen_code__None2_, ccode1_19, &for_loc_0, &v_1027, 0),
-                     _fx_catch_241);
-                  FX_COPY_PTR(v_1027.t0, &iter_exp_0);
-                  FX_COPY_PTR(v_1027.t1, &ccode2_4);
-                  _fx_R9Ast__id_t v_1042;
-                  fx_str_t slit_230 = FX_MAKE_STR("FX_RRB_START_WRITE");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_230, &v_1042, 0), _fx_catch_241);
+                        &v_1063, iter_t_0, &v_1048, &slit_230, &_fx_g18C_gen_code__None2_, ccode1_19, &for_loc_0, &v_1049, 0),
+                     _fx_catch_248);
+                  FX_COPY_PTR(v_1049.t0, &iter_exp_0);
+                  FX_COPY_PTR(v_1049.t1, &ccode2_4);
+                  _fx_R9Ast__id_t v_1064;
+                  fx_str_t slit_231 = FX_MAKE_STR("FX_RRB_START_WRITE");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_231, &v_1064, 0), _fx_catch_248);
                   FX_CALL(
-                     _fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2, &for_loc_0, &v_1028),
-                     _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, 0, true, &v_1029), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_exp_18, v_1029, false, &v_1029), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_3, v_1029, false, &v_1029), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_3, v_1029, false, &v_1029), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_3, v_1029, false, &v_1029), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1028, v_1029, false, &v_1029), _fx_catch_241);
+                     _fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2, &for_loc_0, &v_1050),
+                     _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, 0, true, &v_1051), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_exp_18, v_1051, false, &v_1051), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_3, v_1051, false, &v_1051), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_3, v_1051, false, &v_1051), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_3, v_1051, false, &v_1051), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1050, v_1051, false, &v_1051), _fx_catch_248);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_1042, v_1029, _fx_g23C_form__std_CTypVoidPtr, &for_loc_0, &call_start_write_0, 0), _fx_catch_241);
-                  _fx_R9Ast__id_t v_1043;
-                  fx_str_t slit_231 = FX_MAKE_STR("dstptr");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_231, &v_1043, 0), _fx_catch_241);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_2, &v_1030, 0), _fx_catch_241);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1031, 0), _fx_catch_241);
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(call_start_write_0, &v_1032);
-                  fx_str_t slit_232 = FX_MAKE_STR("");
+                        &v_1064, v_1051, _fx_g23C_form__std_CTypVoidPtr, &for_loc_0, &call_start_write_0, 0), _fx_catch_248);
+                  _fx_R9Ast__id_t v_1065;
+                  fx_str_t slit_232 = FX_MAKE_STR("dstptr");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_232, &v_1065, 0), _fx_catch_248);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_2, &v_1052, 0), _fx_catch_248);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1053, 0), _fx_catch_248);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(call_start_write_0, &v_1054);
+                  fx_str_t slit_233 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_1043, v_1030, &v_1031, &slit_232, &v_1032, ccode2_4, &for_loc_0, &v_1033, 0), _fx_catch_241);
-                  FX_COPY_PTR(v_1033.t0, &dst_ptr_2);
-                  FX_COPY_PTR(v_1033.t1, &ccode3_1);
-                  _fx_R9Ast__id_t v_1044;
-                  fx_str_t slit_233 = FX_MAKE_STR("FX_RRB_END_WRITE");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_233, &v_1044, 0), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_ptr_2, 0, true, &v_1034), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, v_1034, false, &v_1034), _fx_catch_241);
+                        &v_1065, v_1052, &v_1053, &slit_233, &v_1054, ccode2_4, &for_loc_0, &v_1055, 0), _fx_catch_248);
+                  FX_COPY_PTR(v_1055.t0, &dst_ptr_2);
+                  FX_COPY_PTR(v_1055.t1, &ccode3_1);
+                  _fx_R9Ast__id_t v_1066;
+                  fx_str_t slit_234 = FX_MAKE_STR("FX_RRB_END_WRITE");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_234, &v_1066, 0), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_ptr_2, 0, true, &v_1056), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, v_1056, false, &v_1056), _fx_catch_248);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_1044, v_1034, _fx_g20C_gen_code__CTypVoid, &for_loc_0, &call_end_write_0, 0), _fx_catch_241);
+                        &v_1066, v_1056, _fx_g20C_gen_code__CTypVoid, &for_loc_0, &call_end_write_0, 0), _fx_catch_248);
                   _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                     elemtyp_2, dst_exp_18, dst_ptr_2, iter_exp_0, &v_1035);
+                     elemtyp_2, dst_exp_18, dst_ptr_2, iter_exp_0, &v_1057);
                   FX_CALL(
-                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1035,
-                        dst_data_0, true, &v_1036), _fx_catch_241);
+                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1057,
+                        dst_data_0, true, &v_1058), _fx_catch_248);
                   _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
                      &dst_data_0);
-                  FX_COPY_PTR(v_1036, &dst_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_144);
-                  FX_COPY_PTR(ccode3_1, &ccode_144);
-                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_end_write_0, &v_1037), _fx_catch_241);
-                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1037, finalize_ccode_0, true, &v_1038), _fx_catch_241);
+                  FX_COPY_PTR(v_1058, &dst_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_149);
+                  FX_COPY_PTR(ccode3_1, &ccode_149);
+                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_end_write_0, &v_1059), _fx_catch_248);
+                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1059, finalize_ccode_0, true, &v_1060), _fx_catch_248);
                   _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
-                  FX_COPY_PTR(v_1038, &finalize_ccode_0);
+                  FX_COPY_PTR(v_1060, &finalize_ccode_0);
 
-               _fx_catch_241: ;
-                  if (v_1038) {
-                     _fx_free_LN15C_form__cstmt_t(&v_1038);
+               _fx_catch_248: ;
+                  if (v_1060) {
+                     _fx_free_LN15C_form__cstmt_t(&v_1060);
                   }
-                  if (v_1037) {
-                     _fx_free_N15C_form__cstmt_t(&v_1037);
+                  if (v_1059) {
+                     _fx_free_N15C_form__cstmt_t(&v_1059);
                   }
-                  if (v_1036) {
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1036);
+                  if (v_1058) {
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1058);
                   }
-                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1035);
+                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1057);
                   if (call_end_write_0) {
                      _fx_free_N14C_form__cexp_t(&call_end_write_0);
                   }
-                  if (v_1034) {
-                     _fx_free_LN14C_form__cexp_t(&v_1034);
+                  if (v_1056) {
+                     _fx_free_LN14C_form__cexp_t(&v_1056);
                   }
                   if (ccode3_1) {
                      _fx_free_LN15C_form__cstmt_t(&ccode3_1);
@@ -32229,20 +32435,20 @@ static int
                   if (dst_ptr_2) {
                      _fx_free_N14C_form__cexp_t(&dst_ptr_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1033);
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1032);
-                  _fx_free_R16Ast__val_flags_t(&v_1031);
-                  if (v_1030) {
-                     _fx_free_N14C_form__ctyp_t(&v_1030);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1055);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1054);
+                  _fx_free_R16Ast__val_flags_t(&v_1053);
+                  if (v_1052) {
+                     _fx_free_N14C_form__ctyp_t(&v_1052);
                   }
                   if (call_start_write_0) {
                      _fx_free_N14C_form__cexp_t(&call_start_write_0);
                   }
-                  if (v_1029) {
-                     _fx_free_LN14C_form__cexp_t(&v_1029);
+                  if (v_1051) {
+                     _fx_free_LN14C_form__cexp_t(&v_1051);
                   }
-                  if (v_1028) {
-                     _fx_free_N14C_form__cexp_t(&v_1028);
+                  if (v_1050) {
+                     _fx_free_N14C_form__cexp_t(&v_1050);
                   }
                   if (ccode2_4) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_4);
@@ -32250,8 +32456,8 @@ static int
                   if (iter_exp_0) {
                      _fx_free_N14C_form__cexp_t(&iter_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1027);
-                  _fx_free_R16Ast__val_flags_t(&v_1026);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1049);
+                  _fx_free_R16Ast__val_flags_t(&v_1048);
                   if (iter_t_0) {
                      _fx_free_N14C_form__ctyp_t(&iter_t_0);
                   }
@@ -32264,87 +32470,87 @@ static int
                   if (sizeof_elem_exp_3) {
                      _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_3);
                   }
-                  _fx_free_Ta3N14C_form__cexp_t(&v_1025);
+                  _fx_free_Ta3N14C_form__cexp_t(&v_1047);
                   if (ccode1_19) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_19);
                   }
                   if (dst_exp_18) {
                      _fx_free_N14C_form__cexp_t(&dst_exp_18);
                   }
-                  _fx_free_R16Ast__val_flags_t(&v_1024);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1023);
-                  goto _fx_endmatch_40;
+                  _fx_free_R16Ast__val_flags_t(&v_1046);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1045);
+                  goto _fx_endmatch_43;
                }
             }
          }
          if (for_flag_make_0.tag == 3) {
-            if (FX_REC_VARIANT_TAG(v_985) == 20) {
+            if (FX_REC_VARIANT_TAG(v_1007) == 20) {
                _fx_N14C_form__ctyp_t elemtyp_3 = 0;
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1045 = {0};
-               _fx_R16Ast__val_flags_t v_1046 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1067 = {0};
+               _fx_R16Ast__val_flags_t v_1068 = {0};
                _fx_N14C_form__cexp_t dst_exp_19 = 0;
                _fx_LN15C_form__cstmt_t ccode1_20 = 0;
-               _fx_R16Ast__val_flags_t v_1047 = {0};
-               _fx_N14C_form__cexp_t v_1048 = 0;
-               _fx_Nt6option1N14C_form__cexp_t v_1049 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1050 = {0};
+               _fx_R16Ast__val_flags_t v_1069 = {0};
+               _fx_N14C_form__cexp_t v_1070 = 0;
+               _fx_Nt6option1N14C_form__cexp_t v_1071 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1072 = {0};
                _fx_N14C_form__cexp_t lst_end_0 = 0;
                _fx_LN15C_form__cstmt_t ccode2_5 = 0;
-               _fx_N14C_form__cexp_t v_1051 = 0;
-               _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1052 = {0};
-               _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1053 = 0;
+               _fx_N14C_form__cexp_t v_1073 = 0;
+               _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1074 = {0};
+               _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1075 = 0;
                FX_CALL(
-                  _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_985->u.KTypList, &for_loc_0,
-                     &elemtyp_3, 0), _fx_catch_242);
+                  _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_1007->u.KTypList, &for_loc_0,
+                     &elemtyp_3, 0), _fx_catch_249);
                if (unzip_mode_0) {
-                  _fx_R9Ast__id_t v_1054;
-                  fx_str_t slit_234 = FX_MAKE_STR("lst");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_234, &v_1054, 0), _fx_catch_242);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1046, 0), _fx_catch_242);
+                  _fx_R9Ast__id_t v_1076;
+                  fx_str_t slit_235 = FX_MAKE_STR("lst");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_235, &v_1076, 0), _fx_catch_249);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1068, 0), _fx_catch_249);
                   FX_CALL(
                      _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        &v_1054, coll_ctyp_0, &v_1046, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
-                        &v_1045, 0), _fx_catch_242);
+                        &v_1076, coll_ctyp_0, &v_1068, &_fx_g18C_gen_code__None2_, ccode_149, &for_loc_0, block_stack_ref_0,
+                        &v_1067, 0), _fx_catch_249);
                }
                else {
-                  fx_str_t slit_235 = FX_MAKE_STR("lst");
+                  fx_str_t slit_236 = FX_MAKE_STR("lst");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_235, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1045, 0),
-                     _fx_catch_242);
+                        dstexp_r_0, &slit_236, coll_ctyp_0, ccode_149, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1067, 0),
+                     _fx_catch_249);
                }
-               FX_COPY_PTR(v_1045.t0, &dst_exp_19);
-               FX_COPY_PTR(v_1045.t1, &ccode1_20);
-               _fx_R9Ast__id_t v_1055;
-               fx_str_t slit_236 = FX_MAKE_STR("lstend");
-               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_236, &v_1055, 0), _fx_catch_242);
-               FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1047, 0), _fx_catch_242);
-               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1048, 0), _fx_catch_242);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1048, &v_1049);
-               fx_str_t slit_237 = FX_MAKE_STR("");
+               FX_COPY_PTR(v_1067.t0, &dst_exp_19);
+               FX_COPY_PTR(v_1067.t1, &ccode1_20);
+               _fx_R9Ast__id_t v_1077;
+               fx_str_t slit_237 = FX_MAKE_STR("lstend");
+               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_237, &v_1077, 0), _fx_catch_249);
+               FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1069, 0), _fx_catch_249);
+               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1070, 0), _fx_catch_249);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1070, &v_1071);
+               fx_str_t slit_238 = FX_MAKE_STR("");
                FX_CALL(
                   _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     &v_1055, coll_ctyp_0, &v_1047, &slit_237, &v_1049, ccode1_20, &for_loc_0, &v_1050, 0), _fx_catch_242);
-               FX_COPY_PTR(v_1050.t0, &lst_end_0);
-               FX_COPY_PTR(v_1050.t1, &ccode2_5);
-               FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1051, 0), _fx_catch_242);
+                     &v_1077, coll_ctyp_0, &v_1069, &slit_238, &v_1071, ccode1_20, &for_loc_0, &v_1072, 0), _fx_catch_249);
+               FX_COPY_PTR(v_1072.t0, &lst_end_0);
+               FX_COPY_PTR(v_1072.t1, &ccode2_5);
+               FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1073, 0), _fx_catch_249);
                _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                  elemtyp_3, dst_exp_19, v_1051, lst_end_0, &v_1052);
+                  elemtyp_3, dst_exp_19, v_1073, lst_end_0, &v_1074);
                FX_CALL(
-                  _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1052,
-                     dst_data_0, true, &v_1053), _fx_catch_242);
+                  _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1074,
+                     dst_data_0, true, &v_1075), _fx_catch_249);
                _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_0);
-               FX_COPY_PTR(v_1053, &dst_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_144);
-               FX_COPY_PTR(ccode2_5, &ccode_144);
+               FX_COPY_PTR(v_1075, &dst_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_149);
+               FX_COPY_PTR(ccode2_5, &ccode_149);
 
-            _fx_catch_242: ;
-               if (v_1053) {
-                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1053);
+            _fx_catch_249: ;
+               if (v_1075) {
+                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1075);
                }
-               _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1052);
-               if (v_1051) {
-                  _fx_free_N14C_form__cexp_t(&v_1051);
+               _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1074);
+               if (v_1073) {
+                  _fx_free_N14C_form__cexp_t(&v_1073);
                }
                if (ccode2_5) {
                   _fx_free_LN15C_form__cstmt_t(&ccode2_5);
@@ -32352,116 +32558,116 @@ static int
                if (lst_end_0) {
                   _fx_free_N14C_form__cexp_t(&lst_end_0);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1050);
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1049);
-               if (v_1048) {
-                  _fx_free_N14C_form__cexp_t(&v_1048);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1072);
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1071);
+               if (v_1070) {
+                  _fx_free_N14C_form__cexp_t(&v_1070);
                }
-               _fx_free_R16Ast__val_flags_t(&v_1047);
+               _fx_free_R16Ast__val_flags_t(&v_1069);
                if (ccode1_20) {
                   _fx_free_LN15C_form__cstmt_t(&ccode1_20);
                }
                if (dst_exp_19) {
                   _fx_free_N14C_form__cexp_t(&dst_exp_19);
                }
-               _fx_free_R16Ast__val_flags_t(&v_1046);
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1045);
+               _fx_free_R16Ast__val_flags_t(&v_1068);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1067);
                if (elemtyp_3) {
                   _fx_free_N14C_form__ctyp_t(&elemtyp_3);
                }
-               goto _fx_endmatch_40;
+               goto _fx_endmatch_43;
             }
          }
          fx_str_t maptype_str_0 = {0};
-         fx_str_t v_1056 = {0};
-         fx_str_t v_1057 = {0};
-         fx_str_t v_1058 = {0};
-         fx_exn_t v_1059 = {0};
+         fx_str_t v_1078 = {0};
+         fx_str_t v_1079 = {0};
+         fx_str_t v_1080 = {0};
+         fx_exn_t v_1081 = {0};
          int tag_30 = for_flag_make_0.tag;
          if (tag_30 == 2) {
-            fx_str_t slit_238 = FX_MAKE_STR("make_array"); fx_copy_str(&slit_238, &maptype_str_0);
+            fx_str_t slit_239 = FX_MAKE_STR("make_array"); fx_copy_str(&slit_239, &maptype_str_0);
          }
          else if (tag_30 == 3) {
-            fx_str_t slit_239 = FX_MAKE_STR("make_list"); fx_copy_str(&slit_239, &maptype_str_0);
+            fx_str_t slit_240 = FX_MAKE_STR("make_list"); fx_copy_str(&slit_240, &maptype_str_0);
          }
          else if (tag_30 == 4) {
-            fx_str_t slit_240 = FX_MAKE_STR("make_rrbvec"); fx_copy_str(&slit_240, &maptype_str_0);
+            fx_str_t slit_241 = FX_MAKE_STR("make_rrbvec"); fx_copy_str(&slit_241, &maptype_str_0);
          }
          else if (tag_30 == 5) {
-            fx_str_t slit_241 = FX_MAKE_STR("make_vector"); fx_copy_str(&slit_241, &maptype_str_0);
+            fx_str_t slit_242 = FX_MAKE_STR("make_vector"); fx_copy_str(&slit_242, &maptype_str_0);
          }
          else {
-            fx_str_t slit_242 = FX_MAKE_STR("???"); fx_copy_str(&slit_242, &maptype_str_0);
+            fx_str_t slit_243 = FX_MAKE_STR("???"); fx_copy_str(&slit_243, &maptype_str_0);
          }
-         FX_CHECK_EXN(_fx_catch_243);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&maptype_str_0, &v_1056, 0), _fx_catch_243);
-         FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(coll_typ_0, &v_1057, 0), _fx_catch_243);
-         fx_str_t slit_243 = FX_MAKE_STR("cgen: invalid combination of comprehension type \'");
-         fx_str_t slit_244 = FX_MAKE_STR("\' and the output collection type \'");
-         fx_str_t slit_245 = FX_MAKE_STR("\'");
+         FX_CHECK_EXN(_fx_catch_250);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&maptype_str_0, &v_1078, 0), _fx_catch_250);
+         FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(coll_typ_0, &v_1079, 0), _fx_catch_250);
+         fx_str_t slit_244 = FX_MAKE_STR("cgen: invalid combination of comprehension type \'");
+         fx_str_t slit_245 = FX_MAKE_STR("\' and the output collection type \'");
+         fx_str_t slit_246 = FX_MAKE_STR("\'");
          {
-            const fx_str_t strs_35[] = { slit_243, v_1056, slit_244, v_1057, slit_245 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_35, 5, &v_1058), _fx_catch_243);
+            const fx_str_t strs_35[] = { slit_244, v_1078, slit_245, v_1079, slit_246 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_35, 5, &v_1080), _fx_catch_250);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1058, &v_1059, 0), _fx_catch_243);
-         FX_THROW(&v_1059, false, _fx_catch_243);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1080, &v_1081, 0), _fx_catch_250);
+         FX_THROW(&v_1081, false, _fx_catch_250);
 
-      _fx_catch_243: ;
-         fx_free_exn(&v_1059);
-         FX_FREE_STR(&v_1058);
-         FX_FREE_STR(&v_1057);
-         FX_FREE_STR(&v_1056);
+      _fx_catch_250: ;
+         fx_free_exn(&v_1081);
+         FX_FREE_STR(&v_1080);
+         FX_FREE_STR(&v_1079);
+         FX_FREE_STR(&v_1078);
          FX_FREE_STR(&maptype_str_0);
 
-      _fx_endmatch_40: ;
-         FX_CHECK_EXN(_fx_catch_244);
+      _fx_endmatch_43: ;
+         FX_CHECK_EXN(_fx_catch_251);
 
-      _fx_catch_244: ;
-         if (v_985) {
-            _fx_free_N14K_form__ktyp_t(&v_985);
+      _fx_catch_251: ;
+         if (v_1007) {
+            _fx_free_N14K_form__ktyp_t(&v_1007);
          }
          if (coll_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&coll_ctyp_0);
          }
-         FX_CHECK_EXN(_fx_catch_246);
+         FX_CHECK_EXN(_fx_catch_253);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM3revLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t1LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-            dst_data_0, &dst_data_1, 0), _fx_catch_246);
+            dst_data_0, &dst_data_1, 0), _fx_catch_253);
       _fx_M10C_gen_codeFM7make_fpFPTa2LN15C_form__cstmt_t36LN15C_form__cstmt_tiLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14C_form__cexp_tLN14C_form__cexp_trLrRM11block_ctx_tLN15C_form__cstmt_trNt10Hashset__t1R9Ast__id_tLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_tN15Ast__for_make_tLSR10Ast__loc_trrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tBR10Ast__loc_tiN14C_form__cexp_tLN12Ast__scope_trLN15C_form__cstmt_triBBBN14C_form__cexp_tiN14C_form__cexp_tBrirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_tB5rLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
          block_stack_ref_1, defined_syms_ref_1, fwd_fdecls_ref_1, i2e_ref_1, *km_idx_1, &form_map_0);
-      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(vcase_24->t1, 0, 0, &v_962);
-      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_962, 0, true, &v_963), _fx_catch_246);
+      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(vcase_24->t1, 0, 0, &v_984);
+      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_984, 0, true, &v_985), _fx_catch_253);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t2LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(
-            e_idoml_l_2, v_963, &v_964, 0), _fx_catch_246);
+            e_idoml_l_2, v_985, &v_986, 0), _fx_catch_253);
       FX_CALL(
-         form_map_0.fp(0, 0, v_964, 0, 0, block_stack_ref_0, decl_nested_status_1, defined_syms_ref_0, dst_data_1,
+         form_map_0.fp(0, 0, v_986, 0, 0, block_stack_ref_0, decl_nested_status_1, defined_syms_ref_0, dst_data_1,
             &end_for_loc_0, &for_flag_make_0, for_letters_0, &for_loc_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0,
             glob_data_ccode_ref_0, i2e_ref_0, is_parallel_map_0, &kloc_0, km_idx_0, map_lbl_0, mod_sc_0, module_cleanup_ref_0,
             ndims_ref_0, need_make_array_0, need_make_contig_0, need_make_vec_0, nested_status_1, nfors_0, par_status_1,
-            pre_alloc_array_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, unzip_mode_0, &v_965, form_map_0.fcv),
-         _fx_catch_246);
-      FX_COPY_PTR(v_965.t0, &pre_map_ccode_0);
-      FX_COPY_PTR(v_965.t1, &map_ccode_0);
+            pre_alloc_array_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, unzip_mode_0, &v_987, form_map_0.fcv),
+         _fx_catch_253);
+      FX_COPY_PTR(v_987.t0, &pre_map_ccode_0);
+      FX_COPY_PTR(v_987.t1, &map_ccode_0);
       if (!is_parallel_map_0) {
          FX_COPY_PTR(map_ccode_0, &map_ccode_1);
       }
       else {
-         _fx_R9Ast__id_t v_1060;
-         fx_str_t slit_246 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_246, &v_1060, 0), _fx_catch_246);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(map_lbl_0, 0, true, &v_966), _fx_catch_246);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_1, v_966, false, &v_966), _fx_catch_246);
+         _fx_R9Ast__id_t v_1082;
+         fx_str_t slit_247 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_247, &v_1082, 0), _fx_catch_253);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(map_lbl_0, 0, true, &v_988), _fx_catch_253);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_1, v_988, false, &v_988), _fx_catch_253);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1060,
-               v_966, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_0, 0), _fx_catch_246);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_0, &v_967), _fx_catch_246);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_967, map_ccode_0, true, &map_ccode_1), _fx_catch_246);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1082,
+               v_988, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_0, 0), _fx_catch_253);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_0, &v_989), _fx_catch_253);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_989, map_ccode_0, true, &map_ccode_1), _fx_catch_253);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(finalize_ccode_0, map_ccode_1,
-            &map_ccode_2, 0), _fx_catch_246);
+            &map_ccode_2, 0), _fx_catch_253);
       if (!unzip_mode_0) {
          FX_COPY_PTR(map_ccode_2, &map_ccode_3);
       }
@@ -32469,7 +32675,7 @@ static int
          _fx_R9Ast__id_t tcon_1;
          FX_CALL(
             _fx_M11C_gen_typesFM15get_constructorR9Ast__id_t3N14C_form__ctyp_tBR10Ast__loc_t(ctyp_0, false, &kloc_0, &tcon_1,
-               0), _fx_catch_246);
+               0), _fx_catch_253);
          _fx_LN14C_form__cexp_t lstend_1 = 0;
          _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t lst_27 = dst_data_1;
          for (; lst_27; lst_27 = lst_27->tl) {
@@ -32480,65 +32686,65 @@ static int
             FX_COPY_PTR(__pat___9->t2, &dst_exp_20);
             FX_CALL(
                _fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(dst_exp_20, &kloc_0, &res_25,
-                  0), _fx_catch_245);
+                  0), _fx_catch_252);
             _fx_LN14C_form__cexp_t node_1 = 0;
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_25, 0, false, &node_1), _fx_catch_245);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_25, 0, false, &node_1), _fx_catch_252);
             FX_LIST_APPEND(cargs_5, lstend_1, node_1);
 
-         _fx_catch_245: ;
+         _fx_catch_252: ;
             if (res_25) {
                _fx_free_N14C_form__cexp_t(&res_25);
             }
             if (dst_exp_20) {
                _fx_free_N14C_form__cexp_t(&dst_exp_20);
             }
-            FX_CHECK_EXN(_fx_catch_246);
+            FX_CHECK_EXN(_fx_catch_253);
          }
-         fx_str_t slit_247 = FX_MAKE_STR("tup");
+         fx_str_t slit_248 = FX_MAKE_STR("tup");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_247, ctyp_0, map_ccode_2, &kloc_0, block_stack_ref_0, km_idx_0, &v_968, 0), _fx_catch_246);
-         FX_COPY_PTR(v_968.t0, &t_exp_2);
-         FX_COPY_PTR(v_968.t1, &map_ccode_4);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_2, &v_969, 0), _fx_catch_246);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_969, 0, true, &v_970), _fx_catch_246);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(cargs_5, v_970, &v_971, 0),
-            _fx_catch_246);
+               dstexp_r_0, &slit_248, ctyp_0, map_ccode_2, &kloc_0, block_stack_ref_0, km_idx_0, &v_990, 0), _fx_catch_253);
+         FX_COPY_PTR(v_990.t0, &t_exp_2);
+         FX_COPY_PTR(v_990.t1, &map_ccode_4);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_2, &v_991, 0), _fx_catch_253);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_991, 0, true, &v_992), _fx_catch_253);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(cargs_5, v_992, &v_993, 0),
+            _fx_catch_253);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&tcon_1,
-               v_971, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_1, 0), _fx_catch_246);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_1, &v_972), _fx_catch_246);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_972, map_ccode_4, true, &map_ccode_3), _fx_catch_246);
+               v_993, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_1, 0), _fx_catch_253);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_1, &v_994), _fx_catch_253);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_994, map_ccode_4, true, &map_ccode_3), _fx_catch_253);
       }
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(pre_map_ccode_0, ccode_144,
-            &v_973, 0), _fx_catch_246);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(pre_map_ccode_0, ccode_149,
+            &v_995, 0), _fx_catch_253);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(map_ccode_3, v_973, &v_974, 0),
-         _fx_catch_246);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_974, &v_1);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(map_ccode_3, v_995, &v_996, 0),
+         _fx_catch_253);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_996, &v_1);
 
-   _fx_catch_246: ;
-      if (v_974) {
-         _fx_free_LN15C_form__cstmt_t(&v_974);
+   _fx_catch_253: ;
+      if (v_996) {
+         _fx_free_LN15C_form__cstmt_t(&v_996);
       }
-      if (v_973) {
-         _fx_free_LN15C_form__cstmt_t(&v_973);
+      if (v_995) {
+         _fx_free_LN15C_form__cstmt_t(&v_995);
       }
-      if (v_972) {
-         _fx_free_N15C_form__cstmt_t(&v_972);
+      if (v_994) {
+         _fx_free_N15C_form__cstmt_t(&v_994);
       }
       if (call_mktup_1) {
          _fx_free_N14C_form__cexp_t(&call_mktup_1);
       }
-      if (v_971) {
-         _fx_free_LN14C_form__cexp_t(&v_971);
+      if (v_993) {
+         _fx_free_LN14C_form__cexp_t(&v_993);
       }
-      if (v_970) {
-         _fx_free_LN14C_form__cexp_t(&v_970);
+      if (v_992) {
+         _fx_free_LN14C_form__cexp_t(&v_992);
       }
-      if (v_969) {
-         _fx_free_N14C_form__cexp_t(&v_969);
+      if (v_991) {
+         _fx_free_N14C_form__cexp_t(&v_991);
       }
       if (map_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_4);
@@ -32546,7 +32752,7 @@ static int
       if (t_exp_2) {
          _fx_free_N14C_form__cexp_t(&t_exp_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_968);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_990);
       if (cargs_5) {
          _fx_free_LN14C_form__cexp_t(&cargs_5);
       }
@@ -32556,14 +32762,14 @@ static int
       if (map_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_2);
       }
-      if (v_967) {
-         _fx_free_N15C_form__cstmt_t(&v_967);
+      if (v_989) {
+         _fx_free_N15C_form__cstmt_t(&v_989);
       }
       if (update_exn_parallel_0) {
          _fx_free_N14C_form__cexp_t(&update_exn_parallel_0);
       }
-      if (v_966) {
-         _fx_free_LN14C_form__cexp_t(&v_966);
+      if (v_988) {
+         _fx_free_LN14C_form__cexp_t(&v_988);
       }
       if (map_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_1);
@@ -32574,14 +32780,14 @@ static int
       if (pre_map_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&pre_map_ccode_0);
       }
-      _fx_free_Ta2LN15C_form__cstmt_t(&v_965);
-      if (v_964) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_964);
+      _fx_free_Ta2LN15C_form__cstmt_t(&v_987);
+      if (v_986) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_986);
       }
-      if (v_963) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_963);
+      if (v_985) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_985);
       }
-      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_962);
+      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_984);
       FX_FREE_FP(&form_map_0);
       if (dst_data_1) {
          _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_1);
@@ -32589,8 +32795,8 @@ static int
       if (finalize_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
       }
-      if (ccode_144) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_144);
+      if (ccode_149) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_149);
       }
       if (dst_data_0) {
          _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_0);
@@ -32598,8 +32804,8 @@ static int
       if (coll_typs_0) {
          _fx_free_LN14K_form__ktyp_t(&coll_typs_0);
       }
-      if (v_961) {
-         _fx_free_N14K_form__ktyp_t(&v_961);
+      if (v_983) {
+         _fx_free_N14K_form__ktyp_t(&v_983);
       }
       if (decl_nested_status_1) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_1);
@@ -32607,14 +32813,14 @@ static int
       if (nested_status_1) {
          _fx_free_N14C_form__cexp_t(&nested_status_1);
       }
-      if (ccode_143) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_143);
+      if (ccode_148) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_148);
       }
       if (par_status_1) {
          _fx_free_N14C_form__cexp_t(&par_status_1);
       }
-      if (v_960) {
-         _fx_free_N14C_form__cexp_t(&v_960);
+      if (v_982) {
+         _fx_free_N14C_form__cexp_t(&v_982);
       }
       if (decl_nested_status_0) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_0);
@@ -32622,25 +32828,25 @@ static int
       if (nested_status_0) {
          _fx_free_N14C_form__cexp_t(&nested_status_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_959);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_958);
-      if (v_957) {
-         _fx_free_N14C_form__cexp_t(&v_957);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_981);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_980);
+      if (v_979) {
+         _fx_free_N14C_form__cexp_t(&v_979);
       }
-      _fx_free_R16Ast__val_flags_t(&v_956);
-      if (ccode_142) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_142);
+      _fx_free_R16Ast__val_flags_t(&v_978);
+      if (ccode_147) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_147);
       }
       if (par_status_0) {
          _fx_free_N14C_form__cexp_t(&par_status_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_955);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_954);
-      if (v_953) {
-         _fx_free_N14C_form__cexp_t(&v_953);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_977);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_976);
+      if (v_975) {
+         _fx_free_N14C_form__cexp_t(&v_975);
       }
-      _fx_free_R16Ast__val_flags_t(&v_952);
-      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_951);
+      _fx_free_R16Ast__val_flags_t(&v_974);
+      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_973);
       if (glob_status_0) {
          _fx_free_N14C_form__cexp_t(&glob_status_0);
       }
@@ -32657,82 +32863,82 @@ static int
       if (map_lbl_0) {
          _fx_free_N14C_form__cexp_t(&map_lbl_0);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 27) {
       _fx_N14C_form__cexp_t lbl_9 = 0;
       _fx_N14C_form__cexp_t glob_status_1 = 0;
-      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_1061 = {0};
-      _fx_R16Ast__val_flags_t v_1062 = {0};
-      _fx_N14C_form__cexp_t v_1063 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1064 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1065 = {0};
+      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_1083 = {0};
+      _fx_R16Ast__val_flags_t v_1084 = {0};
+      _fx_N14C_form__cexp_t v_1085 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1086 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1087 = {0};
       _fx_N14C_form__cexp_t par_status_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_145 = 0;
-      _fx_R16Ast__val_flags_t v_1066 = {0};
-      _fx_N14C_form__cexp_t v_1067 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1068 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1069 = {0};
+      _fx_LN15C_form__cstmt_t ccode_150 = 0;
+      _fx_R16Ast__val_flags_t v_1088 = {0};
+      _fx_N14C_form__cexp_t v_1089 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1090 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1091 = {0};
       _fx_N14C_form__cexp_t nested_status_2 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_2 = 0;
-      _fx_N14C_form__cexp_t v_1070 = 0;
+      _fx_N14C_form__cexp_t v_1092 = 0;
       _fx_N14C_form__cexp_t par_status_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_146 = 0;
+      _fx_LN15C_form__cstmt_t ccode_151 = 0;
       _fx_N14C_form__cexp_t nested_status_3 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_3 = 0;
-      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1071 = {0};
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1072 = 0;
+      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1093 = {0};
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1094 = 0;
       _fx_T8LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_tLT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_t
-         v_1073 = {0};
+         v_1095 = {0};
       _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t for_headers_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_147 = 0;
+      _fx_LN15C_form__cstmt_t ccode_152 = 0;
       _fx_LN15C_form__cstmt_t pre_body_ccode_0 = 0;
       _fx_LT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_t body_elems_0 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_0 = 0;
-      _fx_LN14C_form__cexp_t v_1074 = 0;
+      _fx_LN14C_form__cexp_t v_1096 = 0;
       _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_2 = 0;
       _fx_FPB1N14C_form__cexp_t __lambda___0 = {0};
       _fx_LN14C_form__cexp_t locked_vec_exps_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t wbctx_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1075 = 0;
-      _fx_LN15C_form__cstmt_t v_1076 = 0;
+      _fx_LN15C_form__cstmt_t v_1097 = 0;
+      _fx_LN15C_form__cstmt_t v_1098 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_1 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1077 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1078 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1099 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1100 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_2 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1079 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1101 = {0};
       _fx_N15C_form__cstmt_t body_stmt_0 = 0;
       _fx_N15C_form__cstmt_t for_stmt_0 = 0;
-      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t v_1080 = 0;
+      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t v_1102 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_1 = 0;
-      _fx_N15C_form__cstmt_t v_1081 = 0;
-      _fx_Ta2LN15C_form__cstmt_t v_1082 = {0};
-      _fx_LN14C_form__cexp_t v_1083 = 0;
+      _fx_N15C_form__cstmt_t v_1103 = 0;
+      _fx_Ta2LN15C_form__cstmt_t v_1104 = {0};
+      _fx_LN14C_form__cexp_t v_1105 = 0;
       _fx_N14C_form__cexp_t update_exn_parallel_1 = 0;
-      _fx_N15C_form__cstmt_t v_1084 = 0;
-      _fx_LN15C_form__cstmt_t v_1085 = 0;
-      _fx_N15C_form__cstmt_t v_1086 = 0;
-      _fx_LN15C_form__cstmt_t v_1087 = 0;
+      _fx_N15C_form__cstmt_t v_1106 = 0;
+      _fx_LN15C_form__cstmt_t v_1107 = 0;
+      _fx_N15C_form__cstmt_t v_1108 = 0;
+      _fx_LN15C_form__cstmt_t v_1109 = 0;
       _fx_LN15C_form__cstmt_t omp_pragma_0 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_2 = 0;
-      _fx_LN15C_form__cstmt_t v_1088 = 0;
-      _fx_LN15C_form__cstmt_t v_1089 = 0;
+      _fx_LN15C_form__cstmt_t v_1110 = 0;
+      _fx_LN15C_form__cstmt_t v_1111 = 0;
       _fx_LN15C_form__cstmt_t loop_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t result_ccode_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t wbctx_1 = 0;
       _fx_LN15C_form__cstmt_t bctx_cleanup_2 = 0;
       _fx_LN15C_form__cstmt_t bctx_prologue_2 = 0;
       _fx_LN15C_form__cstmt_t epilogue_2 = 0;
-      _fx_N15C_form__cstmt_t v_1090 = 0;
-      _fx_LN15C_form__cstmt_t v_1091 = 0;
-      _fx_LN15C_form__cstmt_t v_1092 = 0;
+      _fx_N15C_form__cstmt_t v_1112 = 0;
+      _fx_LN15C_form__cstmt_t v_1113 = 0;
+      _fx_LN15C_form__cstmt_t v_1114 = 0;
       _fx_LN15C_form__cstmt_t wrapped_0 = 0;
       _fx_N15C_form__cstmt_t c_e_3 = 0;
-      _fx_LN14C_form__cexp_t v_1093 = 0;
-      _fx_N14C_form__cexp_t v_1094 = 0;
+      _fx_LN14C_form__cexp_t v_1115 = 0;
+      _fx_N14C_form__cexp_t v_1116 = 0;
       _fx_N15C_form__cstmt_t check_exn_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1095 = 0;
+      _fx_LN15C_form__cstmt_t v_1117 = 0;
       _fx_T5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_27 =
          &kexp_0->u.KExpFor;
       _fx_R16Ast__for_flags_t* flags_1 = &vcase_27->t3;
@@ -32740,259 +32946,259 @@ static int
       _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_3 = vcase_27->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_9, 0), _fx_catch_251);
+            &lbl_9, 0), _fx_catch_258);
       _fx_R10Ast__loc_t for_loc_1;
-      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_1, 0), _fx_catch_251);
+      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_1, 0), _fx_catch_258);
       _fx_R10Ast__loc_t end_for_loc_1;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_1, 0), _fx_catch_251);
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_1, 0), _fx_catch_258);
       int_ ndims_4;
       FX_CALL(
          _fx_M10C_gen_codeFM17compute_for_ndimsi4iiLT2R9Ast__id_tN13K_form__dom_tR10Ast__loc_t(0, 1, idoml_3, &for_loc_1,
-            &ndims_4, 0), _fx_catch_251);
+            &ndims_4, 0), _fx_catch_258);
       FX_CALL(
          _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(fx_status__0,
-            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_1, 0), _fx_catch_251);
+            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_1, 0), _fx_catch_258);
       bool is_parallel_for_0 = flags_1->for_flag_parallel;
       if (is_parallel_for_0) {
-         _fx_R9Ast__id_t v_1096;
-         fx_str_t slit_248 = FX_MAKE_STR("par_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_248, &v_1096, 0), _fx_catch_251);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1062, 0), _fx_catch_251);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1063, 0), _fx_catch_251);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1063, &v_1064);
-         fx_str_t slit_249 = FX_MAKE_STR("");
+         _fx_R9Ast__id_t v_1118;
+         fx_str_t slit_249 = FX_MAKE_STR("par_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_249, &v_1118, 0), _fx_catch_258);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1084, 0), _fx_catch_258);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1085, 0), _fx_catch_258);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1085, &v_1086);
+         fx_str_t slit_250 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1096, _fx_g20C_gen_code__CTypCInt, &v_1062, &slit_249, &v_1064, ccode_0, &kloc_0, &v_1065, 0), _fx_catch_251);
-         FX_COPY_PTR(v_1065.t0, &par_status_2);
-         FX_COPY_PTR(v_1065.t1, &ccode_145);
-         _fx_R9Ast__id_t v_1097;
-         fx_str_t slit_250 = FX_MAKE_STR("status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_250, &v_1097, 0), _fx_catch_251);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1066, 0), _fx_catch_251);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1067, 0), _fx_catch_251);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1067, &v_1068);
-         fx_str_t slit_251 = FX_MAKE_STR("fx_status");
+               &v_1118, _fx_g20C_gen_code__CTypCInt, &v_1084, &slit_250, &v_1086, ccode_0, &kloc_0, &v_1087, 0), _fx_catch_258);
+         FX_COPY_PTR(v_1087.t0, &par_status_2);
+         FX_COPY_PTR(v_1087.t1, &ccode_150);
+         _fx_R9Ast__id_t v_1119;
+         fx_str_t slit_251 = FX_MAKE_STR("status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_251, &v_1119, 0), _fx_catch_258);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1088, 0), _fx_catch_258);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1089, 0), _fx_catch_258);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1089, &v_1090);
+         fx_str_t slit_252 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1097, _fx_g20C_gen_code__CTypCInt, &v_1066, &slit_251, &v_1068, 0, &kloc_0, &v_1069, 0), _fx_catch_251);
-         FX_COPY_PTR(v_1069.t0, &nested_status_2);
-         FX_COPY_PTR(v_1069.t1, &decl_nested_status_2);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_2, ccode_145,
-            nested_status_2, decl_nested_status_2, &v_1061);
+               &v_1119, _fx_g20C_gen_code__CTypCInt, &v_1088, &slit_252, &v_1090, 0, &kloc_0, &v_1091, 0), _fx_catch_258);
+         FX_COPY_PTR(v_1091.t0, &nested_status_2);
+         FX_COPY_PTR(v_1091.t1, &decl_nested_status_2);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_2, ccode_150,
+            nested_status_2, decl_nested_status_2, &v_1083);
       }
       else {
-         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1070, 0), _fx_catch_251);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_1070, ccode_0, glob_status_1, 0,
-            &v_1061);
+         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1092, 0), _fx_catch_258);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_1092, ccode_0, glob_status_1, 0,
+            &v_1083);
       }
-      FX_COPY_PTR(v_1061.t0, &par_status_3);
-      FX_COPY_PTR(v_1061.t1, &ccode_146);
-      FX_COPY_PTR(v_1061.t2, &nested_status_3);
-      FX_COPY_PTR(v_1061.t3, &decl_nested_status_3);
-      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(body_0, 0, 0, &v_1071);
-      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1071, 0, true, &v_1072),
-         _fx_catch_251);
+      FX_COPY_PTR(v_1083.t0, &par_status_3);
+      FX_COPY_PTR(v_1083.t1, &ccode_151);
+      FX_COPY_PTR(v_1083.t2, &nested_status_3);
+      FX_COPY_PTR(v_1083.t3, &decl_nested_status_3);
+      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(body_0, 0, 0, &v_1093);
+      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1093, 0, true, &v_1094),
+         _fx_catch_258);
       FX_CALL(
-         process_for_0.fp(lbl_9, idoml_3, vcase_27->t1, 0, 1, ndims_4, 0, v_1072, ccode_146, &kloc_0, block_stack_ref_0,
-            defined_syms_ref_0, for_letters_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_1073, process_for_0.fcv),
-         _fx_catch_251);
-      FX_COPY_PTR(v_1073.t0, &for_headers_0);
-      FX_COPY_PTR(v_1073.t4, &ccode_147);
-      FX_COPY_PTR(v_1073.t5, &pre_body_ccode_0);
-      FX_COPY_PTR(v_1073.t6, &body_elems_0);
-      FX_COPY_PTR(v_1073.t7, &post_ccode_0);
+         process_for_0.fp(lbl_9, idoml_3, vcase_27->t1, 0, 1, ndims_4, 0, v_1094, ccode_151, &kloc_0, block_stack_ref_0,
+            defined_syms_ref_0, for_letters_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_1095, process_for_0.fcv),
+         _fx_catch_258);
+      FX_COPY_PTR(v_1095.t0, &for_headers_0);
+      FX_COPY_PTR(v_1095.t4, &ccode_152);
+      FX_COPY_PTR(v_1095.t5, &pre_body_ccode_0);
+      FX_COPY_PTR(v_1095.t6, &body_elems_0);
+      FX_COPY_PTR(v_1095.t7, &post_ccode_0);
       _fx_LN14C_form__cexp_t lstend_2 = 0;
       FX_COPY_PTR(idoml_3, &idoml_2);
       _fx_LT2R9Ast__id_tN13K_form__dom_t lst_28 = idoml_2;
       for (; lst_28; lst_28 = lst_28->tl) {
          _fx_N13K_form__dom_t dom_1 = {0};
-         _fx_N14K_form__ktyp_t v_1098 = 0;
+         _fx_N14K_form__ktyp_t v_1120 = 0;
          _fx_N14C_form__cexp_t t_14 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1099 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1121 = {0};
          _fx_T2R9Ast__id_tN13K_form__dom_t* __pat___10 = &lst_28->hd;
          _fx_copy_N13K_form__dom_t(&__pat___10->t1, &dom_1);
          int tag_31 = dom_1.tag;
          _fx_R9Ast__id_t col_1;
          if (tag_31 == 1) {
-            _fx_N14K_form__atom_t* v_1100 = &dom_1.u.DomainElem;
-            if (v_1100->tag == 1) {
-               col_1 = v_1100->u.AtomId; goto _fx_endmatch_41;
+            _fx_N14K_form__atom_t* v_1122 = &dom_1.u.DomainElem;
+            if (v_1122->tag == 1) {
+               col_1 = v_1122->u.AtomId; goto _fx_endmatch_44;
             }
          }
          if (tag_31 == 2) {
-            _fx_N14K_form__atom_t* v_1101 = &dom_1.u.DomainFast;
-            if (v_1101->tag == 1) {
-               col_1 = v_1101->u.AtomId; goto _fx_endmatch_41;
+            _fx_N14K_form__atom_t* v_1123 = &dom_1.u.DomainFast;
+            if (v_1123->tag == 1) {
+               col_1 = v_1123->u.AtomId; goto _fx_endmatch_44;
             }
          }
          col_1 = _fx_g9Ast__noid;
 
-      _fx_endmatch_41: ;
-         FX_CHECK_EXN(_fx_catch_247);
-         bool v_1102;
+      _fx_endmatch_44: ;
+         FX_CHECK_EXN(_fx_catch_254);
+         bool v_1124;
          bool res_26;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&col_1, &_fx_g9Ast__noid, &res_26, 0), _fx_catch_247);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&col_1, &_fx_g9Ast__noid, &res_26, 0), _fx_catch_254);
          if (res_26) {
-            FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&col_1, &kloc_0, &v_1098, 0),
-               _fx_catch_247);
-            if (FX_REC_VARIANT_TAG(v_1098) == 19) {
-               v_1102 = true;
+            FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&col_1, &kloc_0, &v_1120, 0),
+               _fx_catch_254);
+            if (FX_REC_VARIANT_TAG(v_1120) == 19) {
+               v_1124 = true;
             }
             else {
-               v_1102 = false;
+               v_1124 = false;
             }
-            FX_CHECK_EXN(_fx_catch_247);
+            FX_CHECK_EXN(_fx_catch_254);
          }
          else {
-            v_1102 = false;
+            v_1124 = false;
          }
-         if (v_1102) {
+         if (v_1124) {
             FX_CALL(
                _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                   &col_1, false, 0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-                  &v_1099, 0), _fx_catch_247);
-            FX_COPY_PTR(v_1099.t0, &t_14);
+                  &v_1121, 0), _fx_catch_254);
+            FX_COPY_PTR(v_1121.t0, &t_14);
          }
          else {
-            FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &t_14, 0), _fx_catch_247);
+            FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &t_14, 0), _fx_catch_254);
          }
          _fx_LN14C_form__cexp_t node_2 = 0;
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(t_14, 0, false, &node_2), _fx_catch_247);
-         FX_LIST_APPEND(v_1074, lstend_2, node_2);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(t_14, 0, false, &node_2), _fx_catch_254);
+         FX_LIST_APPEND(v_1096, lstend_2, node_2);
 
-      _fx_catch_247: ;
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1099);
+      _fx_catch_254: ;
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1121);
          if (t_14) {
             _fx_free_N14C_form__cexp_t(&t_14);
          }
-         if (v_1098) {
-            _fx_free_N14K_form__ktyp_t(&v_1098);
+         if (v_1120) {
+            _fx_free_N14K_form__ktyp_t(&v_1120);
          }
          _fx_free_N13K_form__dom_t(&dom_1);
-         FX_CHECK_EXN(_fx_catch_251);
+         FX_CHECK_EXN(_fx_catch_258);
       }
       _fx_FPB1N14C_form__cexp_t __lambda___fp_0 = { _fx_M10C_gen_codeFM10__lambda__B1N14C_form__cexp_t, 0 };
       FX_COPY_FP(&__lambda___fp_0, &__lambda___0);
       FX_CALL(
-         _fx_M10C_gen_codeFM6filterLN14C_form__cexp_t2LN14C_form__cexp_tFPB1N14C_form__cexp_t(v_1074, &__lambda___0,
-            &locked_vec_exps_0, 0), _fx_catch_251);
+         _fx_M10C_gen_codeFM6filterLN14C_form__cexp_t2LN14C_form__cexp_tFPB1N14C_form__cexp_t(v_1096, &__lambda___0,
+            &locked_vec_exps_0, 0), _fx_catch_258);
       bool have_lock_0 = locked_vec_exps_0 != 0;
       if (have_lock_0) {
          FX_CALL(
             _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-               &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_251);
+               &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_258);
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &wbctx_0, 0), _fx_catch_251);
+               &wbctx_0, 0), _fx_catch_258);
          _fx_LN15C_form__cstmt_t lstend_3 = 0;
          _fx_LN14C_form__cexp_t lst_29 = locked_vec_exps_0;
          for (; lst_29; lst_29 = lst_29->tl) {
-            _fx_LN14C_form__cexp_t v_1103 = 0;
-            _fx_N14C_form__cexp_t v_1104 = 0;
+            _fx_LN14C_form__cexp_t v_1125 = 0;
+            _fx_N14C_form__cexp_t v_1126 = 0;
             _fx_N15C_form__cstmt_t res_27 = 0;
             _fx_N14C_form__cexp_t e_15 = lst_29->hd;
-            _fx_R9Ast__id_t v_1105;
-            fx_str_t slit_252 = FX_MAKE_STR("FX_VEC_START_READ");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_252, &v_1105, 0), _fx_catch_248);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_15, 0, true, &v_1103), _fx_catch_248);
+            _fx_R9Ast__id_t v_1127;
+            fx_str_t slit_253 = FX_MAKE_STR("FX_VEC_START_READ");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_253, &v_1127, 0), _fx_catch_255);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_15, 0, true, &v_1125), _fx_catch_255);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1105,
-                  v_1103, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1104, 0), _fx_catch_248);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1104, &res_27), _fx_catch_248);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1127,
+                  v_1125, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1126, 0), _fx_catch_255);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1126, &res_27), _fx_catch_255);
             _fx_LN15C_form__cstmt_t node_3 = 0;
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_27, 0, false, &node_3), _fx_catch_248);
-            FX_LIST_APPEND(v_1075, lstend_3, node_3);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_27, 0, false, &node_3), _fx_catch_255);
+            FX_LIST_APPEND(v_1097, lstend_3, node_3);
 
-         _fx_catch_248: ;
+         _fx_catch_255: ;
             if (res_27) {
                _fx_free_N15C_form__cstmt_t(&res_27);
             }
-            if (v_1104) {
-               _fx_free_N14C_form__cexp_t(&v_1104);
+            if (v_1126) {
+               _fx_free_N14C_form__cexp_t(&v_1126);
             }
-            if (v_1103) {
-               _fx_free_LN14C_form__cexp_t(&v_1103);
+            if (v_1125) {
+               _fx_free_LN14C_form__cexp_t(&v_1125);
             }
-            FX_CHECK_EXN(_fx_catch_251);
+            FX_CHECK_EXN(_fx_catch_258);
          }
-         _fx_R23C_gen_code__block_ctx_t* v_1106 = &wbctx_0->data;
-         _fx_LN15C_form__cstmt_t* v_1107 = &v_1106->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1107);
-         FX_COPY_PTR(v_1075, v_1107);
+         _fx_R23C_gen_code__block_ctx_t* v_1128 = &wbctx_0->data;
+         _fx_LN15C_form__cstmt_t* v_1129 = &v_1128->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1129);
+         FX_COPY_PTR(v_1097, v_1129);
          _fx_LN15C_form__cstmt_t lstend_4 = 0;
          _fx_LN14C_form__cexp_t lst_30 = locked_vec_exps_0;
          for (; lst_30; lst_30 = lst_30->tl) {
-            _fx_LN14C_form__cexp_t v_1108 = 0;
-            _fx_N14C_form__cexp_t v_1109 = 0;
+            _fx_LN14C_form__cexp_t v_1130 = 0;
+            _fx_N14C_form__cexp_t v_1131 = 0;
             _fx_N15C_form__cstmt_t res_28 = 0;
             _fx_N14C_form__cexp_t e_16 = lst_30->hd;
-            _fx_R9Ast__id_t v_1110;
-            fx_str_t slit_253 = FX_MAKE_STR("FX_VEC_END_READ");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_253, &v_1110, 0), _fx_catch_249);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_16, 0, true, &v_1108), _fx_catch_249);
+            _fx_R9Ast__id_t v_1132;
+            fx_str_t slit_254 = FX_MAKE_STR("FX_VEC_END_READ");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_254, &v_1132, 0), _fx_catch_256);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_16, 0, true, &v_1130), _fx_catch_256);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1110,
-                  v_1108, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1109, 0), _fx_catch_249);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1109, &res_28), _fx_catch_249);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1132,
+                  v_1130, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1131, 0), _fx_catch_256);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1131, &res_28), _fx_catch_256);
             _fx_LN15C_form__cstmt_t node_4 = 0;
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_28, 0, false, &node_4), _fx_catch_249);
-            FX_LIST_APPEND(v_1076, lstend_4, node_4);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_28, 0, false, &node_4), _fx_catch_256);
+            FX_LIST_APPEND(v_1098, lstend_4, node_4);
 
-         _fx_catch_249: ;
+         _fx_catch_256: ;
             if (res_28) {
                _fx_free_N15C_form__cstmt_t(&res_28);
             }
-            if (v_1109) {
-               _fx_free_N14C_form__cexp_t(&v_1109);
+            if (v_1131) {
+               _fx_free_N14C_form__cexp_t(&v_1131);
             }
-            if (v_1108) {
-               _fx_free_LN14C_form__cexp_t(&v_1108);
+            if (v_1130) {
+               _fx_free_LN14C_form__cexp_t(&v_1130);
             }
-            FX_CHECK_EXN(_fx_catch_251);
+            FX_CHECK_EXN(_fx_catch_258);
          }
-         _fx_R23C_gen_code__block_ctx_t* v_1111 = &wbctx_0->data;
-         _fx_LN15C_form__cstmt_t* v_1112 = &v_1111->bctx_cleanup;
-         _fx_free_LN15C_form__cstmt_t(v_1112);
-         FX_COPY_PTR(v_1076, v_1112);
+         _fx_R23C_gen_code__block_ctx_t* v_1133 = &wbctx_0->data;
+         _fx_LN15C_form__cstmt_t* v_1134 = &v_1133->bctx_cleanup;
+         _fx_free_LN15C_form__cstmt_t(v_1134);
+         FX_COPY_PTR(v_1098, v_1134);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM17new_for_block_ctxv7iR16Ast__for_flags_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_trLrRM11block_ctx_ti(
-            ndims_4, flags_1, nested_status_3, par_status_3, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_251);
+            ndims_4, flags_1, nested_status_3, par_status_3, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_258);
       if (is_parallel_for_0) {
          FX_COPY_PTR(decl_nested_status_3, &body_ccode_0);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM19decl_for_body_elemsLN15C_form__cstmt_t4LT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_t(
-            body_elems_0, body_ccode_0, block_stack_ref_0, i2e_ref_0, &body_ccode_1, 0), _fx_catch_251);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1077), _fx_catch_251);
+            body_elems_0, body_ccode_0, block_stack_ref_0, i2e_ref_0, &body_ccode_1, 0), _fx_catch_258);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1099), _fx_catch_258);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            body_0, v_1077, body_ccode_1, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            body_0, v_1099, body_ccode_1, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1078, fx_fv), _fx_catch_251);
-      FX_COPY_PTR(v_1078.t1, &body_ccode_2);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1100, fx_fv), _fx_catch_258);
+      FX_COPY_PTR(v_1100.t1, &body_ccode_2);
       _fx_R10Ast__loc_t body_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(body_0, &body_loc_0, 0), _fx_catch_251);
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(body_0, &body_loc_0, 0), _fx_catch_258);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_2, true, &body_loc_0, block_stack_ref_0, &v_1079, 0), _fx_catch_251);
-      _fx_R9Ast__id_t br_label_0 = v_1079.t0;
-      FX_COPY_PTR(v_1079.t1, &body_stmt_0);
+            body_ccode_2, true, &body_loc_0, block_stack_ref_0, &v_1101, 0), _fx_catch_258);
+      _fx_R9Ast__id_t br_label_0 = v_1101.t0;
+      FX_COPY_PTR(v_1101.t1, &body_stmt_0);
       FX_COPY_PTR(body_stmt_0, &for_stmt_0);
       FX_CALL(
          _fx_M10C_gen_codeFM3revLT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t1LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(
-            for_headers_0, &v_1080, 0), _fx_catch_251);
+            for_headers_0, &v_1102, 0), _fx_catch_258);
       int_ k_0 = 0;
-      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t lst_31 = v_1080;
+      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t lst_31 = v_1102;
       for (; lst_31; lst_31 = lst_31->tl, k_0 += 1) {
          _fx_Nt6option1N14C_form__ctyp_t t_opt_0 = {0};
          _fx_LN14C_form__cexp_t for_inits_0 = 0;
          _fx_Nt6option1N14C_form__cexp_t for_check_opt_0 = {0};
          _fx_LN14C_form__cexp_t for_incrs_0 = 0;
          _fx_N15C_form__cstmt_t for_stmt1_0 = 0;
-         _fx_N15C_form__cstmt_t v_1113 = 0;
-         _fx_LN15C_form__cstmt_t v_1114 = 0;
+         _fx_N15C_form__cstmt_t v_1135 = 0;
+         _fx_LN15C_form__cstmt_t v_1136 = 0;
          _fx_T4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t* __pat___11 =
             &lst_31->hd;
          _fx_copy_Nt6option1N14C_form__ctyp_t(&__pat___11->t0, &t_opt_0);
@@ -33001,7 +33207,7 @@ static int
          FX_COPY_PTR(__pat___11->t3, &for_incrs_0);
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
-               &t_opt_0, for_inits_0, &for_check_opt_0, for_incrs_0, for_stmt_0, &kloc_0, &for_stmt1_0), _fx_catch_250);
+               &t_opt_0, for_inits_0, &for_check_opt_0, for_incrs_0, for_stmt_0, &kloc_0, &for_stmt1_0), _fx_catch_257);
          bool t_15;
          if (k_0 > 0) {
             t_15 = true;
@@ -33010,23 +33216,23 @@ static int
             t_15 = pre_body_ccode_0 == 0;
          }
          if (t_15) {
-            FX_COPY_PTR(for_stmt1_0, &v_1113);
+            FX_COPY_PTR(for_stmt1_0, &v_1135);
          }
          else {
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt1_0, pre_body_ccode_0, true, &v_1114), _fx_catch_250);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt1_0, pre_body_ccode_0, true, &v_1136), _fx_catch_257);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(v_1114, &for_loc_1, &v_1113, 0),
-               _fx_catch_250);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(v_1136, &for_loc_1, &v_1135, 0),
+               _fx_catch_257);
          }
          _fx_free_N15C_form__cstmt_t(&for_stmt_0);
-         FX_COPY_PTR(v_1113, &for_stmt_0);
+         FX_COPY_PTR(v_1135, &for_stmt_0);
 
-      _fx_catch_250: ;
-         if (v_1114) {
-            _fx_free_LN15C_form__cstmt_t(&v_1114);
+      _fx_catch_257: ;
+         if (v_1136) {
+            _fx_free_LN15C_form__cstmt_t(&v_1136);
          }
-         if (v_1113) {
-            _fx_free_N15C_form__cstmt_t(&v_1113);
+         if (v_1135) {
+            _fx_free_N15C_form__cstmt_t(&v_1135);
          }
          if (for_stmt1_0) {
             _fx_free_N15C_form__cstmt_t(&for_stmt1_0);
@@ -33039,105 +33245,105 @@ static int
             _fx_free_LN14C_form__cexp_t(&for_inits_0);
          }
          _fx_free_Nt6option1N14C_form__ctyp_t(&t_opt_0);
-         FX_CHECK_EXN(_fx_catch_251);
+         FX_CHECK_EXN(_fx_catch_258);
       }
       bool res_29;
-      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&br_label_0, &_fx_g9Ast__noid, &res_29, 0), _fx_catch_251);
+      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&br_label_0, &_fx_g9Ast__noid, &res_29, 0), _fx_catch_258);
       if (res_29) {
          FX_COPY_PTR(post_ccode_0, &post_ccode_1);
       }
       else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&br_label_0, &end_for_loc_1, &v_1081),
-            _fx_catch_251);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1081, post_ccode_0, true, &post_ccode_1), _fx_catch_251);
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&br_label_0, &end_for_loc_1, &v_1103),
+            _fx_catch_258);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1103, post_ccode_0, true, &post_ccode_1), _fx_catch_258);
       }
       if (!is_parallel_for_0) {
-         _fx_make_Ta2LN15C_form__cstmt_t(0, post_ccode_1, &v_1082);
+         _fx_make_Ta2LN15C_form__cstmt_t(0, post_ccode_1, &v_1104);
       }
       else {
-         _fx_R9Ast__id_t v_1115;
-         fx_str_t slit_254 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_254, &v_1115, 0), _fx_catch_251);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1083), _fx_catch_251);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_3, v_1083, false, &v_1083), _fx_catch_251);
+         _fx_R9Ast__id_t v_1137;
+         fx_str_t slit_255 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_255, &v_1137, 0), _fx_catch_258);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1105), _fx_catch_258);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_3, v_1105, false, &v_1105), _fx_catch_258);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1115,
-               v_1083, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_1, 0), _fx_catch_251);
-         fx_str_t slit_255 = FX_MAKE_STR("omp parallel for");
-         FX_CALL(_fx_M6C_formFM12CMacroPragmaN15C_form__cstmt_t2SR10Ast__loc_t(&slit_255, &kloc_0, &v_1084), _fx_catch_251);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1084, 0, true, &v_1085), _fx_catch_251);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_1, &v_1086), _fx_catch_251);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1086, post_ccode_1, true, &v_1087), _fx_catch_251);
-         _fx_make_Ta2LN15C_form__cstmt_t(v_1085, v_1087, &v_1082);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1137,
+               v_1105, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_1, 0), _fx_catch_258);
+         fx_str_t slit_256 = FX_MAKE_STR("omp parallel for");
+         FX_CALL(_fx_M6C_formFM12CMacroPragmaN15C_form__cstmt_t2SR10Ast__loc_t(&slit_256, &kloc_0, &v_1106), _fx_catch_258);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1106, 0, true, &v_1107), _fx_catch_258);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_1, &v_1108), _fx_catch_258);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1108, post_ccode_1, true, &v_1109), _fx_catch_258);
+         _fx_make_Ta2LN15C_form__cstmt_t(v_1107, v_1109, &v_1104);
       }
-      FX_COPY_PTR(v_1082.t0, &omp_pragma_0);
-      FX_COPY_PTR(v_1082.t1, &post_ccode_2);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt_0, 0, true, &v_1088), _fx_catch_251);
+      FX_COPY_PTR(v_1104.t0, &omp_pragma_0);
+      FX_COPY_PTR(v_1104.t1, &post_ccode_2);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt_0, 0, true, &v_1110), _fx_catch_258);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1088, omp_pragma_0, &v_1089,
-            0), _fx_catch_251);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1110, omp_pragma_0, &v_1111,
+            0), _fx_catch_258);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(post_ccode_2, v_1089,
-            &loop_ccode_0, 0), _fx_catch_251);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(post_ccode_2, v_1111,
+            &loop_ccode_0, 0), _fx_catch_258);
       if (have_lock_0) {
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &wbctx_1, 0), _fx_catch_251);
-         _fx_R23C_gen_code__block_ctx_t* v_1116 = &wbctx_1->data;
-         int_ bctx_label_used_2 = v_1116->bctx_label_used;
-         _fx_R9Ast__id_t bctx_label_2 = v_1116->bctx_label;
-         FX_COPY_PTR(v_1116->bctx_cleanup, &bctx_cleanup_2);
-         FX_COPY_PTR(v_1116->bctx_prologue, &bctx_prologue_2);
+               &wbctx_1, 0), _fx_catch_258);
+         _fx_R23C_gen_code__block_ctx_t* v_1138 = &wbctx_1->data;
+         int_ bctx_label_used_2 = v_1138->bctx_label_used;
+         _fx_R9Ast__id_t bctx_label_2 = v_1138->bctx_label;
+         FX_COPY_PTR(v_1138->bctx_cleanup, &bctx_cleanup_2);
+         FX_COPY_PTR(v_1138->bctx_prologue, &bctx_prologue_2);
          if (bctx_label_used_2 == 0) {
             FX_COPY_PTR(bctx_cleanup_2, &epilogue_2);
          }
          else {
             FX_CALL(
-               _fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_2, &end_for_loc_1, &v_1090),
-               _fx_catch_251);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1090, 0, true, &v_1091), _fx_catch_251);
+               _fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_2, &end_for_loc_1, &v_1112),
+               _fx_catch_258);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1112, 0, true, &v_1113), _fx_catch_258);
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_2, v_1091,
-                  &epilogue_2, 0), _fx_catch_251);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_2, v_1113,
+                  &epilogue_2, 0), _fx_catch_258);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, bctx_prologue_2,
-               &v_1092, 0), _fx_catch_251);
+               &v_1114, 0), _fx_catch_258);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_2, v_1092,
-               &wrapped_0, 0), _fx_catch_251);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_2, v_1114,
+               &wrapped_0, 0), _fx_catch_258);
          FX_CALL(
             _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(wrapped_0, &for_loc_1, &c_e_3, 0),
-            _fx_catch_251);
+            _fx_catch_258);
          FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
-            _fx_catch_251);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1093), _fx_catch_251);
+            _fx_catch_258);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1115), _fx_catch_258);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g24C_form__std_FX_CHECK_EXN, v_1093, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1094, 0), _fx_catch_251);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1094, &check_exn_1), _fx_catch_251);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(c_e_3, ccode_147, true, &v_1095), _fx_catch_251);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_exn_1, v_1095, true, &result_ccode_0), _fx_catch_251);
+               &_fx_g24C_form__std_FX_CHECK_EXN, v_1115, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1116, 0), _fx_catch_258);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1116, &check_exn_1), _fx_catch_258);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(c_e_3, ccode_152, true, &v_1117), _fx_catch_258);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_exn_1, v_1117, true, &result_ccode_0), _fx_catch_258);
       }
       else {
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, ccode_147,
-               &result_ccode_0, 0), _fx_catch_251);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, ccode_152,
+               &result_ccode_0, 0), _fx_catch_258);
       }
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, result_ccode_0, &v_1);
 
-   _fx_catch_251: ;
-      if (v_1095) {
-         _fx_free_LN15C_form__cstmt_t(&v_1095);
+   _fx_catch_258: ;
+      if (v_1117) {
+         _fx_free_LN15C_form__cstmt_t(&v_1117);
       }
       if (check_exn_1) {
          _fx_free_N15C_form__cstmt_t(&check_exn_1);
       }
-      if (v_1094) {
-         _fx_free_N14C_form__cexp_t(&v_1094);
+      if (v_1116) {
+         _fx_free_N14C_form__cexp_t(&v_1116);
       }
-      if (v_1093) {
-         _fx_free_LN14C_form__cexp_t(&v_1093);
+      if (v_1115) {
+         _fx_free_LN14C_form__cexp_t(&v_1115);
       }
       if (c_e_3) {
          _fx_free_N15C_form__cstmt_t(&c_e_3);
@@ -33145,14 +33351,14 @@ static int
       if (wrapped_0) {
          _fx_free_LN15C_form__cstmt_t(&wrapped_0);
       }
-      if (v_1092) {
-         _fx_free_LN15C_form__cstmt_t(&v_1092);
+      if (v_1114) {
+         _fx_free_LN15C_form__cstmt_t(&v_1114);
       }
-      if (v_1091) {
-         _fx_free_LN15C_form__cstmt_t(&v_1091);
+      if (v_1113) {
+         _fx_free_LN15C_form__cstmt_t(&v_1113);
       }
-      if (v_1090) {
-         _fx_free_N15C_form__cstmt_t(&v_1090);
+      if (v_1112) {
+         _fx_free_N15C_form__cstmt_t(&v_1112);
       }
       if (epilogue_2) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_2);
@@ -33172,11 +33378,11 @@ static int
       if (loop_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&loop_ccode_0);
       }
-      if (v_1089) {
-         _fx_free_LN15C_form__cstmt_t(&v_1089);
+      if (v_1111) {
+         _fx_free_LN15C_form__cstmt_t(&v_1111);
       }
-      if (v_1088) {
-         _fx_free_LN15C_form__cstmt_t(&v_1088);
+      if (v_1110) {
+         _fx_free_LN15C_form__cstmt_t(&v_1110);
       }
       if (post_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_2);
@@ -33184,33 +33390,33 @@ static int
       if (omp_pragma_0) {
          _fx_free_LN15C_form__cstmt_t(&omp_pragma_0);
       }
-      if (v_1087) {
-         _fx_free_LN15C_form__cstmt_t(&v_1087);
+      if (v_1109) {
+         _fx_free_LN15C_form__cstmt_t(&v_1109);
       }
-      if (v_1086) {
-         _fx_free_N15C_form__cstmt_t(&v_1086);
+      if (v_1108) {
+         _fx_free_N15C_form__cstmt_t(&v_1108);
       }
-      if (v_1085) {
-         _fx_free_LN15C_form__cstmt_t(&v_1085);
+      if (v_1107) {
+         _fx_free_LN15C_form__cstmt_t(&v_1107);
       }
-      if (v_1084) {
-         _fx_free_N15C_form__cstmt_t(&v_1084);
+      if (v_1106) {
+         _fx_free_N15C_form__cstmt_t(&v_1106);
       }
       if (update_exn_parallel_1) {
          _fx_free_N14C_form__cexp_t(&update_exn_parallel_1);
       }
-      if (v_1083) {
-         _fx_free_LN14C_form__cexp_t(&v_1083);
+      if (v_1105) {
+         _fx_free_LN14C_form__cexp_t(&v_1105);
       }
-      _fx_free_Ta2LN15C_form__cstmt_t(&v_1082);
-      if (v_1081) {
-         _fx_free_N15C_form__cstmt_t(&v_1081);
+      _fx_free_Ta2LN15C_form__cstmt_t(&v_1104);
+      if (v_1103) {
+         _fx_free_N15C_form__cstmt_t(&v_1103);
       }
       if (post_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_1);
       }
-      if (v_1080) {
-         _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&v_1080);
+      if (v_1102) {
+         _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&v_1102);
       }
       if (for_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&for_stmt_0);
@@ -33218,13 +33424,13 @@ static int
       if (body_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_0);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1079);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1101);
       if (body_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1078);
-      if (v_1077) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1077);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1100);
+      if (v_1099) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1099);
       }
       if (body_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_1);
@@ -33232,11 +33438,11 @@ static int
       if (body_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_0);
       }
-      if (v_1076) {
-         _fx_free_LN15C_form__cstmt_t(&v_1076);
+      if (v_1098) {
+         _fx_free_LN15C_form__cstmt_t(&v_1098);
       }
-      if (v_1075) {
-         _fx_free_LN15C_form__cstmt_t(&v_1075);
+      if (v_1097) {
+         _fx_free_LN15C_form__cstmt_t(&v_1097);
       }
       if (wbctx_0) {
          _fx_free_rR23C_gen_code__block_ctx_t(&wbctx_0);
@@ -33248,8 +33454,8 @@ static int
       if (idoml_2) {
          _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idoml_2);
       }
-      if (v_1074) {
-         _fx_free_LN14C_form__cexp_t(&v_1074);
+      if (v_1096) {
+         _fx_free_LN14C_form__cexp_t(&v_1096);
       }
       if (post_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_0);
@@ -33260,32 +33466,32 @@ static int
       if (pre_body_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&pre_body_ccode_0);
       }
-      if (ccode_147) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_147);
+      if (ccode_152) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_152);
       }
       if (for_headers_0) {
          _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&for_headers_0);
       }
       _fx_free_T8LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_tLT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_t(
-         &v_1073);
-      if (v_1072) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1072);
+         &v_1095);
+      if (v_1094) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1094);
       }
-      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1071);
+      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1093);
       if (decl_nested_status_3) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_3);
       }
       if (nested_status_3) {
          _fx_free_N14C_form__cexp_t(&nested_status_3);
       }
-      if (ccode_146) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_146);
+      if (ccode_151) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_151);
       }
       if (par_status_3) {
          _fx_free_N14C_form__cexp_t(&par_status_3);
       }
-      if (v_1070) {
-         _fx_free_N14C_form__cexp_t(&v_1070);
+      if (v_1092) {
+         _fx_free_N14C_form__cexp_t(&v_1092);
       }
       if (decl_nested_status_2) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_2);
@@ -33293,104 +33499,104 @@ static int
       if (nested_status_2) {
          _fx_free_N14C_form__cexp_t(&nested_status_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1069);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1068);
-      if (v_1067) {
-         _fx_free_N14C_form__cexp_t(&v_1067);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1091);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1090);
+      if (v_1089) {
+         _fx_free_N14C_form__cexp_t(&v_1089);
       }
-      _fx_free_R16Ast__val_flags_t(&v_1066);
-      if (ccode_145) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_145);
+      _fx_free_R16Ast__val_flags_t(&v_1088);
+      if (ccode_150) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_150);
       }
       if (par_status_2) {
          _fx_free_N14C_form__cexp_t(&par_status_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1065);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1064);
-      if (v_1063) {
-         _fx_free_N14C_form__cexp_t(&v_1063);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1087);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1086);
+      if (v_1085) {
+         _fx_free_N14C_form__cexp_t(&v_1085);
       }
-      _fx_free_R16Ast__val_flags_t(&v_1062);
-      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_1061);
+      _fx_free_R16Ast__val_flags_t(&v_1084);
+      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_1083);
       if (glob_status_1) {
          _fx_free_N14C_form__cexp_t(&glob_status_1);
       }
       if (lbl_9) {
          _fx_free_N14C_form__cexp_t(&lbl_9);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 28) {
-      _fx_rNt6option1N14C_form__cexp_t v_1117 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1118 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1139 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1140 = {0};
       _fx_N14C_form__cexp_t cc_1 = 0;
       _fx_LN15C_form__cstmt_t cc_code_0 = 0;
-      _fx_T2BLN15C_form__cstmt_t v_1119 = {0};
+      _fx_T2BLN15C_form__cstmt_t v_1141 = {0};
       _fx_LN15C_form__cstmt_t check_code_0 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1120 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1121 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1142 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1143 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_3 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_4 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1122 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1144 = {0};
       _fx_N15C_form__cstmt_t body_stmt_1 = 0;
       _fx_N15C_form__cstmt_t loop_stmt_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1123 = 0;
+      _fx_LN15C_form__cstmt_t v_1145 = 0;
       _fx_T3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t* vcase_28 = &kexp_0->u.KExpWhile;
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_253);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1117), _fx_catch_253);
+            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_260);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1139), _fx_catch_260);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_28->t0, v_1117, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_28->t0, v_1139, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1118, fx_fv), _fx_catch_253);
-      FX_COPY_PTR(v_1118.t0, &cc_1);
-      FX_COPY_PTR(v_1118.t1, &cc_code_0);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1140, fx_fv), _fx_catch_260);
+      FX_COPY_PTR(v_1140.t0, &cc_1);
+      FX_COPY_PTR(v_1140.t1, &cc_code_0);
       if (cc_code_0 == 0) {
          if (FX_REC_VARIANT_TAG(cc_1) == 2) {
-            _fx_N14K_form__klit_t* v_1124 = &cc_1->u.CExpLit.t0;
-            if (v_1124->tag == 7) {
-               if (v_1124->u.KLitBool == true) {
-                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1119); goto _fx_endmatch_42;
+            _fx_N14K_form__klit_t* v_1146 = &cc_1->u.CExpLit.t0;
+            if (v_1146->tag == 7) {
+               if (v_1146->u.KLitBool == true) {
+                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1141); goto _fx_endmatch_45;
                }
             }
          }
       }
       if (cc_code_0 == 0) {
-         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1119); goto _fx_endmatch_42;
+         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1141); goto _fx_endmatch_45;
       }
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1125 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1147 = {0};
       _fx_N14C_form__cexp_t not_cc_0 = 0;
       _fx_N15C_form__cstmt_t break_stmt_1 = 0;
-      _fx_N15C_form__cstmt_t v_1126 = 0;
+      _fx_N15C_form__cstmt_t v_1148 = 0;
       _fx_N15C_form__cstmt_t check_cc_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1127 = 0;
+      _fx_LN15C_form__cstmt_t v_1149 = 0;
       _fx_R10Ast__loc_t cc_loc_0;
-      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_1, &cc_loc_0, 0), _fx_catch_252);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_0, &v_1125);
+      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_1, &cc_loc_0, 0), _fx_catch_259);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_0, &v_1147);
       FX_CALL(
          _fx_M6C_formFM9CExpUnaryN14C_form__cexp_t3N16C_form__cunary_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g23C_gen_code__COpLogicNot, cc_1, &v_1125, &not_cc_0), _fx_catch_252);
+            &_fx_g23C_gen_code__COpLogicNot, cc_1, &v_1147, &not_cc_0), _fx_catch_259);
       FX_CALL(
          _fx_M10C_gen_codeFM15make_break_stmtN15C_form__cstmt_t2R10Ast__loc_trLrRM11block_ctx_t(&cc_loc_0, block_stack_ref_0,
-            &break_stmt_1, 0), _fx_catch_252);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_0, &v_1126), _fx_catch_252);
+            &break_stmt_1, 0), _fx_catch_259);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_0, &v_1148), _fx_catch_259);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            not_cc_0, break_stmt_1, v_1126, &cc_loc_0, &check_cc_0, 0), _fx_catch_252);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_0, cc_code_0, true, &v_1127), _fx_catch_252);
-      _fx_make_T2BLN15C_form__cstmt_t(true, v_1127, &v_1119);
+            not_cc_0, break_stmt_1, v_1148, &cc_loc_0, &check_cc_0, 0), _fx_catch_259);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_0, cc_code_0, true, &v_1149), _fx_catch_259);
+      _fx_make_T2BLN15C_form__cstmt_t(true, v_1149, &v_1141);
 
-   _fx_catch_252: ;
-      if (v_1127) {
-         _fx_free_LN15C_form__cstmt_t(&v_1127);
+   _fx_catch_259: ;
+      if (v_1149) {
+         _fx_free_LN15C_form__cstmt_t(&v_1149);
       }
       if (check_cc_0) {
          _fx_free_N15C_form__cstmt_t(&check_cc_0);
       }
-      if (v_1126) {
-         _fx_free_N15C_form__cstmt_t(&v_1126);
+      if (v_1148) {
+         _fx_free_N15C_form__cstmt_t(&v_1148);
       }
       if (break_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&break_stmt_1);
@@ -33398,43 +33604,43 @@ static int
       if (not_cc_0) {
          _fx_free_N14C_form__cexp_t(&not_cc_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1125);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1147);
 
-   _fx_endmatch_42: ;
-      FX_CHECK_EXN(_fx_catch_253);
-      bool is_for_loop_0 = v_1119.t0;
-      FX_COPY_PTR(v_1119.t1, &check_code_0);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1120), _fx_catch_253);
+   _fx_endmatch_45: ;
+      FX_CHECK_EXN(_fx_catch_260);
+      bool is_for_loop_0 = v_1141.t0;
+      FX_COPY_PTR(v_1141.t1, &check_code_0);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1142), _fx_catch_260);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_28->t1, v_1120, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_28->t1, v_1142, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1121, fx_fv), _fx_catch_253);
-      FX_COPY_PTR(v_1121.t1, &body_ccode_3);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1143, fx_fv), _fx_catch_260);
+      FX_COPY_PTR(v_1143.t1, &body_ccode_3);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(body_ccode_3, check_code_0,
-            &body_ccode_4, 0), _fx_catch_253);
+            &body_ccode_4, 0), _fx_catch_260);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_4, true, &kloc_0, block_stack_ref_0, &v_1122, 0), _fx_catch_253);
-      FX_COPY_PTR(v_1122.t1, &body_stmt_1);
+            body_ccode_4, true, &kloc_0, block_stack_ref_0, &v_1144, 0), _fx_catch_260);
+      FX_COPY_PTR(v_1144.t1, &body_stmt_1);
       if (is_for_loop_0) {
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
                &_fx_g18C_gen_code__None1_, 0, &_fx_g18C_gen_code__None2_, 0, body_stmt_1, &kloc_0, &loop_stmt_0),
-            _fx_catch_253);
+            _fx_catch_260);
       }
       else {
          FX_CALL(
             _fx_M6C_formFM10CStmtWhileN15C_form__cstmt_t3N14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(cc_1, body_stmt_1,
-               &kloc_0, &loop_stmt_0), _fx_catch_253);
+               &kloc_0, &loop_stmt_0), _fx_catch_260);
       }
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_0, ccode_0, true, &v_1123), _fx_catch_253);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1123, &v_1);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_0, ccode_0, true, &v_1145), _fx_catch_260);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1145, &v_1);
 
-   _fx_catch_253: ;
-      if (v_1123) {
-         _fx_free_LN15C_form__cstmt_t(&v_1123);
+   _fx_catch_260: ;
+      if (v_1145) {
+         _fx_free_LN15C_form__cstmt_t(&v_1145);
       }
       if (loop_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&loop_stmt_0);
@@ -33442,111 +33648,111 @@ static int
       if (body_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_1);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1122);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1144);
       if (body_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_4);
       }
       if (body_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1121);
-      if (v_1120) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1120);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1143);
+      if (v_1142) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1142);
       }
       if (check_code_0) {
          _fx_free_LN15C_form__cstmt_t(&check_code_0);
       }
-      _fx_free_T2BLN15C_form__cstmt_t(&v_1119);
+      _fx_free_T2BLN15C_form__cstmt_t(&v_1141);
       if (cc_code_0) {
          _fx_free_LN15C_form__cstmt_t(&cc_code_0);
       }
       if (cc_1) {
          _fx_free_N14C_form__cexp_t(&cc_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1118);
-      if (v_1117) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1117);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1140);
+      if (v_1139) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1139);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 29) {
-      _fx_rNt6option1N14C_form__cexp_t v_1128 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1129 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1150 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1151 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_5 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1130 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1131 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1152 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1153 = {0};
       _fx_N14C_form__cexp_t cc_2 = 0;
       _fx_LN15C_form__cstmt_t cc_code_1 = 0;
-      _fx_T2BLN15C_form__cstmt_t v_1132 = {0};
+      _fx_T2BLN15C_form__cstmt_t v_1154 = {0};
       _fx_LN15C_form__cstmt_t check_code_1 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_6 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1133 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1155 = {0};
       _fx_N15C_form__cstmt_t body_stmt_2 = 0;
       _fx_N15C_form__cstmt_t loop_stmt_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1134 = 0;
+      _fx_LN15C_form__cstmt_t v_1156 = 0;
       _fx_T3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t* vcase_29 = &kexp_0->u.KExpDoWhile;
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_255);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1128), _fx_catch_255);
+            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_262);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1150), _fx_catch_262);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_29->t0, v_1128, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_29->t0, v_1150, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1129, fx_fv), _fx_catch_255);
-      FX_COPY_PTR(v_1129.t1, &body_ccode_5);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1130), _fx_catch_255);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1151, fx_fv), _fx_catch_262);
+      FX_COPY_PTR(v_1151.t1, &body_ccode_5);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1152), _fx_catch_262);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_29->t1, v_1130, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_29->t1, v_1152, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1131, fx_fv), _fx_catch_255);
-      FX_COPY_PTR(v_1131.t0, &cc_2);
-      FX_COPY_PTR(v_1131.t1, &cc_code_1);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1153, fx_fv), _fx_catch_262);
+      FX_COPY_PTR(v_1153.t0, &cc_2);
+      FX_COPY_PTR(v_1153.t1, &cc_code_1);
       if (cc_code_1 == 0) {
          if (FX_REC_VARIANT_TAG(cc_2) == 2) {
-            _fx_N14K_form__klit_t* v_1135 = &cc_2->u.CExpLit.t0;
-            if (v_1135->tag == 7) {
-               if (v_1135->u.KLitBool == true) {
-                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1132); goto _fx_endmatch_43;
+            _fx_N14K_form__klit_t* v_1157 = &cc_2->u.CExpLit.t0;
+            if (v_1157->tag == 7) {
+               if (v_1157->u.KLitBool == true) {
+                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1154); goto _fx_endmatch_46;
                }
             }
          }
       }
       if (cc_code_1 == 0) {
-         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1132); goto _fx_endmatch_43;
+         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1154); goto _fx_endmatch_46;
       }
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1136 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1158 = {0};
       _fx_N14C_form__cexp_t not_cc_1 = 0;
       _fx_N15C_form__cstmt_t break_stmt_2 = 0;
-      _fx_N15C_form__cstmt_t v_1137 = 0;
+      _fx_N15C_form__cstmt_t v_1159 = 0;
       _fx_N15C_form__cstmt_t check_cc_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1138 = 0;
+      _fx_LN15C_form__cstmt_t v_1160 = 0;
       _fx_R10Ast__loc_t cc_loc_1;
-      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_2, &cc_loc_1, 0), _fx_catch_254);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_1, &v_1136);
+      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_2, &cc_loc_1, 0), _fx_catch_261);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_1, &v_1158);
       FX_CALL(
          _fx_M6C_formFM9CExpUnaryN14C_form__cexp_t3N16C_form__cunary_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g23C_gen_code__COpLogicNot, cc_2, &v_1136, &not_cc_1), _fx_catch_254);
+            &_fx_g23C_gen_code__COpLogicNot, cc_2, &v_1158, &not_cc_1), _fx_catch_261);
       FX_CALL(
          _fx_M10C_gen_codeFM15make_break_stmtN15C_form__cstmt_t2R10Ast__loc_trLrRM11block_ctx_t(&cc_loc_1, block_stack_ref_0,
-            &break_stmt_2, 0), _fx_catch_254);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_1, &v_1137), _fx_catch_254);
+            &break_stmt_2, 0), _fx_catch_261);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_1, &v_1159), _fx_catch_261);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            not_cc_1, break_stmt_2, v_1137, &cc_loc_1, &check_cc_1, 0), _fx_catch_254);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_1, cc_code_1, true, &v_1138), _fx_catch_254);
-      _fx_make_T2BLN15C_form__cstmt_t(true, v_1138, &v_1132);
+            not_cc_1, break_stmt_2, v_1159, &cc_loc_1, &check_cc_1, 0), _fx_catch_261);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_1, cc_code_1, true, &v_1160), _fx_catch_261);
+      _fx_make_T2BLN15C_form__cstmt_t(true, v_1160, &v_1154);
 
-   _fx_catch_254: ;
-      if (v_1138) {
-         _fx_free_LN15C_form__cstmt_t(&v_1138);
+   _fx_catch_261: ;
+      if (v_1160) {
+         _fx_free_LN15C_form__cstmt_t(&v_1160);
       }
       if (check_cc_1) {
          _fx_free_N15C_form__cstmt_t(&check_cc_1);
       }
-      if (v_1137) {
-         _fx_free_N15C_form__cstmt_t(&v_1137);
+      if (v_1159) {
+         _fx_free_N15C_form__cstmt_t(&v_1159);
       }
       if (break_stmt_2) {
          _fx_free_N15C_form__cstmt_t(&break_stmt_2);
@@ -33554,36 +33760,36 @@ static int
       if (not_cc_1) {
          _fx_free_N14C_form__cexp_t(&not_cc_1);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1136);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1158);
 
-   _fx_endmatch_43: ;
-      FX_CHECK_EXN(_fx_catch_255);
-      bool is_for_loop_1 = v_1132.t0;
-      FX_COPY_PTR(v_1132.t1, &check_code_1);
+   _fx_endmatch_46: ;
+      FX_CHECK_EXN(_fx_catch_262);
+      bool is_for_loop_1 = v_1154.t0;
+      FX_COPY_PTR(v_1154.t1, &check_code_1);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(check_code_1, body_ccode_5,
-            &body_ccode_6, 0), _fx_catch_255);
+            &body_ccode_6, 0), _fx_catch_262);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_6, true, &kloc_0, block_stack_ref_0, &v_1133, 0), _fx_catch_255);
-      FX_COPY_PTR(v_1133.t1, &body_stmt_2);
+            body_ccode_6, true, &kloc_0, block_stack_ref_0, &v_1155, 0), _fx_catch_262);
+      FX_COPY_PTR(v_1155.t1, &body_stmt_2);
       if (is_for_loop_1) {
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
                &_fx_g18C_gen_code__None1_, 0, &_fx_g18C_gen_code__None2_, 0, body_stmt_2, &kloc_0, &loop_stmt_1),
-            _fx_catch_255);
+            _fx_catch_262);
       }
       else {
          FX_CALL(
             _fx_M6C_formFM12CStmtDoWhileN15C_form__cstmt_t3N15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_t(body_stmt_2, cc_2,
-               &kloc_0, &loop_stmt_1), _fx_catch_255);
+               &kloc_0, &loop_stmt_1), _fx_catch_262);
       }
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_1, ccode_0, true, &v_1134), _fx_catch_255);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1134, &v_1);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_1, ccode_0, true, &v_1156), _fx_catch_262);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1156, &v_1);
 
-   _fx_catch_255: ;
-      if (v_1134) {
-         _fx_free_LN15C_form__cstmt_t(&v_1134);
+   _fx_catch_262: ;
+      if (v_1156) {
+         _fx_free_LN15C_form__cstmt_t(&v_1156);
       }
       if (loop_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&loop_stmt_1);
@@ -33591,167 +33797,167 @@ static int
       if (body_stmt_2) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_2);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1133);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1155);
       if (body_ccode_6) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_6);
       }
       if (check_code_1) {
          _fx_free_LN15C_form__cstmt_t(&check_code_1);
       }
-      _fx_free_T2BLN15C_form__cstmt_t(&v_1132);
+      _fx_free_T2BLN15C_form__cstmt_t(&v_1154);
       if (cc_code_1) {
          _fx_free_LN15C_form__cstmt_t(&cc_code_1);
       }
       if (cc_2) {
          _fx_free_N14C_form__cexp_t(&cc_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1131);
-      if (v_1130) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1130);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1153);
+      if (v_1152) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1152);
       }
       if (body_ccode_5) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1129);
-      if (v_1128) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1128);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1151);
+      if (v_1150) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1150);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 30) {
-      _fx_rR23C_gen_code__block_ctx_t v_1139 = 0;
-      fx_exn_t v_1140 = {0};
-      _fx_N14C_form__cexp_t v_1141 = 0;
-      _fx_N15C_form__cstmt_t v_1142 = 0;
-      _fx_LN15C_form__cstmt_t v_1143 = 0;
+      _fx_rR23C_gen_code__block_ctx_t v_1161 = 0;
+      fx_exn_t v_1162 = {0};
+      _fx_N14C_form__cexp_t v_1163 = 0;
+      _fx_N15C_form__cstmt_t v_1164 = 0;
+      _fx_LN15C_form__cstmt_t v_1165 = 0;
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &v_1139, 0), _fx_catch_256);
-      _fx_R23C_gen_code__block_ctx_t* v_1144 = &v_1139->data;
-      _fx_N24C_gen_code__block_kind_t v_1145 = v_1144->bctx_kind;
-      if (v_1145.tag != 1) {
-         fx_str_t slit_256 = FX_MAKE_STR("cgen: unexpected ccode expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_256, &v_1140, 0), _fx_catch_256);
-         FX_THROW(&v_1140, false, _fx_catch_256);
+            &v_1161, 0), _fx_catch_263);
+      _fx_R23C_gen_code__block_ctx_t* v_1166 = &v_1161->data;
+      _fx_N24C_gen_code__block_kind_t v_1167 = v_1166->bctx_kind;
+      if (v_1167.tag != 1) {
+         fx_str_t slit_257 = FX_MAKE_STR("cgen: unexpected ccode expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_257, &v_1162, 0), _fx_catch_263);
+         FX_THROW(&v_1162, false, _fx_catch_263);
       }
-      FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&kexp_0->u.KExpCCode.t0, &kloc_0, &v_1141),
-         _fx_catch_256);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1141, &v_1142), _fx_catch_256);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1142, *top_inline_ccode_0, true, &v_1143), _fx_catch_256);
+      FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&kexp_0->u.KExpCCode.t0, &kloc_0, &v_1163),
+         _fx_catch_263);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1163, &v_1164), _fx_catch_263);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1164, *top_inline_ccode_0, true, &v_1165), _fx_catch_263);
       _fx_free_LN15C_form__cstmt_t(top_inline_ccode_0);
-      FX_COPY_PTR(v_1143, top_inline_ccode_0);
+      FX_COPY_PTR(v_1165, top_inline_ccode_0);
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1);
 
-   _fx_catch_256: ;
-      if (v_1143) {
-         _fx_free_LN15C_form__cstmt_t(&v_1143);
+   _fx_catch_263: ;
+      if (v_1165) {
+         _fx_free_LN15C_form__cstmt_t(&v_1165);
       }
-      if (v_1142) {
-         _fx_free_N15C_form__cstmt_t(&v_1142);
+      if (v_1164) {
+         _fx_free_N15C_form__cstmt_t(&v_1164);
       }
-      if (v_1141) {
-         _fx_free_N14C_form__cexp_t(&v_1141);
+      if (v_1163) {
+         _fx_free_N14C_form__cexp_t(&v_1163);
       }
-      fx_free_exn(&v_1140);
-      if (v_1139) {
-         _fx_free_rR23C_gen_code__block_ctx_t(&v_1139);
+      fx_free_exn(&v_1162);
+      if (v_1161) {
+         _fx_free_rR23C_gen_code__block_ctx_t(&v_1161);
       }
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 31) {
-      _fx_R17K_form__kdefval_t v_1146 = {0};
+      _fx_R17K_form__kdefval_t v_1168 = {0};
       _fx_R16Ast__val_flags_t kv_flags_1 = {0};
       fx_str_t kv_cname_0 = {0};
       _fx_N14K_form__ktyp_t kv_typ_1 = 0;
       _fx_N14C_form__ctyp_t ctyp_4 = 0;
       _fx_rR23C_gen_code__block_ctx_t bctx_1 = 0;
-      _fx_T3SSR10Ast__loc_t v_1147 = {0};
+      _fx_T3SSR10Ast__loc_t v_1169 = {0};
       fx_str_t ccode_data_kind_0 = {0};
       fx_str_t ccode_data_lit_0 = {0};
-      _fx_LN15C_form__cstmt_t ccode_148 = 0;
-      _fx_N14C_form__cexp_t v_1148 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1149 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1150 = {0};
-      _fx_LN15C_form__cstmt_t delta_ccode_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1151 = 0;
-      _fx_LN15C_form__cstmt_t v_1152 = 0;
-      _fx_N14C_form__cexp_t tag_exp_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1153 = {0};
-      _fx_LN14C_form__cexp_t v_1154 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1155 = {0};
-      _fx_N14C_form__cexp_t init_exp_0 = 0;
-      _fx_N14C_form__cexp_t v_1156 = 0;
-      _fx_R16Ast__val_flags_t v_1157 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1158 = {0};
-      _fx_N14C_form__cexp_t i_exp_17 = 0;
-      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_1159 = {0};
-      _fx_N14C_form__ctyp_t struct_ctyp_0 = 0;
-      fx_str_t v_1160 = {0};
-      fx_str_t v_1161 = {0};
-      _fx_N14C_form__cexp_t rc_exp_0 = 0;
-      _fx_LN14C_form__cexp_t v_1162 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1163 = {0};
-      _fx_N14C_form__cexp_t data_init_0 = 0;
-      _fx_R16Ast__val_flags_t v_1164 = {0};
-      _fx_R16Ast__val_flags_t v_1165 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_1166 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1167 = {0};
-      _fx_N14C_form__cexp_t data_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t delta_ccode_1 = 0;
-      _fx_N14C_form__cexp_t v_1168 = 0;
-      _fx_N14C_form__cexp_t init_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t delta_ccode_2 = 0;
-      _fx_R16Ast__val_flags_t v_1169 = {0};
-      _fx_R16Ast__val_flags_t v_1170 = {0};
+      _fx_LN15C_form__cstmt_t ccode_153 = 0;
+      _fx_N14C_form__cexp_t v_1170 = 0;
       _fx_Nt6option1N14C_form__cexp_t v_1171 = {0};
       _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1172 = {0};
-      _fx_LN15C_form__cstmt_t delta_ccode_3 = 0;
+      _fx_LN15C_form__cstmt_t delta_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t v_1173 = 0;
       _fx_LN15C_form__cstmt_t v_1174 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1175 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1176 = {0};
+      _fx_N14C_form__cexp_t tag_exp_0 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1175 = {0};
+      _fx_LN14C_form__cexp_t v_1176 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1177 = {0};
+      _fx_N14C_form__cexp_t init_exp_0 = 0;
+      _fx_N14C_form__cexp_t v_1178 = 0;
+      _fx_R16Ast__val_flags_t v_1179 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1180 = {0};
+      _fx_N14C_form__cexp_t i_exp_17 = 0;
+      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_1181 = {0};
+      _fx_N14C_form__ctyp_t struct_ctyp_0 = 0;
+      fx_str_t v_1182 = {0};
+      fx_str_t v_1183 = {0};
+      _fx_N14C_form__cexp_t rc_exp_0 = 0;
+      _fx_LN14C_form__cexp_t v_1184 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1185 = {0};
+      _fx_N14C_form__cexp_t data_init_0 = 0;
+      _fx_R16Ast__val_flags_t v_1186 = {0};
+      _fx_R16Ast__val_flags_t v_1187 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_1188 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1189 = {0};
+      _fx_N14C_form__cexp_t data_exp_1 = 0;
+      _fx_LN15C_form__cstmt_t delta_ccode_1 = 0;
+      _fx_N14C_form__cexp_t v_1190 = 0;
+      _fx_N14C_form__cexp_t init_exp_1 = 0;
+      _fx_LN15C_form__cstmt_t delta_ccode_2 = 0;
+      _fx_R16Ast__val_flags_t v_1191 = {0};
+      _fx_R16Ast__val_flags_t v_1192 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_1193 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1194 = {0};
+      _fx_LN15C_form__cstmt_t delta_ccode_3 = 0;
+      _fx_LN15C_form__cstmt_t v_1195 = 0;
+      _fx_LN15C_form__cstmt_t v_1196 = 0;
+      _fx_rNt6option1N14C_form__cexp_t v_1197 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1198 = {0};
       _fx_N14C_form__cexp_t ce2_5 = 0;
-      _fx_LN15C_form__cstmt_t ccode_149 = 0;
+      _fx_LN15C_form__cstmt_t ccode_154 = 0;
       _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t res_30 = {0};
-      _fx_rNt6option1N14C_form__cexp_t v_1177 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1178 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1199 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1200 = {0};
       _fx_N14C_form__cexp_t ce2_6 = 0;
-      _fx_LN15C_form__cstmt_t ccode_150 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1179 = {0};
+      _fx_LN15C_form__cstmt_t ccode_155 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1201 = {0};
       _fx_LN15C_form__cstmt_t saved_cleanup_0 = 0;
-      _fx_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB v_1180 = {0};
-      _fx_T2Nt6option1N14C_form__cexp_tB v_1181 = {0};
+      _fx_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB v_1202 = {0};
+      _fx_T2Nt6option1N14C_form__cexp_tB v_1203 = {0};
       _fx_Nt6option1N14C_form__cexp_t e0_opt_0 = {0};
       _fx_R16Ast__val_flags_t flags_2 = {0};
       _fx_Nt6option1N14C_form__cexp_t e0_opt_1 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1182 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1204 = {0};
       _fx_N14C_form__cexp_t i_exp_18 = 0;
       _fx_LN15C_form__cstmt_t delta_ccode_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_151 = 0;
-      _fx_LN15C_form__cstmt_t v_1183 = 0;
-      _fx_LN15C_form__cstmt_t v_1184 = 0;
-      _fx_LN15C_form__cstmt_t v_1185 = 0;
-      _fx_LN15C_form__cstmt_t v_1186 = 0;
-      _fx_LN15C_form__cstmt_t v_1187 = 0;
-      _fx_LN15C_form__cstmt_t v_1188 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1189 = {0};
-      _fx_rNt6option1N14C_form__cexp_t v_1190 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1191 = {0};
-      _fx_LN15C_form__cstmt_t ccode_152 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1192 = {0};
+      _fx_LN15C_form__cstmt_t ccode_156 = 0;
+      _fx_LN15C_form__cstmt_t v_1205 = 0;
+      _fx_LN15C_form__cstmt_t v_1206 = 0;
+      _fx_LN15C_form__cstmt_t v_1207 = 0;
+      _fx_LN15C_form__cstmt_t v_1208 = 0;
+      _fx_LN15C_form__cstmt_t v_1209 = 0;
+      _fx_LN15C_form__cstmt_t v_1210 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1211 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1212 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1213 = {0};
+      _fx_LN15C_form__cstmt_t ccode_157 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1214 = {0};
       _fx_N14C_form__cexp_t ce2_7 = 0;
-      _fx_LN15C_form__cstmt_t ccode_153 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1193 = {0};
-      _fx_N15C_form__cinfo_t v_1194 = {0};
+      _fx_LN15C_form__cstmt_t ccode_158 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1215 = {0};
+      _fx_N15C_form__cinfo_t v_1216 = {0};
       _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_30 = &kexp_0->u.KDefVal;
       _fx_N14K_form__kexp_t e2_1 = vcase_30->t1;
       _fx_R9Ast__id_t* i_11 = &vcase_30->t0;
-      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1146, 0), _fx_catch_268);
-      _fx_copy_R16Ast__val_flags_t(&v_1146.kv_flags, &kv_flags_1);
-      fx_copy_str(&v_1146.kv_cname, &kv_cname_0);
-      FX_COPY_PTR(v_1146.kv_typ, &kv_typ_1);
+      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1168, 0), _fx_catch_275);
+      _fx_copy_R16Ast__val_flags_t(&v_1168.kv_flags, &kv_flags_1);
+      fx_copy_str(&v_1168.kv_cname, &kv_cname_0);
+      FX_COPY_PTR(v_1168.kv_typ, &kv_typ_1);
       bool res_31;
-      FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(&kv_flags_1, &res_31, 0), _fx_catch_268);
+      FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(&kv_flags_1, &res_31, 0), _fx_catch_275);
       bool t_16;
       if (res_31) {
          t_16 = true;
@@ -33760,42 +33966,42 @@ static int
          t_16 = kv_flags_1.val_flag_ctor > 0;
       }
       if (t_16) {
-         FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, i_11, 0), _fx_catch_268);
+         FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, i_11, 0), _fx_catch_275);
       }
-      _fx_R17K_form__ktprops_t v_1195;
+      _fx_R17K_form__ktprops_t v_1217;
       FX_CALL(
-         _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &v_1195, 0),
-         _fx_catch_268);
-      bool ktp_scalar_0 = v_1195.ktp_scalar;
-      bool ktp_complex_3 = v_1195.ktp_complex;
-      bool ktp_ptr_2 = v_1195.ktp_ptr;
+         _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &v_1217, 0),
+         _fx_catch_275);
+      bool ktp_scalar_0 = v_1217.ktp_scalar;
+      bool ktp_complex_3 = v_1217.ktp_complex;
+      bool ktp_ptr_2 = v_1217.ktp_ptr;
       FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &ctyp_4, 0),
-         _fx_catch_268);
+         _fx_catch_275);
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_1, 0), _fx_catch_268);
+            &bctx_1, 0), _fx_catch_275);
       if (FX_REC_VARIANT_TAG(e2_1) == 30) {
          _fx_T2ST2N14K_form__ktyp_tR10Ast__loc_t* vcase_31 = &e2_1->u.KExpCCode;
-         fx_str_t slit_257 = FX_MAKE_STR("ccode");
-         _fx_make_T3SSR10Ast__loc_t(&slit_257, &vcase_31->t0, &vcase_31->t1.t1, &v_1147);
+         fx_str_t slit_258 = FX_MAKE_STR("ccode");
+         _fx_make_T3SSR10Ast__loc_t(&slit_258, &vcase_31->t0, &vcase_31->t1.t1, &v_1169);
       }
       else {
-         fx_str_t slit_258 = FX_MAKE_STR("");
          fx_str_t slit_259 = FX_MAKE_STR("");
-         _fx_make_T3SSR10Ast__loc_t(&slit_258, &slit_259, &kloc_0, &v_1147);
+         fx_str_t slit_260 = FX_MAKE_STR("");
+         _fx_make_T3SSR10Ast__loc_t(&slit_259, &slit_260, &kloc_0, &v_1169);
       }
-      FX_CHECK_EXN(_fx_catch_268);
-      fx_copy_str(&v_1147.t0, &ccode_data_kind_0);
-      fx_copy_str(&v_1147.t1, &ccode_data_lit_0);
-      _fx_R10Ast__loc_t ccode_loc_0 = v_1147.t2;
+      FX_CHECK_EXN(_fx_catch_275);
+      fx_copy_str(&v_1169.t0, &ccode_data_kind_0);
+      fx_copy_str(&v_1169.t1, &ccode_data_lit_0);
+      _fx_R10Ast__loc_t ccode_loc_0 = v_1169.t2;
       int_ ctor_id_0 = kv_flags_1.val_flag_ctor;
       bool is_temp_0 = kv_flags_1.val_flag_temp;
       bool is_temp_ref_0 = kv_flags_1.val_flag_tempref;
-      _fx_R23C_gen_code__block_ctx_t* v_1196 = &bctx_1->data;
-      _fx_N24C_gen_code__block_kind_t v_1197 = v_1196->bctx_kind;
+      _fx_R23C_gen_code__block_ctx_t* v_1218 = &bctx_1->data;
+      _fx_N24C_gen_code__block_kind_t v_1219 = v_1218->bctx_kind;
       bool is_global_0;
       bool t_17;
-      if (v_1197.tag == 1) {
+      if (v_1219.tag == 1) {
          t_17 = !is_temp_0;
       }
       else {
@@ -33813,175 +34019,175 @@ static int
             _fx_T4N13Ast__binary_tN14K_form__atom_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_32 =
                &e2_1->u.KExpBinary;
             if (FX_REC_VARIANT_TAG(vcase_32->t0) == 26) {
-               _fx_N14K_form__atom_t* v_1198 = &vcase_32->t2;
-               if (v_1198->tag == 1) {
-                  _fx_R9Ast__id_t* l_0 = &v_1198->u.AtomId;
+               _fx_N14K_form__atom_t* v_1220 = &vcase_32->t2;
+               if (v_1220->tag == 1) {
+                  _fx_R9Ast__id_t* l_0 = &v_1220->u.AtomId;
                   bool res_32;
                   FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, l_0, &res_32, 0),
-                     _fx_catch_268);
+                     _fx_catch_275);
                   if (res_32) {
-                     _fx_N15K_form__kinfo_t v_1199 = {0};
-                     FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(l_0, &kloc_0, &v_1199, 0),
-                        _fx_catch_257);
-                     if (v_1199.tag == 2) {
-                        is_fast_cons_0 = v_1199.u.KVal.kv_flags.val_flag_temp;
+                     _fx_N15K_form__kinfo_t v_1221 = {0};
+                     FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(l_0, &kloc_0, &v_1221, 0),
+                        _fx_catch_264);
+                     if (v_1221.tag == 2) {
+                        is_fast_cons_0 = v_1221.u.KVal.kv_flags.val_flag_temp;
                      }
                      else {
                         is_fast_cons_0 = false;
                      }
-                     FX_CHECK_EXN(_fx_catch_257);
+                     FX_CHECK_EXN(_fx_catch_264);
 
-                  _fx_catch_257: ;
-                     _fx_free_N15K_form__kinfo_t(&v_1199);
-                     goto _fx_endmatch_44;
+                  _fx_catch_264: ;
+                     _fx_free_N15K_form__kinfo_t(&v_1221);
+                     goto _fx_endmatch_47;
                   }
                }
             }
          }
          is_fast_cons_0 = false;
 
-      _fx_endmatch_44: ;
-         FX_CHECK_EXN(_fx_catch_268);
+      _fx_endmatch_47: ;
+         FX_CHECK_EXN(_fx_catch_275);
       }
       else {
          is_fast_cons_0 = false;
       }
-      bool v_1200;
-      fx_str_t slit_260 = FX_MAKE_STR("ccode");
-      v_1200 = _fx_F6__eq__B2SS(&ccode_data_kind_0, &slit_260, 0);
-      if (v_1200) {
-         FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&ccode_data_lit_0, &ccode_loc_0, &v_1148),
-            _fx_catch_268);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1148, &v_1149);
-         fx_str_t slit_261 = FX_MAKE_STR("");
+      bool v_1222;
+      fx_str_t slit_261 = FX_MAKE_STR("ccode");
+      v_1222 = _fx_F6__eq__B2SS(&ccode_data_kind_0, &slit_261, 0);
+      if (v_1222) {
+         FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&ccode_data_lit_0, &ccode_loc_0, &v_1170),
+            _fx_catch_275);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1170, &v_1171);
+         fx_str_t slit_262 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               i_11, ctyp_4, &kv_flags_1, &slit_261, &v_1149, 0, &kloc_0, &v_1150, 0), _fx_catch_268);
-         FX_COPY_PTR(v_1150.t1, &delta_ccode_0);
-         _fx_R23C_gen_code__block_ctx_t* v_1201 = &bctx_1->data;
-         FX_COPY_PTR(v_1201->bctx_prologue, &v_1151);
+               i_11, ctyp_4, &kv_flags_1, &slit_262, &v_1171, 0, &kloc_0, &v_1172, 0), _fx_catch_275);
+         FX_COPY_PTR(v_1172.t1, &delta_ccode_0);
+         _fx_R23C_gen_code__block_ctx_t* v_1223 = &bctx_1->data;
+         FX_COPY_PTR(v_1223->bctx_prologue, &v_1173);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_0, v_1151,
-               &v_1152, 0), _fx_catch_268);
-         _fx_R23C_gen_code__block_ctx_t* v_1202 = &bctx_1->data;
-         _fx_LN15C_form__cstmt_t* v_1203 = &v_1202->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1203);
-         FX_COPY_PTR(v_1152, v_1203);
-         FX_COPY_PTR(ccode_0, &ccode_148);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_0, v_1173,
+               &v_1174, 0), _fx_catch_275);
+         _fx_R23C_gen_code__block_ctx_t* v_1224 = &bctx_1->data;
+         _fx_LN15C_form__cstmt_t* v_1225 = &v_1224->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1225);
+         FX_COPY_PTR(v_1174, v_1225);
+         FX_COPY_PTR(ccode_0, &ccode_153);
       }
       else if (ctor_id_0 > 0) {
          FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_id_0, &kloc_0, &tag_exp_0, 0),
-            _fx_catch_268);
+            _fx_catch_275);
          bool is_null_0;
          if (FX_REC_VARIANT_TAG(kv_typ_1) == 16) {
-            _fx_N15K_form__kinfo_t v_1204 = {0};
+            _fx_N15K_form__kinfo_t v_1226 = {0};
             FX_CALL(
-               _fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&kv_typ_1->u.KTypName, &kloc_0, &v_1204, 0),
-               _fx_catch_258);
-            if (v_1204.tag == 5) {
-               _fx_R21K_form__kdefvariant_t v_1205 = {0};
-               _fx_copy_R21K_form__kdefvariant_t(&v_1204.u.KVariant->data, &v_1205);
-               _fx_R16Ast__var_flags_t* kvar_flags_1 = &v_1205.kvar_flags;
+               _fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&kv_typ_1->u.KTypName, &kloc_0, &v_1226, 0),
+               _fx_catch_265);
+            if (v_1226.tag == 5) {
+               _fx_R21K_form__kdefvariant_t v_1227 = {0};
+               _fx_copy_R21K_form__kdefvariant_t(&v_1226.u.KVariant->data, &v_1227);
+               _fx_R16Ast__var_flags_t* kvar_flags_1 = &v_1227.kvar_flags;
                if (kvar_flags_1->var_flag_recursive) {
                   is_null_0 = kvar_flags_1->var_flag_opt;
                }
                else {
                   is_null_0 = false;
                }
-               _fx_free_R21K_form__kdefvariant_t(&v_1205);
+               _fx_free_R21K_form__kdefvariant_t(&v_1227);
             }
             else {
                is_null_0 = false;
             }
-            FX_CHECK_EXN(_fx_catch_258);
+            FX_CHECK_EXN(_fx_catch_265);
 
-         _fx_catch_258: ;
-            _fx_free_N15K_form__kinfo_t(&v_1204);
+         _fx_catch_265: ;
+            _fx_free_N15K_form__kinfo_t(&v_1226);
          }
          else {
             is_null_0 = false;
          }
-         FX_CHECK_EXN(_fx_catch_268);
+         FX_CHECK_EXN(_fx_catch_275);
          if (!ktp_ptr_2) {
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1154), _fx_catch_268);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &kloc_0, &v_1155);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1176), _fx_catch_275);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &kloc_0, &v_1177);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1154, &v_1155,
-                  &init_exp_0), _fx_catch_268);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(init_exp_0, 0, &v_1153);
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1176, &v_1177,
+                  &init_exp_0), _fx_catch_275);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(init_exp_0, 0, &v_1175);
          }
          else if (is_null_0) {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1156, 0), _fx_catch_268);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1156, 0, &v_1153);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1178, 0), _fx_catch_275);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1178, 0, &v_1175);
          }
          else {
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1157, 0), _fx_catch_268);
-            fx_str_t slit_262 = FX_MAKE_STR("");
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1179, 0), _fx_catch_275);
+            fx_str_t slit_263 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_11, ctyp_4, &v_1157, &slit_262, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &v_1158, 0), _fx_catch_268);
-            FX_COPY_PTR(v_1158.t0, &i_exp_17);
+                  i_11, ctyp_4, &v_1179, &slit_263, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &v_1180, 0), _fx_catch_275);
+            FX_COPY_PTR(v_1180.t0, &i_exp_17);
             FX_CALL(
                _fx_M10C_gen_codeFM10get_structT4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti1N14C_form__cexp_t(
-                  i_exp_17, &v_1159, 0), _fx_catch_268);
-            _fx_R9Ast__id_t rn_0 = v_1159.t0;
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&rn_0, &struct_ctyp_0), _fx_catch_268);
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_11, &v_1160, 0), _fx_catch_268);
-            fx_str_t slit_263 = FX_MAKE_STR("_data");
+                  i_exp_17, &v_1181, 0), _fx_catch_275);
+            _fx_R9Ast__id_t rn_0 = v_1181.t0;
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&rn_0, &struct_ctyp_0), _fx_catch_275);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_11, &v_1182, 0), _fx_catch_275);
+            fx_str_t slit_264 = FX_MAKE_STR("_data");
             {
-               const fx_str_t strs_36[] = { v_1160, slit_263 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_36, 2, &v_1161), _fx_catch_268);
+               const fx_str_t strs_36[] = { v_1182, slit_264 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_36, 2, &v_1183), _fx_catch_275);
             }
             _fx_R9Ast__id_t data_id_1;
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &v_1161, &data_id_1, 0), _fx_catch_268);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &rc_exp_0, 0), _fx_catch_268);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1162), _fx_catch_268);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(rc_exp_0, v_1162, false, &v_1162), _fx_catch_268);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(struct_ctyp_0, &kloc_0, &v_1163);
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &v_1183, &data_id_1, 0), _fx_catch_275);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &rc_exp_0, 0), _fx_catch_275);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1184), _fx_catch_275);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(rc_exp_0, v_1184, false, &v_1184), _fx_catch_275);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(struct_ctyp_0, &kloc_0, &v_1185);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1162, &v_1163,
-                  &data_init_0), _fx_catch_268);
-            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1164, 0), _fx_catch_268);
-            _fx_make_R16Ast__val_flags_t(v_1164.val_flag_arg, v_1164.val_flag_mutable, v_1164.val_flag_temp,
-               v_1164.val_flag_tempref, true, v_1164.val_flag_subarray, v_1164.val_flag_instance, &v_1164.val_flag_method,
-               v_1164.val_flag_ctor, v_1164.val_flag_global, &v_1165);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(data_init_0, &v_1166);
-            fx_str_t slit_264 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1184, &v_1185,
+                  &data_init_0), _fx_catch_275);
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1186, 0), _fx_catch_275);
+            _fx_make_R16Ast__val_flags_t(v_1186.val_flag_arg, v_1186.val_flag_mutable, v_1186.val_flag_temp,
+               v_1186.val_flag_tempref, true, v_1186.val_flag_subarray, v_1186.val_flag_instance, &v_1186.val_flag_method,
+               v_1186.val_flag_ctor, v_1186.val_flag_global, &v_1187);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(data_init_0, &v_1188);
+            fx_str_t slit_265 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &data_id_1, struct_ctyp_0, &v_1165, &slit_264, &v_1166, 0, &kloc_0, &v_1167, 0), _fx_catch_268);
-            FX_COPY_PTR(v_1167.t0, &data_exp_1);
-            FX_COPY_PTR(v_1167.t1, &delta_ccode_1);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(data_exp_1, &v_1168, 0), _fx_catch_268);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1168, delta_ccode_1, &v_1153);
+                  &data_id_1, struct_ctyp_0, &v_1187, &slit_265, &v_1188, 0, &kloc_0, &v_1189, 0), _fx_catch_275);
+            FX_COPY_PTR(v_1189.t0, &data_exp_1);
+            FX_COPY_PTR(v_1189.t1, &delta_ccode_1);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(data_exp_1, &v_1190, 0), _fx_catch_275);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1190, delta_ccode_1, &v_1175);
          }
-         FX_COPY_PTR(v_1153.t0, &init_exp_1);
-         FX_COPY_PTR(v_1153.t1, &delta_ccode_2);
-         FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1169, 0), _fx_catch_268);
-         _fx_make_R16Ast__val_flags_t(v_1169.val_flag_arg, v_1169.val_flag_mutable, v_1169.val_flag_temp,
-            v_1169.val_flag_tempref, v_1169.val_flag_private, v_1169.val_flag_subarray, v_1169.val_flag_instance,
-            &v_1169.val_flag_method, v_1169.val_flag_ctor, mod_sc_0, &v_1170);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(init_exp_1, &v_1171);
-         fx_str_t slit_265 = FX_MAKE_STR("");
+         FX_COPY_PTR(v_1175.t0, &init_exp_1);
+         FX_COPY_PTR(v_1175.t1, &delta_ccode_2);
+         FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1191, 0), _fx_catch_275);
+         _fx_make_R16Ast__val_flags_t(v_1191.val_flag_arg, v_1191.val_flag_mutable, v_1191.val_flag_temp,
+            v_1191.val_flag_tempref, v_1191.val_flag_private, v_1191.val_flag_subarray, v_1191.val_flag_instance,
+            &v_1191.val_flag_method, v_1191.val_flag_ctor, mod_sc_0, &v_1192);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(init_exp_1, &v_1193);
+         fx_str_t slit_266 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               i_11, ctyp_4, &v_1170, &slit_265, &v_1171, delta_ccode_2, &kloc_0, &v_1172, 0), _fx_catch_268);
-         FX_COPY_PTR(v_1172.t1, &delta_ccode_3);
-         _fx_R23C_gen_code__block_ctx_t* v_1206 = &bctx_1->data;
-         FX_COPY_PTR(v_1206->bctx_prologue, &v_1173);
+               i_11, ctyp_4, &v_1192, &slit_266, &v_1193, delta_ccode_2, &kloc_0, &v_1194, 0), _fx_catch_275);
+         FX_COPY_PTR(v_1194.t1, &delta_ccode_3);
+         _fx_R23C_gen_code__block_ctx_t* v_1228 = &bctx_1->data;
+         FX_COPY_PTR(v_1228->bctx_prologue, &v_1195);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_3, v_1173,
-               &v_1174, 0), _fx_catch_268);
-         _fx_R23C_gen_code__block_ctx_t* v_1207 = &bctx_1->data;
-         _fx_LN15C_form__cstmt_t* v_1208 = &v_1207->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1208);
-         FX_COPY_PTR(v_1174, v_1208);
-         FX_COPY_PTR(ccode_0, &ccode_148);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_3, v_1195,
+               &v_1196, 0), _fx_catch_275);
+         _fx_R23C_gen_code__block_ctx_t* v_1229 = &bctx_1->data;
+         _fx_LN15C_form__cstmt_t* v_1230 = &v_1229->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1230);
+         FX_COPY_PTR(v_1196, v_1230);
+         FX_COPY_PTR(ccode_0, &ccode_153);
       }
       else {
-         bool v_1209;
+         bool v_1231;
          if (is_fast_cons_0) {
-            v_1209 = true;
+            v_1231 = true;
          }
          else {
             bool t_18;
@@ -33995,44 +34201,44 @@ static int
                t_18 = false;
             }
             if (t_18) {
-               FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_11, &v_1209, 0),
-                  _fx_catch_268);
+               FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_11, &v_1231, 0),
+                  _fx_catch_275);
             }
             else {
-               v_1209 = false;
+               v_1231 = false;
             }
          }
-         if (v_1209) {
-            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1175), _fx_catch_268);
+         if (v_1231) {
+            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1197), _fx_catch_275);
             FX_CALL(
                _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                  e2_1, v_1175, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                  e2_1, v_1197, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                   fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1176, fx_fv), _fx_catch_268);
-            FX_COPY_PTR(v_1176.t0, &ce2_5);
-            FX_COPY_PTR(v_1176.t1, &ccode_149);
-            fx_str_t slit_266 = FX_MAKE_STR("");
+                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1198, fx_fv), _fx_catch_275);
+            FX_COPY_PTR(v_1198.t0, &ce2_5);
+            FX_COPY_PTR(v_1198.t1, &ccode_154);
+            fx_str_t slit_267 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_11, ctyp_4, &kv_flags_1, &slit_266, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &res_30, 0), _fx_catch_268);
+                  i_11, ctyp_4, &kv_flags_1, &slit_267, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &res_30, 0), _fx_catch_275);
             FX_CALL(
                _fx_M10C_gen_codeFM3addv3Nt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tR9Ast__id_tN14C_form__cexp_t(*i2e_0, i_11,
-                  ce2_5, 0), _fx_catch_268);
-            FX_COPY_PTR(ccode_149, &ccode_148);
+                  ce2_5, 0), _fx_catch_275);
+            FX_COPY_PTR(ccode_154, &ccode_153);
          }
          else if (is_temp_ref_0) {
-            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1177), _fx_catch_268);
+            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1199), _fx_catch_275);
             FX_CALL(
                _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                  e2_1, v_1177, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                  e2_1, v_1199, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                   fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1178, fx_fv), _fx_catch_268);
-            FX_COPY_PTR(v_1178.t0, &ce2_6);
-            FX_COPY_PTR(v_1178.t1, &ccode_150);
+                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1200, fx_fv), _fx_catch_275);
+            FX_COPY_PTR(v_1200.t0, &ce2_6);
+            FX_COPY_PTR(v_1200.t1, &ccode_155);
             FX_CALL(
                _fx_M10C_gen_codeFM17add_local_temprefT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_t(
-                  i_11, ctyp_4, &kv_flags_1, ce2_6, ccode_150, &kloc_0, i2e_ref_0, &v_1179, 0), _fx_catch_268);
-            FX_COPY_PTR(v_1179.t1, &ccode_148);
+                  i_11, ctyp_4, &kv_flags_1, ce2_6, ccode_155, &kloc_0, i2e_ref_0, &v_1201, 0), _fx_catch_275);
+            FX_COPY_PTR(v_1201.t1, &ccode_153);
          }
          else {
             bool t_19;
@@ -34082,61 +34288,61 @@ static int
                else {
                   res_33 = false;
                }
-               FX_CHECK_EXN(_fx_catch_268);
+               FX_CHECK_EXN(_fx_catch_275);
                if (res_33) {
-                  t_20 = false; goto _fx_endmatch_45;
+                  t_20 = false; goto _fx_endmatch_48;
                }
                t_20 = true;
 
-            _fx_endmatch_45: ;
-               FX_CHECK_EXN(_fx_catch_268);
+            _fx_endmatch_48: ;
+               FX_CHECK_EXN(_fx_catch_275);
             }
             if (t_20) {
-               _fx_R23C_gen_code__block_ctx_t* v_1210 = &bctx_1->data;
-               FX_COPY_PTR(v_1210->bctx_cleanup, &saved_cleanup_0);
-               _fx_R23C_gen_code__block_ctx_t* v_1211 = &bctx_1->data;
-               _fx_LN15C_form__cstmt_t* v_1212 = &v_1211->bctx_cleanup;
-               _fx_free_LN15C_form__cstmt_t(v_1212);
-               *v_1212 = 0;
+               _fx_R23C_gen_code__block_ctx_t* v_1232 = &bctx_1->data;
+               FX_COPY_PTR(v_1232->bctx_cleanup, &saved_cleanup_0);
+               _fx_R23C_gen_code__block_ctx_t* v_1233 = &bctx_1->data;
+               _fx_LN15C_form__cstmt_t* v_1234 = &v_1233->bctx_cleanup;
+               _fx_free_LN15C_form__cstmt_t(v_1234);
+               *v_1234 = 0;
                bool assign_e2_0;
                if (ktp_complex_3 == true) {
                   if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                      _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_33 = &e2_1->u.KExpAtom;
-                     _fx_N14K_form__atom_t* v_1213 = &vcase_33->t0;
-                     if (v_1213->tag == 2) {
-                        if (v_1213->u.AtomLit.tag == 8) {
-                           _fx_N14K_form__ktyp_t v_1214 = 0;
+                     _fx_N14K_form__atom_t* v_1235 = &vcase_33->t0;
+                     if (v_1235->tag == 2) {
+                        if (v_1235->u.AtomLit.tag == 8) {
+                           _fx_N14K_form__ktyp_t v_1236 = 0;
                            FX_CALL(
                               _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(vcase_33->t1.t0,
-                                 &kloc_0, &v_1214, 0), _fx_catch_259);
-                           if (FX_REC_VARIANT_TAG(v_1214) == 19) {
+                                 &kloc_0, &v_1236, 0), _fx_catch_266);
+                           if (FX_REC_VARIANT_TAG(v_1236) == 19) {
                               assign_e2_0 = true;
                            }
                            else {
                               assign_e2_0 = false;
                            }
-                           FX_CHECK_EXN(_fx_catch_259);
+                           FX_CHECK_EXN(_fx_catch_266);
 
-                        _fx_catch_259: ;
-                           if (v_1214) {
-                              _fx_free_N14K_form__ktyp_t(&v_1214);
+                        _fx_catch_266: ;
+                           if (v_1236) {
+                              _fx_free_N14K_form__ktyp_t(&v_1236);
                            }
-                           goto _fx_endmatch_46;
+                           goto _fx_endmatch_49;
                         }
                      }
                   }
                }
                assign_e2_0 = true;
 
-            _fx_endmatch_46: ;
-               FX_CHECK_EXN(_fx_catch_268);
+            _fx_endmatch_49: ;
+               FX_CHECK_EXN(_fx_catch_275);
                if (!is_global_0) {
                   _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &_fx_g18C_gen_code__None2_,
-                     assign_e2_0, &v_1180);
+                     assign_e2_0, &v_1202);
                }
                else {
                   if (ktp_complex_3) {
-                     _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
+                     _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1203);
                   }
                   else {
                      bool t_21;
@@ -34149,146 +34355,146 @@ static int
                      if (t_21) {
                         if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                            _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_34 = &e2_1->u.KExpAtom;
-                           _fx_N14K_form__atom_t* v_1215 = &vcase_34->t0;
-                           if (v_1215->tag == 2) {
+                           _fx_N14K_form__atom_t* v_1237 = &vcase_34->t0;
+                           if (v_1237->tag == 2) {
                               _fx_N14C_form__ctyp_t e2_ctyp_0 = 0;
-                              _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1216 = {0};
-                              _fx_N14C_form__cexp_t v_1217 = 0;
-                              _fx_Nt6option1N14C_form__cexp_t v_1218 = {0};
-                              _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_1219 = &vcase_34->t1;
-                              _fx_R10Ast__loc_t* e2_loc_0 = &v_1219->t1;
+                              _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1238 = {0};
+                              _fx_N14C_form__cexp_t v_1239 = 0;
+                              _fx_Nt6option1N14C_form__cexp_t v_1240 = {0};
+                              _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_1241 = &vcase_34->t1;
+                              _fx_R10Ast__loc_t* e2_loc_0 = &v_1241->t1;
                               FX_CALL(
-                                 _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_1219->t0,
-                                    e2_loc_0, &e2_ctyp_0, 0), _fx_catch_260);
-                              _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(e2_ctyp_0, e2_loc_0, &v_1216);
+                                 _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_1241->t0,
+                                    e2_loc_0, &e2_ctyp_0, 0), _fx_catch_267);
+                              _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(e2_ctyp_0, e2_loc_0, &v_1238);
                               FX_CALL(
                                  _fx_M6C_formFM7CExpLitN14C_form__cexp_t2N14K_form__klit_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                                    &v_1215->u.AtomLit, &v_1216, &v_1217), _fx_catch_260);
-                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1217, &v_1218);
-                              _fx_make_T2Nt6option1N14C_form__cexp_tB(&v_1218, false, &v_1181);
+                                    &v_1237->u.AtomLit, &v_1238, &v_1239), _fx_catch_267);
+                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1239, &v_1240);
+                              _fx_make_T2Nt6option1N14C_form__cexp_tB(&v_1240, false, &v_1203);
 
-                           _fx_catch_260: ;
-                              _fx_free_Nt6option1N14C_form__cexp_t(&v_1218);
-                              if (v_1217) {
-                                 _fx_free_N14C_form__cexp_t(&v_1217);
+                           _fx_catch_267: ;
+                              _fx_free_Nt6option1N14C_form__cexp_t(&v_1240);
+                              if (v_1239) {
+                                 _fx_free_N14C_form__cexp_t(&v_1239);
                               }
-                              _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1216);
+                              _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1238);
                               if (e2_ctyp_0) {
                                  _fx_free_N14C_form__ctyp_t(&e2_ctyp_0);
                               }
-                              goto _fx_endmatch_47;
+                              goto _fx_endmatch_50;
                            }
                         }
-                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
+                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1203);
 
-                     _fx_endmatch_47: ;
-                        FX_CHECK_EXN(_fx_catch_268);
+                     _fx_endmatch_50: ;
+                        FX_CHECK_EXN(_fx_catch_275);
                      }
                      else {
-                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
+                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1203);
                      }
                   }
-                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_1181.t0, &e0_opt_0);
-                  bool assign_e2_1 = v_1181.t1;
-                  _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &e0_opt_0, assign_e2_1, &v_1180);
+                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_1203.t0, &e0_opt_0);
+                  bool assign_e2_1 = v_1203.t1;
+                  _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &e0_opt_0, assign_e2_1, &v_1202);
                }
-               _fx_copy_R16Ast__val_flags_t(&v_1180.t0, &flags_2);
-               _fx_copy_Nt6option1N14C_form__cexp_t(&v_1180.t1, &e0_opt_1);
-               bool assign_e2_2 = v_1180.t2;
+               _fx_copy_R16Ast__val_flags_t(&v_1202.t0, &flags_2);
+               _fx_copy_Nt6option1N14C_form__cexp_t(&v_1202.t1, &e0_opt_1);
+               bool assign_e2_2 = v_1202.t2;
                FX_CALL(
                   _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                     i_11, ctyp_4, &flags_2, &e0_opt_1, 0, &kloc_0, block_stack_ref_0, &v_1182, 0), _fx_catch_268);
-               FX_COPY_PTR(v_1182.t0, &i_exp_18);
-               FX_COPY_PTR(v_1182.t1, &delta_ccode_4);
+                     i_11, ctyp_4, &flags_2, &e0_opt_1, 0, &kloc_0, block_stack_ref_0, &v_1204, 0), _fx_catch_275);
+               FX_COPY_PTR(v_1204.t0, &i_exp_18);
+               FX_COPY_PTR(v_1204.t1, &delta_ccode_4);
                if (is_global_0) {
-                  _fx_R23C_gen_code__block_ctx_t* v_1220 = &bctx_1->data;
-                  FX_COPY_PTR(v_1220->bctx_prologue, &v_1183);
+                  _fx_R23C_gen_code__block_ctx_t* v_1242 = &bctx_1->data;
+                  FX_COPY_PTR(v_1242->bctx_prologue, &v_1205);
                   FX_CALL(
                      _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_4,
-                        v_1183, &v_1184, 0), _fx_catch_268);
-                  _fx_R23C_gen_code__block_ctx_t* v_1221 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1222 = &v_1221->bctx_prologue;
-                  _fx_free_LN15C_form__cstmt_t(v_1222);
-                  FX_COPY_PTR(v_1184, v_1222);
-                  FX_COPY_PTR(ccode_0, &ccode_151);
+                        v_1205, &v_1206, 0), _fx_catch_275);
+                  _fx_R23C_gen_code__block_ctx_t* v_1243 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1244 = &v_1243->bctx_prologue;
+                  _fx_free_LN15C_form__cstmt_t(v_1244);
+                  FX_COPY_PTR(v_1206, v_1244);
+                  FX_COPY_PTR(ccode_0, &ccode_156);
                }
                else {
                   FX_CALL(
                      _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_4,
-                        ccode_0, &ccode_151, 0), _fx_catch_268);
+                        ccode_0, &ccode_156, 0), _fx_catch_275);
                }
                if (is_global_0) {
-                  _fx_R23C_gen_code__block_ctx_t* v_1223 = &bctx_1->data;
-                  FX_COPY_PTR(v_1223->bctx_cleanup, &v_1185);
+                  _fx_R23C_gen_code__block_ctx_t* v_1245 = &bctx_1->data;
+                  FX_COPY_PTR(v_1245->bctx_cleanup, &v_1207);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1185,
-                        *module_cleanup_0, &v_1186, 0), _fx_catch_268);
+                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1207,
+                        *module_cleanup_0, &v_1208, 0), _fx_catch_275);
                   _fx_free_LN15C_form__cstmt_t(module_cleanup_0);
-                  FX_COPY_PTR(v_1186, module_cleanup_0);
-                  _fx_R23C_gen_code__block_ctx_t* v_1224 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1225 = &v_1224->bctx_cleanup;
-                  _fx_free_LN15C_form__cstmt_t(v_1225);
-                  FX_COPY_PTR(saved_cleanup_0, v_1225);
+                  FX_COPY_PTR(v_1208, module_cleanup_0);
+                  _fx_R23C_gen_code__block_ctx_t* v_1246 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1247 = &v_1246->bctx_cleanup;
+                  _fx_free_LN15C_form__cstmt_t(v_1247);
+                  FX_COPY_PTR(saved_cleanup_0, v_1247);
                }
                else {
-                  _fx_R23C_gen_code__block_ctx_t* v_1226 = &bctx_1->data;
-                  FX_COPY_PTR(v_1226->bctx_cleanup, &v_1187);
+                  _fx_R23C_gen_code__block_ctx_t* v_1248 = &bctx_1->data;
+                  FX_COPY_PTR(v_1248->bctx_cleanup, &v_1209);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1187,
-                        saved_cleanup_0, &v_1188, 0), _fx_catch_268);
-                  _fx_R23C_gen_code__block_ctx_t* v_1227 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1228 = &v_1227->bctx_cleanup;
-                  _fx_free_LN15C_form__cstmt_t(v_1228);
-                  FX_COPY_PTR(v_1188, v_1228);
+                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1209,
+                        saved_cleanup_0, &v_1210, 0), _fx_catch_275);
+                  _fx_R23C_gen_code__block_ctx_t* v_1249 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1250 = &v_1249->bctx_cleanup;
+                  _fx_free_LN15C_form__cstmt_t(v_1250);
+                  FX_COPY_PTR(v_1210, v_1250);
                }
                if (assign_e2_2) {
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(i_exp_18, &v_1189);
-                  FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1189, &v_1190), _fx_catch_268);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(i_exp_18, &v_1211);
+                  FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1211, &v_1212), _fx_catch_275);
                   FX_CALL(
                      _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                        e2_1, v_1190, ccode_151, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                        e2_1, v_1212, ccode_156, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                         fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0,
-                        module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1191, fx_fv),
-                     _fx_catch_268);
-                  FX_COPY_PTR(v_1191.t1, &ccode_152);
-                  if (ccode_152 != 0) {
-                     _fx_LN15C_form__cstmt_t v_1229 = ccode_152->tl;
-                     if (v_1229 != 0) {
-                        _fx_N15C_form__cstmt_t v_1230 = v_1229->hd;
-                        if (FX_REC_VARIANT_TAG(v_1230) == 16) {
+                        module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1213, fx_fv),
+                     _fx_catch_275);
+                  FX_COPY_PTR(v_1213.t1, &ccode_157);
+                  if (ccode_157 != 0) {
+                     _fx_LN15C_form__cstmt_t v_1251 = ccode_157->tl;
+                     if (v_1251 != 0) {
+                        _fx_N15C_form__cstmt_t v_1252 = v_1251->hd;
+                        if (FX_REC_VARIANT_TAG(v_1252) == 16) {
                            _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t* vcase_35 =
-                              &v_1230->u.CDefVal;
+                              &v_1252->u.CDefVal;
                            if (vcase_35->t2.tag == 1) {
-                              _fx_N15C_form__cstmt_t v_1231 = ccode_152->hd;
-                              if (FX_REC_VARIANT_TAG(v_1231) == 3) {
-                                 _fx_N14C_form__cexp_t v_1232 = v_1231->u.CExp;
-                                 if (FX_REC_VARIANT_TAG(v_1232) == 3) {
+                              _fx_N15C_form__cstmt_t v_1253 = ccode_157->hd;
+                              if (FX_REC_VARIANT_TAG(v_1253) == 3) {
+                                 _fx_N14C_form__cexp_t v_1254 = v_1253->u.CExp;
+                                 if (FX_REC_VARIANT_TAG(v_1254) == 3) {
                                     _fx_T4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t*
-                                       vcase_36 = &v_1232->u.CExpBinary;
+                                       vcase_36 = &v_1254->u.CExpBinary;
                                     if (vcase_36->t0.tag == 15) {
-                                       _fx_N14C_form__cexp_t v_1233 = vcase_36->t1;
-                                       if (FX_REC_VARIANT_TAG(v_1233) == 1) {
+                                       _fx_N14C_form__cexp_t v_1255 = vcase_36->t1;
+                                       if (FX_REC_VARIANT_TAG(v_1255) == 1) {
                                           _fx_R9Ast__id_t* i_12 = &vcase_35->t1;
                                           bool res_34;
-                                          FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1233->u.CExpIdent.t0, i_12, &res_34, 0),
-                                             _fx_catch_268);
+                                          FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1255->u.CExpIdent.t0, i_12, &res_34, 0),
+                                             _fx_catch_275);
                                           if (res_34) {
-                                             _fx_Nt6option1N14C_form__cexp_t v_1234 = {0};
-                                             _fx_N15C_form__cstmt_t v_1235 = 0;
+                                             _fx_Nt6option1N14C_form__cexp_t v_1256 = {0};
+                                             _fx_N15C_form__cstmt_t v_1257 = 0;
                                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(vcase_36->t2,
-                                                &v_1234);
+                                                &v_1256);
                                              FX_CALL(
                                                 _fx_M6C_formFM7CDefValN15C_form__cstmt_t4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t(
-                                                   vcase_35->t0, i_12, &v_1234, &vcase_36->t3.t1, &v_1235), _fx_catch_261);
-                                             FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1235, v_1229->tl, true, &ccode_148),
-                                                _fx_catch_261);
+                                                   vcase_35->t0, i_12, &v_1256, &vcase_36->t3.t1, &v_1257), _fx_catch_268);
+                                             FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1257, v_1251->tl, true, &ccode_153),
+                                                _fx_catch_268);
 
-                                          _fx_catch_261: ;
-                                             if (v_1235) {
-                                                _fx_free_N15C_form__cstmt_t(&v_1235);
+                                          _fx_catch_268: ;
+                                             if (v_1257) {
+                                                _fx_free_N15C_form__cstmt_t(&v_1257);
                                              }
-                                             _fx_free_Nt6option1N14C_form__cexp_t(&v_1234);
-                                             goto _fx_endmatch_48;
+                                             _fx_free_Nt6option1N14C_form__cexp_t(&v_1256);
+                                             goto _fx_endmatch_51;
                                           }
                                        }
                                     }
@@ -34298,168 +34504,168 @@ static int
                         }
                      }
                   }
-                  FX_COPY_PTR(ccode_152, &ccode_148);
+                  FX_COPY_PTR(ccode_157, &ccode_153);
 
-               _fx_endmatch_48: ;
-                  FX_CHECK_EXN(_fx_catch_268);
+               _fx_endmatch_51: ;
+                  FX_CHECK_EXN(_fx_catch_275);
                }
                else {
-                  FX_COPY_PTR(ccode_151, &ccode_148);
+                  FX_COPY_PTR(ccode_156, &ccode_153);
                }
             }
             else {
                if (ktp_ptr_2 == false) {
                   if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                      _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_37 = &e2_1->u.KExpAtom;
-                     _fx_N14K_form__atom_t* v_1236 = &vcase_37->t0;
-                     if (v_1236->tag == 2) {
-                        if (v_1236->u.AtomLit.tag == 8) {
-                           _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1237 = {0};
-                           _fx_N14C_form__cexp_t v_1238 = 0;
-                           _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &vcase_37->t1.t1, &v_1237);
+                     _fx_N14K_form__atom_t* v_1258 = &vcase_37->t0;
+                     if (v_1258->tag == 2) {
+                        if (v_1258->u.AtomLit.tag == 8) {
+                           _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1259 = {0};
+                           _fx_N14C_form__cexp_t v_1260 = 0;
+                           _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &vcase_37->t1.t1, &v_1259);
                            FX_CALL(
                               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(0,
-                                 &v_1237, &v_1238), _fx_catch_262);
-                           _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1238, ccode_0, &v_1192);
+                                 &v_1259, &v_1260), _fx_catch_269);
+                           _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1260, ccode_0, &v_1214);
 
-                        _fx_catch_262: ;
-                           if (v_1238) {
-                              _fx_free_N14C_form__cexp_t(&v_1238);
+                        _fx_catch_269: ;
+                           if (v_1260) {
+                              _fx_free_N14C_form__cexp_t(&v_1260);
                            }
-                           _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1237);
-                           goto _fx_endmatch_49;
+                           _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1259);
+                           goto _fx_endmatch_52;
                         }
                      }
                   }
                }
-               _fx_rNt6option1N14C_form__cexp_t v_1239 = 0;
-               FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1239), _fx_catch_263);
+               _fx_rNt6option1N14C_form__cexp_t v_1261 = 0;
+               FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1261), _fx_catch_270);
                FX_CALL(
                   _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                     e2_1, v_1239, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                     e2_1, v_1261, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                      fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                     return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1192, fx_fv), _fx_catch_263);
+                     return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1214, fx_fv), _fx_catch_270);
 
-            _fx_catch_263: ;
-               if (v_1239) {
-                  _fx_free_rNt6option1N14C_form__cexp_t(&v_1239);
+            _fx_catch_270: ;
+               if (v_1261) {
+                  _fx_free_rNt6option1N14C_form__cexp_t(&v_1261);
                }
 
-            _fx_endmatch_49: ;
-               FX_CHECK_EXN(_fx_catch_268);
-               FX_COPY_PTR(v_1192.t0, &ce2_7);
-               FX_COPY_PTR(v_1192.t1, &ccode_153);
+            _fx_endmatch_52: ;
+               FX_CHECK_EXN(_fx_catch_275);
+               FX_COPY_PTR(v_1214.t0, &ce2_7);
+               FX_COPY_PTR(v_1214.t1, &ccode_158);
                if (FX_REC_VARIANT_TAG(e2_1) == 15) {
-                  if (ccode_153 != 0) {
-                     _fx_N15C_form__cstmt_t v_1240 = ccode_153->hd;
-                     if (FX_REC_VARIANT_TAG(v_1240) == 16) {
-                        _fx_Nt6option1N14C_form__cexp_t* v_1241 = &v_1240->u.CDefVal.t2;
-                        if (v_1241->tag == 2) {
-                           _fx_Nt6option1N14C_form__cexp_t v_1242 = {0};
-                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1241->u.Some, &v_1242);
+                  if (ccode_158 != 0) {
+                     _fx_N15C_form__cstmt_t v_1262 = ccode_158->hd;
+                     if (FX_REC_VARIANT_TAG(v_1262) == 16) {
+                        _fx_Nt6option1N14C_form__cexp_t* v_1263 = &v_1262->u.CDefVal.t2;
+                        if (v_1263->tag == 2) {
+                           _fx_Nt6option1N14C_form__cexp_t v_1264 = {0};
+                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1263->u.Some, &v_1264);
                            FX_CALL(
                               _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                                 i_11, ctyp_4, &kv_flags_1, &v_1242, ccode_153->tl, &kloc_0, block_stack_ref_0, &v_1193, 0),
-                              _fx_catch_264);
+                                 i_11, ctyp_4, &kv_flags_1, &v_1264, ccode_158->tl, &kloc_0, block_stack_ref_0, &v_1215, 0),
+                              _fx_catch_271);
 
-                        _fx_catch_264: ;
-                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1242);
-                           goto _fx_endmatch_50;
+                        _fx_catch_271: ;
+                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1264);
+                           goto _fx_endmatch_53;
                         }
                      }
                   }
                }
                if (FX_REC_VARIANT_TAG(e2_1) == 14) {
-                  if (ccode_153 != 0) {
-                     _fx_N15C_form__cstmt_t v_1243 = ccode_153->hd;
-                     if (FX_REC_VARIANT_TAG(v_1243) == 16) {
-                        _fx_Nt6option1N14C_form__cexp_t* v_1244 = &v_1243->u.CDefVal.t2;
-                        if (v_1244->tag == 2) {
-                           _fx_Nt6option1N14C_form__cexp_t v_1245 = {0};
-                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1244->u.Some, &v_1245);
+                  if (ccode_158 != 0) {
+                     _fx_N15C_form__cstmt_t v_1265 = ccode_158->hd;
+                     if (FX_REC_VARIANT_TAG(v_1265) == 16) {
+                        _fx_Nt6option1N14C_form__cexp_t* v_1266 = &v_1265->u.CDefVal.t2;
+                        if (v_1266->tag == 2) {
+                           _fx_Nt6option1N14C_form__cexp_t v_1267 = {0};
+                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1266->u.Some, &v_1267);
                            FX_CALL(
                               _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                                 i_11, ctyp_4, &kv_flags_1, &v_1245, ccode_153->tl, &kloc_0, block_stack_ref_0, &v_1193, 0),
-                              _fx_catch_265);
+                                 i_11, ctyp_4, &kv_flags_1, &v_1267, ccode_158->tl, &kloc_0, block_stack_ref_0, &v_1215, 0),
+                              _fx_catch_272);
 
-                        _fx_catch_265: ;
-                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1245);
-                           goto _fx_endmatch_50;
+                        _fx_catch_272: ;
+                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1267);
+                           goto _fx_endmatch_53;
                         }
                      }
                   }
                }
-               _fx_Nt6option1N14C_form__cexp_t v_1246 = {0};
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ce2_7, &v_1246);
+               _fx_Nt6option1N14C_form__cexp_t v_1268 = {0};
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ce2_7, &v_1268);
                FX_CALL(
                   _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                     i_11, ctyp_4, &kv_flags_1, &v_1246, ccode_153, &kloc_0, block_stack_ref_0, &v_1193, 0), _fx_catch_266);
+                     i_11, ctyp_4, &kv_flags_1, &v_1268, ccode_158, &kloc_0, block_stack_ref_0, &v_1215, 0), _fx_catch_273);
 
-            _fx_catch_266: ;
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1246);
+            _fx_catch_273: ;
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1268);
 
-            _fx_endmatch_50: ;
-               FX_CHECK_EXN(_fx_catch_268);
-               FX_COPY_PTR(v_1193.t1, &ccode_148);
+            _fx_endmatch_53: ;
+               FX_CHECK_EXN(_fx_catch_275);
+               FX_COPY_PTR(v_1215.t1, &ccode_153);
             }
          }
       }
       if (FX_STR_LENGTH(kv_cname_0) != 0) {
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1194, 0), _fx_catch_268);
-         if (v_1194.tag == 2) {
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1216, 0), _fx_catch_275);
+         if (v_1216.tag == 2) {
             _fx_R17C_form__cdefval_t cv_3 = {0};
-            _fx_N15C_form__cinfo_t v_1247 = {0};
-            _fx_R17C_form__cdefval_t* cv_4 = &v_1194.u.CVal;
+            _fx_N15C_form__cinfo_t v_1269 = {0};
+            _fx_R17C_form__cdefval_t* cv_4 = &v_1216.u.CVal;
             _fx_make_R17C_form__cdefval_t(&cv_4->cv_name, cv_4->cv_typ, &kv_cname_0, &cv_4->cv_flags, &cv_4->cv_loc, &cv_3);
-            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&cv_3, &v_1247);
-            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(i_11, &v_1247, 0), _fx_catch_267);
+            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&cv_3, &v_1269);
+            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(i_11, &v_1269, 0), _fx_catch_274);
 
-         _fx_catch_267: ;
-            _fx_free_N15C_form__cinfo_t(&v_1247);
+         _fx_catch_274: ;
+            _fx_free_N15C_form__cinfo_t(&v_1269);
             _fx_free_R17C_form__cdefval_t(&cv_3);
          }
-         FX_CHECK_EXN(_fx_catch_268);
+         FX_CHECK_EXN(_fx_catch_275);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_148, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_153, &v_1);
 
-   _fx_catch_268: ;
-      _fx_free_N15C_form__cinfo_t(&v_1194);
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1193);
-      if (ccode_153) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_153);
+   _fx_catch_275: ;
+      _fx_free_N15C_form__cinfo_t(&v_1216);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1215);
+      if (ccode_158) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_158);
       }
       if (ce2_7) {
          _fx_free_N14C_form__cexp_t(&ce2_7);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1192);
-      if (ccode_152) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_152);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1214);
+      if (ccode_157) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_157);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1191);
-      if (v_1190) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1190);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1213);
+      if (v_1212) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1212);
       }
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1189);
-      if (v_1188) {
-         _fx_free_LN15C_form__cstmt_t(&v_1188);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1211);
+      if (v_1210) {
+         _fx_free_LN15C_form__cstmt_t(&v_1210);
       }
-      if (v_1187) {
-         _fx_free_LN15C_form__cstmt_t(&v_1187);
+      if (v_1209) {
+         _fx_free_LN15C_form__cstmt_t(&v_1209);
       }
-      if (v_1186) {
-         _fx_free_LN15C_form__cstmt_t(&v_1186);
+      if (v_1208) {
+         _fx_free_LN15C_form__cstmt_t(&v_1208);
       }
-      if (v_1185) {
-         _fx_free_LN15C_form__cstmt_t(&v_1185);
+      if (v_1207) {
+         _fx_free_LN15C_form__cstmt_t(&v_1207);
       }
-      if (v_1184) {
-         _fx_free_LN15C_form__cstmt_t(&v_1184);
+      if (v_1206) {
+         _fx_free_LN15C_form__cstmt_t(&v_1206);
       }
-      if (v_1183) {
-         _fx_free_LN15C_form__cstmt_t(&v_1183);
+      if (v_1205) {
+         _fx_free_LN15C_form__cstmt_t(&v_1205);
       }
-      if (ccode_151) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_151);
+      if (ccode_156) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_156);
       }
       if (delta_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_4);
@@ -34467,58 +34673,58 @@ static int
       if (i_exp_18) {
          _fx_free_N14C_form__cexp_t(&i_exp_18);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1182);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1204);
       _fx_free_Nt6option1N14C_form__cexp_t(&e0_opt_1);
       _fx_free_R16Ast__val_flags_t(&flags_2);
       _fx_free_Nt6option1N14C_form__cexp_t(&e0_opt_0);
-      _fx_free_T2Nt6option1N14C_form__cexp_tB(&v_1181);
-      _fx_free_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&v_1180);
+      _fx_free_T2Nt6option1N14C_form__cexp_tB(&v_1203);
+      _fx_free_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&v_1202);
       if (saved_cleanup_0) {
          _fx_free_LN15C_form__cstmt_t(&saved_cleanup_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1179);
-      if (ccode_150) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_150);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1201);
+      if (ccode_155) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_155);
       }
       if (ce2_6) {
          _fx_free_N14C_form__cexp_t(&ce2_6);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1178);
-      if (v_1177) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1177);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1200);
+      if (v_1199) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1199);
       }
       _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&res_30);
-      if (ccode_149) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_149);
+      if (ccode_154) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_154);
       }
       if (ce2_5) {
          _fx_free_N14C_form__cexp_t(&ce2_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1176);
-      if (v_1175) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1175);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1198);
+      if (v_1197) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1197);
       }
-      if (v_1174) {
-         _fx_free_LN15C_form__cstmt_t(&v_1174);
+      if (v_1196) {
+         _fx_free_LN15C_form__cstmt_t(&v_1196);
       }
-      if (v_1173) {
-         _fx_free_LN15C_form__cstmt_t(&v_1173);
+      if (v_1195) {
+         _fx_free_LN15C_form__cstmt_t(&v_1195);
       }
       if (delta_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1172);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1171);
-      _fx_free_R16Ast__val_flags_t(&v_1170);
-      _fx_free_R16Ast__val_flags_t(&v_1169);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1194);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1193);
+      _fx_free_R16Ast__val_flags_t(&v_1192);
+      _fx_free_R16Ast__val_flags_t(&v_1191);
       if (delta_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_2);
       }
       if (init_exp_1) {
          _fx_free_N14C_form__cexp_t(&init_exp_1);
       }
-      if (v_1168) {
-         _fx_free_N14C_form__cexp_t(&v_1168);
+      if (v_1190) {
+         _fx_free_N14C_form__cexp_t(&v_1190);
       }
       if (delta_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_1);
@@ -34526,65 +34732,65 @@ static int
       if (data_exp_1) {
          _fx_free_N14C_form__cexp_t(&data_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1167);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1166);
-      _fx_free_R16Ast__val_flags_t(&v_1165);
-      _fx_free_R16Ast__val_flags_t(&v_1164);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1189);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1188);
+      _fx_free_R16Ast__val_flags_t(&v_1187);
+      _fx_free_R16Ast__val_flags_t(&v_1186);
       if (data_init_0) {
          _fx_free_N14C_form__cexp_t(&data_init_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1163);
-      if (v_1162) {
-         _fx_free_LN14C_form__cexp_t(&v_1162);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1185);
+      if (v_1184) {
+         _fx_free_LN14C_form__cexp_t(&v_1184);
       }
       if (rc_exp_0) {
          _fx_free_N14C_form__cexp_t(&rc_exp_0);
       }
-      FX_FREE_STR(&v_1161);
-      FX_FREE_STR(&v_1160);
+      FX_FREE_STR(&v_1183);
+      FX_FREE_STR(&v_1182);
       if (struct_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&struct_ctyp_0);
       }
-      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_1159);
+      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_1181);
       if (i_exp_17) {
          _fx_free_N14C_form__cexp_t(&i_exp_17);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1158);
-      _fx_free_R16Ast__val_flags_t(&v_1157);
-      if (v_1156) {
-         _fx_free_N14C_form__cexp_t(&v_1156);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1180);
+      _fx_free_R16Ast__val_flags_t(&v_1179);
+      if (v_1178) {
+         _fx_free_N14C_form__cexp_t(&v_1178);
       }
       if (init_exp_0) {
          _fx_free_N14C_form__cexp_t(&init_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1155);
-      if (v_1154) {
-         _fx_free_LN14C_form__cexp_t(&v_1154);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1177);
+      if (v_1176) {
+         _fx_free_LN14C_form__cexp_t(&v_1176);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1153);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1175);
       if (tag_exp_0) {
          _fx_free_N14C_form__cexp_t(&tag_exp_0);
       }
-      if (v_1152) {
-         _fx_free_LN15C_form__cstmt_t(&v_1152);
+      if (v_1174) {
+         _fx_free_LN15C_form__cstmt_t(&v_1174);
       }
-      if (v_1151) {
-         _fx_free_LN15C_form__cstmt_t(&v_1151);
+      if (v_1173) {
+         _fx_free_LN15C_form__cstmt_t(&v_1173);
       }
       if (delta_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1150);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1149);
-      if (v_1148) {
-         _fx_free_N14C_form__cexp_t(&v_1148);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1172);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1171);
+      if (v_1170) {
+         _fx_free_N14C_form__cexp_t(&v_1170);
       }
-      if (ccode_148) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_148);
+      if (ccode_153) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_153);
       }
       FX_FREE_STR(&ccode_data_lit_0);
       FX_FREE_STR(&ccode_data_kind_0);
-      _fx_free_T3SSR10Ast__loc_t(&v_1147);
+      _fx_free_T3SSR10Ast__loc_t(&v_1169);
       if (bctx_1) {
          _fx_free_rR23C_gen_code__block_ctx_t(&bctx_1);
       }
@@ -34596,192 +34802,192 @@ static int
       }
       FX_FREE_STR(&kv_cname_0);
       _fx_free_R16Ast__val_flags_t(&kv_flags_1);
-      _fx_free_R17K_form__kdefval_t(&v_1146);
-      goto _fx_endmatch_55;
+      _fx_free_R17K_form__kdefval_t(&v_1168);
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 32) {
       fx_str_t kf_cname_0 = {0};
       _fx_N14K_form__kexp_t kf_body_0 = 0;
       _fx_N14K_form__ktyp_t kf_rt_0 = 0;
-      _fx_N15C_form__cinfo_t v_1248 = {0};
-      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t v_1249 = {0};
+      _fx_N15C_form__cinfo_t v_1270 = {0};
+      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t v_1271 = {0};
       _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t args_13 = 0;
       _fx_N14C_form__ctyp_t rt_0 = 0;
       _fx_rR17C_form__cdeffun_t cf_0 = 0;
-      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_1250 = {0};
+      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_1272 = {0};
       _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t real_args_0 = 0;
       _fx_rB really_nothrow_0 = 0;
       _fx_LN15C_form__cstmt_t new_body_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1251 = 0;
-      _fx_R17C_form__cdeffun_t v_1252 = {0};
-      _fx_R17K_form__kdeffun_t* v_1253 = &kexp_0->u.KDefFun->data;
-      _fx_R10Ast__loc_t kf_loc_0 = v_1253->kf_loc;
-      _fx_R16Ast__fun_flags_t kf_flags_0 = v_1253->kf_flags;
-      fx_copy_str(&v_1253->kf_cname, &kf_cname_0);
-      FX_COPY_PTR(v_1253->kf_body, &kf_body_0);
-      _fx_R25K_form__kdefclosureinfo_t kf_closure_0 = v_1253->kf_closure;
-      FX_COPY_PTR(v_1253->kf_rt, &kf_rt_0);
-      _fx_R9Ast__id_t kf_name_0 = v_1253->kf_name;
+      _fx_LN15C_form__cstmt_t v_1273 = 0;
+      _fx_R17C_form__cdeffun_t v_1274 = {0};
+      _fx_R17K_form__kdeffun_t* v_1275 = &kexp_0->u.KDefFun->data;
+      _fx_R10Ast__loc_t kf_loc_0 = v_1275->kf_loc;
+      _fx_R16Ast__fun_flags_t kf_flags_0 = v_1275->kf_flags;
+      fx_copy_str(&v_1275->kf_cname, &kf_cname_0);
+      FX_COPY_PTR(v_1275->kf_body, &kf_body_0);
+      _fx_R25K_form__kdefclosureinfo_t kf_closure_0 = v_1275->kf_closure;
+      FX_COPY_PTR(v_1275->kf_rt, &kf_rt_0);
+      _fx_R9Ast__id_t kf_name_0 = v_1275->kf_name;
       _fx_R9Ast__id_t kci_fcv_t_0 = kf_closure_0.kci_fcv_t;
       _fx_R9Ast__id_t kci_arg_0 = kf_closure_0.kci_arg;
       _fx_N17Ast__fun_constr_t ctor_0 = kf_flags_0.fun_flag_ctor;
       bool res_35;
-      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_35, 0), _fx_catch_288);
+      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_35, 0), _fx_catch_295);
       if (res_35) {
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               &kf_name_0, &kf_loc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_288);
+               &kf_name_0, &kf_loc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_295);
       }
-      FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, &kf_name_0, 0), _fx_catch_288);
-      _fx_N24C_gen_code__block_kind_t v_1254;
-      _fx_M10C_gen_codeFM13BlockKind_FunN24C_gen_code__block_kind_t1R9Ast__id_t(&kf_name_0, &v_1254);
+      FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, &kf_name_0, 0), _fx_catch_295);
+      _fx_N24C_gen_code__block_kind_t v_1276;
+      _fx_M10C_gen_codeFM13BlockKind_FunN24C_gen_code__block_kind_t1R9Ast__id_t(&kf_name_0, &v_1276);
       FX_CALL(
-         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(&v_1254, &kloc_0,
-            block_stack_ref_0, km_idx_0, 0), _fx_catch_288);
-      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1248, 0),
-         _fx_catch_288);
-      if (v_1248.tag == 3) {
-         _fx_R17C_form__cdeffun_t v_1255 = {0};
-         _fx_rR17C_form__cdeffun_t cf_1 = v_1248.u.CFun;
-         _fx_copy_R17C_form__cdeffun_t(&cf_1->data, &v_1255);
-         bool is_nothrow_2 = v_1255.cf_flags.fun_flag_nothrow;
+         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(&v_1276, &kloc_0,
+            block_stack_ref_0, km_idx_0, 0), _fx_catch_295);
+      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1270, 0),
+         _fx_catch_295);
+      if (v_1270.tag == 3) {
+         _fx_R17C_form__cdeffun_t v_1277 = {0};
+         _fx_rR17C_form__cdeffun_t cf_1 = v_1270.u.CFun;
+         _fx_copy_R17C_form__cdeffun_t(&cf_1->data, &v_1277);
+         bool is_nothrow_2 = v_1277.cf_flags.fun_flag_nothrow;
          _fx_make_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(
-            v_1255.cf_args, v_1255.cf_rt, is_nothrow_2, cf_1, &v_1249);
-         _fx_free_R17C_form__cdeffun_t(&v_1255);
+            v_1277.cf_args, v_1277.cf_rt, is_nothrow_2, cf_1, &v_1271);
+         _fx_free_R17C_form__cdeffun_t(&v_1277);
       }
       else {
-         fx_str_t v_1256 = {0};
-         fx_str_t v_1257 = {0};
-         fx_str_t v_1258 = {0};
-         fx_exn_t v_1259 = {0};
-         FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1256, 0), _fx_catch_269);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1256, &v_1257, 0), _fx_catch_269);
-         fx_str_t slit_267 = FX_MAKE_STR("cgen: the function \'");
-         fx_str_t slit_268 = FX_MAKE_STR("\' declaration was not properly converted");
+         fx_str_t v_1278 = {0};
+         fx_str_t v_1279 = {0};
+         fx_str_t v_1280 = {0};
+         fx_exn_t v_1281 = {0};
+         FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1278, 0), _fx_catch_276);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1278, &v_1279, 0), _fx_catch_276);
+         fx_str_t slit_268 = FX_MAKE_STR("cgen: the function \'");
+         fx_str_t slit_269 = FX_MAKE_STR("\' declaration was not properly converted");
          {
-            const fx_str_t strs_37[] = { slit_267, v_1257, slit_268 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_37, 3, &v_1258), _fx_catch_269);
+            const fx_str_t strs_37[] = { slit_268, v_1279, slit_269 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_37, 3, &v_1280), _fx_catch_276);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1258, &v_1259, 0), _fx_catch_269);
-         FX_THROW(&v_1259, false, _fx_catch_269);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1280, &v_1281, 0), _fx_catch_276);
+         FX_THROW(&v_1281, false, _fx_catch_276);
 
-      _fx_catch_269: ;
-         fx_free_exn(&v_1259);
-         FX_FREE_STR(&v_1258);
-         FX_FREE_STR(&v_1257);
-         FX_FREE_STR(&v_1256);
+      _fx_catch_276: ;
+         fx_free_exn(&v_1281);
+         FX_FREE_STR(&v_1280);
+         FX_FREE_STR(&v_1279);
+         FX_FREE_STR(&v_1278);
       }
-      FX_CHECK_EXN(_fx_catch_288);
-      FX_COPY_PTR(v_1249.t0, &args_13);
-      FX_COPY_PTR(v_1249.t1, &rt_0);
-      bool is_nothrow_3 = v_1249.t2;
-      FX_COPY_PTR(v_1249.t3, &cf_0);
+      FX_CHECK_EXN(_fx_catch_295);
+      FX_COPY_PTR(v_1271.t0, &args_13);
+      FX_COPY_PTR(v_1271.t1, &rt_0);
+      bool is_nothrow_3 = v_1271.t2;
+      FX_COPY_PTR(v_1271.t3, &cf_0);
       FX_CALL(
          _fx_M10C_gen_codeFM15unpack_fun_argsT4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB3LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tB(
-            args_13, rt_0, is_nothrow_3, &v_1250, 0), _fx_catch_288);
-      FX_COPY_PTR(v_1250.t0, &real_args_0);
-      _fx_R9Ast__id_t retid_0 = v_1250.t1;
-      FX_CALL(_fx_make_rB(false, &really_nothrow_0), _fx_catch_288);
+            args_13, rt_0, is_nothrow_3, &v_1272, 0), _fx_catch_295);
+      FX_COPY_PTR(v_1272.t0, &real_args_0);
+      _fx_R9Ast__id_t retid_0 = v_1272.t1;
+      FX_CALL(_fx_make_rB(false, &really_nothrow_0), _fx_catch_295);
       int_ nreal_args_0;
       FX_CALL(
          _fx_M10C_gen_codeFM8length1_i1LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(real_args_0, &nreal_args_0, 0),
-         _fx_catch_288);
+         _fx_catch_295);
       if (ctor_0.tag == 1) {
          if (FX_REC_VARIANT_TAG(kf_body_0) == 30) {
-            _fx_N14C_form__cexp_t v_1260 = 0;
-            _fx_N15C_form__cstmt_t v_1261 = 0;
+            _fx_N14C_form__cexp_t v_1282 = 0;
+            _fx_N15C_form__cstmt_t v_1283 = 0;
             _fx_T2ST2N14K_form__ktyp_tR10Ast__loc_t* vcase_38 = &kf_body_0->u.KExpCCode;
-            FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&vcase_38->t0, &vcase_38->t1.t1, &v_1260),
-               _fx_catch_270);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1260, &v_1261), _fx_catch_270);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1261, 0, true, &new_body_0), _fx_catch_270);
+            FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&vcase_38->t0, &vcase_38->t1.t1, &v_1282),
+               _fx_catch_277);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1282, &v_1283), _fx_catch_277);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1283, 0, true, &new_body_0), _fx_catch_277);
 
-         _fx_catch_270: ;
-            if (v_1261) {
-               _fx_free_N15C_form__cstmt_t(&v_1261);
+         _fx_catch_277: ;
+            if (v_1283) {
+               _fx_free_N15C_form__cstmt_t(&v_1283);
             }
-            if (v_1260) {
-               _fx_free_N14C_form__cexp_t(&v_1260);
+            if (v_1282) {
+               _fx_free_N14C_form__cexp_t(&v_1282);
             }
-            goto _fx_endmatch_54;
+            goto _fx_endmatch_57;
          }
       }
       if (ctor_0.tag == 1) {
-         _fx_Nt6option1N14C_form__cexp_t v_1262 = {0};
-         _fx_N14C_form__cexp_t v_1263 = 0;
-         _fx_N14C_form__cexp_t v_1264 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1284 = {0};
+         _fx_N14C_form__cexp_t v_1285 = 0;
+         _fx_N14C_form__cexp_t v_1286 = 0;
          _fx_rNt6option1N14C_form__cexp_t dstexp_r_1 = 0;
-         _fx_R16Ast__val_flags_t v_1265 = {0};
-         _fx_N14C_form__cexp_t v_1266 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1267 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1268 = {0};
+         _fx_R16Ast__val_flags_t v_1287 = {0};
+         _fx_N14C_form__cexp_t v_1288 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1289 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1290 = {0};
          _fx_N14C_form__cexp_t status_exp_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_154 = 0;
-         _fx_LN15C_form__cstmt_t ccode_155 = 0;
+         _fx_LN15C_form__cstmt_t ccode_159 = 0;
+         _fx_LN15C_form__cstmt_t ccode_160 = 0;
          _fx_N14C_form__cexp_t call_chkstk_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_156 = 0;
-         _fx_N14C_form__ctyp_t v_1269 = 0;
+         _fx_LN15C_form__cstmt_t ccode_161 = 0;
+         _fx_N14C_form__ctyp_t v_1291 = 0;
          _fx_N14C_form__ctyp_t fcv_ptr_ctyp_0 = 0;
          _fx_N14C_form__cexp_t fcv_arg_exp0_0 = 0;
          _fx_N14C_form__cexp_t cast_ptr_0 = 0;
-         _fx_R16Ast__val_flags_t v_1270 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_1271 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1272 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1273 = {0};
+         _fx_R16Ast__val_flags_t v_1292 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_1293 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1294 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1295 = {0};
          _fx_N14C_form__cexp_t ret_e_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_157 = 0;
+         _fx_LN15C_form__cstmt_t ccode_162 = 0;
          _fx_rR23C_gen_code__block_ctx_t bctx_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_158 = 0;
+         _fx_LN15C_form__cstmt_t ccode_163 = 0;
          _fx_LN15C_form__cstmt_t bctx_cleanup_3 = 0;
          _fx_LN15C_form__cstmt_t bctx_prologue_3 = 0;
-         _fx_LN15C_form__cstmt_t ccode_159 = 0;
-         _fx_N15C_form__cstmt_t v_1274 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1275 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_1276 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1277 = {0};
+         _fx_LN15C_form__cstmt_t ccode_164 = 0;
+         _fx_N15C_form__cstmt_t v_1296 = 0;
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1297 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_1298 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1299 = {0};
          _fx_N14C_form__cexp_t ret_e_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_160 = 0;
-         _fx_LN15C_form__cstmt_t v_1278 = 0;
+         _fx_LN15C_form__cstmt_t ccode_165 = 0;
+         _fx_LN15C_form__cstmt_t v_1300 = 0;
          _fx_N14C_form__cexp_t ret_e_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_161 = 0;
-         _fx_LN15C_form__cstmt_t ccode_162 = 0;
+         _fx_LN15C_form__cstmt_t ccode_166 = 0;
+         _fx_LN15C_form__cstmt_t ccode_167 = 0;
          _fx_N14C_form__cexp_t chk_ret_0 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1279 = {0};
-         _fx_N15C_form__cstmt_t v_1280 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1281 = {0};
-         _fx_N15C_form__cstmt_t v_1282 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1283 = {0};
-         _fx_N15C_form__cstmt_t v_1284 = 0;
-         _fx_LN15C_form__cstmt_t v_1285 = 0;
-         _fx_LN15C_form__cstmt_t v_1286 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1301 = {0};
+         _fx_N15C_form__cstmt_t v_1302 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1303 = {0};
+         _fx_N15C_form__cstmt_t v_1304 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1305 = {0};
+         _fx_N15C_form__cstmt_t v_1306 = 0;
+         _fx_LN15C_form__cstmt_t v_1307 = 0;
+         _fx_LN15C_form__cstmt_t v_1308 = 0;
          bool res_36;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&retid_0, &_fx_g9Ast__noid, &res_36, 0), _fx_catch_273);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&retid_0, &_fx_g9Ast__noid, &res_36, 0), _fx_catch_280);
          if (res_36) {
-            _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1262);
+            _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1284);
          }
          else {
-            FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &v_1263, 0),
-               _fx_catch_273);
-            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1263, &v_1264, 0), _fx_catch_273);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1264, &v_1262);
+            FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &v_1285, 0),
+               _fx_catch_280);
+            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1285, &v_1286, 0), _fx_catch_280);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1286, &v_1284);
          }
-         FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1262, &dstexp_r_1), _fx_catch_273);
+         FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1284, &dstexp_r_1), _fx_catch_280);
          _fx_free_rNt6option1N14C_form__cexp_t(func_dstexp_r_0);
          FX_COPY_PTR(dstexp_r_1, func_dstexp_r_0);
          *return_used_0 = 0;
          _fx_R9Ast__id_t orig_status_id_0;
-         fx_str_t slit_269 = FX_MAKE_STR("fx_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_269, &orig_status_id_0, 0), _fx_catch_273);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1265, 0), _fx_catch_273);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1266, 0), _fx_catch_273);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1266, &v_1267);
          fx_str_t slit_270 = FX_MAKE_STR("fx_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_270, &orig_status_id_0, 0), _fx_catch_280);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1287, 0), _fx_catch_280);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1288, 0), _fx_catch_280);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1288, &v_1289);
+         fx_str_t slit_271 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &orig_status_id_0, _fx_g20C_gen_code__CTypCInt, &v_1265, &slit_270, &v_1267, 0, &kf_loc_0, &v_1268, 0),
-            _fx_catch_273);
-         FX_COPY_PTR(v_1268.t0, &status_exp_0);
-         FX_COPY_PTR(v_1268.t1, &ccode_154);
+               &orig_status_id_0, _fx_g20C_gen_code__CTypCInt, &v_1287, &slit_271, &v_1289, 0, &kf_loc_0, &v_1290, 0),
+            _fx_catch_280);
+         FX_COPY_PTR(v_1290.t0, &status_exp_0);
+         FX_COPY_PTR(v_1290.t1, &ccode_159);
          _fx_R9Ast__id_t status_id_0;
          if (is_nothrow_3) {
             status_id_0 = _fx_g9Ast__noid;
@@ -34790,7 +34996,7 @@ static int
             status_id_0 = orig_status_id_0;
          }
          bool res_37;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&status_id_0, &_fx_g9Ast__noid, &res_37, 0), _fx_catch_273);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&status_id_0, &_fx_g9Ast__noid, &res_37, 0), _fx_catch_280);
          bool t_22;
          if (res_37) {
             t_22 = true;
@@ -34799,118 +35005,118 @@ static int
             t_22 = !kf_flags_0.fun_flag_recursive;
          }
          if (t_22) {
-            FX_COPY_PTR(ccode_154, &ccode_155);
+            FX_COPY_PTR(ccode_159, &ccode_160);
          }
          else {
-            _fx_R9Ast__id_t v_1287;
-            fx_str_t slit_271 = FX_MAKE_STR("fx_check_stack");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_271, &v_1287, 0), _fx_catch_273);
+            _fx_R9Ast__id_t v_1309;
+            fx_str_t slit_272 = FX_MAKE_STR("fx_check_stack");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_272, &v_1309, 0), _fx_catch_280);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1287, 0,
-                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &call_chkstk_0, 0), _fx_catch_273);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1309, 0,
+                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &call_chkstk_0, 0), _fx_catch_280);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_chkstk_0, ccode_154, &kf_loc_0, block_stack_ref_0, &ccode_155, 0), _fx_catch_273);
+                  call_chkstk_0, ccode_159, &kf_loc_0, block_stack_ref_0, &ccode_160, 0), _fx_catch_280);
          }
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_32 = real_args_0;
          for (; lst_32; lst_32 = lst_32->tl) {
             _fx_LN19C_form__carg_attr_t flags_3 = 0;
-            _fx_N14C_form__cexp_t v_1288 = 0;
-            _fx_N14C_form__cexp_t v_1289 = 0;
+            _fx_N14C_form__cexp_t v_1310 = 0;
+            _fx_N14C_form__cexp_t v_1311 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___12 = &lst_32->hd;
-            _fx_R9Ast__id_t a_13 = __pat___12->t0;
+            _fx_R9Ast__id_t a_14 = __pat___12->t0;
             FX_COPY_PTR(__pat___12->t2, &flags_3);
-            bool v_1290;
+            bool v_1312;
             FX_CALL(
                _fx_M10C_gen_codeFM3memB2LN19C_form__carg_attr_tN19C_form__carg_attr_t(flags_3,
-                  &_fx_g25C_gen_code__CArgPassByPtr, &v_1290, 0), _fx_catch_271);
-            if (v_1290) {
-               FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&a_13, &kf_loc_0, &v_1288, 0),
-                  _fx_catch_271);
-               FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1288, &v_1289, 0), _fx_catch_271);
+                  &_fx_g25C_gen_code__CArgPassByPtr, &v_1312, 0), _fx_catch_278);
+            if (v_1312) {
+               FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&a_14, &kf_loc_0, &v_1310, 0),
+                  _fx_catch_278);
+               FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1310, &v_1311, 0), _fx_catch_278);
                FX_CALL(
                   _fx_M10C_gen_codeFM3addv3Nt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tR9Ast__id_tN14C_form__cexp_t(*i2e_0,
-                     &a_13, v_1289, 0), _fx_catch_271);
+                     &a_14, v_1311, 0), _fx_catch_278);
             }
 
-         _fx_catch_271: ;
-            if (v_1289) {
-               _fx_free_N14C_form__cexp_t(&v_1289);
+         _fx_catch_278: ;
+            if (v_1311) {
+               _fx_free_N14C_form__cexp_t(&v_1311);
             }
-            if (v_1288) {
-               _fx_free_N14C_form__cexp_t(&v_1288);
+            if (v_1310) {
+               _fx_free_N14C_form__cexp_t(&v_1310);
             }
             FX_FREE_LIST_SIMPLE(&flags_3);
-            FX_CHECK_EXN(_fx_catch_273);
+            FX_CHECK_EXN(_fx_catch_280);
          }
          bool res_38;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_38, 0), _fx_catch_273);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_38, 0), _fx_catch_280);
          if (res_38) {
-            FX_COPY_PTR(ccode_155, &ccode_156);
+            FX_COPY_PTR(ccode_160, &ccode_161);
          }
          else {
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&kci_fcv_t_0, &v_1269), _fx_catch_273);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(v_1269, &fcv_ptr_ctyp_0, 0), _fx_catch_273);
-            _fx_R9Ast__id_t v_1291;
-            fx_str_t slit_272 = FX_MAKE_STR("fx_fv");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_272, &v_1291, 0), _fx_catch_273);
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&kci_fcv_t_0, &v_1291), _fx_catch_280);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(v_1291, &fcv_ptr_ctyp_0, 0), _fx_catch_280);
+            _fx_R9Ast__id_t v_1313;
+            fx_str_t slit_273 = FX_MAKE_STR("fx_fv");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_273, &v_1313, 0), _fx_catch_280);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1291,
-                  _fx_g23C_form__std_CTypVoidPtr, &kf_loc_0, &fcv_arg_exp0_0, 0), _fx_catch_273);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1313,
+                  _fx_g23C_form__std_CTypVoidPtr, &kf_loc_0, &fcv_arg_exp0_0, 0), _fx_catch_280);
             FX_CALL(
                _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(fcv_arg_exp0_0,
-                  fcv_ptr_ctyp_0, &kf_loc_0, &cast_ptr_0), _fx_catch_273);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1270, 0), _fx_catch_273);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(cast_ptr_0, &v_1271);
-            fx_str_t slit_273 = FX_MAKE_STR("");
+                  fcv_ptr_ctyp_0, &kf_loc_0, &cast_ptr_0), _fx_catch_280);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1292, 0), _fx_catch_280);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(cast_ptr_0, &v_1293);
+            fx_str_t slit_274 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &kci_arg_0, fcv_ptr_ctyp_0, &v_1270, &slit_273, &v_1271, ccode_155, &kf_loc_0, &v_1272, 0), _fx_catch_273);
-            FX_COPY_PTR(v_1272.t1, &ccode_156);
+                  &kci_arg_0, fcv_ptr_ctyp_0, &v_1292, &slit_274, &v_1293, ccode_160, &kf_loc_0, &v_1294, 0), _fx_catch_280);
+            FX_COPY_PTR(v_1294.t1, &ccode_161);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-               kf_body_0, dstexp_r_1, ccode_156, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+               kf_body_0, dstexp_r_1, ccode_161, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-               return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1273, fx_fv), _fx_catch_273);
-         FX_COPY_PTR(v_1273.t0, &ret_e_0);
-         FX_COPY_PTR(v_1273.t1, &ccode_157);
+               return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1295, fx_fv), _fx_catch_280);
+         FX_COPY_PTR(v_1295.t0, &ret_e_0);
+         FX_COPY_PTR(v_1295.t1, &ccode_162);
          _fx_R10Ast__loc_t end_loc_0;
-         FX_CALL(_fx_M6K_formFM12get_kexp_endR10Ast__loc_t1N14K_form__kexp_t(kf_body_0, &end_loc_0, 0), _fx_catch_273);
+         FX_CALL(_fx_M6K_formFM12get_kexp_endR10Ast__loc_t1N14K_form__kexp_t(kf_body_0, &end_loc_0, 0), _fx_catch_280);
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&end_loc_0, block_stack_ref_0,
-               &bctx_2, 0), _fx_catch_273);
-         if (ccode_157 != 0) {
-            _fx_N15C_form__cstmt_t v_1292 = ccode_157->hd;
-            if (FX_REC_VARIANT_TAG(v_1292) == 3) {
-               _fx_N14C_form__cexp_t v_1293 = v_1292->u.CExp;
-               if (FX_REC_VARIANT_TAG(v_1293) == 9) {
-                  _fx_N14C_form__cexp_t v_1294 = v_1293->u.CExpCall.t0;
-                  if (FX_REC_VARIANT_TAG(v_1294) == 1) {
+               &bctx_2, 0), _fx_catch_280);
+         if (ccode_162 != 0) {
+            _fx_N15C_form__cstmt_t v_1314 = ccode_162->hd;
+            if (FX_REC_VARIANT_TAG(v_1314) == 3) {
+               _fx_N14C_form__cexp_t v_1315 = v_1314->u.CExp;
+               if (FX_REC_VARIANT_TAG(v_1315) == 9) {
+                  _fx_N14C_form__cexp_t v_1316 = v_1315->u.CExpCall.t0;
+                  if (FX_REC_VARIANT_TAG(v_1316) == 1) {
                      bool res_39;
                      FX_CALL(
-                        _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1294->u.CExpIdent.t0, &_fx_g24C_form__std_FX_CHECK_EXN, &res_39,
-                           0), _fx_catch_273);
+                        _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1316->u.CExpIdent.t0, &_fx_g24C_form__std_FX_CHECK_EXN, &res_39,
+                           0), _fx_catch_280);
                      if (res_39) {
-                        _fx_R23C_gen_code__block_ctx_t* v_1295 = &bctx_2->data;
-                        _fx_R23C_gen_code__block_ctx_t* v_1296 = &bctx_2->data;
-                        v_1296->bctx_label_used = v_1295->bctx_label_used - 1;
-                        FX_COPY_PTR(ccode_157->tl, &ccode_158);
-                        goto _fx_endmatch_51;
+                        _fx_R23C_gen_code__block_ctx_t* v_1317 = &bctx_2->data;
+                        _fx_R23C_gen_code__block_ctx_t* v_1318 = &bctx_2->data;
+                        v_1318->bctx_label_used = v_1317->bctx_label_used - 1;
+                        FX_COPY_PTR(ccode_162->tl, &ccode_163);
+                        goto _fx_endmatch_54;
                      }
                   }
                }
             }
          }
-         FX_COPY_PTR(ccode_157, &ccode_158);
+         FX_COPY_PTR(ccode_162, &ccode_163);
 
-      _fx_endmatch_51: ;
-         FX_CHECK_EXN(_fx_catch_273);
-         _fx_R23C_gen_code__block_ctx_t* v_1297 = &bctx_2->data;
-         int_ bctx_label_used_3 = v_1297->bctx_label_used;
-         FX_COPY_PTR(v_1297->bctx_cleanup, &bctx_cleanup_3);
-         FX_COPY_PTR(v_1297->bctx_prologue, &bctx_prologue_3);
-         _fx_R9Ast__id_t bctx_label_3 = v_1297->bctx_label;
+      _fx_endmatch_54: ;
+         FX_CHECK_EXN(_fx_catch_280);
+         _fx_R23C_gen_code__block_ctx_t* v_1319 = &bctx_2->data;
+         int_ bctx_label_used_3 = v_1319->bctx_label_used;
+         FX_COPY_PTR(v_1319->bctx_cleanup, &bctx_cleanup_3);
+         FX_COPY_PTR(v_1319->bctx_prologue, &bctx_prologue_3);
+         _fx_R9Ast__id_t bctx_label_3 = v_1319->bctx_label;
          bool t_23;
          if (bctx_label_used_3 > 0) {
             t_23 = true;
@@ -34919,180 +35125,180 @@ static int
             t_23 = *return_used_0 > 0;
          }
          if (t_23) {
-            FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_3, &end_loc_0, &v_1274),
-               _fx_catch_273);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1274, ccode_158, true, &ccode_159), _fx_catch_273);
+            FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_3, &end_loc_0, &v_1296),
+               _fx_catch_280);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1296, ccode_163, true, &ccode_164), _fx_catch_280);
          }
          else {
-            FX_COPY_PTR(ccode_158, &ccode_159);
+            FX_COPY_PTR(ccode_163, &ccode_164);
          }
          if (bctx_cleanup_3 == 0) {
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1275);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_164, &v_1297);
          }
          else {
-            bool v_1298;
+            bool v_1320;
             bool res_40;
-            FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&retid_0, &_fx_g9Ast__noid, &res_40, 0), _fx_catch_273);
+            FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&retid_0, &_fx_g9Ast__noid, &res_40, 0), _fx_catch_280);
             bool t_24;
             if (res_40) {
                t_24 = true;
             }
             else {
                FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &t_24, 0),
-                  _fx_catch_273);
+                  _fx_catch_280);
             }
             if (t_24) {
-               v_1298 = true;
+               v_1320 = true;
             }
             else {
-               _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_1->data, &v_1276);
-               FX_CALL(_fx_M10C_gen_codeFM6issomeB1Nt6option1N14C_form__cexp_t(&v_1276, &v_1298, 0), _fx_catch_273);
+               _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_1->data, &v_1298);
+               FX_CALL(_fx_M10C_gen_codeFM6issomeB1Nt6option1N14C_form__cexp_t(&v_1298, &v_1320, 0), _fx_catch_280);
             }
-            if (v_1298) {
-               _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1277);
+            if (v_1320) {
+               _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_164, &v_1299);
             }
             else {
                int tag_33 = FX_REC_VARIANT_TAG(ret_e_0);
                bool res_41;
                if (tag_33 == 10) {
                   if (ret_e_0->u.CExpInit.t0 == 0) {
-                     res_41 = true; goto _fx_endmatch_52;
+                     res_41 = true; goto _fx_endmatch_55;
                   }
                }
                if (tag_33 == 2) {
-                  res_41 = true; goto _fx_endmatch_52;
+                  res_41 = true; goto _fx_endmatch_55;
                }
                if (tag_33 == 1) {
-                  res_41 = true; goto _fx_endmatch_52;
+                  res_41 = true; goto _fx_endmatch_55;
                }
                res_41 = false;
 
-            _fx_endmatch_52: ;
-               FX_CHECK_EXN(_fx_catch_273);
+            _fx_endmatch_55: ;
+               FX_CHECK_EXN(_fx_catch_280);
                if (res_41) {
-                  _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1277); goto _fx_endmatch_53;
+                  _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_164, &v_1299); goto _fx_endmatch_56;
                }
-               _fx_N14C_form__ctyp_t v_1299 = 0;
-               _fx_R16Ast__val_flags_t v_1300 = {0};
-               _fx_Nt6option1N14C_form__cexp_t v_1301 = {0};
-               _fx_R9Ast__id_t v_1302;
-               fx_str_t slit_274 = FX_MAKE_STR("result");
-               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_274, &v_1302, 0), _fx_catch_272);
-               FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(ret_e_0, &v_1299, 0), _fx_catch_272);
-               FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1300, 0), _fx_catch_272);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_0, &v_1301);
-               fx_str_t slit_275 = FX_MAKE_STR("");
+               _fx_N14C_form__ctyp_t v_1321 = 0;
+               _fx_R16Ast__val_flags_t v_1322 = {0};
+               _fx_Nt6option1N14C_form__cexp_t v_1323 = {0};
+               _fx_R9Ast__id_t v_1324;
+               fx_str_t slit_275 = FX_MAKE_STR("result");
+               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_275, &v_1324, 0), _fx_catch_279);
+               FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(ret_e_0, &v_1321, 0), _fx_catch_279);
+               FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1322, 0), _fx_catch_279);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_0, &v_1323);
+               fx_str_t slit_276 = FX_MAKE_STR("");
                FX_CALL(
                   _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     &v_1302, v_1299, &v_1300, &slit_275, &v_1301, ccode_159, &end_loc_0, &v_1277, 0), _fx_catch_272);
+                     &v_1324, v_1321, &v_1322, &slit_276, &v_1323, ccode_164, &end_loc_0, &v_1299, 0), _fx_catch_279);
 
-            _fx_catch_272: ;
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1301);
-               _fx_free_R16Ast__val_flags_t(&v_1300);
-               if (v_1299) {
-                  _fx_free_N14C_form__ctyp_t(&v_1299);
+            _fx_catch_279: ;
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1323);
+               _fx_free_R16Ast__val_flags_t(&v_1322);
+               if (v_1321) {
+                  _fx_free_N14C_form__ctyp_t(&v_1321);
                }
 
-            _fx_endmatch_53: ;
-               FX_CHECK_EXN(_fx_catch_273);
+            _fx_endmatch_56: ;
+               FX_CHECK_EXN(_fx_catch_280);
             }
-            FX_COPY_PTR(v_1277.t0, &ret_e_1);
-            FX_COPY_PTR(v_1277.t1, &ccode_160);
+            FX_COPY_PTR(v_1299.t0, &ret_e_1);
+            FX_COPY_PTR(v_1299.t1, &ccode_165);
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_3, ccode_160,
-                  &v_1278, 0), _fx_catch_273);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_1, v_1278, &v_1275);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_3, ccode_165,
+                  &v_1300, 0), _fx_catch_280);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_1, v_1300, &v_1297);
          }
-         FX_COPY_PTR(v_1275.t0, &ret_e_2);
-         FX_COPY_PTR(v_1275.t1, &ccode_161);
+         FX_COPY_PTR(v_1297.t0, &ret_e_2);
+         FX_COPY_PTR(v_1297.t1, &ccode_166);
          bool res_42;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &res_42, 0), _fx_catch_273);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &res_42, 0), _fx_catch_280);
          if (res_42) {
             if (*return_used_0 > 0) {
-               _fx_R9Ast__id_t v_1303;
-               fx_str_t slit_276 = FX_MAKE_STR("FX_CHECK_RETURN");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_276, &v_1303, 0), _fx_catch_273);
+               _fx_R9Ast__id_t v_1325;
+               fx_str_t slit_277 = FX_MAKE_STR("FX_CHECK_RETURN");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_277, &v_1325, 0), _fx_catch_280);
                FX_CALL(
-                  _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1303,
-                     0, _fx_g20C_gen_code__CTypCInt, &end_loc_0, &chk_ret_0, 0), _fx_catch_273);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_ret_0, &v_1279);
+                  _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1325,
+                     0, _fx_g20C_gen_code__CTypCInt, &end_loc_0, &chk_ret_0, 0), _fx_catch_280);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_ret_0, &v_1301);
                FX_CALL(
-                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1279, &end_loc_0,
-                     &v_1280), _fx_catch_273);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1280, ccode_161, true, &ccode_162), _fx_catch_273);
+                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1301, &end_loc_0,
+                     &v_1302), _fx_catch_280);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1302, ccode_166, true, &ccode_167), _fx_catch_280);
             }
             else {
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(status_exp_0, &v_1281);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(status_exp_0, &v_1303);
                FX_CALL(
-                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1281, &end_loc_0,
-                     &v_1282), _fx_catch_273);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1282, ccode_161, true, &ccode_162), _fx_catch_273);
+                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1303, &end_loc_0,
+                     &v_1304), _fx_catch_280);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1304, ccode_166, true, &ccode_167), _fx_catch_280);
             }
          }
          else if (FX_REC_VARIANT_TAG(rt_0) == 8) {
-            FX_COPY_PTR(ccode_161, &ccode_162);
+            FX_COPY_PTR(ccode_166, &ccode_167);
          }
          else {
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_2, &v_1283);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_2, &v_1305);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1283, &end_loc_0,
-                  &v_1284), _fx_catch_273);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1284, ccode_161, true, &ccode_162), _fx_catch_273);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1305, &end_loc_0,
+                  &v_1306), _fx_catch_280);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1306, ccode_166, true, &ccode_167), _fx_catch_280);
          }
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(bctx_prologue_3, &v_1285, 0), _fx_catch_273);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(ccode_162, &v_1286, 0), _fx_catch_273);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(bctx_prologue_3, &v_1307, 0), _fx_catch_280);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(ccode_167, &v_1308, 0), _fx_catch_280);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1285, v_1286, &new_body_0,
-               0), _fx_catch_273);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1307, v_1308, &new_body_0,
+               0), _fx_catch_280);
 
-      _fx_catch_273: ;
-         if (v_1286) {
-            _fx_free_LN15C_form__cstmt_t(&v_1286);
+      _fx_catch_280: ;
+         if (v_1308) {
+            _fx_free_LN15C_form__cstmt_t(&v_1308);
          }
-         if (v_1285) {
-            _fx_free_LN15C_form__cstmt_t(&v_1285);
+         if (v_1307) {
+            _fx_free_LN15C_form__cstmt_t(&v_1307);
          }
-         if (v_1284) {
-            _fx_free_N15C_form__cstmt_t(&v_1284);
+         if (v_1306) {
+            _fx_free_N15C_form__cstmt_t(&v_1306);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1283);
-         if (v_1282) {
-            _fx_free_N15C_form__cstmt_t(&v_1282);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1305);
+         if (v_1304) {
+            _fx_free_N15C_form__cstmt_t(&v_1304);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1281);
-         if (v_1280) {
-            _fx_free_N15C_form__cstmt_t(&v_1280);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1303);
+         if (v_1302) {
+            _fx_free_N15C_form__cstmt_t(&v_1302);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1279);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1301);
          if (chk_ret_0) {
             _fx_free_N14C_form__cexp_t(&chk_ret_0);
          }
-         if (ccode_162) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_162);
+         if (ccode_167) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_167);
          }
-         if (ccode_161) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_161);
+         if (ccode_166) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_166);
          }
          if (ret_e_2) {
             _fx_free_N14C_form__cexp_t(&ret_e_2);
          }
-         if (v_1278) {
-            _fx_free_LN15C_form__cstmt_t(&v_1278);
+         if (v_1300) {
+            _fx_free_LN15C_form__cstmt_t(&v_1300);
          }
-         if (ccode_160) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_160);
+         if (ccode_165) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_165);
          }
          if (ret_e_1) {
             _fx_free_N14C_form__cexp_t(&ret_e_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1277);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1276);
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1275);
-         if (v_1274) {
-            _fx_free_N15C_form__cstmt_t(&v_1274);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1299);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1298);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1297);
+         if (v_1296) {
+            _fx_free_N15C_form__cstmt_t(&v_1296);
          }
-         if (ccode_159) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_159);
+         if (ccode_164) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_164);
          }
          if (bctx_prologue_3) {
             _fx_free_LN15C_form__cstmt_t(&bctx_prologue_3);
@@ -35100,22 +35306,22 @@ static int
          if (bctx_cleanup_3) {
             _fx_free_LN15C_form__cstmt_t(&bctx_cleanup_3);
          }
-         if (ccode_158) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_158);
+         if (ccode_163) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_163);
          }
          if (bctx_2) {
             _fx_free_rR23C_gen_code__block_ctx_t(&bctx_2);
          }
-         if (ccode_157) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_157);
+         if (ccode_162) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_162);
          }
          if (ret_e_0) {
             _fx_free_N14C_form__cexp_t(&ret_e_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1273);
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1272);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1271);
-         _fx_free_R16Ast__val_flags_t(&v_1270);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1295);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1294);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1293);
+         _fx_free_R16Ast__val_flags_t(&v_1292);
          if (cast_ptr_0) {
             _fx_free_N14C_form__cexp_t(&cast_ptr_0);
          }
@@ -35125,314 +35331,314 @@ static int
          if (fcv_ptr_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&fcv_ptr_ctyp_0);
          }
-         if (v_1269) {
-            _fx_free_N14C_form__ctyp_t(&v_1269);
+         if (v_1291) {
+            _fx_free_N14C_form__ctyp_t(&v_1291);
          }
-         if (ccode_156) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_156);
+         if (ccode_161) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_161);
          }
          if (call_chkstk_0) {
             _fx_free_N14C_form__cexp_t(&call_chkstk_0);
          }
-         if (ccode_155) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_155);
+         if (ccode_160) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_160);
          }
-         if (ccode_154) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_154);
+         if (ccode_159) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_159);
          }
          if (status_exp_0) {
             _fx_free_N14C_form__cexp_t(&status_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1268);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1267);
-         if (v_1266) {
-            _fx_free_N14C_form__cexp_t(&v_1266);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1290);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1289);
+         if (v_1288) {
+            _fx_free_N14C_form__cexp_t(&v_1288);
          }
-         _fx_free_R16Ast__val_flags_t(&v_1265);
+         _fx_free_R16Ast__val_flags_t(&v_1287);
          if (dstexp_r_1) {
             _fx_free_rNt6option1N14C_form__cexp_t(&dstexp_r_1);
          }
-         if (v_1264) {
-            _fx_free_N14C_form__cexp_t(&v_1264);
+         if (v_1286) {
+            _fx_free_N14C_form__cexp_t(&v_1286);
          }
-         if (v_1263) {
-            _fx_free_N14C_form__cexp_t(&v_1263);
+         if (v_1285) {
+            _fx_free_N14C_form__cexp_t(&v_1285);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1262);
-         goto _fx_endmatch_54;
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1284);
+         goto _fx_endmatch_57;
       }
       if (ctor_0.tag == 3) {
          _fx_N14C_form__cexp_t var_exp_0 = 0;
          _fx_N14C_form__ctyp_t result_ctyp_0 = 0;
-         _fx_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t v_1304 = {0};
-         _fx_N14C_form__cexp_t v_1305 = 0;
-         _fx_LN14C_form__cexp_t v_1306 = 0;
+         _fx_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t v_1326 = {0};
+         _fx_N14C_form__cexp_t v_1327 = 0;
+         _fx_LN14C_form__cexp_t v_1328 = 0;
          _fx_N14C_form__cexp_t alloc_var_0 = 0;
-         _fx_R16Ast__val_flags_t v_1307 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1308 = {0};
+         _fx_R16Ast__val_flags_t v_1329 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1330 = {0};
          _fx_N14C_form__cexp_t var_exp_1 = 0;
-         _fx_N15C_form__cstmt_t v_1309 = 0;
-         _fx_LN15C_form__cstmt_t ccode_163 = 0;
-         _fx_LN15C_form__cstmt_t ccode_164 = 0;
+         _fx_N15C_form__cstmt_t v_1331 = 0;
+         _fx_LN15C_form__cstmt_t ccode_168 = 0;
+         _fx_LN15C_form__cstmt_t ccode_169 = 0;
          _fx_N14C_form__ctyp_t ifaces_ctyp_0 = 0;
          _fx_N14C_form__ctyp_t ifaces_ptr_ctyp_0 = 0;
-         _fx_N14C_form__cexp_t v_1310 = 0;
-         _fx_N14C_form__cexp_t v_1311 = 0;
-         _fx_N14C_form__cexp_t v_1312 = 0;
-         _fx_N14C_form__cexp_t v_1313 = 0;
-         _fx_N15C_form__cstmt_t v_1314 = 0;
-         _fx_N14C_form__cexp_t v_1315 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1316 = {0};
-         _fx_N15C_form__cstmt_t v_1317 = 0;
+         _fx_N14C_form__cexp_t v_1332 = 0;
+         _fx_N14C_form__cexp_t v_1333 = 0;
+         _fx_N14C_form__cexp_t v_1334 = 0;
+         _fx_N14C_form__cexp_t v_1335 = 0;
+         _fx_N15C_form__cstmt_t v_1336 = 0;
+         _fx_N14C_form__cexp_t v_1337 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1338 = {0};
+         _fx_N15C_form__cstmt_t v_1339 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_0 = 0;
          _fx_N14C_form__cexp_t var_exp_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_165 = 0;
+         _fx_LN15C_form__cstmt_t ccode_170 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_1 = 0;
-         _fx_N14C_form__cexp_t v_1318 = 0;
-         _fx_N14C_form__cexp_t v_1319 = 0;
+         _fx_N14C_form__cexp_t v_1340 = 0;
+         _fx_N14C_form__cexp_t v_1341 = 0;
          _fx_N14C_form__cexp_t init_tag_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_166 = 0;
-         _fx_N15C_form__cstmt_t v_1320 = 0;
+         _fx_LN15C_form__cstmt_t ccode_171 = 0;
+         _fx_N15C_form__cstmt_t v_1342 = 0;
          _fx_N14C_form__cexp_t dst_base_0 = 0;
          _fx_N14C_form__cexp_t dst_base_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_167 = 0;
-         _fx_LN15C_form__cstmt_t v_1321 = 0;
-         _fx_T3BBR9Ast__id_t v_1322;
+         _fx_LN15C_form__cstmt_t ccode_172 = 0;
+         _fx_LN15C_form__cstmt_t v_1343 = 0;
+         _fx_T3BBR9Ast__id_t v_1344;
          if (FX_REC_VARIANT_TAG(kf_rt_0) == 16) {
-            _fx_N15K_form__kinfo_t v_1323 = {0};
+            _fx_N15K_form__kinfo_t v_1345 = {0};
             _fx_R9Ast__id_t* vn_1 = &kf_rt_0->u.KTypName;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1323, 0),
-               _fx_catch_276);
-            if (v_1323.tag == 5) {
-               _fx_R21K_form__kdefvariant_t v_1324 = {0};
-               _fx_N15C_form__cinfo_t v_1325 = {0};
-               _fx_copy_R21K_form__kdefvariant_t(&v_1323.u.KVariant->data, &v_1324);
-               _fx_R16Ast__var_flags_t* kvar_flags_2 = &v_1324.kvar_flags;
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1345, 0),
+               _fx_catch_283);
+            if (v_1345.tag == 5) {
+               _fx_R21K_form__kdefvariant_t v_1346 = {0};
+               _fx_N15C_form__cinfo_t v_1347 = {0};
+               _fx_copy_R21K_form__kdefvariant_t(&v_1345.u.KVariant->data, &v_1346);
+               _fx_R16Ast__var_flags_t* kvar_flags_2 = &v_1346.kvar_flags;
                bool have_tag_1 = kvar_flags_2->var_flag_have_tag;
                bool is_recursive_1 = kvar_flags_2->var_flag_recursive;
-               FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1325, 0),
-                  _fx_catch_274);
+               FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1347, 0),
+                  _fx_catch_281);
                _fx_R9Ast__id_t ifaces_id_0;
-               if (v_1325.tag == 4) {
-                  _fx_R17C_form__cdeftyp_t v_1326 = {0};
-                  _fx_copy_R17C_form__cdeftyp_t(&v_1325.u.CTyp->data, &v_1326);
-                  ifaces_id_0 = v_1326.ct_ifaces_id;
-                  _fx_free_R17C_form__cdeftyp_t(&v_1326);
+               if (v_1347.tag == 4) {
+                  _fx_R17C_form__cdeftyp_t v_1348 = {0};
+                  _fx_copy_R17C_form__cdeftyp_t(&v_1347.u.CTyp->data, &v_1348);
+                  ifaces_id_0 = v_1348.ct_ifaces_id;
+                  _fx_free_R17C_form__cdeftyp_t(&v_1348);
                }
                else {
                   ifaces_id_0 = _fx_g9Ast__noid;
                }
-               FX_CHECK_EXN(_fx_catch_274);
+               FX_CHECK_EXN(_fx_catch_281);
                _fx_T3BBR9Ast__id_t tup_3 = { have_tag_1, is_recursive_1, ifaces_id_0 };
-               v_1322 = tup_3;
+               v_1344 = tup_3;
 
-            _fx_catch_274: ;
-               _fx_free_N15C_form__cinfo_t(&v_1325);
-               _fx_free_R21K_form__kdefvariant_t(&v_1324);
+            _fx_catch_281: ;
+               _fx_free_N15C_form__cinfo_t(&v_1347);
+               _fx_free_R21K_form__kdefvariant_t(&v_1346);
             }
             else {
-               fx_str_t v_1327 = {0};
-               fx_str_t v_1328 = {0};
-               fx_str_t v_1329 = {0};
-               fx_exn_t v_1330 = {0};
-               FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1327, 0), _fx_catch_275);
-               FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1327, &v_1328, 0), _fx_catch_275);
-               fx_str_t slit_277 = FX_MAKE_STR("cgen: the return type of variant constructor ");
-               fx_str_t slit_278 = FX_MAKE_STR(" is not variant");
+               fx_str_t v_1349 = {0};
+               fx_str_t v_1350 = {0};
+               fx_str_t v_1351 = {0};
+               fx_exn_t v_1352 = {0};
+               FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1349, 0), _fx_catch_282);
+               FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1349, &v_1350, 0), _fx_catch_282);
+               fx_str_t slit_278 = FX_MAKE_STR("cgen: the return type of variant constructor ");
+               fx_str_t slit_279 = FX_MAKE_STR(" is not variant");
                {
-                  const fx_str_t strs_38[] = { slit_277, v_1328, slit_278 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_38, 3, &v_1329), _fx_catch_275);
+                  const fx_str_t strs_38[] = { slit_278, v_1350, slit_279 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_38, 3, &v_1351), _fx_catch_282);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1329, &v_1330, 0), _fx_catch_275);
-               FX_THROW(&v_1330, false, _fx_catch_275);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1351, &v_1352, 0), _fx_catch_282);
+               FX_THROW(&v_1352, false, _fx_catch_282);
 
-            _fx_catch_275: ;
-               fx_free_exn(&v_1330);
-               FX_FREE_STR(&v_1329);
-               FX_FREE_STR(&v_1328);
-               FX_FREE_STR(&v_1327);
+            _fx_catch_282: ;
+               fx_free_exn(&v_1352);
+               FX_FREE_STR(&v_1351);
+               FX_FREE_STR(&v_1350);
+               FX_FREE_STR(&v_1349);
             }
-            FX_CHECK_EXN(_fx_catch_276);
+            FX_CHECK_EXN(_fx_catch_283);
 
-         _fx_catch_276: ;
-            _fx_free_N15K_form__kinfo_t(&v_1323);
+         _fx_catch_283: ;
+            _fx_free_N15K_form__kinfo_t(&v_1345);
          }
          else {
-            fx_str_t v_1331 = {0};
-            fx_str_t v_1332 = {0};
-            fx_str_t v_1333 = {0};
-            fx_exn_t v_1334 = {0};
-            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1331, 0), _fx_catch_277);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1331, &v_1332, 0), _fx_catch_277);
-            fx_str_t slit_279 = FX_MAKE_STR("cgen: the return type of variant constructor ");
-            fx_str_t slit_280 = FX_MAKE_STR(" is not variant");
+            fx_str_t v_1353 = {0};
+            fx_str_t v_1354 = {0};
+            fx_str_t v_1355 = {0};
+            fx_exn_t v_1356 = {0};
+            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1353, 0), _fx_catch_284);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1353, &v_1354, 0), _fx_catch_284);
+            fx_str_t slit_280 = FX_MAKE_STR("cgen: the return type of variant constructor ");
+            fx_str_t slit_281 = FX_MAKE_STR(" is not variant");
             {
-               const fx_str_t strs_39[] = { slit_279, v_1332, slit_280 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_39, 3, &v_1333), _fx_catch_277);
+               const fx_str_t strs_39[] = { slit_280, v_1354, slit_281 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_39, 3, &v_1355), _fx_catch_284);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1333, &v_1334, 0), _fx_catch_277);
-            FX_THROW(&v_1334, false, _fx_catch_277);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1355, &v_1356, 0), _fx_catch_284);
+            FX_THROW(&v_1356, false, _fx_catch_284);
 
-         _fx_catch_277: ;
-            fx_free_exn(&v_1334);
-            FX_FREE_STR(&v_1333);
-            FX_FREE_STR(&v_1332);
-            FX_FREE_STR(&v_1331);
+         _fx_catch_284: ;
+            fx_free_exn(&v_1356);
+            FX_FREE_STR(&v_1355);
+            FX_FREE_STR(&v_1354);
+            FX_FREE_STR(&v_1353);
          }
-         FX_CHECK_EXN(_fx_catch_279);
-         bool have_tag_2 = v_1322.t0;
-         bool is_recursive_variant_0 = v_1322.t1;
-         _fx_R9Ast__id_t ifaces_id_1 = v_1322.t2;
+         FX_CHECK_EXN(_fx_catch_286);
+         bool have_tag_2 = v_1344.t0;
+         bool is_recursive_variant_0 = v_1344.t1;
+         _fx_R9Ast__id_t ifaces_id_1 = v_1344.t2;
          FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &var_exp_0, 0),
-            _fx_catch_279);
+            _fx_catch_286);
          FX_CALL(
             _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(kf_rt_0, &kf_loc_0, &result_ctyp_0,
-               0), _fx_catch_279);
+               0), _fx_catch_286);
          if (is_recursive_variant_0) {
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(result_ctyp_0, &kf_loc_0, &v_1305),
-               _fx_catch_279);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1305, 0, true, &v_1306), _fx_catch_279);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(result_ctyp_0, &kf_loc_0, &v_1327),
+               _fx_catch_286);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1327, 0, true, &v_1328), _fx_catch_286);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g48C_form__std_FX_MAKE_RECURSIVE_VARIANT_IMPL_START, v_1306, _fx_g20C_gen_code__CTypVoid, &kf_loc_0,
-                  &alloc_var_0, 0), _fx_catch_279);
-            _fx_R9Ast__id_t v_1335;
-            fx_str_t slit_281 = FX_MAKE_STR("v");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_281, &v_1335, 0), _fx_catch_279);
-            FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1307, 0), _fx_catch_279);
+                  &_fx_g48C_form__std_FX_MAKE_RECURSIVE_VARIANT_IMPL_START, v_1328, _fx_g20C_gen_code__CTypVoid, &kf_loc_0,
+                  &alloc_var_0, 0), _fx_catch_286);
+            _fx_R9Ast__id_t v_1357;
             fx_str_t slit_282 = FX_MAKE_STR("v");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_282, &v_1357, 0), _fx_catch_286);
+            FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1329, 0), _fx_catch_286);
+            fx_str_t slit_283 = FX_MAKE_STR("v");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_1335, result_ctyp_0, &v_1307, &slit_282, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1308, 0),
-               _fx_catch_279);
-            FX_COPY_PTR(v_1308.t0, &var_exp_1);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_var_0, &v_1309), _fx_catch_279);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1309, 0, true, &ccode_163), _fx_catch_279);
+                  &v_1357, result_ctyp_0, &v_1329, &slit_283, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1330, 0),
+               _fx_catch_286);
+            FX_COPY_PTR(v_1330.t0, &var_exp_1);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_var_0, &v_1331), _fx_catch_286);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1331, 0, true, &ccode_168), _fx_catch_286);
             bool res_43;
-            FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ifaces_id_1, &_fx_g9Ast__noid, &res_43, 0), _fx_catch_279);
+            FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ifaces_id_1, &_fx_g9Ast__noid, &res_43, 0), _fx_catch_286);
             if (res_43) {
-               FX_COPY_PTR(ccode_163, &ccode_164);
+               FX_COPY_PTR(ccode_168, &ccode_169);
             }
             else {
-               _fx_R9Ast__id_t v_1336;
-               fx_str_t slit_283 = FX_MAKE_STR("fx_ifaces_t");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_283, &v_1336, 0), _fx_catch_279);
-               FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1336, &ifaces_ctyp_0), _fx_catch_279);
+               _fx_R9Ast__id_t v_1358;
+               fx_str_t slit_284 = FX_MAKE_STR("fx_ifaces_t");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_284, &v_1358, 0), _fx_catch_286);
+               FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1358, &ifaces_ctyp_0), _fx_catch_286);
                FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ifaces_ctyp_0, &ifaces_ptr_ctyp_0, 0),
-                  _fx_catch_279);
-               _fx_R9Ast__id_t v_1337;
-               fx_str_t slit_284 = FX_MAKE_STR("ifaces");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_284, &v_1337, 0), _fx_catch_279);
+                  _fx_catch_286);
+               _fx_R9Ast__id_t v_1359;
+               fx_str_t slit_285 = FX_MAKE_STR("ifaces");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_285, &v_1359, 0), _fx_catch_286);
                FX_CALL(
-                  _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_1, &v_1337,
-                     ifaces_ptr_ctyp_0, &v_1310, 0), _fx_catch_279);
+                  _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_1, &v_1359,
+                     ifaces_ptr_ctyp_0, &v_1332, 0), _fx_catch_286);
                FX_CALL(
                   _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&ifaces_id_1,
-                     ifaces_ctyp_0, &kloc_0, &v_1311, 0), _fx_catch_279);
-               FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(v_1311, &v_1312, 0), _fx_catch_279);
+                     ifaces_ctyp_0, &kloc_0, &v_1333, 0), _fx_catch_286);
+               FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(v_1333, &v_1334, 0), _fx_catch_286);
                FX_CALL(
-                  _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1310, v_1312, &v_1313, 0),
-                  _fx_catch_279);
-               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1313, &v_1314), _fx_catch_279);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1314, ccode_163, true, &ccode_164), _fx_catch_279);
+                  _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1332, v_1334, &v_1335, 0),
+                  _fx_catch_286);
+               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1335, &v_1336), _fx_catch_286);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1336, ccode_168, true, &ccode_169), _fx_catch_286);
             }
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1315, 0), _fx_catch_279);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1315, &v_1316);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1337, 0), _fx_catch_286);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1337, &v_1338);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1316, &kf_loc_0,
-                  &v_1317), _fx_catch_279);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1317, 0, true, &ret_ccode_0), _fx_catch_279);
-            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_1, ccode_164, ret_ccode_0, &v_1304);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1338, &kf_loc_0,
+                  &v_1339), _fx_catch_286);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1339, 0, true, &ret_ccode_0), _fx_catch_286);
+            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_1, ccode_169, ret_ccode_0, &v_1326);
          }
          else {
-            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_0, 0, 0, &v_1304);
+            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_0, 0, 0, &v_1326);
          }
-         FX_COPY_PTR(v_1304.t0, &var_exp_2);
-         FX_COPY_PTR(v_1304.t1, &ccode_165);
-         FX_COPY_PTR(v_1304.t2, &ret_ccode_1);
-         _fx_R9Ast__id_t v_1338;
-         fx_str_t slit_285 = FX_MAKE_STR("tag");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_285, &v_1338, 0), _fx_catch_279);
+         FX_COPY_PTR(v_1326.t0, &var_exp_2);
+         FX_COPY_PTR(v_1326.t1, &ccode_170);
+         FX_COPY_PTR(v_1326.t2, &ret_ccode_1);
+         _fx_R9Ast__id_t v_1360;
+         fx_str_t slit_286 = FX_MAKE_STR("tag");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_286, &v_1360, 0), _fx_catch_286);
          FX_CALL(
-            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1338,
-               _fx_g19C_gen_code__CTypInt, &v_1318, 0), _fx_catch_279);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_0.u.CtorVariant, &kloc_0, &v_1319, 0),
-            _fx_catch_279);
+            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1360,
+               _fx_g19C_gen_code__CTypInt, &v_1340, 0), _fx_catch_286);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_0.u.CtorVariant, &kloc_0, &v_1341, 0),
+            _fx_catch_286);
          FX_CALL(
-            _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1318, v_1319, &init_tag_0, 0),
-            _fx_catch_279);
+            _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1340, v_1341, &init_tag_0, 0),
+            _fx_catch_286);
          if (have_tag_2) {
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(init_tag_0, &v_1320), _fx_catch_279);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1320, ccode_165, true, &ccode_166), _fx_catch_279);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(init_tag_0, &v_1342), _fx_catch_286);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1342, ccode_170, true, &ccode_171), _fx_catch_286);
          }
          else {
-            FX_COPY_PTR(ccode_165, &ccode_166);
+            FX_COPY_PTR(ccode_170, &ccode_171);
          }
-         _fx_R9Ast__id_t v_1339;
-         fx_str_t slit_286 = FX_MAKE_STR("u");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_286, &v_1339, 0), _fx_catch_279);
+         _fx_R9Ast__id_t v_1361;
+         fx_str_t slit_287 = FX_MAKE_STR("u");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_287, &v_1361, 0), _fx_catch_286);
          FX_CALL(
-            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1339,
-               _fx_g19C_gen_code__CTypAny, &dst_base_0, 0), _fx_catch_279);
-         _fx_R9Ast__id_t v_1340;
-         FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(&kf_name_0, &v_1340, 0), _fx_catch_279);
+            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1361,
+               _fx_g19C_gen_code__CTypAny, &dst_base_0, 0), _fx_catch_286);
+         _fx_R9Ast__id_t v_1362;
+         FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(&kf_name_0, &v_1362, 0), _fx_catch_286);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_0, &v_1340,
-               _fx_g19C_gen_code__CTypAny, &dst_base_1, 0), _fx_catch_279);
-         FX_COPY_PTR(ccode_166, &ccode_167);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_0, &v_1362,
+               _fx_g19C_gen_code__CTypAny, &dst_base_1, 0), _fx_catch_286);
+         FX_COPY_PTR(ccode_171, &ccode_172);
          int_ idx_2 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_33 = real_args_0;
          for (; lst_33; lst_33 = lst_33->tl, idx_2 += 1) {
             _fx_N14C_form__ctyp_t t_25 = 0;
             _fx_LN19C_form__carg_attr_t flags_4 = 0;
             _fx_N14C_form__cexp_t src_exp_2 = 0;
-            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1341 = {0};
+            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1363 = {0};
             _fx_N14C_form__cexp_t src_exp_3 = 0;
             _fx_N14C_form__ctyp_t t_26 = 0;
             _fx_N14C_form__cexp_t dst_exp_21 = 0;
-            fx_str_t v_1342 = {0};
-            fx_str_t v_1343 = {0};
-            _fx_LN15C_form__cstmt_t v_1344 = 0;
+            fx_str_t v_1364 = {0};
+            fx_str_t v_1365 = {0};
+            _fx_LN15C_form__cstmt_t v_1366 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___13 = &lst_33->hd;
-            _fx_R9Ast__id_t a_14 = __pat___13->t0;
+            _fx_R9Ast__id_t a_15 = __pat___13->t0;
             FX_COPY_PTR(__pat___13->t1, &t_25);
             FX_COPY_PTR(__pat___13->t2, &flags_4);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_14, t_25, &kf_loc_0,
-                  &src_exp_2, 0), _fx_catch_278);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_15, t_25, &kf_loc_0,
+                  &src_exp_2, 0), _fx_catch_285);
             FX_CALL(
                _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                  idx_2, src_exp_2, t_25, flags_4, &kf_loc_0, &v_1341, 0), _fx_catch_278);
-            FX_COPY_PTR(v_1341.t0, &src_exp_3);
-            FX_COPY_PTR(v_1341.t1, &t_26);
+                  idx_2, src_exp_2, t_25, flags_4, &kf_loc_0, &v_1363, 0), _fx_catch_285);
+            FX_COPY_PTR(v_1363.t0, &src_exp_3);
+            FX_COPY_PTR(v_1363.t1, &t_26);
             if (nreal_args_0 == 1) {
                FX_COPY_PTR(dst_base_1, &dst_exp_21);
             }
             else {
-               FX_CALL(_fx_F6stringS1i(idx_2, &v_1342, 0), _fx_catch_278);
-               fx_str_t slit_287 = FX_MAKE_STR("t");
+               FX_CALL(_fx_F6stringS1i(idx_2, &v_1364, 0), _fx_catch_285);
+               fx_str_t slit_288 = FX_MAKE_STR("t");
                {
-                  const fx_str_t strs_40[] = { slit_287, v_1342 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_40, 2, &v_1343), _fx_catch_278);
+                  const fx_str_t strs_40[] = { slit_288, v_1364 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_40, 2, &v_1365), _fx_catch_285);
                }
                _fx_R9Ast__id_t tup_elem_0;
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1343, &tup_elem_0, 0), _fx_catch_278);
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1365, &tup_elem_0, 0), _fx_catch_285);
                FX_CALL(
                   _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_1,
-                     &tup_elem_0, t_26, &dst_exp_21, 0), _fx_catch_278);
+                     &tup_elem_0, t_26, &dst_exp_21, 0), _fx_catch_285);
             }
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  src_exp_3, dst_exp_21, t_26, ccode_167, &kf_loc_0, &v_1344, 0), _fx_catch_278);
-            _fx_free_LN15C_form__cstmt_t(&ccode_167);
-            FX_COPY_PTR(v_1344, &ccode_167);
+                  src_exp_3, dst_exp_21, t_26, ccode_172, &kf_loc_0, &v_1366, 0), _fx_catch_285);
+            _fx_free_LN15C_form__cstmt_t(&ccode_172);
+            FX_COPY_PTR(v_1366, &ccode_172);
 
-         _fx_catch_278: ;
-            if (v_1344) {
-               _fx_free_LN15C_form__cstmt_t(&v_1344);
+         _fx_catch_285: ;
+            if (v_1366) {
+               _fx_free_LN15C_form__cstmt_t(&v_1366);
             }
-            FX_FREE_STR(&v_1343);
-            FX_FREE_STR(&v_1342);
+            FX_FREE_STR(&v_1365);
+            FX_FREE_STR(&v_1364);
             if (dst_exp_21) {
                _fx_free_N14C_form__cexp_t(&dst_exp_21);
             }
@@ -35442,7 +35648,7 @@ static int
             if (src_exp_3) {
                _fx_free_N14C_form__cexp_t(&src_exp_3);
             }
-            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1341);
+            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1363);
             if (src_exp_2) {
                _fx_free_N14C_form__cexp_t(&src_exp_2);
             }
@@ -35450,19 +35656,19 @@ static int
             if (t_25) {
                _fx_free_N14C_form__ctyp_t(&t_25);
             }
-            FX_CHECK_EXN(_fx_catch_279);
+            FX_CHECK_EXN(_fx_catch_286);
          }
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_1, ccode_167,
-               &v_1321, 0), _fx_catch_279);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1321, &new_body_0, 0), _fx_catch_279);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_1, ccode_172,
+               &v_1343, 0), _fx_catch_286);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1343, &new_body_0, 0), _fx_catch_286);
 
-      _fx_catch_279: ;
-         if (v_1321) {
-            _fx_free_LN15C_form__cstmt_t(&v_1321);
+      _fx_catch_286: ;
+         if (v_1343) {
+            _fx_free_LN15C_form__cstmt_t(&v_1343);
          }
-         if (ccode_167) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_167);
+         if (ccode_172) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_172);
          }
          if (dst_base_1) {
             _fx_free_N14C_form__cexp_t(&dst_base_1);
@@ -35470,26 +35676,26 @@ static int
          if (dst_base_0) {
             _fx_free_N14C_form__cexp_t(&dst_base_0);
          }
-         if (v_1320) {
-            _fx_free_N15C_form__cstmt_t(&v_1320);
+         if (v_1342) {
+            _fx_free_N15C_form__cstmt_t(&v_1342);
          }
-         if (ccode_166) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_166);
+         if (ccode_171) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_171);
          }
          if (init_tag_0) {
             _fx_free_N14C_form__cexp_t(&init_tag_0);
          }
-         if (v_1319) {
-            _fx_free_N14C_form__cexp_t(&v_1319);
+         if (v_1341) {
+            _fx_free_N14C_form__cexp_t(&v_1341);
          }
-         if (v_1318) {
-            _fx_free_N14C_form__cexp_t(&v_1318);
+         if (v_1340) {
+            _fx_free_N14C_form__cexp_t(&v_1340);
          }
          if (ret_ccode_1) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_1);
          }
-         if (ccode_165) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_165);
+         if (ccode_170) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_170);
          }
          if (var_exp_2) {
             _fx_free_N14C_form__cexp_t(&var_exp_2);
@@ -35497,27 +35703,27 @@ static int
          if (ret_ccode_0) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_0);
          }
-         if (v_1317) {
-            _fx_free_N15C_form__cstmt_t(&v_1317);
+         if (v_1339) {
+            _fx_free_N15C_form__cstmt_t(&v_1339);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1316);
-         if (v_1315) {
-            _fx_free_N14C_form__cexp_t(&v_1315);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1338);
+         if (v_1337) {
+            _fx_free_N14C_form__cexp_t(&v_1337);
          }
-         if (v_1314) {
-            _fx_free_N15C_form__cstmt_t(&v_1314);
+         if (v_1336) {
+            _fx_free_N15C_form__cstmt_t(&v_1336);
          }
-         if (v_1313) {
-            _fx_free_N14C_form__cexp_t(&v_1313);
+         if (v_1335) {
+            _fx_free_N14C_form__cexp_t(&v_1335);
          }
-         if (v_1312) {
-            _fx_free_N14C_form__cexp_t(&v_1312);
+         if (v_1334) {
+            _fx_free_N14C_form__cexp_t(&v_1334);
          }
-         if (v_1311) {
-            _fx_free_N14C_form__cexp_t(&v_1311);
+         if (v_1333) {
+            _fx_free_N14C_form__cexp_t(&v_1333);
          }
-         if (v_1310) {
-            _fx_free_N14C_form__cexp_t(&v_1310);
+         if (v_1332) {
+            _fx_free_N14C_form__cexp_t(&v_1332);
          }
          if (ifaces_ptr_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&ifaces_ptr_ctyp_0);
@@ -35525,212 +35731,212 @@ static int
          if (ifaces_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&ifaces_ctyp_0);
          }
-         if (ccode_164) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_164);
+         if (ccode_169) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_169);
          }
-         if (ccode_163) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_163);
+         if (ccode_168) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_168);
          }
-         if (v_1309) {
-            _fx_free_N15C_form__cstmt_t(&v_1309);
+         if (v_1331) {
+            _fx_free_N15C_form__cstmt_t(&v_1331);
          }
          if (var_exp_1) {
             _fx_free_N14C_form__cexp_t(&var_exp_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1308);
-         _fx_free_R16Ast__val_flags_t(&v_1307);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1330);
+         _fx_free_R16Ast__val_flags_t(&v_1329);
          if (alloc_var_0) {
             _fx_free_N14C_form__cexp_t(&alloc_var_0);
          }
-         if (v_1306) {
-            _fx_free_LN14C_form__cexp_t(&v_1306);
+         if (v_1328) {
+            _fx_free_LN14C_form__cexp_t(&v_1328);
          }
-         if (v_1305) {
-            _fx_free_N14C_form__cexp_t(&v_1305);
+         if (v_1327) {
+            _fx_free_N14C_form__cexp_t(&v_1327);
          }
-         _fx_free_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(&v_1304);
+         _fx_free_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(&v_1326);
          if (result_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&result_ctyp_0);
          }
          if (var_exp_0) {
             _fx_free_N14C_form__cexp_t(&var_exp_0);
          }
-         goto _fx_endmatch_54;
+         goto _fx_endmatch_57;
       }
       if (ctor_0.tag == 4) {
-         _fx_N15K_form__kinfo_t v_1345 = {0};
+         _fx_N15K_form__kinfo_t v_1367 = {0};
          _fx_N14C_form__ctyp_t fcv_t_0 = 0;
-         _fx_T2BNt6option1N14C_form__cexp_t v_1346 = {0};
+         _fx_T2BNt6option1N14C_form__cexp_t v_1368 = {0};
          _fx_N14C_form__cexp_t free_f_exp_4 = 0;
-         _fx_N14C_form__cexp_t v_1347 = 0;
-         _fx_N14C_form__cexp_t v_1348 = 0;
-         _fx_LN14C_form__cexp_t v_1349 = 0;
+         _fx_N14C_form__cexp_t v_1369 = 0;
+         _fx_N14C_form__cexp_t v_1370 = 0;
+         _fx_LN14C_form__cexp_t v_1371 = 0;
          _fx_N14C_form__cexp_t alloc_fcv_0 = 0;
-         _fx_N14C_form__ctyp_t v_1350 = 0;
-         _fx_R16Ast__val_flags_t v_1351 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1352 = {0};
+         _fx_N14C_form__ctyp_t v_1372 = 0;
+         _fx_R16Ast__val_flags_t v_1373 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1374 = {0};
          _fx_N14C_form__cexp_t fcv_exp_0 = 0;
-         _fx_N14C_form__cexp_t v_1353 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1354 = {0};
-         _fx_N15C_form__cstmt_t v_1355 = 0;
+         _fx_N14C_form__cexp_t v_1375 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1376 = {0};
+         _fx_N15C_form__cstmt_t v_1377 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_2 = 0;
-         _fx_N15C_form__cstmt_t v_1356 = 0;
-         _fx_LN15C_form__cstmt_t ccode_168 = 0;
-         _fx_LN15C_form__cstmt_t ccode_169 = 0;
-         _fx_LN15C_form__cstmt_t v_1357 = 0;
+         _fx_N15C_form__cstmt_t v_1378 = 0;
+         _fx_LN15C_form__cstmt_t ccode_173 = 0;
+         _fx_LN15C_form__cstmt_t ccode_174 = 0;
+         _fx_LN15C_form__cstmt_t v_1379 = 0;
          _fx_R9Ast__id_t* f_id_0 = &ctor_0.u.CtorFP;
-         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1345, 0),
-            _fx_catch_283);
+         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1367, 0),
+            _fx_catch_290);
          _fx_R9Ast__id_t fcv_t_id_0;
-         if (v_1345.tag == 3) {
-            _fx_R17K_form__kdeffun_t v_1358 = {0};
-            _fx_copy_R17K_form__kdeffun_t(&v_1345.u.KFun->data, &v_1358);
-            fcv_t_id_0 = v_1358.kf_closure.kci_fcv_t;
-            _fx_free_R17K_form__kdeffun_t(&v_1358);
+         if (v_1367.tag == 3) {
+            _fx_R17K_form__kdeffun_t v_1380 = {0};
+            _fx_copy_R17K_form__kdeffun_t(&v_1367.u.KFun->data, &v_1380);
+            fcv_t_id_0 = v_1380.kf_closure.kci_fcv_t;
+            _fx_free_R17K_form__kdeffun_t(&v_1380);
          }
          else {
-            fx_str_t v_1359 = {0};
-            fx_str_t v_1360 = {0};
-            fx_str_t v_1361 = {0};
-            fx_exn_t v_1362 = {0};
-            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1359, 0), _fx_catch_280);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1359, &v_1360, 0), _fx_catch_280);
-            fx_str_t slit_288 = FX_MAKE_STR("cgen: \'");
-            fx_str_t slit_289 = FX_MAKE_STR("\' is not a function");
+            fx_str_t v_1381 = {0};
+            fx_str_t v_1382 = {0};
+            fx_str_t v_1383 = {0};
+            fx_exn_t v_1384 = {0};
+            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1381, 0), _fx_catch_287);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1381, &v_1382, 0), _fx_catch_287);
+            fx_str_t slit_289 = FX_MAKE_STR("cgen: \'");
+            fx_str_t slit_290 = FX_MAKE_STR("\' is not a function");
             {
-               const fx_str_t strs_41[] = { slit_288, v_1360, slit_289 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_41, 3, &v_1361), _fx_catch_280);
+               const fx_str_t strs_41[] = { slit_289, v_1382, slit_290 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_41, 3, &v_1383), _fx_catch_287);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1361, &v_1362, 0), _fx_catch_280);
-            FX_THROW(&v_1362, false, _fx_catch_280);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1383, &v_1384, 0), _fx_catch_287);
+            FX_THROW(&v_1384, false, _fx_catch_287);
 
-         _fx_catch_280: ;
-            fx_free_exn(&v_1362);
-            FX_FREE_STR(&v_1361);
-            FX_FREE_STR(&v_1360);
-            FX_FREE_STR(&v_1359);
+         _fx_catch_287: ;
+            fx_free_exn(&v_1384);
+            FX_FREE_STR(&v_1383);
+            FX_FREE_STR(&v_1382);
+            FX_FREE_STR(&v_1381);
          }
-         FX_CHECK_EXN(_fx_catch_283);
-         FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&fcv_t_id_0, &fcv_t_0), _fx_catch_283);
+         FX_CHECK_EXN(_fx_catch_290);
+         FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&fcv_t_id_0, &fcv_t_0), _fx_catch_290);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(fcv_t_0, true,
-               false, &kf_loc_0, &v_1346, 0), _fx_catch_283);
-         _fx_Nt6option1N14C_form__cexp_t* v_1363 = &v_1346.t1;
-         if (v_1363->tag == 2) {
-            FX_COPY_PTR(v_1363->u.Some, &free_f_exp_4);
+               false, &kf_loc_0, &v_1368, 0), _fx_catch_290);
+         _fx_Nt6option1N14C_form__cexp_t* v_1385 = &v_1368.t1;
+         if (v_1385->tag == 2) {
+            FX_COPY_PTR(v_1385->u.Some, &free_f_exp_4);
          }
          else {
-            fx_str_t v_1364 = {0};
-            fx_str_t v_1365 = {0};
-            fx_str_t v_1366 = {0};
-            fx_exn_t v_1367 = {0};
-            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(&fcv_t_id_0, &kf_loc_0, &v_1364, 0), _fx_catch_281);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1364, &v_1365, 0), _fx_catch_281);
-            fx_str_t slit_290 = FX_MAKE_STR("cgen: missing destructor for closure vars \'");
-            fx_str_t slit_291 = FX_MAKE_STR("\'");
+            fx_str_t v_1386 = {0};
+            fx_str_t v_1387 = {0};
+            fx_str_t v_1388 = {0};
+            fx_exn_t v_1389 = {0};
+            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(&fcv_t_id_0, &kf_loc_0, &v_1386, 0), _fx_catch_288);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1386, &v_1387, 0), _fx_catch_288);
+            fx_str_t slit_291 = FX_MAKE_STR("cgen: missing destructor for closure vars \'");
+            fx_str_t slit_292 = FX_MAKE_STR("\'");
             {
-               const fx_str_t strs_42[] = { slit_290, v_1365, slit_291 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_42, 3, &v_1366), _fx_catch_281);
+               const fx_str_t strs_42[] = { slit_291, v_1387, slit_292 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_42, 3, &v_1388), _fx_catch_288);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1366, &v_1367, 0), _fx_catch_281);
-            FX_THROW(&v_1367, false, _fx_catch_281);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1388, &v_1389, 0), _fx_catch_288);
+            FX_THROW(&v_1389, false, _fx_catch_288);
 
-         _fx_catch_281: ;
-            fx_free_exn(&v_1367);
-            FX_FREE_STR(&v_1366);
-            FX_FREE_STR(&v_1365);
-            FX_FREE_STR(&v_1364);
+         _fx_catch_288: ;
+            fx_free_exn(&v_1389);
+            FX_FREE_STR(&v_1388);
+            FX_FREE_STR(&v_1387);
+            FX_FREE_STR(&v_1386);
          }
-         FX_CHECK_EXN(_fx_catch_283);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(fcv_t_0, &kf_loc_0, &v_1347),
-            _fx_catch_283);
+         FX_CHECK_EXN(_fx_catch_290);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(fcv_t_0, &kf_loc_0, &v_1369),
+            _fx_catch_290);
          FX_CALL(
             _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(f_id_0,
-               _fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_1348, 0), _fx_catch_283);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1348, 0, true, &v_1349), _fx_catch_283);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_4, v_1349, false, &v_1349), _fx_catch_283);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1347, v_1349, false, &v_1349), _fx_catch_283);
+               _fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_1370, 0), _fx_catch_290);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1370, 0, true, &v_1371), _fx_catch_290);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_4, v_1371, false, &v_1371), _fx_catch_290);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1369, v_1371, false, &v_1371), _fx_catch_290);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g33C_form__std_FX_MAKE_FP_IMPL_START, v_1349, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_fcv_0, 0),
-            _fx_catch_283);
-         _fx_R9Ast__id_t v_1368;
-         fx_str_t slit_292 = FX_MAKE_STR("fcv");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_292, &v_1368, 0), _fx_catch_283);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(fcv_t_0, &v_1350, 0), _fx_catch_283);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1351, 0), _fx_catch_283);
+               &_fx_g33C_form__std_FX_MAKE_FP_IMPL_START, v_1371, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_fcv_0, 0),
+            _fx_catch_290);
+         _fx_R9Ast__id_t v_1390;
          fx_str_t slit_293 = FX_MAKE_STR("fcv");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_293, &v_1390, 0), _fx_catch_290);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(fcv_t_0, &v_1372, 0), _fx_catch_290);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1373, 0), _fx_catch_290);
+         fx_str_t slit_294 = FX_MAKE_STR("fcv");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1368, v_1350, &v_1351, &slit_293, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1352, 0), _fx_catch_283);
-         FX_COPY_PTR(v_1352.t0, &fcv_exp_0);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1353, 0), _fx_catch_283);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1353, &v_1354);
+               &v_1390, v_1372, &v_1373, &slit_294, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1374, 0), _fx_catch_290);
+         FX_COPY_PTR(v_1374.t0, &fcv_exp_0);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1375, 0), _fx_catch_290);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1375, &v_1376);
          FX_CALL(
-            _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1354, &kf_loc_0, &v_1355),
-            _fx_catch_283);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1355, 0, true, &ret_ccode_2), _fx_catch_283);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_fcv_0, &v_1356), _fx_catch_283);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1356, 0, true, &ccode_168), _fx_catch_283);
-         FX_COPY_PTR(ccode_168, &ccode_169);
+            _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1376, &kf_loc_0, &v_1377),
+            _fx_catch_290);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1377, 0, true, &ret_ccode_2), _fx_catch_290);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_fcv_0, &v_1378), _fx_catch_290);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1378, 0, true, &ccode_173), _fx_catch_290);
+         FX_COPY_PTR(ccode_173, &ccode_174);
          int_ idx_3 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_34 = real_args_0;
          for (; lst_34; lst_34 = lst_34->tl, idx_3 += 1) {
             _fx_N14C_form__ctyp_t t_27 = 0;
             _fx_LN19C_form__carg_attr_t flags_5 = 0;
             _fx_N14C_form__cexp_t src_exp_4 = 0;
-            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1369 = {0};
+            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1391 = {0};
             _fx_N14C_form__cexp_t src_exp_5 = 0;
             _fx_N14C_form__ctyp_t t_28 = 0;
-            fx_str_t v_1370 = {0};
-            fx_str_t v_1371 = {0};
+            fx_str_t v_1392 = {0};
+            fx_str_t v_1393 = {0};
             _fx_N14C_form__cexp_t dst_exp_22 = 0;
-            _fx_LN15C_form__cstmt_t v_1372 = 0;
+            _fx_LN15C_form__cstmt_t v_1394 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___14 = &lst_34->hd;
-            _fx_R9Ast__id_t a_15 = __pat___14->t0;
+            _fx_R9Ast__id_t a_16 = __pat___14->t0;
             FX_COPY_PTR(__pat___14->t1, &t_27);
             FX_COPY_PTR(__pat___14->t2, &flags_5);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_15, t_27, &kf_loc_0,
-                  &src_exp_4, 0), _fx_catch_282);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_16, t_27, &kf_loc_0,
+                  &src_exp_4, 0), _fx_catch_289);
             FX_CALL(
                _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                  idx_3, src_exp_4, t_27, flags_5, &kf_loc_0, &v_1369, 0), _fx_catch_282);
-            FX_COPY_PTR(v_1369.t0, &src_exp_5);
-            FX_COPY_PTR(v_1369.t1, &t_28);
-            FX_CALL(_fx_F6stringS1i(idx_3, &v_1370, 0), _fx_catch_282);
-            fx_str_t slit_294 = FX_MAKE_STR("t");
+                  idx_3, src_exp_4, t_27, flags_5, &kf_loc_0, &v_1391, 0), _fx_catch_289);
+            FX_COPY_PTR(v_1391.t0, &src_exp_5);
+            FX_COPY_PTR(v_1391.t1, &t_28);
+            FX_CALL(_fx_F6stringS1i(idx_3, &v_1392, 0), _fx_catch_289);
+            fx_str_t slit_295 = FX_MAKE_STR("t");
             {
-               const fx_str_t strs_43[] = { slit_294, v_1370 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_43, 2, &v_1371), _fx_catch_282);
+               const fx_str_t strs_43[] = { slit_295, v_1392 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_43, 2, &v_1393), _fx_catch_289);
             }
             _fx_R9Ast__id_t fcv_elem_0;
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1371, &fcv_elem_0, 0), _fx_catch_282);
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1393, &fcv_elem_0, 0), _fx_catch_289);
             FX_CALL(
                _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fcv_exp_0, &fcv_elem_0,
-                  t_28, &dst_exp_22, 0), _fx_catch_282);
+                  t_28, &dst_exp_22, 0), _fx_catch_289);
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  src_exp_5, dst_exp_22, t_28, ccode_169, &kf_loc_0, &v_1372, 0), _fx_catch_282);
-            _fx_free_LN15C_form__cstmt_t(&ccode_169);
-            FX_COPY_PTR(v_1372, &ccode_169);
+                  src_exp_5, dst_exp_22, t_28, ccode_174, &kf_loc_0, &v_1394, 0), _fx_catch_289);
+            _fx_free_LN15C_form__cstmt_t(&ccode_174);
+            FX_COPY_PTR(v_1394, &ccode_174);
 
-         _fx_catch_282: ;
-            if (v_1372) {
-               _fx_free_LN15C_form__cstmt_t(&v_1372);
+         _fx_catch_289: ;
+            if (v_1394) {
+               _fx_free_LN15C_form__cstmt_t(&v_1394);
             }
             if (dst_exp_22) {
                _fx_free_N14C_form__cexp_t(&dst_exp_22);
             }
-            FX_FREE_STR(&v_1371);
-            FX_FREE_STR(&v_1370);
+            FX_FREE_STR(&v_1393);
+            FX_FREE_STR(&v_1392);
             if (t_28) {
                _fx_free_N14C_form__ctyp_t(&t_28);
             }
             if (src_exp_5) {
                _fx_free_N14C_form__cexp_t(&src_exp_5);
             }
-            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1369);
+            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1391);
             if (src_exp_4) {
                _fx_free_N14C_form__cexp_t(&src_exp_4);
             }
@@ -35738,220 +35944,220 @@ static int
             if (t_27) {
                _fx_free_N14C_form__ctyp_t(&t_27);
             }
-            FX_CHECK_EXN(_fx_catch_283);
+            FX_CHECK_EXN(_fx_catch_290);
          }
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_2, ccode_169,
-               &v_1357, 0), _fx_catch_283);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1357, &new_body_0, 0), _fx_catch_283);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_2, ccode_174,
+               &v_1379, 0), _fx_catch_290);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1379, &new_body_0, 0), _fx_catch_290);
 
-      _fx_catch_283: ;
-         if (v_1357) {
-            _fx_free_LN15C_form__cstmt_t(&v_1357);
+      _fx_catch_290: ;
+         if (v_1379) {
+            _fx_free_LN15C_form__cstmt_t(&v_1379);
          }
-         if (ccode_169) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_169);
+         if (ccode_174) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_174);
          }
-         if (ccode_168) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_168);
+         if (ccode_173) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_173);
          }
-         if (v_1356) {
-            _fx_free_N15C_form__cstmt_t(&v_1356);
+         if (v_1378) {
+            _fx_free_N15C_form__cstmt_t(&v_1378);
          }
          if (ret_ccode_2) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_2);
          }
-         if (v_1355) {
-            _fx_free_N15C_form__cstmt_t(&v_1355);
+         if (v_1377) {
+            _fx_free_N15C_form__cstmt_t(&v_1377);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1354);
-         if (v_1353) {
-            _fx_free_N14C_form__cexp_t(&v_1353);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1376);
+         if (v_1375) {
+            _fx_free_N14C_form__cexp_t(&v_1375);
          }
          if (fcv_exp_0) {
             _fx_free_N14C_form__cexp_t(&fcv_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1352);
-         _fx_free_R16Ast__val_flags_t(&v_1351);
-         if (v_1350) {
-            _fx_free_N14C_form__ctyp_t(&v_1350);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1374);
+         _fx_free_R16Ast__val_flags_t(&v_1373);
+         if (v_1372) {
+            _fx_free_N14C_form__ctyp_t(&v_1372);
          }
          if (alloc_fcv_0) {
             _fx_free_N14C_form__cexp_t(&alloc_fcv_0);
          }
-         if (v_1349) {
-            _fx_free_LN14C_form__cexp_t(&v_1349);
+         if (v_1371) {
+            _fx_free_LN14C_form__cexp_t(&v_1371);
          }
-         if (v_1348) {
-            _fx_free_N14C_form__cexp_t(&v_1348);
+         if (v_1370) {
+            _fx_free_N14C_form__cexp_t(&v_1370);
          }
-         if (v_1347) {
-            _fx_free_N14C_form__cexp_t(&v_1347);
+         if (v_1369) {
+            _fx_free_N14C_form__cexp_t(&v_1369);
          }
          if (free_f_exp_4) {
             _fx_free_N14C_form__cexp_t(&free_f_exp_4);
          }
-         _fx_free_T2BNt6option1N14C_form__cexp_t(&v_1346);
+         _fx_free_T2BNt6option1N14C_form__cexp_t(&v_1368);
          if (fcv_t_0) {
             _fx_free_N14C_form__ctyp_t(&fcv_t_0);
          }
-         _fx_free_N15K_form__kinfo_t(&v_1345);
-         goto _fx_endmatch_54;
+         _fx_free_N15K_form__kinfo_t(&v_1367);
+         goto _fx_endmatch_57;
       }
       if (ctor_0.tag == 5) {
-         _fx_N15C_form__cinfo_t v_1373 = {0};
-         _fx_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t v_1374 = {0};
+         _fx_N15C_form__cinfo_t v_1395 = {0};
+         _fx_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t v_1396 = {0};
          _fx_N14C_form__ctyp_t exn_typ_0 = 0;
          _fx_N14C_form__ctyp_t exn_data_t_0 = 0;
-         _fx_N14C_form__cexp_t v_1375 = 0;
-         _fx_N14C_form__cexp_t v_1376 = 0;
-         _fx_N14C_form__cexp_t v_1377 = 0;
-         _fx_LN14C_form__cexp_t v_1378 = 0;
+         _fx_N14C_form__cexp_t v_1397 = 0;
+         _fx_N14C_form__cexp_t v_1398 = 0;
+         _fx_N14C_form__cexp_t v_1399 = 0;
+         _fx_LN14C_form__cexp_t v_1400 = 0;
          _fx_N14C_form__cexp_t alloc_exn_data_0 = 0;
-         _fx_N14C_form__cexp_t v_1379 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1380 = {0};
-         _fx_N15C_form__cstmt_t v_1381 = 0;
+         _fx_N14C_form__cexp_t v_1401 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1402 = {0};
+         _fx_N15C_form__cstmt_t v_1403 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_3 = 0;
-         _fx_N14C_form__ctyp_t v_1382 = 0;
+         _fx_N14C_form__ctyp_t v_1404 = 0;
          _fx_N14C_form__cexp_t exn_data_2 = 0;
          _fx_N14C_form__cexp_t dst_exp_23 = 0;
-         _fx_N15C_form__cstmt_t v_1383 = 0;
-         _fx_LN15C_form__cstmt_t ccode_170 = 0;
-         _fx_LN15C_form__cstmt_t ccode_171 = 0;
-         _fx_LN15C_form__cstmt_t v_1384 = 0;
+         _fx_N15C_form__cstmt_t v_1405 = 0;
+         _fx_LN15C_form__cstmt_t ccode_175 = 0;
+         _fx_LN15C_form__cstmt_t ccode_176 = 0;
+         _fx_LN15C_form__cstmt_t v_1406 = 0;
          _fx_R9Ast__id_t* exn_id_0 = &ctor_0.u.CtorExn;
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1373, 0),
-            _fx_catch_286);
-         if (v_1373.tag == 5) {
-            _fx_R17C_form__cdefexn_t v_1385 = {0};
-            _fx_copy_R17C_form__cdefexn_t(&v_1373.u.CExn->data, &v_1385);
-            _fx_make_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(v_1385.cexn_typ, &v_1385.cexn_tag, v_1385.cexn_std,
-               &v_1385.cexn_data, &v_1385.cexn_info, &v_1374);
-            _fx_free_R17C_form__cdefexn_t(&v_1385);
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1395, 0),
+            _fx_catch_293);
+         if (v_1395.tag == 5) {
+            _fx_R17C_form__cdefexn_t v_1407 = {0};
+            _fx_copy_R17C_form__cdefexn_t(&v_1395.u.CExn->data, &v_1407);
+            _fx_make_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(v_1407.cexn_typ, &v_1407.cexn_tag, v_1407.cexn_std,
+               &v_1407.cexn_data, &v_1407.cexn_info, &v_1396);
+            _fx_free_R17C_form__cdefexn_t(&v_1407);
          }
          else {
-            fx_str_t v_1386 = {0};
-            fx_str_t v_1387 = {0};
-            fx_str_t v_1388 = {0};
-            fx_exn_t v_1389 = {0};
-            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1386, 0), _fx_catch_284);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1386, &v_1387, 0), _fx_catch_284);
-            fx_str_t slit_295 = FX_MAKE_STR("cgen: constructor of exception \'");
-            fx_str_t slit_296 = FX_MAKE_STR("\' is expecting converted KExn=>CExn structure");
+            fx_str_t v_1408 = {0};
+            fx_str_t v_1409 = {0};
+            fx_str_t v_1410 = {0};
+            fx_exn_t v_1411 = {0};
+            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1408, 0), _fx_catch_291);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1408, &v_1409, 0), _fx_catch_291);
+            fx_str_t slit_296 = FX_MAKE_STR("cgen: constructor of exception \'");
+            fx_str_t slit_297 = FX_MAKE_STR("\' is expecting converted KExn=>CExn structure");
             {
-               const fx_str_t strs_44[] = { slit_295, v_1387, slit_296 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_44, 3, &v_1388), _fx_catch_284);
+               const fx_str_t strs_44[] = { slit_296, v_1409, slit_297 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_44, 3, &v_1410), _fx_catch_291);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1388, &v_1389, 0), _fx_catch_284);
-            FX_THROW(&v_1389, false, _fx_catch_284);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1410, &v_1411, 0), _fx_catch_291);
+            FX_THROW(&v_1411, false, _fx_catch_291);
 
-         _fx_catch_284: ;
-            fx_free_exn(&v_1389);
-            FX_FREE_STR(&v_1388);
-            FX_FREE_STR(&v_1387);
-            FX_FREE_STR(&v_1386);
+         _fx_catch_291: ;
+            fx_free_exn(&v_1411);
+            FX_FREE_STR(&v_1410);
+            FX_FREE_STR(&v_1409);
+            FX_FREE_STR(&v_1408);
          }
-         FX_CHECK_EXN(_fx_catch_286);
-         FX_COPY_PTR(v_1374.t0, &exn_typ_0);
-         _fx_R9Ast__id_t exn_tag_0 = v_1374.t1;
-         bool exn_std_0 = v_1374.t2;
-         _fx_R9Ast__id_t exn_data_id_0 = v_1374.t3;
-         _fx_R9Ast__id_t exn_info_0 = v_1374.t4;
+         FX_CHECK_EXN(_fx_catch_293);
+         FX_COPY_PTR(v_1396.t0, &exn_typ_0);
+         _fx_R9Ast__id_t exn_tag_0 = v_1396.t1;
+         bool exn_std_0 = v_1396.t2;
+         _fx_R9Ast__id_t exn_data_id_0 = v_1396.t3;
+         _fx_R9Ast__id_t exn_info_0 = v_1396.t4;
          if (exn_std_0) {
             FX_COPY_PTR(ccode_0, &new_body_0);
          }
          else {
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&exn_data_id_0, &exn_data_t_0), _fx_catch_286);
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&exn_data_id_0, &exn_data_t_0), _fx_catch_293);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&exn_tag_0,
-                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &v_1375, 0), _fx_catch_286);
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(exn_data_t_0, &kf_loc_0, &v_1376),
-               _fx_catch_286);
+                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &v_1397, 0), _fx_catch_293);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(exn_data_t_0, &kf_loc_0, &v_1398),
+               _fx_catch_293);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&exn_info_0,
-                  _fx_g25C_form__std_fx_exn_info_t, &kf_loc_0, &v_1377, 0), _fx_catch_286);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1377, 0, true, &v_1378), _fx_catch_286);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1376, v_1378, false, &v_1378), _fx_catch_286);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1375, v_1378, false, &v_1378), _fx_catch_286);
+                  _fx_g25C_form__std_fx_exn_info_t, &kf_loc_0, &v_1399, 0), _fx_catch_293);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1399, 0, true, &v_1400), _fx_catch_293);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1398, v_1400, false, &v_1400), _fx_catch_293);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1397, v_1400, false, &v_1400), _fx_catch_293);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g34C_form__std_FX_MAKE_EXN_IMPL_START, v_1378, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_exn_data_0,
-                  0), _fx_catch_286);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1379, 0), _fx_catch_286);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1379, &v_1380);
+                  &_fx_g34C_form__std_FX_MAKE_EXN_IMPL_START, v_1400, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_exn_data_0,
+                  0), _fx_catch_293);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1401, 0), _fx_catch_293);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1401, &v_1402);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1380, &kf_loc_0,
-                  &v_1381), _fx_catch_286);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1381, 0, true, &ret_ccode_3), _fx_catch_286);
-            _fx_R9Ast__id_t v_1390;
-            fx_str_t slit_297 = FX_MAKE_STR("exn_data");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_297, &v_1390, 0), _fx_catch_286);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(exn_data_t_0, &v_1382, 0), _fx_catch_286);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1402, &kf_loc_0,
+                  &v_1403), _fx_catch_293);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1403, 0, true, &ret_ccode_3), _fx_catch_293);
+            _fx_R9Ast__id_t v_1412;
+            fx_str_t slit_298 = FX_MAKE_STR("exn_data");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_298, &v_1412, 0), _fx_catch_293);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(exn_data_t_0, &v_1404, 0), _fx_catch_293);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1390, v_1382,
-                  &kf_loc_0, &exn_data_2, 0), _fx_catch_286);
-            _fx_R9Ast__id_t v_1391;
-            fx_str_t slit_298 = FX_MAKE_STR("data");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_298, &v_1391, 0), _fx_catch_286);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1412, v_1404,
+                  &kf_loc_0, &exn_data_2, 0), _fx_catch_293);
+            _fx_R9Ast__id_t v_1413;
+            fx_str_t slit_299 = FX_MAKE_STR("data");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_299, &v_1413, 0), _fx_catch_293);
             FX_CALL(
-               _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(exn_data_2, &v_1391,
-                  exn_typ_0, &dst_exp_23, 0), _fx_catch_286);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_exn_data_0, &v_1383), _fx_catch_286);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1383, 0, true, &ccode_170), _fx_catch_286);
-            FX_COPY_PTR(ccode_170, &ccode_171);
+               _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(exn_data_2, &v_1413,
+                  exn_typ_0, &dst_exp_23, 0), _fx_catch_293);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_exn_data_0, &v_1405), _fx_catch_293);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1405, 0, true, &ccode_175), _fx_catch_293);
+            FX_COPY_PTR(ccode_175, &ccode_176);
             int_ idx_4 = 0;
             _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_35 = real_args_0;
             for (; lst_35; lst_35 = lst_35->tl, idx_4 += 1) {
                _fx_N14C_form__ctyp_t t_29 = 0;
                _fx_LN19C_form__carg_attr_t flags_6 = 0;
                _fx_N14C_form__cexp_t src_exp_6 = 0;
-               _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1392 = {0};
+               _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1414 = {0};
                _fx_N14C_form__cexp_t src_exp_7 = 0;
                _fx_N14C_form__ctyp_t t_30 = 0;
                _fx_N14C_form__cexp_t dst_exp_24 = 0;
-               fx_str_t v_1393 = {0};
-               fx_str_t v_1394 = {0};
-               _fx_LN15C_form__cstmt_t v_1395 = 0;
+               fx_str_t v_1415 = {0};
+               fx_str_t v_1416 = {0};
+               _fx_LN15C_form__cstmt_t v_1417 = 0;
                _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___15 = &lst_35->hd;
-               _fx_R9Ast__id_t a_16 = __pat___15->t0;
+               _fx_R9Ast__id_t a_17 = __pat___15->t0;
                FX_COPY_PTR(__pat___15->t1, &t_29);
                FX_COPY_PTR(__pat___15->t2, &flags_6);
                FX_CALL(
-                  _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_16, t_29,
-                     &kf_loc_0, &src_exp_6, 0), _fx_catch_285);
+                  _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_17, t_29,
+                     &kf_loc_0, &src_exp_6, 0), _fx_catch_292);
                FX_CALL(
                   _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                     idx_4, src_exp_6, t_29, flags_6, &kf_loc_0, &v_1392, 0), _fx_catch_285);
-               FX_COPY_PTR(v_1392.t0, &src_exp_7);
-               FX_COPY_PTR(v_1392.t1, &t_30);
+                     idx_4, src_exp_6, t_29, flags_6, &kf_loc_0, &v_1414, 0), _fx_catch_292);
+               FX_COPY_PTR(v_1414.t0, &src_exp_7);
+               FX_COPY_PTR(v_1414.t1, &t_30);
                if (nreal_args_0 == 1) {
                   FX_COPY_PTR(dst_exp_23, &dst_exp_24);
                }
                else {
-                  FX_CALL(_fx_F6stringS1i(idx_4, &v_1393, 0), _fx_catch_285);
-                  fx_str_t slit_299 = FX_MAKE_STR("t");
+                  FX_CALL(_fx_F6stringS1i(idx_4, &v_1415, 0), _fx_catch_292);
+                  fx_str_t slit_300 = FX_MAKE_STR("t");
                   {
-                     const fx_str_t strs_45[] = { slit_299, v_1393 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_45, 2, &v_1394), _fx_catch_285);
+                     const fx_str_t strs_45[] = { slit_300, v_1415 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_45, 2, &v_1416), _fx_catch_292);
                   }
                   _fx_R9Ast__id_t t_elem_0;
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1394, &t_elem_0, 0), _fx_catch_285);
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1416, &t_elem_0, 0), _fx_catch_292);
                   FX_CALL(
                      _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_23,
-                        &t_elem_0, t_30, &dst_exp_24, 0), _fx_catch_285);
+                        &t_elem_0, t_30, &dst_exp_24, 0), _fx_catch_292);
                }
                FX_CALL(
                   _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     src_exp_7, dst_exp_24, t_30, ccode_171, &kf_loc_0, &v_1395, 0), _fx_catch_285);
-               _fx_free_LN15C_form__cstmt_t(&ccode_171);
-               FX_COPY_PTR(v_1395, &ccode_171);
+                     src_exp_7, dst_exp_24, t_30, ccode_176, &kf_loc_0, &v_1417, 0), _fx_catch_292);
+               _fx_free_LN15C_form__cstmt_t(&ccode_176);
+               FX_COPY_PTR(v_1417, &ccode_176);
 
-            _fx_catch_285: ;
-               if (v_1395) {
-                  _fx_free_LN15C_form__cstmt_t(&v_1395);
+            _fx_catch_292: ;
+               if (v_1417) {
+                  _fx_free_LN15C_form__cstmt_t(&v_1417);
                }
-               FX_FREE_STR(&v_1394);
-               FX_FREE_STR(&v_1393);
+               FX_FREE_STR(&v_1416);
+               FX_FREE_STR(&v_1415);
                if (dst_exp_24) {
                   _fx_free_N14C_form__cexp_t(&dst_exp_24);
                }
@@ -35961,7 +36167,7 @@ static int
                if (src_exp_7) {
                   _fx_free_N14C_form__cexp_t(&src_exp_7);
                }
-               _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1392);
+               _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1414);
                if (src_exp_6) {
                   _fx_free_N14C_form__cexp_t(&src_exp_6);
                }
@@ -35969,26 +36175,26 @@ static int
                if (t_29) {
                   _fx_free_N14C_form__ctyp_t(&t_29);
                }
-               FX_CHECK_EXN(_fx_catch_286);
+               FX_CHECK_EXN(_fx_catch_293);
             }
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_3, ccode_171,
-                  &v_1384, 0), _fx_catch_286);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1384, &new_body_0, 0), _fx_catch_286);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_3, ccode_176,
+                  &v_1406, 0), _fx_catch_293);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1406, &new_body_0, 0), _fx_catch_293);
          }
 
-      _fx_catch_286: ;
-         if (v_1384) {
-            _fx_free_LN15C_form__cstmt_t(&v_1384);
+      _fx_catch_293: ;
+         if (v_1406) {
+            _fx_free_LN15C_form__cstmt_t(&v_1406);
          }
-         if (ccode_171) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_171);
+         if (ccode_176) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_176);
          }
-         if (ccode_170) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_170);
+         if (ccode_175) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_175);
          }
-         if (v_1383) {
-            _fx_free_N15C_form__cstmt_t(&v_1383);
+         if (v_1405) {
+            _fx_free_N15C_form__cstmt_t(&v_1405);
          }
          if (dst_exp_23) {
             _fx_free_N14C_form__cexp_t(&dst_exp_23);
@@ -35996,33 +36202,33 @@ static int
          if (exn_data_2) {
             _fx_free_N14C_form__cexp_t(&exn_data_2);
          }
-         if (v_1382) {
-            _fx_free_N14C_form__ctyp_t(&v_1382);
+         if (v_1404) {
+            _fx_free_N14C_form__ctyp_t(&v_1404);
          }
          if (ret_ccode_3) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_3);
          }
-         if (v_1381) {
-            _fx_free_N15C_form__cstmt_t(&v_1381);
+         if (v_1403) {
+            _fx_free_N15C_form__cstmt_t(&v_1403);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1380);
-         if (v_1379) {
-            _fx_free_N14C_form__cexp_t(&v_1379);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1402);
+         if (v_1401) {
+            _fx_free_N14C_form__cexp_t(&v_1401);
          }
          if (alloc_exn_data_0) {
             _fx_free_N14C_form__cexp_t(&alloc_exn_data_0);
          }
-         if (v_1378) {
-            _fx_free_LN14C_form__cexp_t(&v_1378);
+         if (v_1400) {
+            _fx_free_LN14C_form__cexp_t(&v_1400);
          }
-         if (v_1377) {
-            _fx_free_N14C_form__cexp_t(&v_1377);
+         if (v_1399) {
+            _fx_free_N14C_form__cexp_t(&v_1399);
          }
-         if (v_1376) {
-            _fx_free_N14C_form__cexp_t(&v_1376);
+         if (v_1398) {
+            _fx_free_N14C_form__cexp_t(&v_1398);
          }
-         if (v_1375) {
-            _fx_free_N14C_form__cexp_t(&v_1375);
+         if (v_1397) {
+            _fx_free_N14C_form__cexp_t(&v_1397);
          }
          if (exn_data_t_0) {
             _fx_free_N14C_form__ctyp_t(&exn_data_t_0);
@@ -36030,58 +36236,58 @@ static int
          if (exn_typ_0) {
             _fx_free_N14C_form__ctyp_t(&exn_typ_0);
          }
-         _fx_free_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(&v_1374);
-         _fx_free_N15C_form__cinfo_t(&v_1373);
-         goto _fx_endmatch_54;
+         _fx_free_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(&v_1396);
+         _fx_free_N15C_form__cinfo_t(&v_1395);
+         goto _fx_endmatch_57;
       }
-      fx_str_t v_1396 = {0};
-      fx_str_t v_1397 = {0};
-      fx_str_t v_1398 = {0};
-      fx_str_t v_1399 = {0};
-      fx_exn_t v_1400 = {0};
-      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&kf_cname_0, &v_1396, 0), _fx_catch_287);
-      FX_CALL(_fx_M3AstFM8ctor2strS1N17Ast__fun_constr_t(&ctor_0, &v_1397, 0), _fx_catch_287);
-      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1397, &v_1398, 0), _fx_catch_287);
-      fx_str_t slit_300 = FX_MAKE_STR("cgen: unsupported type of constructor ");
-      fx_str_t slit_301 = FX_MAKE_STR(": ");
+      fx_str_t v_1418 = {0};
+      fx_str_t v_1419 = {0};
+      fx_str_t v_1420 = {0};
+      fx_str_t v_1421 = {0};
+      fx_exn_t v_1422 = {0};
+      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&kf_cname_0, &v_1418, 0), _fx_catch_294);
+      FX_CALL(_fx_M3AstFM8ctor2strS1N17Ast__fun_constr_t(&ctor_0, &v_1419, 0), _fx_catch_294);
+      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1419, &v_1420, 0), _fx_catch_294);
+      fx_str_t slit_301 = FX_MAKE_STR("cgen: unsupported type of constructor ");
+      fx_str_t slit_302 = FX_MAKE_STR(": ");
       {
-         const fx_str_t strs_46[] = { slit_300, v_1396, slit_301, v_1398 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_46, 4, &v_1399), _fx_catch_287);
+         const fx_str_t strs_46[] = { slit_301, v_1418, slit_302, v_1420 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_46, 4, &v_1421), _fx_catch_294);
       }
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1399, &v_1400, 0), _fx_catch_287);
-      FX_THROW(&v_1400, false, _fx_catch_287);
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1421, &v_1422, 0), _fx_catch_294);
+      FX_THROW(&v_1422, false, _fx_catch_294);
 
-   _fx_catch_287: ;
-      fx_free_exn(&v_1400);
-      FX_FREE_STR(&v_1399);
-      FX_FREE_STR(&v_1398);
-      FX_FREE_STR(&v_1397);
-      FX_FREE_STR(&v_1396);
+   _fx_catch_294: ;
+      fx_free_exn(&v_1422);
+      FX_FREE_STR(&v_1421);
+      FX_FREE_STR(&v_1420);
+      FX_FREE_STR(&v_1419);
+      FX_FREE_STR(&v_1418);
 
-   _fx_endmatch_54: ;
-      FX_CHECK_EXN(_fx_catch_288);
+   _fx_endmatch_57: ;
+      FX_CHECK_EXN(_fx_catch_295);
       FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
-         _fx_catch_288);
-      _fx_R17C_form__cdeffun_t* v_1401 = &cf_0->data;
-      _fx_R16Ast__fun_flags_t* v_1402 = &v_1401->cf_flags;
-      bool v_1403 = really_nothrow_0->data;
+         _fx_catch_295);
+      _fx_R17C_form__cdeffun_t* v_1423 = &cf_0->data;
+      _fx_R16Ast__fun_flags_t* v_1424 = &v_1423->cf_flags;
+      bool v_1425 = really_nothrow_0->data;
       _fx_R16Ast__fun_flags_t new_cf_flags_0 =
-         { v_1402->fun_flag_pure, v_1402->fun_flag_ccode, v_1402->fun_flag_have_keywords, v_1402->fun_flag_inline,
-            v_1402->fun_flag_nothrow, v_1403, v_1402->fun_flag_private, v_1402->fun_flag_ctor, v_1402->fun_flag_method_of,
-            v_1402->fun_flag_uses_fv, v_1402->fun_flag_recursive, v_1402->fun_flag_instance };
-      _fx_R17C_form__cdeffun_t* v_1404 = &cf_0->data;
-      FX_CALL(_fx_M6C_formFM15filter_out_nopsLN15C_form__cstmt_t1LN15C_form__cstmt_t(new_body_0, &v_1251, 0), _fx_catch_288);
-      _fx_make_R17C_form__cdeffun_t(&v_1404->cf_name, &v_1404->cf_cname, v_1404->cf_args, v_1404->cf_rt, v_1251,
-         &new_cf_flags_0, v_1404->cf_scope, &v_1404->cf_loc, &v_1252);
-      _fx_R17C_form__cdeffun_t* v_1405 = &cf_0->data;
-      _fx_free_R17C_form__cdeffun_t(v_1405);
-      _fx_copy_R17C_form__cdeffun_t(&v_1252, v_1405);
+         { v_1424->fun_flag_pure, v_1424->fun_flag_ccode, v_1424->fun_flag_have_keywords, v_1424->fun_flag_inline,
+            v_1424->fun_flag_nothrow, v_1425, v_1424->fun_flag_private, v_1424->fun_flag_ctor, v_1424->fun_flag_method_of,
+            v_1424->fun_flag_uses_fv, v_1424->fun_flag_recursive, v_1424->fun_flag_instance };
+      _fx_R17C_form__cdeffun_t* v_1426 = &cf_0->data;
+      FX_CALL(_fx_M6C_formFM15filter_out_nopsLN15C_form__cstmt_t1LN15C_form__cstmt_t(new_body_0, &v_1273, 0), _fx_catch_295);
+      _fx_make_R17C_form__cdeffun_t(&v_1426->cf_name, &v_1426->cf_cname, v_1426->cf_args, v_1426->cf_rt, v_1273,
+         &new_cf_flags_0, v_1426->cf_scope, &v_1426->cf_loc, &v_1274);
+      _fx_R17C_form__cdeffun_t* v_1427 = &cf_0->data;
+      _fx_free_R17C_form__cdeffun_t(v_1427);
+      _fx_copy_R17C_form__cdeffun_t(&v_1274, v_1427);
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1);
 
-   _fx_catch_288: ;
-      _fx_free_R17C_form__cdeffun_t(&v_1252);
-      if (v_1251) {
-         _fx_free_LN15C_form__cstmt_t(&v_1251);
+   _fx_catch_295: ;
+      _fx_free_R17C_form__cdeffun_t(&v_1274);
+      if (v_1273) {
+         _fx_free_LN15C_form__cstmt_t(&v_1273);
       }
       if (new_body_0) {
          _fx_free_LN15C_form__cstmt_t(&new_body_0);
@@ -36090,7 +36296,7 @@ static int
       if (real_args_0) {
          _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&real_args_0);
       }
-      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_1250);
+      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_1272);
       if (cf_0) {
          _fx_free_rR17C_form__cdeffun_t(&cf_0);
       }
@@ -36100,8 +36306,8 @@ static int
       if (args_13) {
          _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&args_13);
       }
-      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(&v_1249);
-      _fx_free_N15C_form__cinfo_t(&v_1248);
+      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(&v_1271);
+      _fx_free_N15C_form__cinfo_t(&v_1270);
       if (kf_rt_0) {
          _fx_free_N14K_form__ktyp_t(&kf_rt_0);
       }
@@ -36109,26 +36315,26 @@ static int
          _fx_free_N14K_form__kexp_t(&kf_body_0);
       }
       FX_FREE_STR(&kf_cname_0);
-      goto _fx_endmatch_55;
+      goto _fx_endmatch_58;
    }
    if (tag_0 == 33) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    if (tag_0 == 34) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    if (tag_0 == 36) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    if (tag_0 == 35) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    if (tag_0 == 37) {
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_55;
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1); goto _fx_endmatch_58;
    }
    FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
 
-_fx_endmatch_55: ;
+_fx_endmatch_58: ;
    FX_CHECK_EXN(_fx_cleanup);
    bool assign_0 = v_1.t0;
    FX_COPY_PTR(v_1.t1, &result_exp_0);
@@ -36146,39 +36352,39 @@ _fx_endmatch_55: ;
    else {
       _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_0->data, &v_3);
       if (v_3.tag == 2) {
-         _fx_LN15C_form__cstmt_t ccode_172 = 0;
+         _fx_LN15C_form__cstmt_t ccode_177 = 0;
          _fx_N14C_form__cexp_t dst_exp_25 = v_3.u.Some;
          bool skip_copy_0;
          if (FX_REC_VARIANT_TAG(result_exp_0) == 2) {
             if (result_exp_0->u.CExpLit.t0.tag == 8) {
-               _fx_R17C_form__ctprops_t v_1406 = {0};
+               _fx_R17C_form__ctprops_t v_1428 = {0};
                FX_CALL(
-                  _fx_M11C_gen_typesFM11get_ctpropsR17C_form__ctprops_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_1406,
-                     0), _fx_catch_289);
-               skip_copy_0 = v_1406.ctp_ptr;
+                  _fx_M11C_gen_typesFM11get_ctpropsR17C_form__ctprops_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_1428,
+                     0), _fx_catch_296);
+               skip_copy_0 = v_1428.ctp_ptr;
 
-            _fx_catch_289: ;
-               _fx_free_R17C_form__ctprops_t(&v_1406);
-               goto _fx_endmatch_56;
+            _fx_catch_296: ;
+               _fx_free_R17C_form__ctprops_t(&v_1428);
+               goto _fx_endmatch_59;
             }
          }
          skip_copy_0 = false;
 
-      _fx_endmatch_56: ;
-         FX_CHECK_EXN(_fx_catch_290);
+      _fx_endmatch_59: ;
+         FX_CHECK_EXN(_fx_catch_297);
          if (skip_copy_0) {
-            FX_COPY_PTR(ccode_1, &ccode_172);
+            FX_COPY_PTR(ccode_1, &ccode_177);
          }
          else {
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  result_exp_0, dst_exp_25, ctyp_0, ccode_1, &kloc_0, &ccode_172, 0), _fx_catch_290);
+                  result_exp_0, dst_exp_25, ctyp_0, ccode_1, &kloc_0, &ccode_177, 0), _fx_catch_297);
          }
-         _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(dst_exp_25, ccode_172, fx_result);
+         _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(dst_exp_25, ccode_177, fx_result);
 
-      _fx_catch_290: ;
-         if (ccode_172) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_172);
+      _fx_catch_297: ;
+         if (ccode_177) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_177);
          }
       }
       else {

--- a/compiler/bootstrap/C_gen_code.c
+++ b/compiler/bootstrap/C_gen_code.c
@@ -80,95 +80,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -210,15 +121,74 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* root;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -250,6 +220,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -261,6 +255,12 @@ typedef struct _fx_R16Ast__for_flags_t {
    bool for_flag_fold;
    bool for_flag_nested;
 } _fx_R16Ast__for_flags_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -434,55 +434,13 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N13Ast__border_t {
+   int tag;
+} _fx_N13Ast__border_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+typedef struct _fx_N18Ast__interpolate_t {
+   int tag;
+} _fx_N18Ast__interpolate_t;
 
 typedef struct _fx_R16Ast__var_flags_t {
    int_ var_flag_class_from;
@@ -494,97 +452,16 @@ typedef struct _fx_R16Ast__var_flags_t {
    bool var_flag_instance;
 } _fx_R16Ast__var_flags_t;
 
+typedef struct _fx_R14Ast__pragmas_t {
+   bool pragma_cpp;
+   struct _fx_LT2SR10Ast__loc_t_data_t* pragma_clibs;
+} _fx_R14Ast__pragmas_t;
+
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N13Ast__border_t {
-   int tag;
-} _fx_N13Ast__border_t;
-
-typedef struct _fx_N18Ast__interpolate_t {
-   int tag;
-} _fx_N18Ast__interpolate_t;
-
-typedef struct _fx_R14Ast__pragmas_t {
-   bool pragma_cpp;
-   struct _fx_LT2SR10Ast__loc_t_data_t* pragma_clibs;
-} _fx_R14Ast__pragmas_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -850,6 +727,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -896,6 +875,14 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
 
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
 typedef struct _fx_R17K_form__kmodule_t {
    struct _fx_R9Ast__id_t km_name;
    int_ km_idx;
@@ -907,6 +894,19 @@ typedef struct _fx_R17K_form__kmodule_t {
    bool km_main;
    struct _fx_R14Ast__pragmas_t km_pragmas;
 } _fx_R17K_form__kmodule_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_LR17K_form__kmodule_t_data_t {
    int_ rc;
@@ -1002,161 +1002,10 @@ typedef struct _fx_LN15C_form__cstmt_t_data_t {
    struct _fx_N15C_form__cstmt_t_data_t* hd;
 } _fx_LN15C_form__cstmt_t_data_t, *_fx_LN15C_form__cstmt_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
-
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -1177,6 +1026,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -1379,6 +1242,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -1430,6 +1383,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_T2SR9Ast__id_t {
    fx_str_t t0;
@@ -2063,68 +2063,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -2260,6 +2198,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2272,6 +2263,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -2578,414 +2578,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
-static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
-}
-
-static int _fx_cons_LN14K_form__ktyp_t(
-   struct _fx_N14K_form__ktyp_t_data_t* hd,
-   struct _fx_LN14K_form__ktyp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)
 {
    _fx_free_LT2SR10Ast__loc_t(&dst->pragma_clibs);
@@ -3004,6 +2596,20 @@ static void _fx_make_R14Ast__pragmas_t(
 {
    fx_result->pragma_cpp = r_pragma_cpp;
    FX_COPY_PTR(r_pragma_clibs, &fx_result->pragma_clibs);
+}
+
+static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
+}
+
+static int _fx_cons_LN14K_form__ktyp_t(
+   struct _fx_N14K_form__ktyp_t_data_t* hd,
+   struct _fx_LN14K_form__ktyp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -4022,6 +3628,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -4108,6 +4031,37 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
    *dst = 0;
 }
 
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
 static void _fx_free_R17K_form__kmodule_t(struct _fx_R17K_form__kmodule_t* dst)
 {
    fx_free_str(&dst->km_cname);
@@ -4150,6 +4104,52 @@ static void _fx_make_R17K_form__kmodule_t(
    fx_result->km_skip = r_km_skip;
    fx_result->km_main = r_km_main;
    _fx_copy_R14Ast__pragmas_t(r_km_pragmas, &fx_result->km_pragmas);
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_LR17K_form__kmodule_t(struct _fx_LR17K_form__kmodule_t_data_t** dst)
@@ -4399,167 +4399,6 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
-}
-
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
-{
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
-}
-
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
-{
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
-}
-
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
 {
    fx_free_list_simple(&dst->ctp_make);
@@ -4593,305 +4432,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -5643,6 +5183,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -5757,6 +5591,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2SR9Ast__id_t(struct _fx_T2SR9Ast__id_t* dst)
@@ -24780,7 +24780,7 @@ static int
             }
          }
       }
-      if (intr_0->tag == 16) {
+      if (intr_0->tag == 18) {
          _fx_LN14C_form__cexp_t cargs_0 = 0;
          _fx_LN15C_form__cstmt_t ccode_58 = 0;
          _fx_LN14K_form__atom_t args_2 = 0;
@@ -24916,7 +24916,7 @@ static int
       }
       if (args_0 != 0) {
          if (args_0->tl == 0) {
-            if (intr_0->tag == 17) {
+            if (intr_0->tag == 19) {
                _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_367 = {0};
                _fx_N14C_form__cexp_t c_exp_2 = 0;
                _fx_LN15C_form__cstmt_t ccode_59 = 0;
@@ -25250,161 +25250,400 @@ static int
             }
          }
       }
-      fx_str_t v_395 = {0};
-      fx_str_t v_396 = {0};
-      fx_str_t v_397 = {0};
-      fx_exn_t v_398 = {0};
-      FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(intr_0, &v_395, 0), _fx_catch_93);
-      int_ v_399;
-      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14K_form__atom_t(args_0, &v_399, 0), _fx_catch_93);
-      FX_CALL(_fx_F6stringS1i(v_399, &v_396, 0), _fx_catch_93);
-      fx_str_t slit_105 = FX_MAKE_STR("cgen: unsupported KExpIntrin(");
-      fx_str_t slit_106 = FX_MAKE_STR(", ...) or the wrong number of arguments (");
-      fx_str_t slit_107 = FX_MAKE_STR(")");
-      {
-         const fx_str_t strs_23[] = { slit_105, v_395, slit_106, v_396, slit_107 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_23, 5, &v_397), _fx_catch_93);
-      }
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_397, &v_398, 0), _fx_catch_93);
-      FX_THROW(&v_398, false, _fx_catch_93);
+      if (intr_0->tag == 16) {
+         if (args_0 != 0) {
+            _fx_LN14K_form__atom_t v_395 = args_0->tl;
+            if (v_395 != 0) {
+               if (v_395->tl == 0) {
+                  _fx_N14C_form__cexp_t lbl_5 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_396 = {0};
+                  _fx_N14C_form__cexp_t vec_exp_0 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_64 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_397 = {0};
+                  _fx_N14C_form__cexp_t elem_exp_0 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_65 = 0;
+                  _fx_N14K_form__ktyp_t v_398 = 0;
+                  _fx_N14K_form__ktyp_t et_1 = 0;
+                  _fx_N14C_form__ctyp_t elem_ctyp_1 = 0;
+                  _fx_N14C_form__cexp_t v_399 = 0;
+                  _fx_LN14C_form__cexp_t v_400 = 0;
+                  _fx_N14C_form__cexp_t push_0 = 0;
+                  _fx_N15C_form__cstmt_t v_401 = 0;
+                  _fx_LN15C_form__cstmt_t v_402 = 0;
+                  _fx_N14K_form__atom_t* vec_0 = &args_0->hd;
+                  FX_CALL(
+                     _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0,
+                        block_stack_ref_0, &lbl_5, 0), _fx_catch_94);
+                  FX_CALL(
+                     atom2cexp_0.fp(vec_0, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_396, atom2cexp_0.fcv), _fx_catch_94);
+                  FX_COPY_PTR(v_396.t0, &vec_exp_0);
+                  FX_COPY_PTR(v_396.t1, &ccode_64);
+                  FX_CALL(
+                     atom2cexp_0.fp(&v_395->hd, ccode_64, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_397, atom2cexp_0.fcv), _fx_catch_94);
+                  FX_COPY_PTR(v_397.t0, &elem_exp_0);
+                  FX_COPY_PTR(v_397.t1, &ccode_65);
+                  FX_CALL(
+                     _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(vec_0, &kloc_0, &v_398, 0),
+                     _fx_catch_94);
+                  if (FX_REC_VARIANT_TAG(v_398) == 19) {
+                     FX_COPY_PTR(v_398->u.KTypVector, &et_1);
+                  }
+                  else {
+                     fx_str_t v_403 = {0};
+                     fx_str_t v_404 = {0};
+                     fx_exn_t v_405 = {0};
+                     FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(v_398, &v_403, 0), _fx_catch_93);
+                     fx_str_t slit_105 = FX_MAKE_STR("cgen: __intrin_push__ applied to a non-vector type ");
+                     {
+                        const fx_str_t strs_23[] = { slit_105, v_403 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_23, 2, &v_404), _fx_catch_93);
+                     }
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_404, &v_405, 0), _fx_catch_93);
+                     FX_THROW(&v_405, false, _fx_catch_93);
 
-   _fx_catch_93: ;
-      fx_free_exn(&v_398);
-      FX_FREE_STR(&v_397);
-      FX_FREE_STR(&v_396);
-      FX_FREE_STR(&v_395);
+                  _fx_catch_93: ;
+                     fx_free_exn(&v_405);
+                     FX_FREE_STR(&v_404);
+                     FX_FREE_STR(&v_403);
+                  }
+                  FX_CHECK_EXN(_fx_catch_94);
+                  FX_CALL(
+                     _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(et_1, &kloc_0, &elem_ctyp_1,
+                        0), _fx_catch_94);
+                  _fx_R17K_form__ktprops_t v_406;
+                  FX_CALL(
+                     _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(et_1, &kloc_0, &v_406,
+                        0), _fx_catch_94);
+                  bool ktp_complex_0 = v_406.ktp_complex;
+                  _fx_R9Ast__id_t macro_1;
+                  if (ktp_complex_0) {
+                     fx_str_t slit_106 = FX_MAKE_STR("FX_VEC_PUSH_BACK");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_106, &macro_1, 0), _fx_catch_94);
+                  }
+                  else {
+                     fx_str_t slit_107 = FX_MAKE_STR("FX_VEC_PUSH_BACK_FAST");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_107, &macro_1, 0), _fx_catch_94);
+                  }
+                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_1, &kloc_0, &v_399),
+                     _fx_catch_94);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_5, 0, true, &v_400), _fx_catch_94);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_exp_0, v_400, false, &v_400), _fx_catch_94);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_exp_0, v_400, false, &v_400), _fx_catch_94);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_399, v_400, false, &v_400), _fx_catch_94);
+                  FX_CALL(
+                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                        &macro_1, v_400, _fx_g20C_gen_code__CTypVoid, &kloc_0, &push_0, 0), _fx_catch_94);
+                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(push_0, &v_401), _fx_catch_94);
+                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_401, ccode_65, true, &v_402), _fx_catch_94);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_402, &v_1);
+
+               _fx_catch_94: ;
+                  if (v_402) {
+                     _fx_free_LN15C_form__cstmt_t(&v_402);
+                  }
+                  if (v_401) {
+                     _fx_free_N15C_form__cstmt_t(&v_401);
+                  }
+                  if (push_0) {
+                     _fx_free_N14C_form__cexp_t(&push_0);
+                  }
+                  if (v_400) {
+                     _fx_free_LN14C_form__cexp_t(&v_400);
+                  }
+                  if (v_399) {
+                     _fx_free_N14C_form__cexp_t(&v_399);
+                  }
+                  if (elem_ctyp_1) {
+                     _fx_free_N14C_form__ctyp_t(&elem_ctyp_1);
+                  }
+                  if (et_1) {
+                     _fx_free_N14K_form__ktyp_t(&et_1);
+                  }
+                  if (v_398) {
+                     _fx_free_N14K_form__ktyp_t(&v_398);
+                  }
+                  if (ccode_65) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_65);
+                  }
+                  if (elem_exp_0) {
+                     _fx_free_N14C_form__cexp_t(&elem_exp_0);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_397);
+                  if (ccode_64) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_64);
+                  }
+                  if (vec_exp_0) {
+                     _fx_free_N14C_form__cexp_t(&vec_exp_0);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_396);
+                  if (lbl_5) {
+                     _fx_free_N14C_form__cexp_t(&lbl_5);
+                  }
+                  goto _fx_endmatch_16;
+               }
+            }
+         }
+      }
+      if (intr_0->tag == 17) {
+         if (args_0 != 0) {
+            if (args_0->tl == 0) {
+               _fx_N14C_form__cexp_t lbl_6 = 0;
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_407 = {0};
+               _fx_N14C_form__cexp_t vec_exp_1 = 0;
+               _fx_LN15C_form__cstmt_t ccode_66 = 0;
+               _fx_N14K_form__ktyp_t v_408 = 0;
+               _fx_N14K_form__ktyp_t et_2 = 0;
+               _fx_LN14C_form__cexp_t v_409 = 0;
+               _fx_N14C_form__cexp_t pop_0 = 0;
+               _fx_N15C_form__cstmt_t v_410 = 0;
+               _fx_LN15C_form__cstmt_t v_411 = 0;
+               _fx_N14K_form__atom_t* vec_1 = &args_0->hd;
+               FX_CALL(
+                  _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0,
+                     block_stack_ref_0, &lbl_6, 0), _fx_catch_96);
+               FX_CALL(
+                  atom2cexp_0.fp(vec_1, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                     km_idx_0, &v_407, atom2cexp_0.fcv), _fx_catch_96);
+               FX_COPY_PTR(v_407.t0, &vec_exp_1);
+               FX_COPY_PTR(v_407.t1, &ccode_66);
+               FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(vec_1, &kloc_0, &v_408, 0),
+                  _fx_catch_96);
+               if (FX_REC_VARIANT_TAG(v_408) == 19) {
+                  FX_COPY_PTR(v_408->u.KTypVector, &et_2);
+               }
+               else {
+                  fx_str_t v_412 = {0};
+                  fx_str_t v_413 = {0};
+                  fx_exn_t v_414 = {0};
+                  FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(v_408, &v_412, 0), _fx_catch_95);
+                  fx_str_t slit_108 = FX_MAKE_STR("cgen: __intrin_pop__ applied to a non-vector type ");
+                  {
+                     const fx_str_t strs_24[] = { slit_108, v_412 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_24, 2, &v_413), _fx_catch_95);
+                  }
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_413, &v_414, 0), _fx_catch_95);
+                  FX_THROW(&v_414, false, _fx_catch_95);
+
+               _fx_catch_95: ;
+                  fx_free_exn(&v_414);
+                  FX_FREE_STR(&v_413);
+                  FX_FREE_STR(&v_412);
+               }
+               FX_CHECK_EXN(_fx_catch_96);
+               _fx_R17K_form__ktprops_t v_415;
+               FX_CALL(
+                  _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(et_2, &kloc_0, &v_415, 0),
+                  _fx_catch_96);
+               bool ktp_complex_1 = v_415.ktp_complex;
+               _fx_R9Ast__id_t macro_2;
+               if (ktp_complex_1) {
+                  fx_str_t slit_109 = FX_MAKE_STR("FX_VEC_POP_BACK");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_109, &macro_2, 0), _fx_catch_96);
+               }
+               else {
+                  fx_str_t slit_110 = FX_MAKE_STR("FX_VEC_POP_BACK_FAST");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_110, &macro_2, 0), _fx_catch_96);
+               }
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_6, 0, true, &v_409), _fx_catch_96);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_exp_1, v_409, false, &v_409), _fx_catch_96);
+               FX_CALL(
+                  _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                     &macro_2, v_409, _fx_g20C_gen_code__CTypVoid, &kloc_0, &pop_0, 0), _fx_catch_96);
+               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(pop_0, &v_410), _fx_catch_96);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_410, ccode_66, true, &v_411), _fx_catch_96);
+               _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_411, &v_1);
+
+            _fx_catch_96: ;
+               if (v_411) {
+                  _fx_free_LN15C_form__cstmt_t(&v_411);
+               }
+               if (v_410) {
+                  _fx_free_N15C_form__cstmt_t(&v_410);
+               }
+               if (pop_0) {
+                  _fx_free_N14C_form__cexp_t(&pop_0);
+               }
+               if (v_409) {
+                  _fx_free_LN14C_form__cexp_t(&v_409);
+               }
+               if (et_2) {
+                  _fx_free_N14K_form__ktyp_t(&et_2);
+               }
+               if (v_408) {
+                  _fx_free_N14K_form__ktyp_t(&v_408);
+               }
+               if (ccode_66) {
+                  _fx_free_LN15C_form__cstmt_t(&ccode_66);
+               }
+               if (vec_exp_1) {
+                  _fx_free_N14C_form__cexp_t(&vec_exp_1);
+               }
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_407);
+               if (lbl_6) {
+                  _fx_free_N14C_form__cexp_t(&lbl_6);
+               }
+               goto _fx_endmatch_16;
+            }
+         }
+      }
+      fx_str_t v_416 = {0};
+      fx_str_t v_417 = {0};
+      fx_str_t v_418 = {0};
+      fx_exn_t v_419 = {0};
+      FX_CALL(_fx_M3AstFM6stringS1N13Ast__intrin_t(intr_0, &v_416, 0), _fx_catch_97);
+      int_ v_420;
+      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14K_form__atom_t(args_0, &v_420, 0), _fx_catch_97);
+      FX_CALL(_fx_F6stringS1i(v_420, &v_417, 0), _fx_catch_97);
+      fx_str_t slit_111 = FX_MAKE_STR("cgen: unsupported KExpIntrin(");
+      fx_str_t slit_112 = FX_MAKE_STR(", ...) or the wrong number of arguments (");
+      fx_str_t slit_113 = FX_MAKE_STR(")");
+      {
+         const fx_str_t strs_25[] = { slit_111, v_416, slit_112, v_417, slit_113 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_25, 5, &v_418), _fx_catch_97);
+      }
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_418, &v_419, 0), _fx_catch_97);
+      FX_THROW(&v_419, false, _fx_catch_97);
+
+   _fx_catch_97: ;
+      fx_free_exn(&v_419);
+      FX_FREE_STR(&v_418);
+      FX_FREE_STR(&v_417);
+      FX_FREE_STR(&v_416);
 
    _fx_endmatch_16: ;
-      FX_CHECK_EXN(_fx_catch_94);
+      FX_CHECK_EXN(_fx_catch_98);
 
-   _fx_catch_94: ;
+   _fx_catch_98: ;
       goto _fx_endmatch_55;
    }
    if (tag_0 == 10) {
       _fx_FPT2N14C_form__cexp_tLN15C_form__cstmt_t18LN14K_form__kexp_tLN15C_form__cstmt_trLrR23C_gen_code__block_ctx_trNt10Hashset__t1R9Ast__id_trNt6option1N14C_form__cexp_tN14C_form__cexp_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t
          process_seq_0 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_400 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_421 = {0};
       _fx_N14C_form__cexp_t e_8 = 0;
-      _fx_LN15C_form__cstmt_t ccode_64 = 0;
+      _fx_LN15C_form__cstmt_t ccode_67 = 0;
       _fx_M10C_gen_codeFM7make_fpFPT2N14C_form__cexp_tLN15C_form__cstmt_t18LN14K_form__kexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trNt6option1N14C_form__cexp_tN14C_form__cexp_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t5rLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
          block_stack_ref_1, defined_syms_ref_1, fwd_fdecls_ref_1, i2e_ref_1, *km_idx_1, &process_seq_0);
       FX_CALL(
          process_seq_0.fp(kexp_0->u.KExpSeq.t0, ccode_0, block_stack_ref_0, defined_syms_ref_0, dstexp_r_0, dummy_exp_0,
             for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0,
-            mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_400, process_seq_0.fcv),
-         _fx_catch_95);
-      FX_COPY_PTR(v_400.t0, &e_8);
-      FX_COPY_PTR(v_400.t1, &ccode_64);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, e_8, ccode_64, &v_1);
+            mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_421, process_seq_0.fcv),
+         _fx_catch_99);
+      FX_COPY_PTR(v_421.t0, &e_8);
+      FX_COPY_PTR(v_421.t1, &ccode_67);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, e_8, ccode_67, &v_1);
 
-   _fx_catch_95: ;
-      if (ccode_64) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_64);
+   _fx_catch_99: ;
+      if (ccode_67) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_67);
       }
       if (e_8) {
          _fx_free_N14C_form__cexp_t(&e_8);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_400);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_421);
       FX_FREE_FP(&process_seq_0);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 9) {
       _fx_N14C_form__cexp_t parent_lbl_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_401 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_422 = {0};
       _fx_N14C_form__cexp_t dst_exp_8 = 0;
-      _fx_LN15C_form__cstmt_t ccode_65 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_402 = {0};
+      _fx_LN15C_form__cstmt_t ccode_68 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_423 = {0};
       _fx_LN15C_form__cstmt_t sync_ccode_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t bctx_sync_0 = 0;
       _fx_LN15C_form__cstmt_t bctx_cleanup_0 = 0;
       _fx_LN15C_form__cstmt_t bctx_prologue_0 = 0;
       _fx_LN15C_form__cstmt_t epilogue_0 = 0;
-      _fx_N15C_form__cstmt_t v_403 = 0;
-      _fx_LN15C_form__cstmt_t v_404 = 0;
-      _fx_LN15C_form__cstmt_t v_405 = 0;
+      _fx_N15C_form__cstmt_t v_424 = 0;
+      _fx_LN15C_form__cstmt_t v_425 = 0;
+      _fx_LN15C_form__cstmt_t v_426 = 0;
       _fx_LN15C_form__cstmt_t sync_ccode_1 = 0;
       _fx_N15C_form__cstmt_t c_e_2 = 0;
-      _fx_LN14C_form__cexp_t v_406 = 0;
+      _fx_LN14C_form__cexp_t v_427 = 0;
       _fx_N14C_form__cexp_t check_exn_0 = 0;
-      _fx_N15C_form__cstmt_t v_407 = 0;
-      _fx_N15C_form__cstmt_t v_408 = 0;
-      _fx_LN15C_form__cstmt_t v_409 = 0;
+      _fx_N15C_form__cstmt_t v_428 = 0;
+      _fx_N15C_form__cstmt_t v_429 = 0;
+      _fx_LN15C_form__cstmt_t v_430 = 0;
       _fx_T2R9Ast__id_tN14K_form__kexp_t* vcase_5 = &kexp_0->u.KExpSync;
       _fx_N14K_form__kexp_t e_9 = vcase_5->t1;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &parent_lbl_0, 0), _fx_catch_96);
-      fx_str_t slit_108 = FX_MAKE_STR("t");
+            &parent_lbl_0, 0), _fx_catch_100);
+      fx_str_t slit_114 = FX_MAKE_STR("t");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_108, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_401, 0), _fx_catch_96);
-      FX_COPY_PTR(v_401.t0, &dst_exp_8);
-      FX_COPY_PTR(v_401.t1, &ccode_65);
+            dstexp_r_0, &slit_114, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_422, 0), _fx_catch_100);
+      FX_COPY_PTR(v_422.t0, &dst_exp_8);
+      FX_COPY_PTR(v_422.t1, &ccode_68);
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_96);
+            &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_100);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e_9, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_402, fx_fv), _fx_catch_96);
-      FX_COPY_PTR(v_402.t1, &sync_ccode_0);
+            top_inline_ccode_ref_0, u1vals_0, &v_423, fx_fv), _fx_catch_100);
+      FX_COPY_PTR(v_423.t1, &sync_ccode_0);
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_sync_0, 0), _fx_catch_96);
-      _fx_R23C_gen_code__block_ctx_t* v_410 = &bctx_sync_0->data;
-      int_ bctx_label_used_0 = v_410->bctx_label_used;
-      _fx_R9Ast__id_t bctx_label_0 = v_410->bctx_label;
-      FX_COPY_PTR(v_410->bctx_cleanup, &bctx_cleanup_0);
-      FX_COPY_PTR(v_410->bctx_prologue, &bctx_prologue_0);
+            &bctx_sync_0, 0), _fx_catch_100);
+      _fx_R23C_gen_code__block_ctx_t* v_431 = &bctx_sync_0->data;
+      int_ bctx_label_used_0 = v_431->bctx_label_used;
+      _fx_R9Ast__id_t bctx_label_0 = v_431->bctx_label;
+      FX_COPY_PTR(v_431->bctx_cleanup, &bctx_cleanup_0);
+      FX_COPY_PTR(v_431->bctx_prologue, &bctx_prologue_0);
       if (bctx_label_used_0 == 0) {
          FX_COPY_PTR(bctx_cleanup_0, &epilogue_0);
       }
       else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_0, &kloc_0, &v_403),
-            _fx_catch_96);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_403, 0, true, &v_404), _fx_catch_96);
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_0, &kloc_0, &v_424),
+            _fx_catch_100);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_424, 0, true, &v_425), _fx_catch_100);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_0, v_404,
-               &epilogue_0, 0), _fx_catch_96);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_0, v_425,
+               &epilogue_0, 0), _fx_catch_100);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(sync_ccode_0, bctx_prologue_0,
-            &v_405, 0), _fx_catch_96);
+            &v_426, 0), _fx_catch_100);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_0, v_405, &sync_ccode_1,
-            0), _fx_catch_96);
-      _fx_R10Ast__loc_t v_411;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e_9, &v_411, 0), _fx_catch_96);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sync_ccode_1, &v_411, &c_e_2, 0),
-         _fx_catch_96);
-      FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0), _fx_catch_96);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(parent_lbl_0, 0, true, &v_406), _fx_catch_96);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_0, v_426, &sync_ccode_1,
+            0), _fx_catch_100);
+      _fx_R10Ast__loc_t v_432;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e_9, &v_432, 0), _fx_catch_100);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sync_ccode_1, &v_432, &c_e_2, 0),
+         _fx_catch_100);
+      FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
+         _fx_catch_100);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(parent_lbl_0, 0, true, &v_427), _fx_catch_100);
       FX_CALL(
          _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g24C_form__std_FX_CHECK_EXN, v_406, _fx_g20C_gen_code__CTypVoid, &kloc_0, &check_exn_0, 0), _fx_catch_96);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(check_exn_0, &v_407), _fx_catch_96);
-      FX_CALL(_fx_M6C_formFM9CStmtSyncN15C_form__cstmt_t2R9Ast__id_tN15C_form__cstmt_t(&vcase_5->t0, c_e_2, &v_408),
-         _fx_catch_96);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_408, ccode_65, true, &v_409), _fx_catch_96);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_407, v_409, false, &v_409), _fx_catch_96);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_8, v_409, &v_1);
+            &_fx_g24C_form__std_FX_CHECK_EXN, v_427, _fx_g20C_gen_code__CTypVoid, &kloc_0, &check_exn_0, 0), _fx_catch_100);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(check_exn_0, &v_428), _fx_catch_100);
+      FX_CALL(_fx_M6C_formFM9CStmtSyncN15C_form__cstmt_t2R9Ast__id_tN15C_form__cstmt_t(&vcase_5->t0, c_e_2, &v_429),
+         _fx_catch_100);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_429, ccode_68, true, &v_430), _fx_catch_100);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_428, v_430, false, &v_430), _fx_catch_100);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_8, v_430, &v_1);
 
-   _fx_catch_96: ;
-      if (v_409) {
-         _fx_free_LN15C_form__cstmt_t(&v_409);
+   _fx_catch_100: ;
+      if (v_430) {
+         _fx_free_LN15C_form__cstmt_t(&v_430);
       }
-      if (v_408) {
-         _fx_free_N15C_form__cstmt_t(&v_408);
+      if (v_429) {
+         _fx_free_N15C_form__cstmt_t(&v_429);
       }
-      if (v_407) {
-         _fx_free_N15C_form__cstmt_t(&v_407);
+      if (v_428) {
+         _fx_free_N15C_form__cstmt_t(&v_428);
       }
       if (check_exn_0) {
          _fx_free_N14C_form__cexp_t(&check_exn_0);
       }
-      if (v_406) {
-         _fx_free_LN14C_form__cexp_t(&v_406);
+      if (v_427) {
+         _fx_free_LN14C_form__cexp_t(&v_427);
       }
       if (c_e_2) {
          _fx_free_N15C_form__cstmt_t(&c_e_2);
@@ -25412,14 +25651,14 @@ static int
       if (sync_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&sync_ccode_1);
       }
-      if (v_405) {
-         _fx_free_LN15C_form__cstmt_t(&v_405);
+      if (v_426) {
+         _fx_free_LN15C_form__cstmt_t(&v_426);
       }
-      if (v_404) {
-         _fx_free_LN15C_form__cstmt_t(&v_404);
+      if (v_425) {
+         _fx_free_LN15C_form__cstmt_t(&v_425);
       }
-      if (v_403) {
-         _fx_free_N15C_form__cstmt_t(&v_403);
+      if (v_424) {
+         _fx_free_N15C_form__cstmt_t(&v_424);
       }
       if (epilogue_0) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_0);
@@ -25436,84 +25675,84 @@ static int
       if (sync_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&sync_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_402);
-      if (ccode_65) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_65);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_423);
+      if (ccode_68) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_68);
       }
       if (dst_exp_8) {
          _fx_free_N14C_form__cexp_t(&dst_exp_8);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_401);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_422);
       if (parent_lbl_0) {
          _fx_free_N14C_form__cexp_t(&parent_lbl_0);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 11) {
-      _fx_rNt6option1N14C_form__cexp_t v_412 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_413 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_433 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_434 = {0};
       _fx_N14C_form__cexp_t cc_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_66 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_414 = {0};
+      _fx_LN15C_form__cstmt_t ccode_69 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_435 = {0};
       _fx_N14C_form__cexp_t dst_exp_9 = 0;
-      _fx_LN15C_form__cstmt_t ccode_67 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_415 = {0};
+      _fx_LN15C_form__cstmt_t ccode_70 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_436 = {0};
       _fx_LN15C_form__cstmt_t ccode1_3 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_416 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_437 = {0};
       _fx_LN15C_form__cstmt_t ccode2_0 = 0;
       _fx_N15C_form__cstmt_t c_e1_0 = 0;
       _fx_N15C_form__cstmt_t c_e2_0 = 0;
-      _fx_N15C_form__cstmt_t v_417 = 0;
-      _fx_LN15C_form__cstmt_t v_418 = 0;
+      _fx_N15C_form__cstmt_t v_438 = 0;
+      _fx_LN15C_form__cstmt_t v_439 = 0;
       _fx_T4N14K_form__kexp_tN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_6 = &kexp_0->u.KExpIf;
       _fx_N14K_form__kexp_t e2_0 = vcase_6->t2;
       _fx_N14K_form__kexp_t e1_0 = vcase_6->t1;
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_412), _fx_catch_97);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_433), _fx_catch_101);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_6->t0, v_412, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_6->t0, v_433, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_413, fx_fv), _fx_catch_97);
-      FX_COPY_PTR(v_413.t0, &cc_0);
-      FX_COPY_PTR(v_413.t1, &ccode_66);
-      fx_str_t slit_109 = FX_MAKE_STR("t");
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_434, fx_fv), _fx_catch_101);
+      FX_COPY_PTR(v_434.t0, &cc_0);
+      FX_COPY_PTR(v_434.t1, &ccode_69);
+      fx_str_t slit_115 = FX_MAKE_STR("t");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_109, ctyp_0, ccode_66, &kloc_0, block_stack_ref_0, km_idx_0, &v_414, 0), _fx_catch_97);
-      FX_COPY_PTR(v_414.t0, &dst_exp_9);
-      FX_COPY_PTR(v_414.t1, &ccode_67);
+            dstexp_r_0, &slit_115, ctyp_0, ccode_69, &kloc_0, block_stack_ref_0, km_idx_0, &v_435, 0), _fx_catch_101);
+      FX_COPY_PTR(v_435.t0, &dst_exp_9);
+      FX_COPY_PTR(v_435.t1, &ccode_70);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e1_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_415, fx_fv), _fx_catch_97);
-      FX_COPY_PTR(v_415.t1, &ccode1_3);
+            top_inline_ccode_ref_0, u1vals_0, &v_436, fx_fv), _fx_catch_101);
+      FX_COPY_PTR(v_436.t1, &ccode1_3);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             e2_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_416, fx_fv), _fx_catch_97);
-      FX_COPY_PTR(v_416.t1, &ccode2_0);
-      _fx_R10Ast__loc_t v_419;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e1_0, &v_419, 0), _fx_catch_97);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode1_3, &v_419, &c_e1_0, 0),
-         _fx_catch_97);
-      _fx_R10Ast__loc_t v_420;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e2_0, &v_420, 0), _fx_catch_97);
-      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode2_0, &v_420, &c_e2_0, 0),
-         _fx_catch_97);
+            top_inline_ccode_ref_0, u1vals_0, &v_437, fx_fv), _fx_catch_101);
+      FX_COPY_PTR(v_437.t1, &ccode2_0);
+      _fx_R10Ast__loc_t v_440;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e1_0, &v_440, 0), _fx_catch_101);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode1_3, &v_440, &c_e1_0, 0),
+         _fx_catch_101);
+      _fx_R10Ast__loc_t v_441;
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e2_0, &v_441, 0), _fx_catch_101);
+      FX_CALL(_fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode2_0, &v_441, &c_e2_0, 0),
+         _fx_catch_101);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(cc_0,
-            c_e1_0, c_e2_0, &kloc_0, &v_417, 0), _fx_catch_97);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_417, ccode_67, true, &v_418), _fx_catch_97);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_9, v_418, &v_1);
+            c_e1_0, c_e2_0, &kloc_0, &v_438, 0), _fx_catch_101);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_438, ccode_70, true, &v_439), _fx_catch_101);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_9, v_439, &v_1);
 
-   _fx_catch_97: ;
-      if (v_418) {
-         _fx_free_LN15C_form__cstmt_t(&v_418);
+   _fx_catch_101: ;
+      if (v_439) {
+         _fx_free_LN15C_form__cstmt_t(&v_439);
       }
-      if (v_417) {
-         _fx_free_N15C_form__cstmt_t(&v_417);
+      if (v_438) {
+         _fx_free_N15C_form__cstmt_t(&v_438);
       }
       if (c_e2_0) {
          _fx_free_N15C_form__cstmt_t(&c_e2_0);
@@ -25524,90 +25763,90 @@ static int
       if (ccode2_0) {
          _fx_free_LN15C_form__cstmt_t(&ccode2_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_416);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_437);
       if (ccode1_3) {
          _fx_free_LN15C_form__cstmt_t(&ccode1_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_415);
-      if (ccode_67) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_67);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_436);
+      if (ccode_70) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_70);
       }
       if (dst_exp_9) {
          _fx_free_N14C_form__cexp_t(&dst_exp_9);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_414);
-      if (ccode_66) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_66);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_435);
+      if (ccode_69) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_69);
       }
       if (cc_0) {
          _fx_free_N14C_form__cexp_t(&cc_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_413);
-      if (v_412) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_412);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_434);
+      if (v_433) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_433);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 12) {
       _fx_LN14C_form__cexp_t cargs_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_68 = 0;
+      _fx_LN15C_form__cstmt_t ccode_71 = 0;
       _fx_LN14K_form__atom_t args_3 = 0;
-      _fx_N15C_form__cinfo_t v_421 = {0};
-      _fx_T2R9Ast__id_tN15C_form__cinfo_t v_422 = {0};
+      _fx_N15C_form__cinfo_t v_442 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cinfo_t v_443 = {0};
       _fx_N15C_form__cinfo_t ci_0 = {0};
-      _fx_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t v_423 = {0};
+      _fx_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t v_444 = {0};
       _fx_N14C_form__cexp_t f_exp_1 = 0;
       _fx_LN14C_form__cexp_t fv_args_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_69 = 0;
-      _fx_LN14C_form__cexp_t v_424 = 0;
+      _fx_LN15C_form__cstmt_t ccode_72 = 0;
+      _fx_LN14C_form__cexp_t v_445 = 0;
       _fx_LN14C_form__cexp_t args_4 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_425 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_446 = {0};
       _fx_N14C_form__cexp_t call_exp_2 = 0;
-      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_426 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_427 = {0};
+      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_447 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_448 = {0};
       _fx_N14C_form__cexp_t dst_exp_10 = 0;
-      _fx_LN15C_form__cstmt_t ccode_70 = 0;
-      _fx_N14C_form__cexp_t v_428 = 0;
-      _fx_LN14C_form__cexp_t v_429 = 0;
+      _fx_LN15C_form__cstmt_t ccode_73 = 0;
+      _fx_N14C_form__cexp_t v_449 = 0;
+      _fx_LN14C_form__cexp_t v_450 = 0;
       _fx_LN14C_form__cexp_t args_5 = 0;
       _fx_N14C_form__cexp_t dst_exp_11 = 0;
-      _fx_LN15C_form__cstmt_t ccode_71 = 0;
-      _fx_LN14C_form__cexp_t v_430 = 0;
+      _fx_LN15C_form__cstmt_t ccode_74 = 0;
+      _fx_LN14C_form__cexp_t v_451 = 0;
       _fx_LN14C_form__cexp_t args_6 = 0;
       _fx_N14C_form__ctyp_t fcall_rt_0 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_431 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_452 = {0};
       _fx_N14C_form__cexp_t fcall_exp_0 = 0;
-      _fx_N15C_form__cstmt_t v_432 = 0;
-      _fx_LN15C_form__cstmt_t v_433 = 0;
-      _fx_LN15C_form__cstmt_t ccode_72 = 0;
+      _fx_N15C_form__cstmt_t v_453 = 0;
+      _fx_LN15C_form__cstmt_t v_454 = 0;
+      _fx_LN15C_form__cstmt_t ccode_75 = 0;
       _fx_T3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_7 = &kexp_0->u.KExpCall;
       _fx_R9Ast__id_t* f_2 = &vcase_7->t0;
-      FX_COPY_PTR(ccode_0, &ccode_68);
+      FX_COPY_PTR(ccode_0, &ccode_71);
       FX_COPY_PTR(vcase_7->t1, &args_3);
       _fx_LN14K_form__atom_t lst_5 = args_3;
       for (; lst_5; lst_5 = lst_5->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_434 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_455 = {0};
          _fx_N14C_form__cexp_t carg_0 = 0;
          _fx_LN15C_form__cstmt_t ccode1_4 = 0;
          _fx_N14C_form__cexp_t carg_1 = 0;
-         _fx_LN14C_form__cexp_t v_435 = 0;
+         _fx_LN14C_form__cexp_t v_456 = 0;
          _fx_N14K_form__atom_t* arg_1 = &lst_5->hd;
          FX_CALL(
-            atom2cexp_0.fp(arg_1, ccode_68, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_434, atom2cexp_0.fcv), _fx_catch_98);
-         FX_COPY_PTR(v_434.t0, &carg_0);
-         FX_COPY_PTR(v_434.t1, &ccode1_4);
+            atom2cexp_0.fp(arg_1, ccode_71, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_455, atom2cexp_0.fcv), _fx_catch_102);
+         FX_COPY_PTR(v_455.t0, &carg_0);
+         FX_COPY_PTR(v_455.t1, &ccode1_4);
          FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(carg_0, &kloc_0, &carg_1, 0),
-            _fx_catch_98);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_1, cargs_1, true, &v_435), _fx_catch_98);
+            _fx_catch_102);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_1, cargs_1, true, &v_456), _fx_catch_102);
          _fx_free_LN14C_form__cexp_t(&cargs_1);
-         FX_COPY_PTR(v_435, &cargs_1);
-         _fx_free_LN15C_form__cstmt_t(&ccode_68);
-         FX_COPY_PTR(ccode1_4, &ccode_68);
+         FX_COPY_PTR(v_456, &cargs_1);
+         _fx_free_LN15C_form__cstmt_t(&ccode_71);
+         FX_COPY_PTR(ccode1_4, &ccode_71);
 
-      _fx_catch_98: ;
-         if (v_435) {
-            _fx_free_LN14C_form__cexp_t(&v_435);
+      _fx_catch_102: ;
+         if (v_456) {
+            _fx_free_LN14C_form__cexp_t(&v_456);
          }
          if (carg_1) {
             _fx_free_N14C_form__cexp_t(&carg_1);
@@ -25618,109 +25857,109 @@ static int
          if (carg_0) {
             _fx_free_N14C_form__cexp_t(&carg_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_434);
-         FX_CHECK_EXN(_fx_catch_103);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_455);
+         FX_CHECK_EXN(_fx_catch_107);
       }
-      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(f_2, &kloc_0, &v_421, 0), _fx_catch_103);
-      if (v_421.tag == 5) {
-         _fx_R17C_form__cdefexn_t v_436 = {0};
-         _fx_N15C_form__cinfo_t v_437 = {0};
-         _fx_copy_R17C_form__cdefexn_t(&v_421.u.CExn->data, &v_436);
-         _fx_R9Ast__id_t* cexn_make_0 = &v_436.cexn_make;
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(cexn_make_0, &kloc_0, &v_437, 0),
-            _fx_catch_99);
-         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(cexn_make_0, &v_437, &v_422);
+      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(f_2, &kloc_0, &v_442, 0), _fx_catch_107);
+      if (v_442.tag == 5) {
+         _fx_R17C_form__cdefexn_t v_457 = {0};
+         _fx_N15C_form__cinfo_t v_458 = {0};
+         _fx_copy_R17C_form__cdefexn_t(&v_442.u.CExn->data, &v_457);
+         _fx_R9Ast__id_t* cexn_make_0 = &v_457.cexn_make;
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(cexn_make_0, &kloc_0, &v_458, 0),
+            _fx_catch_103);
+         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(cexn_make_0, &v_458, &v_443);
 
-      _fx_catch_99: ;
-         _fx_free_N15C_form__cinfo_t(&v_437);
-         _fx_free_R17C_form__cdefexn_t(&v_436);
+      _fx_catch_103: ;
+         _fx_free_N15C_form__cinfo_t(&v_458);
+         _fx_free_R17C_form__cdefexn_t(&v_457);
       }
       else {
-         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(f_2, &v_421, &v_422);
+         _fx_make_T2R9Ast__id_tN15C_form__cinfo_t(f_2, &v_442, &v_443);
       }
-      FX_CHECK_EXN(_fx_catch_103);
-      _fx_R9Ast__id_t f_3 = v_422.t0;
-      _fx_copy_N15C_form__cinfo_t(&v_422.t1, &ci_0);
+      FX_CHECK_EXN(_fx_catch_107);
+      _fx_R9Ast__id_t f_3 = v_443.t0;
+      _fx_copy_N15C_form__cinfo_t(&v_443.t1, &ci_0);
       int tag_12 = ci_0.tag;
       if (tag_12 == 3) {
          fx_str_t cf_cname_0 = {0};
          _fx_N14C_form__ctyp_t cf_rt_0 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t cf_args_0 = 0;
-         _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_438 = {0};
+         _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_459 = {0};
          _fx_N14C_form__cexp_t f_exp_2 = 0;
          _fx_LN14C_form__cexp_t fv_args_1 = 0;
-         _fx_N14C_form__cexp_t v_439 = 0;
-         _fx_N14C_form__cexp_t v_440 = 0;
-         fx_str_t v_441 = {0};
-         fx_str_t v_442 = {0};
-         fx_exn_t v_443 = {0};
-         _fx_R17C_form__cdeffun_t* v_444 = &ci_0.u.CFun->data;
-         _fx_R10Ast__loc_t cf_loc_0 = v_444->cf_loc;
-         fx_copy_str(&v_444->cf_cname, &cf_cname_0);
-         _fx_R16Ast__fun_flags_t cf_flags_0 = v_444->cf_flags;
-         FX_COPY_PTR(v_444->cf_rt, &cf_rt_0);
-         FX_COPY_PTR(v_444->cf_args, &cf_args_0);
+         _fx_N14C_form__cexp_t v_460 = 0;
+         _fx_N14C_form__cexp_t v_461 = 0;
+         fx_str_t v_462 = {0};
+         fx_str_t v_463 = {0};
+         fx_exn_t v_464 = {0};
+         _fx_R17C_form__cdeffun_t* v_465 = &ci_0.u.CFun->data;
+         _fx_R10Ast__loc_t cf_loc_0 = v_465->cf_loc;
+         fx_copy_str(&v_465->cf_cname, &cf_cname_0);
+         _fx_R16Ast__fun_flags_t cf_flags_0 = v_465->cf_flags;
+         FX_COPY_PTR(v_465->cf_rt, &cf_rt_0);
+         FX_COPY_PTR(v_465->cf_args, &cf_args_0);
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_100);
+               &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_104);
          bool is_nothrow_0 = cf_flags_0.fun_flag_nothrow;
          FX_CALL(
             _fx_M10C_gen_codeFM15unpack_fun_argsT4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB3LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tB(
-               cf_args_0, cf_rt_0, is_nothrow_0, &v_438, 0), _fx_catch_100);
-         _fx_R9Ast__id_t ret_id_0 = v_438.t1;
-         bool have_fv_arg_0 = v_438.t3;
+               cf_args_0, cf_rt_0, is_nothrow_0, &v_459, 0), _fx_catch_104);
+         _fx_R9Ast__id_t ret_id_0 = v_459.t1;
+         bool have_fv_arg_0 = v_459.t3;
          FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &cf_loc_0, &f_exp_2, 0),
-            _fx_catch_100);
+            _fx_catch_104);
          if (have_fv_arg_0) {
             if (!cf_flags_0.fun_flag_uses_fv) {
-               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_439, 0), _fx_catch_100);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_439, 0, true, &fv_args_1), _fx_catch_100);
+               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_460, 0), _fx_catch_104);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_460, 0, true, &fv_args_1), _fx_catch_104);
             }
             else {
-               _fx_R9Ast__id_t v_445;
+               _fx_R9Ast__id_t v_466;
                FX_CALL(
-                  _fx_M10C_gen_codeFM9curr_funcR9Ast__id_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, &v_445,
-                     0), _fx_catch_100);
+                  _fx_M10C_gen_codeFM9curr_funcR9Ast__id_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, &v_466,
+                     0), _fx_catch_104);
                bool res_12;
-               FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&f_3, &v_445, &res_12, 0), _fx_catch_100);
+               FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&f_3, &v_466, &res_12, 0), _fx_catch_104);
                if (res_12) {
-                  _fx_R9Ast__id_t v_446;
-                  fx_str_t slit_110 = FX_MAKE_STR("fx_fv");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_110, &v_446, 0), _fx_catch_100);
+                  _fx_R9Ast__id_t v_467;
+                  fx_str_t slit_116 = FX_MAKE_STR("fx_fv");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_116, &v_467, 0), _fx_catch_104);
                   FX_CALL(
-                     _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_446,
-                        _fx_g23C_form__std_CTypVoidPtr, &cf_loc_0, &v_440, 0), _fx_catch_100);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_440, 0, true, &fv_args_1), _fx_catch_100);
+                     _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_467,
+                        _fx_g23C_form__std_CTypVoidPtr, &cf_loc_0, &v_461, 0), _fx_catch_104);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_461, 0, true, &fv_args_1), _fx_catch_104);
                }
                else {
-                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&cf_cname_0, &v_441, 0), _fx_catch_100);
-                  fx_str_t slit_111 = FX_MAKE_STR("cgen: looks like lambda lifting did not transform \'");
-                  fx_str_t slit_112 =
+                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&cf_cname_0, &v_462, 0), _fx_catch_104);
+                  fx_str_t slit_117 = FX_MAKE_STR("cgen: looks like lambda lifting did not transform \'");
+                  fx_str_t slit_118 =
                      FX_MAKE_STR(
                         "\' call correctly. Functions that access free variables must be called via closure (except for the case when function calls itself)");
                   {
-                     const fx_str_t strs_24[] = { slit_111, v_441, slit_112 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_24, 3, &v_442), _fx_catch_100);
+                     const fx_str_t strs_26[] = { slit_117, v_462, slit_118 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_463), _fx_catch_104);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_442, &v_443, 0), _fx_catch_100);
-                  FX_THROW(&v_443, false, _fx_catch_100);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_463, &v_464, 0), _fx_catch_104);
+                  FX_THROW(&v_464, false, _fx_catch_104);
                }
             }
          }
          bool res_13;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&ret_id_0, &_fx_g9Ast__noid, &res_13, 0), _fx_catch_100);
-         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_2, res_13, fv_args_1, is_nothrow_0, ccode_68,
-            &v_423);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&ret_id_0, &_fx_g9Ast__noid, &res_13, 0), _fx_catch_104);
+         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_2, res_13, fv_args_1, is_nothrow_0, ccode_71,
+            &v_444);
 
-      _fx_catch_100: ;
-         fx_free_exn(&v_443);
-         FX_FREE_STR(&v_442);
-         FX_FREE_STR(&v_441);
-         if (v_440) {
-            _fx_free_N14C_form__cexp_t(&v_440);
+      _fx_catch_104: ;
+         fx_free_exn(&v_464);
+         FX_FREE_STR(&v_463);
+         FX_FREE_STR(&v_462);
+         if (v_461) {
+            _fx_free_N14C_form__cexp_t(&v_461);
          }
-         if (v_439) {
-            _fx_free_N14C_form__cexp_t(&v_439);
+         if (v_460) {
+            _fx_free_N14C_form__cexp_t(&v_460);
          }
          if (fv_args_1) {
             _fx_free_LN14C_form__cexp_t(&fv_args_1);
@@ -25728,7 +25967,7 @@ static int
          if (f_exp_2) {
             _fx_free_N14C_form__cexp_t(&f_exp_2);
          }
-         _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_438);
+         _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_459);
          if (cf_args_0) {
             _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&cf_args_0);
          }
@@ -25738,18 +25977,18 @@ static int
          FX_FREE_STR(&cf_cname_0);
       }
       else if (tag_12 == 2) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_447 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_468 = {0};
          _fx_N14C_form__cexp_t fclo_exp_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_73 = 0;
-         _fx_N14K_form__ktyp_t v_448 = 0;
+         _fx_LN15C_form__cstmt_t ccode_76 = 0;
+         _fx_N14K_form__ktyp_t v_469 = 0;
          _fx_N14K_form__ktyp_t ftyp_0 = 0;
          _fx_N14C_form__ctyp_t cftyp_0 = 0;
          _fx_N14C_form__cexp_t f_exp_3 = 0;
-         _fx_N14C_form__cexp_t v_449 = 0;
+         _fx_N14C_form__cexp_t v_470 = 0;
          _fx_LN14C_form__cexp_t fv_args_2 = 0;
          _fx_R16Ast__val_flags_t* cv_flags_0 = &ci_0.u.CVal.cv_flags;
          bool res_14;
-         FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(cv_flags_0, &res_14, 0), _fx_catch_101);
+         FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(cv_flags_0, &res_14, 0), _fx_catch_105);
          bool t_7;
          if (res_14) {
             t_7 = true;
@@ -25760,41 +25999,41 @@ static int
          if (t_7) {
             FX_CALL(
                _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-                  &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_101);
+                  &f_3, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_105);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
-               &f_3, false, ccode_68, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_447, 0), _fx_catch_101);
-         FX_COPY_PTR(v_447.t0, &fclo_exp_0);
-         FX_COPY_PTR(v_447.t1, &ccode_73);
-         FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_448, 0),
-            _fx_catch_101);
-         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_448, &kloc_0, &ftyp_0, 0),
-            _fx_catch_101);
+               &f_3, false, ccode_71, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
+               &v_468, 0), _fx_catch_105);
+         FX_COPY_PTR(v_468.t0, &fclo_exp_0);
+         FX_COPY_PTR(v_468.t1, &ccode_76);
+         FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_469, 0),
+            _fx_catch_105);
+         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_469, &kloc_0, &ftyp_0, 0),
+            _fx_catch_105);
          FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(ftyp_0, &kloc_0, &cftyp_0, 0),
-            _fx_catch_101);
-         _fx_R9Ast__id_t v_450;
-         fx_str_t slit_113 = FX_MAKE_STR("fp");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_113, &v_450, 0), _fx_catch_101);
+            _fx_catch_105);
+         _fx_R9Ast__id_t v_471;
+         fx_str_t slit_119 = FX_MAKE_STR("fp");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_119, &v_471, 0), _fx_catch_105);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_450, cftyp_0,
-               &f_exp_3, 0), _fx_catch_101);
-         _fx_R9Ast__id_t v_451;
-         fx_str_t slit_114 = FX_MAKE_STR("fcv");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_114, &v_451, 0), _fx_catch_101);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_471, cftyp_0,
+               &f_exp_3, 0), _fx_catch_105);
+         _fx_R9Ast__id_t v_472;
+         fx_str_t slit_120 = FX_MAKE_STR("fcv");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_120, &v_472, 0), _fx_catch_105);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_451,
-               _fx_g23C_form__std_CTypVoidPtr, &v_449, 0), _fx_catch_101);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_449, 0, true, &fv_args_2), _fx_catch_101);
-         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_3, true, fv_args_2, false, ccode_73, &v_423);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fclo_exp_0, &v_472,
+               _fx_g23C_form__std_CTypVoidPtr, &v_470, 0), _fx_catch_105);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_470, 0, true, &fv_args_2), _fx_catch_105);
+         _fx_make_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(f_exp_3, true, fv_args_2, false, ccode_76, &v_444);
 
-      _fx_catch_101: ;
+      _fx_catch_105: ;
          if (fv_args_2) {
             _fx_free_LN14C_form__cexp_t(&fv_args_2);
          }
-         if (v_449) {
-            _fx_free_N14C_form__cexp_t(&v_449);
+         if (v_470) {
+            _fx_free_N14C_form__cexp_t(&v_470);
          }
          if (f_exp_3) {
             _fx_free_N14C_form__cexp_t(&f_exp_3);
@@ -25805,45 +26044,45 @@ static int
          if (ftyp_0) {
             _fx_free_N14K_form__ktyp_t(&ftyp_0);
          }
-         if (v_448) {
-            _fx_free_N14K_form__ktyp_t(&v_448);
+         if (v_469) {
+            _fx_free_N14K_form__ktyp_t(&v_469);
          }
-         if (ccode_73) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_73);
+         if (ccode_76) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_76);
          }
          if (fclo_exp_0) {
             _fx_free_N14C_form__cexp_t(&fclo_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_447);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_468);
       }
       else {
-         fx_str_t v_452 = {0};
-         fx_str_t v_453 = {0};
-         fx_str_t v_454 = {0};
-         fx_exn_t v_455 = {0};
-         FX_CALL(_fx_M6C_formFM7idc2strS2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_452, 0), _fx_catch_102);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_452, &v_453, 0), _fx_catch_102);
-         fx_str_t slit_115 = FX_MAKE_STR("cgen: the called \'");
-         fx_str_t slit_116 = FX_MAKE_STR("\' is not a function nor value");
+         fx_str_t v_473 = {0};
+         fx_str_t v_474 = {0};
+         fx_str_t v_475 = {0};
+         fx_exn_t v_476 = {0};
+         FX_CALL(_fx_M6C_formFM7idc2strS2R9Ast__id_tR10Ast__loc_t(&f_3, &kloc_0, &v_473, 0), _fx_catch_106);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_473, &v_474, 0), _fx_catch_106);
+         fx_str_t slit_121 = FX_MAKE_STR("cgen: the called \'");
+         fx_str_t slit_122 = FX_MAKE_STR("\' is not a function nor value");
          {
-            const fx_str_t strs_25[] = { slit_115, v_453, slit_116 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_25, 3, &v_454), _fx_catch_102);
+            const fx_str_t strs_27[] = { slit_121, v_474, slit_122 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_27, 3, &v_475), _fx_catch_106);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_454, &v_455, 0), _fx_catch_102);
-         FX_THROW(&v_455, false, _fx_catch_102);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_475, &v_476, 0), _fx_catch_106);
+         FX_THROW(&v_476, false, _fx_catch_106);
 
-      _fx_catch_102: ;
-         fx_free_exn(&v_455);
-         FX_FREE_STR(&v_454);
-         FX_FREE_STR(&v_453);
-         FX_FREE_STR(&v_452);
+      _fx_catch_106: ;
+         fx_free_exn(&v_476);
+         FX_FREE_STR(&v_475);
+         FX_FREE_STR(&v_474);
+         FX_FREE_STR(&v_473);
       }
-      FX_CHECK_EXN(_fx_catch_103);
-      FX_COPY_PTR(v_423.t0, &f_exp_1);
-      bool have_out_arg_0 = v_423.t1;
-      FX_COPY_PTR(v_423.t2, &fv_args_0);
-      bool is_nothrow_1 = v_423.t3;
-      FX_COPY_PTR(v_423.t4, &ccode_69);
+      FX_CHECK_EXN(_fx_catch_107);
+      FX_COPY_PTR(v_444.t0, &f_exp_1);
+      bool have_out_arg_0 = v_444.t1;
+      FX_COPY_PTR(v_444.t2, &fv_args_0);
+      bool is_nothrow_1 = v_444.t3;
+      FX_COPY_PTR(v_444.t4, &ccode_72);
       bool t_8;
       if (!have_out_arg_0) {
          t_8 = FX_REC_VARIANT_TAG(ctyp_0) != 8;
@@ -25853,85 +26092,85 @@ static int
       }
       if (t_8) {
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, cargs_1, &v_424, 0),
-            _fx_catch_103);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_424, &args_4, 0), _fx_catch_103);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_425);
+            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, cargs_1, &v_445, 0),
+            _fx_catch_107);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_445, &args_4, 0), _fx_catch_107);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_446);
          FX_CALL(
             _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-               f_exp_1, args_4, &v_425, &call_exp_2), _fx_catch_103);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, call_exp_2, ccode_69, &v_1);
+               f_exp_1, args_4, &v_446, &call_exp_2), _fx_catch_107);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, call_exp_2, ccode_72, &v_1);
       }
       else {
          if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
-            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_1, dummy_exp_0, ccode_69, &v_426);
+            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_1, dummy_exp_0, ccode_72, &v_447);
          }
          else {
-            fx_str_t slit_117 = FX_MAKE_STR("res");
+            fx_str_t slit_123 = FX_MAKE_STR("res");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_117, ctyp_0, ccode_69, &kloc_0, block_stack_ref_0, km_idx_0, &v_427, 0), _fx_catch_103);
-            FX_COPY_PTR(v_427.t0, &dst_exp_10);
-            FX_COPY_PTR(v_427.t1, &ccode_70);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_10, &v_428, 0), _fx_catch_103);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_428, cargs_1, true, &v_429), _fx_catch_103);
-            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_429, dst_exp_10, ccode_70, &v_426);
+                  dstexp_r_0, &slit_123, ctyp_0, ccode_72, &kloc_0, block_stack_ref_0, km_idx_0, &v_448, 0), _fx_catch_107);
+            FX_COPY_PTR(v_448.t0, &dst_exp_10);
+            FX_COPY_PTR(v_448.t1, &ccode_73);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_10, &v_449, 0), _fx_catch_107);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_449, cargs_1, true, &v_450), _fx_catch_107);
+            _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_450, dst_exp_10, ccode_73, &v_447);
          }
-         FX_COPY_PTR(v_426.t0, &args_5);
-         FX_COPY_PTR(v_426.t1, &dst_exp_11);
-         FX_COPY_PTR(v_426.t2, &ccode_71);
+         FX_COPY_PTR(v_447.t0, &args_5);
+         FX_COPY_PTR(v_447.t1, &dst_exp_11);
+         FX_COPY_PTR(v_447.t2, &ccode_74);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, args_5, &v_430, 0),
-            _fx_catch_103);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_430, &args_6, 0), _fx_catch_103);
+            _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(fv_args_0, args_5, &v_451, 0),
+            _fx_catch_107);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_451, &args_6, 0), _fx_catch_107);
          if (is_nothrow_1) {
             FX_COPY_PTR(_fx_g20C_gen_code__CTypVoid, &fcall_rt_0);
          }
          else {
             FX_COPY_PTR(_fx_g20C_gen_code__CTypCInt, &fcall_rt_0);
          }
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(fcall_rt_0, &kloc_0, &v_431);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(fcall_rt_0, &kloc_0, &v_452);
          FX_CALL(
             _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-               f_exp_1, args_6, &v_431, &fcall_exp_0), _fx_catch_103);
+               f_exp_1, args_6, &v_452, &fcall_exp_0), _fx_catch_107);
          if (is_nothrow_1) {
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(fcall_exp_0, &v_432), _fx_catch_103);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_432, ccode_71, true, &v_433), _fx_catch_103);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, v_433, &v_1);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(fcall_exp_0, &v_453), _fx_catch_107);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_453, ccode_74, true, &v_454), _fx_catch_107);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, v_454, &v_1);
          }
          else {
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  fcall_exp_0, ccode_71, &kloc_0, block_stack_ref_0, &ccode_72, 0), _fx_catch_103);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, ccode_72, &v_1);
+                  fcall_exp_0, ccode_74, &kloc_0, block_stack_ref_0, &ccode_75, 0), _fx_catch_107);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_11, ccode_75, &v_1);
          }
       }
 
-   _fx_catch_103: ;
-      if (ccode_72) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_72);
+   _fx_catch_107: ;
+      if (ccode_75) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_75);
       }
-      if (v_433) {
-         _fx_free_LN15C_form__cstmt_t(&v_433);
+      if (v_454) {
+         _fx_free_LN15C_form__cstmt_t(&v_454);
       }
-      if (v_432) {
-         _fx_free_N15C_form__cstmt_t(&v_432);
+      if (v_453) {
+         _fx_free_N15C_form__cstmt_t(&v_453);
       }
       if (fcall_exp_0) {
          _fx_free_N14C_form__cexp_t(&fcall_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_431);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_452);
       if (fcall_rt_0) {
          _fx_free_N14C_form__ctyp_t(&fcall_rt_0);
       }
       if (args_6) {
          _fx_free_LN14C_form__cexp_t(&args_6);
       }
-      if (v_430) {
-         _fx_free_LN14C_form__cexp_t(&v_430);
+      if (v_451) {
+         _fx_free_LN14C_form__cexp_t(&v_451);
       }
-      if (ccode_71) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_71);
+      if (ccode_74) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_74);
       }
       if (dst_exp_11) {
          _fx_free_N14C_form__cexp_t(&dst_exp_11);
@@ -25939,32 +26178,32 @@ static int
       if (args_5) {
          _fx_free_LN14C_form__cexp_t(&args_5);
       }
-      if (v_429) {
-         _fx_free_LN14C_form__cexp_t(&v_429);
+      if (v_450) {
+         _fx_free_LN14C_form__cexp_t(&v_450);
       }
-      if (v_428) {
-         _fx_free_N14C_form__cexp_t(&v_428);
+      if (v_449) {
+         _fx_free_N14C_form__cexp_t(&v_449);
       }
-      if (ccode_70) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_70);
+      if (ccode_73) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_73);
       }
       if (dst_exp_10) {
          _fx_free_N14C_form__cexp_t(&dst_exp_10);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_427);
-      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_426);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_448);
+      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_447);
       if (call_exp_2) {
          _fx_free_N14C_form__cexp_t(&call_exp_2);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_425);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_446);
       if (args_4) {
          _fx_free_LN14C_form__cexp_t(&args_4);
       }
-      if (v_424) {
-         _fx_free_LN14C_form__cexp_t(&v_424);
+      if (v_445) {
+         _fx_free_LN14C_form__cexp_t(&v_445);
       }
-      if (ccode_69) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_69);
+      if (ccode_72) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_72);
       }
       if (fv_args_0) {
          _fx_free_LN14C_form__cexp_t(&fv_args_0);
@@ -25972,15 +26211,15 @@ static int
       if (f_exp_1) {
          _fx_free_N14C_form__cexp_t(&f_exp_1);
       }
-      _fx_free_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(&v_423);
+      _fx_free_T5N14C_form__cexp_tBLN14C_form__cexp_tBLN15C_form__cstmt_t(&v_444);
       _fx_free_N15C_form__cinfo_t(&ci_0);
-      _fx_free_T2R9Ast__id_tN15C_form__cinfo_t(&v_422);
-      _fx_free_N15C_form__cinfo_t(&v_421);
+      _fx_free_T2R9Ast__id_tN15C_form__cinfo_t(&v_443);
+      _fx_free_N15C_form__cinfo_t(&v_442);
       if (args_3) {
          _fx_free_LN14K_form__atom_t(&args_3);
       }
-      if (ccode_68) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_68);
+      if (ccode_71) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_71);
       }
       if (cargs_1) {
          _fx_free_LN14C_form__cexp_t(&cargs_1);
@@ -25988,79 +26227,79 @@ static int
       goto _fx_endmatch_55;
    }
    if (tag_0 == 13) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_456 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_477 = {0};
       _fx_N14C_form__cexp_t io_cexp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_74 = 0;
+      _fx_LN15C_form__cstmt_t ccode_77 = 0;
       _fx_N14C_form__cexp_t obj_cexp_0 = 0;
-      _fx_N14C_form__cexp_t v_457 = 0;
+      _fx_N14C_form__cexp_t v_478 = 0;
       _fx_LN14C_form__cexp_t cargs_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_75 = 0;
+      _fx_LN15C_form__cstmt_t ccode_78 = 0;
       _fx_LN14K_form__atom_t args_7 = 0;
       _fx_N14C_form__ctyp_t t_9 = 0;
-      _fx_Nt6option1rR23C_form__cdefinterface_t v_458 = {0};
+      _fx_Nt6option1rR23C_form__cdefinterface_t v_479 = {0};
       _fx_rR23C_form__cdefinterface_t obj_iface_0 = 0;
-      _fx_LT2R9Ast__id_tN14C_form__ctyp_t v_459 = 0;
-      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_460 = {0};
+      _fx_LT2R9Ast__id_tN14C_form__ctyp_t v_480 = 0;
+      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_481 = {0};
       _fx_N14C_form__ctyp_t mt_0 = 0;
       _fx_N14C_form__cexp_t vtbl_0 = 0;
       _fx_N14C_form__cexp_t mexp_0 = 0;
-      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_461 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_462 = {0};
+      _fx_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t v_482 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_483 = {0};
       _fx_N14C_form__cexp_t dst_exp_12 = 0;
-      _fx_LN15C_form__cstmt_t ccode_76 = 0;
-      _fx_N14C_form__cexp_t v_463 = 0;
-      _fx_LN14C_form__cexp_t v_464 = 0;
+      _fx_LN15C_form__cstmt_t ccode_79 = 0;
+      _fx_N14C_form__cexp_t v_484 = 0;
+      _fx_LN14C_form__cexp_t v_485 = 0;
       _fx_LN14C_form__cexp_t args_8 = 0;
       _fx_N14C_form__cexp_t dst_exp_13 = 0;
-      _fx_LN15C_form__cstmt_t ccode_77 = 0;
-      _fx_N14C_form__cexp_t v_465 = 0;
+      _fx_LN15C_form__cstmt_t ccode_80 = 0;
+      _fx_N14C_form__cexp_t v_486 = 0;
       _fx_LN14C_form__cexp_t args_9 = 0;
-      _fx_LN14C_form__cexp_t v_466 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_467 = {0};
+      _fx_LN14C_form__cexp_t v_487 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_488 = {0};
       _fx_N14C_form__cexp_t mcall_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_78 = 0;
+      _fx_LN15C_form__cstmt_t ccode_81 = 0;
       _fx_T4R9Ast__id_tiLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_8 = &kexp_0->u.KExpICall;
       FX_CALL(
          _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
             &vcase_8->t0, true, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-            &v_456, 0), _fx_catch_106);
-      FX_COPY_PTR(v_456.t0, &io_cexp_0);
-      FX_COPY_PTR(v_456.t1, &ccode_74);
-      _fx_R9Ast__id_t v_468;
-      fx_str_t slit_118 = FX_MAKE_STR("obj");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_118, &v_468, 0), _fx_catch_106);
+            &v_477, 0), _fx_catch_110);
+      FX_COPY_PTR(v_477.t0, &io_cexp_0);
+      FX_COPY_PTR(v_477.t1, &ccode_77);
+      _fx_R9Ast__id_t v_489;
+      fx_str_t slit_124 = FX_MAKE_STR("obj");
+      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_124, &v_489, 0), _fx_catch_110);
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_468,
-            _fx_g23C_form__std_CTypVoidPtr, &obj_cexp_0, 0), _fx_catch_106);
-      FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(obj_cexp_0, &kloc_0, &v_457, 0),
-         _fx_catch_106);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_457, 0, true, &cargs_2), _fx_catch_106);
-      FX_COPY_PTR(ccode_74, &ccode_75);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_489,
+            _fx_g23C_form__std_CTypVoidPtr, &obj_cexp_0, 0), _fx_catch_110);
+      FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(obj_cexp_0, &kloc_0, &v_478, 0),
+         _fx_catch_110);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_478, 0, true, &cargs_2), _fx_catch_110);
+      FX_COPY_PTR(ccode_77, &ccode_78);
       FX_COPY_PTR(vcase_8->t2, &args_7);
       _fx_LN14K_form__atom_t lst_6 = args_7;
       for (; lst_6; lst_6 = lst_6->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_469 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_490 = {0};
          _fx_N14C_form__cexp_t carg_2 = 0;
          _fx_LN15C_form__cstmt_t ccode1_5 = 0;
          _fx_N14C_form__cexp_t carg_3 = 0;
-         _fx_LN14C_form__cexp_t v_470 = 0;
+         _fx_LN14C_form__cexp_t v_491 = 0;
          _fx_N14K_form__atom_t* arg_2 = &lst_6->hd;
          FX_CALL(
-            atom2cexp_0.fp(arg_2, ccode_75, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_469, atom2cexp_0.fcv), _fx_catch_104);
-         FX_COPY_PTR(v_469.t0, &carg_2);
-         FX_COPY_PTR(v_469.t1, &ccode1_5);
+            atom2cexp_0.fp(arg_2, ccode_78, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_490, atom2cexp_0.fcv), _fx_catch_108);
+         FX_COPY_PTR(v_490.t0, &carg_2);
+         FX_COPY_PTR(v_490.t1, &ccode1_5);
          FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(carg_2, &kloc_0, &carg_3, 0),
-            _fx_catch_104);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_3, cargs_2, true, &v_470), _fx_catch_104);
+            _fx_catch_108);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(carg_3, cargs_2, true, &v_491), _fx_catch_108);
          _fx_free_LN14C_form__cexp_t(&cargs_2);
-         FX_COPY_PTR(v_470, &cargs_2);
-         _fx_free_LN15C_form__cstmt_t(&ccode_75);
-         FX_COPY_PTR(ccode1_5, &ccode_75);
+         FX_COPY_PTR(v_491, &cargs_2);
+         _fx_free_LN15C_form__cstmt_t(&ccode_78);
+         FX_COPY_PTR(ccode1_5, &ccode_78);
 
-      _fx_catch_104: ;
-         if (v_470) {
-            _fx_free_LN14C_form__cexp_t(&v_470);
+      _fx_catch_108: ;
+         if (v_491) {
+            _fx_free_LN14C_form__cexp_t(&v_491);
          }
          if (carg_3) {
             _fx_free_N14C_form__cexp_t(&carg_3);
@@ -26071,106 +26310,106 @@ static int
          if (carg_2) {
             _fx_free_N14C_form__cexp_t(&carg_2);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_469);
-         FX_CHECK_EXN(_fx_catch_106);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_490);
+         FX_CHECK_EXN(_fx_catch_110);
       }
-      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(io_cexp_0, &t_9, 0), _fx_catch_106);
+      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(io_cexp_0, &t_9, 0), _fx_catch_110);
       FX_CALL(
-         _fx_M6C_formFM18get_cinterface_optNt6option1rRM15cdefinterface_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_458,
-            0), _fx_catch_106);
-      if (v_458.tag == 2) {
-         FX_COPY_PTR(v_458.u.Some, &obj_iface_0);
+         _fx_M6C_formFM18get_cinterface_optNt6option1rRM15cdefinterface_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_479,
+            0), _fx_catch_110);
+      if (v_479.tag == 2) {
+         FX_COPY_PTR(v_479.u.Some, &obj_iface_0);
       }
       else {
-         _fx_T2SR9Ast__id_t v_471 = {0};
-         fx_str_t v_472 = {0};
-         fx_str_t v_473 = {0};
-         fx_str_t v_474 = {0};
-         fx_exn_t v_475 = {0};
-         FX_CALL(_fx_M6C_formFM8ctyp2strT2SR9Ast__id_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_471, 0), _fx_catch_105);
-         fx_copy_str(&v_471.t0, &v_472);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_472, &v_473, 0), _fx_catch_105);
-         fx_str_t slit_119 = FX_MAKE_STR("the first parameter (of type \'");
-         fx_str_t slit_120 = FX_MAKE_STR("\') of KExpICall is not an interface");
+         _fx_T2SR9Ast__id_t v_492 = {0};
+         fx_str_t v_493 = {0};
+         fx_str_t v_494 = {0};
+         fx_str_t v_495 = {0};
+         fx_exn_t v_496 = {0};
+         FX_CALL(_fx_M6C_formFM8ctyp2strT2SR9Ast__id_t2N14C_form__ctyp_tR10Ast__loc_t(t_9, &kloc_0, &v_492, 0), _fx_catch_109);
+         fx_copy_str(&v_492.t0, &v_493);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_493, &v_494, 0), _fx_catch_109);
+         fx_str_t slit_125 = FX_MAKE_STR("the first parameter (of type \'");
+         fx_str_t slit_126 = FX_MAKE_STR("\') of KExpICall is not an interface");
          {
-            const fx_str_t strs_26[] = { slit_119, v_473, slit_120 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_26, 3, &v_474), _fx_catch_105);
+            const fx_str_t strs_28[] = { slit_125, v_494, slit_126 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_28, 3, &v_495), _fx_catch_109);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_474, &v_475, 0), _fx_catch_105);
-         FX_THROW(&v_475, false, _fx_catch_105);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_495, &v_496, 0), _fx_catch_109);
+         FX_THROW(&v_496, false, _fx_catch_109);
 
-      _fx_catch_105: ;
-         fx_free_exn(&v_475);
-         FX_FREE_STR(&v_474);
-         FX_FREE_STR(&v_473);
-         FX_FREE_STR(&v_472);
-         _fx_free_T2SR9Ast__id_t(&v_471);
+      _fx_catch_109: ;
+         fx_free_exn(&v_496);
+         FX_FREE_STR(&v_495);
+         FX_FREE_STR(&v_494);
+         FX_FREE_STR(&v_493);
+         _fx_free_T2SR9Ast__id_t(&v_492);
       }
-      FX_CHECK_EXN(_fx_catch_106);
-      _fx_R23C_form__cdefinterface_t* v_476 = &obj_iface_0->data;
-      FX_COPY_PTR(v_476->ci_all_methods, &v_459);
+      FX_CHECK_EXN(_fx_catch_110);
+      _fx_R23C_form__cdefinterface_t* v_497 = &obj_iface_0->data;
+      FX_COPY_PTR(v_497->ci_all_methods, &v_480);
       FX_CALL(
-         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(v_459, vcase_8->t1, &v_460, 0),
-         _fx_catch_106);
-      _fx_R9Ast__id_t mname_0 = v_460.t0;
-      FX_COPY_PTR(v_460.t1, &mt_0);
-      _fx_R9Ast__id_t v_477;
-      fx_str_t slit_121 = FX_MAKE_STR("vtbl");
-      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_121, &v_477, 0), _fx_catch_106);
+         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(v_480, vcase_8->t1, &v_481, 0),
+         _fx_catch_110);
+      _fx_R9Ast__id_t mname_0 = v_481.t0;
+      FX_COPY_PTR(v_481.t1, &mt_0);
+      _fx_R9Ast__id_t v_498;
+      fx_str_t slit_127 = FX_MAKE_STR("vtbl");
+      FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_127, &v_498, 0), _fx_catch_110);
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_477,
-            _fx_g23C_form__std_CTypVoidPtr, &vtbl_0, 0), _fx_catch_106);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(io_cexp_0, &v_498,
+            _fx_g23C_form__std_CTypVoidPtr, &vtbl_0, 0), _fx_catch_110);
       FX_CALL(
          _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(vtbl_0, &mname_0, mt_0,
-            &mexp_0, 0), _fx_catch_106);
+            &mexp_0, 0), _fx_catch_110);
       if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
-         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_2, dummy_exp_0, ccode_75, &v_461);
+         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(cargs_2, dummy_exp_0, ccode_78, &v_482);
       }
       else {
-         fx_str_t slit_122 = FX_MAKE_STR("res");
+         fx_str_t slit_128 = FX_MAKE_STR("res");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_122, ctyp_0, ccode_75, &kloc_0, block_stack_ref_0, km_idx_0, &v_462, 0), _fx_catch_106);
-         FX_COPY_PTR(v_462.t0, &dst_exp_12);
-         FX_COPY_PTR(v_462.t1, &ccode_76);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_12, &v_463, 0), _fx_catch_106);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_463, cargs_2, true, &v_464), _fx_catch_106);
-         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_464, dst_exp_12, ccode_76, &v_461);
+               dstexp_r_0, &slit_128, ctyp_0, ccode_78, &kloc_0, block_stack_ref_0, km_idx_0, &v_483, 0), _fx_catch_110);
+         FX_COPY_PTR(v_483.t0, &dst_exp_12);
+         FX_COPY_PTR(v_483.t1, &ccode_79);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(dst_exp_12, &v_484, 0), _fx_catch_110);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_484, cargs_2, true, &v_485), _fx_catch_110);
+         _fx_make_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(v_485, dst_exp_12, ccode_79, &v_482);
       }
-      FX_COPY_PTR(v_461.t0, &args_8);
-      FX_COPY_PTR(v_461.t1, &dst_exp_13);
-      FX_COPY_PTR(v_461.t2, &ccode_77);
-      FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_465, 0), _fx_catch_106);
-      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_465, args_8, true, &args_9), _fx_catch_106);
-      FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(args_9, &v_466, 0), _fx_catch_106);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypCInt, &kloc_0, &v_467);
+      FX_COPY_PTR(v_482.t0, &args_8);
+      FX_COPY_PTR(v_482.t1, &dst_exp_13);
+      FX_COPY_PTR(v_482.t2, &ccode_80);
+      FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_486, 0), _fx_catch_110);
+      FX_CALL(_fx_cons_LN14C_form__cexp_t(v_486, args_8, true, &args_9), _fx_catch_110);
+      FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(args_9, &v_487, 0), _fx_catch_110);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypCInt, &kloc_0, &v_488);
       FX_CALL(
          _fx_M6C_formFM8CExpCallN14C_form__cexp_t3N14C_form__cexp_tLN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(mexp_0,
-            v_466, &v_467, &mcall_exp_0), _fx_catch_106);
+            v_487, &v_488, &mcall_exp_0), _fx_catch_110);
       FX_CALL(
          _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-            mcall_exp_0, ccode_77, &kloc_0, block_stack_ref_0, &ccode_78, 0), _fx_catch_106);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_13, ccode_78, &v_1);
+            mcall_exp_0, ccode_80, &kloc_0, block_stack_ref_0, &ccode_81, 0), _fx_catch_110);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_13, ccode_81, &v_1);
 
-   _fx_catch_106: ;
-      if (ccode_78) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_78);
+   _fx_catch_110: ;
+      if (ccode_81) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_81);
       }
       if (mcall_exp_0) {
          _fx_free_N14C_form__cexp_t(&mcall_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_467);
-      if (v_466) {
-         _fx_free_LN14C_form__cexp_t(&v_466);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_488);
+      if (v_487) {
+         _fx_free_LN14C_form__cexp_t(&v_487);
       }
       if (args_9) {
          _fx_free_LN14C_form__cexp_t(&args_9);
       }
-      if (v_465) {
-         _fx_free_N14C_form__cexp_t(&v_465);
+      if (v_486) {
+         _fx_free_N14C_form__cexp_t(&v_486);
       }
-      if (ccode_77) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_77);
+      if (ccode_80) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_80);
       }
       if (dst_exp_13) {
          _fx_free_N14C_form__cexp_t(&dst_exp_13);
@@ -26178,20 +26417,20 @@ static int
       if (args_8) {
          _fx_free_LN14C_form__cexp_t(&args_8);
       }
-      if (v_464) {
-         _fx_free_LN14C_form__cexp_t(&v_464);
+      if (v_485) {
+         _fx_free_LN14C_form__cexp_t(&v_485);
       }
-      if (v_463) {
-         _fx_free_N14C_form__cexp_t(&v_463);
+      if (v_484) {
+         _fx_free_N14C_form__cexp_t(&v_484);
       }
-      if (ccode_76) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_76);
+      if (ccode_79) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_79);
       }
       if (dst_exp_12) {
          _fx_free_N14C_form__cexp_t(&dst_exp_12);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_462);
-      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_461);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_483);
+      _fx_free_T3LN14C_form__cexp_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_482);
       if (mexp_0) {
          _fx_free_N14C_form__cexp_t(&mexp_0);
       }
@@ -26201,39 +26440,39 @@ static int
       if (mt_0) {
          _fx_free_N14C_form__ctyp_t(&mt_0);
       }
-      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_460);
-      if (v_459) {
-         _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&v_459);
+      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_481);
+      if (v_480) {
+         _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&v_480);
       }
       if (obj_iface_0) {
          _fx_free_rR23C_form__cdefinterface_t(&obj_iface_0);
       }
-      _fx_free_Nt6option1rR23C_form__cdefinterface_t(&v_458);
+      _fx_free_Nt6option1rR23C_form__cdefinterface_t(&v_479);
       if (t_9) {
          _fx_free_N14C_form__ctyp_t(&t_9);
       }
       if (args_7) {
          _fx_free_LN14K_form__atom_t(&args_7);
       }
-      if (ccode_75) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_75);
+      if (ccode_78) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_78);
       }
       if (cargs_2) {
          _fx_free_LN14C_form__cexp_t(&cargs_2);
       }
-      if (v_457) {
-         _fx_free_N14C_form__cexp_t(&v_457);
+      if (v_478) {
+         _fx_free_N14C_form__cexp_t(&v_478);
       }
       if (obj_cexp_0) {
          _fx_free_N14C_form__cexp_t(&obj_cexp_0);
       }
-      if (ccode_74) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_74);
+      if (ccode_77) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_77);
       }
       if (io_cexp_0) {
          _fx_free_N14C_form__cexp_t(&io_cexp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_456);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_477);
       goto _fx_endmatch_55;
    }
    bool res_15;
@@ -26248,84 +26487,84 @@ static int
    }
    FX_CHECK_EXN(_fx_cleanup);
    if (res_15) {
-      _fx_T2LN14K_form__atom_tS v_478 = {0};
+      _fx_T2LN14K_form__atom_tS v_499 = {0};
       _fx_LN14K_form__atom_t args_10 = 0;
       fx_str_t prefix_2 = {0};
       _fx_LN14C_form__cexp_t cargs_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_79 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_479 = {0};
+      _fx_LN15C_form__cstmt_t ccode_82 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_500 = {0};
       _fx_N14C_form__cexp_t t_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_80 = 0;
-      _fx_LN14C_form__cexp_t v_480 = 0;
-      _fx_N14C_form__cexp_t v_481 = 0;
-      _fx_LN14C_form__cexp_t v_482 = 0;
-      _fx_LN14C_form__cexp_t v_483 = 0;
+      _fx_LN15C_form__cstmt_t ccode_83 = 0;
+      _fx_LN14C_form__cexp_t v_501 = 0;
+      _fx_N14C_form__cexp_t v_502 = 0;
+      _fx_LN14C_form__cexp_t v_503 = 0;
+      _fx_LN14C_form__cexp_t v_504 = 0;
       _fx_N14C_form__cexp_t call_mktup_0 = 0;
-      _fx_N15C_form__cstmt_t v_484 = 0;
-      _fx_LN15C_form__cstmt_t v_485 = 0;
-      _fx_LN14C_form__cexp_t v_486 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_487 = {0};
+      _fx_N15C_form__cstmt_t v_505 = 0;
+      _fx_LN15C_form__cstmt_t v_506 = 0;
+      _fx_LN14C_form__cexp_t v_507 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_508 = {0};
       _fx_N14C_form__cexp_t e0_0 = 0;
-      _fx_R16Ast__val_flags_t v_488 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_489 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_490 = {0};
+      _fx_R16Ast__val_flags_t v_509 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_510 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_511 = {0};
       _fx_N14C_form__cexp_t t_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_81 = 0;
+      _fx_LN15C_form__cstmt_t ccode_84 = 0;
       int tag_13 = FX_REC_VARIANT_TAG(kexp_0);
       if (tag_13 == 14) {
-         fx_str_t slit_123 = FX_MAKE_STR("tup"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkTuple.t0, &slit_123, &v_478);
+         fx_str_t slit_129 = FX_MAKE_STR("tup"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkTuple.t0, &slit_129, &v_499);
       }
       else if (tag_13 == 15) {
-         fx_str_t slit_124 = FX_MAKE_STR("rec"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkRecord.t0, &slit_124, &v_478);
+         fx_str_t slit_130 = FX_MAKE_STR("rec"); _fx_make_T2LN14K_form__atom_tS(kexp_0->u.KExpMkRecord.t0, &slit_130, &v_499);
       }
       else {
-         fx_exn_t v_491 = {0};
-         fx_str_t slit_125 = FX_MAKE_STR("unexpected expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_125, &v_491, 0), _fx_catch_107);
-         FX_THROW(&v_491, false, _fx_catch_107);
+         fx_exn_t v_512 = {0};
+         fx_str_t slit_131 = FX_MAKE_STR("unexpected expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_131, &v_512, 0), _fx_catch_111);
+         FX_THROW(&v_512, false, _fx_catch_111);
 
-      _fx_catch_107: ;
-         fx_free_exn(&v_491);
+      _fx_catch_111: ;
+         fx_free_exn(&v_512);
       }
-      FX_CHECK_EXN(_fx_catch_109);
-      FX_COPY_PTR(v_478.t0, &args_10);
-      fx_copy_str(&v_478.t1, &prefix_2);
+      FX_CHECK_EXN(_fx_catch_113);
+      FX_COPY_PTR(v_499.t0, &args_10);
+      fx_copy_str(&v_499.t1, &prefix_2);
       _fx_R9Ast__id_t tcon_0;
       FX_CALL(
          _fx_M11C_gen_typesFM15get_constructorR9Ast__id_t3N14C_form__ctyp_tBR10Ast__loc_t(ctyp_0, false, &kloc_0, &tcon_0, 0),
-         _fx_catch_109);
-      FX_COPY_PTR(ccode_0, &ccode_79);
+         _fx_catch_113);
+      FX_COPY_PTR(ccode_0, &ccode_82);
       _fx_LN14K_form__atom_t lst_7 = args_10;
       for (; lst_7; lst_7 = lst_7->tl) {
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_492 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_513 = {0};
          _fx_N14C_form__cexp_t ca_0 = 0;
          _fx_LN15C_form__cstmt_t ccode1_6 = 0;
          _fx_N14C_form__cexp_t ca_1 = 0;
-         _fx_LN14C_form__cexp_t v_493 = 0;
+         _fx_LN14C_form__cexp_t v_514 = 0;
          _fx_N14K_form__atom_t* a_2 = &lst_7->hd;
          FX_CALL(
-            atom2cexp_0.fp(a_2, ccode_79, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_492, atom2cexp_0.fcv), _fx_catch_108);
-         FX_COPY_PTR(v_492.t0, &ca_0);
-         FX_COPY_PTR(v_492.t1, &ccode1_6);
+            atom2cexp_0.fp(a_2, ccode_82, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
+               &v_513, atom2cexp_0.fcv), _fx_catch_112);
+         FX_COPY_PTR(v_513.t0, &ca_0);
+         FX_COPY_PTR(v_513.t1, &ccode1_6);
          bool res_16;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&tcon_0, &_fx_g9Ast__noid, &res_16, 0), _fx_catch_108);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&tcon_0, &_fx_g9Ast__noid, &res_16, 0), _fx_catch_112);
          if (res_16) {
             FX_COPY_PTR(ca_0, &ca_1);
          }
          else {
             FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(ca_0, &kloc_0, &ca_1, 0),
-               _fx_catch_108);
+               _fx_catch_112);
          }
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_1, cargs_3, true, &v_493), _fx_catch_108);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_1, cargs_3, true, &v_514), _fx_catch_112);
          _fx_free_LN14C_form__cexp_t(&cargs_3);
-         FX_COPY_PTR(v_493, &cargs_3);
-         _fx_free_LN15C_form__cstmt_t(&ccode_79);
-         FX_COPY_PTR(ccode1_6, &ccode_79);
+         FX_COPY_PTR(v_514, &cargs_3);
+         _fx_free_LN15C_form__cstmt_t(&ccode_82);
+         FX_COPY_PTR(ccode1_6, &ccode_82);
 
-      _fx_catch_108: ;
-         if (v_493) {
-            _fx_free_LN14C_form__cexp_t(&v_493);
+      _fx_catch_112: ;
+         if (v_514) {
+            _fx_free_LN14C_form__cexp_t(&v_514);
          }
          if (ca_1) {
             _fx_free_N14C_form__cexp_t(&ca_1);
@@ -26336,95 +26575,95 @@ static int
          if (ca_0) {
             _fx_free_N14C_form__cexp_t(&ca_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_492);
-         FX_CHECK_EXN(_fx_catch_109);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_513);
+         FX_CHECK_EXN(_fx_catch_113);
       }
       bool res_17;
-      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&tcon_0, &_fx_g9Ast__noid, &res_17, 0), _fx_catch_109);
+      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&tcon_0, &_fx_g9Ast__noid, &res_17, 0), _fx_catch_113);
       if (res_17) {
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &prefix_2, ctyp_0, ccode_79, &kloc_0, block_stack_ref_0, km_idx_0, &v_479, 0), _fx_catch_109);
-         FX_COPY_PTR(v_479.t0, &t_exp_0);
-         FX_COPY_PTR(v_479.t1, &ccode_80);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_480, 0), _fx_catch_109);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_0, &v_481, 0), _fx_catch_109);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_481, 0, true, &v_482), _fx_catch_109);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_480, v_482, &v_483, 0),
-            _fx_catch_109);
+               dstexp_r_0, &prefix_2, ctyp_0, ccode_82, &kloc_0, block_stack_ref_0, km_idx_0, &v_500, 0), _fx_catch_113);
+         FX_COPY_PTR(v_500.t0, &t_exp_0);
+         FX_COPY_PTR(v_500.t1, &ccode_83);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_501, 0), _fx_catch_113);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_0, &v_502, 0), _fx_catch_113);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_502, 0, true, &v_503), _fx_catch_113);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_501, v_503, &v_504, 0),
+            _fx_catch_113);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&tcon_0,
-               v_483, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_0, 0), _fx_catch_109);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_0, &v_484), _fx_catch_109);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_484, ccode_80, true, &v_485), _fx_catch_109);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, t_exp_0, v_485, &v_1);
+               v_504, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_0, 0), _fx_catch_113);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_0, &v_505), _fx_catch_113);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_505, ccode_83, true, &v_506), _fx_catch_113);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, t_exp_0, v_506, &v_1);
       }
       else {
          _fx_R9Ast__id_t tup_2;
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &prefix_2, &tup_2, 0), _fx_catch_109);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_486, 0), _fx_catch_109);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_487);
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &prefix_2, &tup_2, 0), _fx_catch_113);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_3, &v_507, 0), _fx_catch_113);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_508);
          FX_CALL(
-            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_486, &v_487, &e0_0),
-            _fx_catch_109);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_488, 0), _fx_catch_109);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_0, &v_489);
-         fx_str_t slit_126 = FX_MAKE_STR("");
+            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_507, &v_508, &e0_0),
+            _fx_catch_113);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_509, 0), _fx_catch_113);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_0, &v_510);
+         fx_str_t slit_132 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &tup_2, ctyp_0, &v_488, &slit_126, &v_489, ccode_79, &kloc_0, &v_490, 0), _fx_catch_109);
-         FX_COPY_PTR(v_490.t0, &t_exp_1);
-         FX_COPY_PTR(v_490.t1, &ccode_81);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, t_exp_1, ccode_81, &v_1);
+               &tup_2, ctyp_0, &v_509, &slit_132, &v_510, ccode_82, &kloc_0, &v_511, 0), _fx_catch_113);
+         FX_COPY_PTR(v_511.t0, &t_exp_1);
+         FX_COPY_PTR(v_511.t1, &ccode_84);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, t_exp_1, ccode_84, &v_1);
       }
 
-   _fx_catch_109: ;
-      if (ccode_81) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_81);
+   _fx_catch_113: ;
+      if (ccode_84) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_84);
       }
       if (t_exp_1) {
          _fx_free_N14C_form__cexp_t(&t_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_490);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_489);
-      _fx_free_R16Ast__val_flags_t(&v_488);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_511);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_510);
+      _fx_free_R16Ast__val_flags_t(&v_509);
       if (e0_0) {
          _fx_free_N14C_form__cexp_t(&e0_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_487);
-      if (v_486) {
-         _fx_free_LN14C_form__cexp_t(&v_486);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_508);
+      if (v_507) {
+         _fx_free_LN14C_form__cexp_t(&v_507);
       }
-      if (v_485) {
-         _fx_free_LN15C_form__cstmt_t(&v_485);
+      if (v_506) {
+         _fx_free_LN15C_form__cstmt_t(&v_506);
       }
-      if (v_484) {
-         _fx_free_N15C_form__cstmt_t(&v_484);
+      if (v_505) {
+         _fx_free_N15C_form__cstmt_t(&v_505);
       }
       if (call_mktup_0) {
          _fx_free_N14C_form__cexp_t(&call_mktup_0);
       }
-      if (v_483) {
-         _fx_free_LN14C_form__cexp_t(&v_483);
+      if (v_504) {
+         _fx_free_LN14C_form__cexp_t(&v_504);
       }
-      if (v_482) {
-         _fx_free_LN14C_form__cexp_t(&v_482);
+      if (v_503) {
+         _fx_free_LN14C_form__cexp_t(&v_503);
       }
-      if (v_481) {
-         _fx_free_N14C_form__cexp_t(&v_481);
+      if (v_502) {
+         _fx_free_N14C_form__cexp_t(&v_502);
       }
-      if (v_480) {
-         _fx_free_LN14C_form__cexp_t(&v_480);
+      if (v_501) {
+         _fx_free_LN14C_form__cexp_t(&v_501);
       }
-      if (ccode_80) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_80);
+      if (ccode_83) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_83);
       }
       if (t_exp_0) {
          _fx_free_N14C_form__cexp_t(&t_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_479);
-      if (ccode_79) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_79);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_500);
+      if (ccode_82) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_82);
       }
       if (cargs_3) {
          _fx_free_LN14C_form__cexp_t(&cargs_3);
@@ -26433,104 +26672,104 @@ static int
       if (args_10) {
          _fx_free_LN14K_form__atom_t(&args_10);
       }
-      _fx_free_T2LN14K_form__atom_tS(&v_478);
+      _fx_free_T2LN14K_form__atom_tS(&v_499);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 16) {
-      fx_str_t v_494 = {0};
+      fx_str_t v_515 = {0};
       fx_str_t fp_prefix_0 = {0};
       _fx_N14C_form__cexp_t f_exp_4 = 0;
-      _fx_N14C_form__cexp_t v_495 = 0;
-      _fx_LN14C_form__cexp_t v_496 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_497 = {0};
+      _fx_N14C_form__cexp_t v_516 = 0;
+      _fx_LN14C_form__cexp_t v_517 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_518 = {0};
       _fx_N14C_form__cexp_t e0_1 = 0;
-      _fx_R16Ast__val_flags_t v_498 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_499 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_500 = {0};
+      _fx_R16Ast__val_flags_t v_519 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_520 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_521 = {0};
       _fx_N14C_form__cexp_t fp_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_82 = 0;
+      _fx_LN15C_form__cstmt_t ccode_85 = 0;
       _fx_LN14C_form__cexp_t cargs_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_83 = 0;
+      _fx_LN15C_form__cstmt_t ccode_86 = 0;
       _fx_LN14K_form__atom_t args_11 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_501 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_522 = {0};
       _fx_N14C_form__cexp_t fp_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_84 = 0;
-      _fx_LN14C_form__cexp_t v_502 = 0;
-      _fx_N14C_form__cexp_t v_503 = 0;
-      _fx_LN14C_form__cexp_t v_504 = 0;
-      _fx_LN14C_form__cexp_t v_505 = 0;
+      _fx_LN15C_form__cstmt_t ccode_87 = 0;
+      _fx_LN14C_form__cexp_t v_523 = 0;
+      _fx_N14C_form__cexp_t v_524 = 0;
+      _fx_LN14C_form__cexp_t v_525 = 0;
+      _fx_LN14C_form__cexp_t v_526 = 0;
       _fx_N14C_form__cexp_t call_mkclo_0 = 0;
-      _fx_N15C_form__cstmt_t v_506 = 0;
-      _fx_LN15C_form__cstmt_t v_507 = 0;
+      _fx_N15C_form__cstmt_t v_527 = 0;
+      _fx_LN15C_form__cstmt_t v_528 = 0;
       _fx_T4R9Ast__id_tR9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_9 = &kexp_0->u.KExpMkClosure;
       _fx_LN14K_form__atom_t args_12 = vcase_9->t2;
       _fx_R9Ast__id_t* f_4 = &vcase_9->t1;
       _fx_R9Ast__id_t* make_fp_0 = &vcase_9->t0;
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(f_4, &v_494, 0), _fx_catch_111);
-      fx_str_t slit_127 = FX_MAKE_STR("_fp");
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(f_4, &v_515, 0), _fx_catch_115);
+      fx_str_t slit_133 = FX_MAKE_STR("_fp");
       {
-         const fx_str_t strs_27[] = { v_494, slit_127 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_27, 2, &fp_prefix_0), _fx_catch_111);
+         const fx_str_t strs_29[] = { v_515, slit_133 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_29, 2, &fp_prefix_0), _fx_catch_115);
       }
       bool t_10;
       if (args_12 == 0) {
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(make_fp_0, &_fx_g9Ast__noid, &t_10, 0), _fx_catch_111);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(make_fp_0, &_fx_g9Ast__noid, &t_10, 0), _fx_catch_115);
       }
       else {
          t_10 = false;
       }
       if (t_10) {
          _fx_R9Ast__id_t fp_id_0;
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &fp_prefix_0, &fp_id_0, 0), _fx_catch_111);
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &fp_prefix_0, &fp_id_0, 0), _fx_catch_115);
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               f_4, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_111);
+               f_4, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_115);
          FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(f_4, &kloc_0, &f_exp_4, 0),
-            _fx_catch_111);
-         FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_495, 0), _fx_catch_111);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_495, 0, true, &v_496), _fx_catch_111);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(f_exp_4, v_496, false, &v_496), _fx_catch_111);
-         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_497);
+            _fx_catch_115);
+         FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_516, 0), _fx_catch_115);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_516, 0, true, &v_517), _fx_catch_115);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(f_exp_4, v_517, false, &v_517), _fx_catch_115);
+         _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_518);
          FX_CALL(
-            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_496, &v_497, &e0_1),
-            _fx_catch_111);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_498, 0), _fx_catch_111);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_1, &v_499);
-         fx_str_t slit_128 = FX_MAKE_STR("");
+            _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_517, &v_518, &e0_1),
+            _fx_catch_115);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_519, 0), _fx_catch_115);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(e0_1, &v_520);
+         fx_str_t slit_134 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &fp_id_0, ctyp_0, &v_498, &slit_128, &v_499, ccode_0, &kloc_0, &v_500, 0), _fx_catch_111);
-         FX_COPY_PTR(v_500.t0, &fp_exp_0);
-         FX_COPY_PTR(v_500.t1, &ccode_82);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, fp_exp_0, ccode_82, &v_1);
+               &fp_id_0, ctyp_0, &v_519, &slit_134, &v_520, ccode_0, &kloc_0, &v_521, 0), _fx_catch_115);
+         FX_COPY_PTR(v_521.t0, &fp_exp_0);
+         FX_COPY_PTR(v_521.t1, &ccode_85);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, fp_exp_0, ccode_85, &v_1);
       }
       else {
-         FX_COPY_PTR(ccode_0, &ccode_83);
+         FX_COPY_PTR(ccode_0, &ccode_86);
          FX_COPY_PTR(args_12, &args_11);
          _fx_LN14K_form__atom_t lst_8 = args_11;
          for (; lst_8; lst_8 = lst_8->tl) {
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_508 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_529 = {0};
             _fx_N14C_form__cexp_t ca_2 = 0;
             _fx_LN15C_form__cstmt_t ccode1_7 = 0;
             _fx_N14C_form__cexp_t ca_3 = 0;
-            _fx_LN14C_form__cexp_t v_509 = 0;
+            _fx_LN14C_form__cexp_t v_530 = 0;
             _fx_N14K_form__atom_t* a_3 = &lst_8->hd;
             FX_CALL(
-               atom2cexp_0.fp(a_3, ccode_83, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_508, atom2cexp_0.fcv), _fx_catch_110);
-            FX_COPY_PTR(v_508.t0, &ca_2);
-            FX_COPY_PTR(v_508.t1, &ccode1_7);
+               atom2cexp_0.fp(a_3, ccode_86, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_529, atom2cexp_0.fcv), _fx_catch_114);
+            FX_COPY_PTR(v_529.t0, &ca_2);
+            FX_COPY_PTR(v_529.t1, &ccode1_7);
             FX_CALL(_fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(ca_2, &kloc_0, &ca_3, 0),
-               _fx_catch_110);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_3, cargs_4, true, &v_509), _fx_catch_110);
+               _fx_catch_114);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ca_3, cargs_4, true, &v_530), _fx_catch_114);
             _fx_free_LN14C_form__cexp_t(&cargs_4);
-            FX_COPY_PTR(v_509, &cargs_4);
-            _fx_free_LN15C_form__cstmt_t(&ccode_83);
-            FX_COPY_PTR(ccode1_7, &ccode_83);
+            FX_COPY_PTR(v_530, &cargs_4);
+            _fx_free_LN15C_form__cstmt_t(&ccode_86);
+            FX_COPY_PTR(ccode1_7, &ccode_86);
 
-         _fx_catch_110: ;
-            if (v_509) {
-               _fx_free_LN14C_form__cexp_t(&v_509);
+         _fx_catch_114: ;
+            if (v_530) {
+               _fx_free_LN14C_form__cexp_t(&v_530);
             }
             if (ca_3) {
                _fx_free_N14C_form__cexp_t(&ca_3);
@@ -26541,179 +26780,179 @@ static int
             if (ca_2) {
                _fx_free_N14C_form__cexp_t(&ca_2);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_508);
-            FX_CHECK_EXN(_fx_catch_111);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_529);
+            FX_CHECK_EXN(_fx_catch_115);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &fp_prefix_0, ctyp_0, ccode_83, &kloc_0, block_stack_ref_0, km_idx_0, &v_501, 0), _fx_catch_111);
-         FX_COPY_PTR(v_501.t0, &fp_exp_1);
-         FX_COPY_PTR(v_501.t1, &ccode_84);
+               dstexp_r_0, &fp_prefix_0, ctyp_0, ccode_86, &kloc_0, block_stack_ref_0, km_idx_0, &v_522, 0), _fx_catch_115);
+         FX_COPY_PTR(v_522.t0, &fp_exp_1);
+         FX_COPY_PTR(v_522.t1, &ccode_87);
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               make_fp_0, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_111);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_4, &v_502, 0), _fx_catch_111);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(fp_exp_1, &v_503, 0), _fx_catch_111);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_503, 0, true, &v_504), _fx_catch_111);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_502, v_504, &v_505, 0),
-            _fx_catch_111);
+               make_fp_0, &kloc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_115);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(cargs_4, &v_523, 0), _fx_catch_115);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(fp_exp_1, &v_524, 0), _fx_catch_115);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_524, 0, true, &v_525), _fx_catch_115);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_523, v_525, &v_526, 0),
+            _fx_catch_115);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(make_fp_0,
-               v_505, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mkclo_0, 0), _fx_catch_111);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mkclo_0, &v_506), _fx_catch_111);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_506, ccode_84, true, &v_507), _fx_catch_111);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, fp_exp_1, v_507, &v_1);
+               v_526, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mkclo_0, 0), _fx_catch_115);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mkclo_0, &v_527), _fx_catch_115);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_527, ccode_87, true, &v_528), _fx_catch_115);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, fp_exp_1, v_528, &v_1);
       }
 
-   _fx_catch_111: ;
-      if (v_507) {
-         _fx_free_LN15C_form__cstmt_t(&v_507);
+   _fx_catch_115: ;
+      if (v_528) {
+         _fx_free_LN15C_form__cstmt_t(&v_528);
       }
-      if (v_506) {
-         _fx_free_N15C_form__cstmt_t(&v_506);
+      if (v_527) {
+         _fx_free_N15C_form__cstmt_t(&v_527);
       }
       if (call_mkclo_0) {
          _fx_free_N14C_form__cexp_t(&call_mkclo_0);
       }
-      if (v_505) {
-         _fx_free_LN14C_form__cexp_t(&v_505);
+      if (v_526) {
+         _fx_free_LN14C_form__cexp_t(&v_526);
       }
-      if (v_504) {
-         _fx_free_LN14C_form__cexp_t(&v_504);
+      if (v_525) {
+         _fx_free_LN14C_form__cexp_t(&v_525);
       }
-      if (v_503) {
-         _fx_free_N14C_form__cexp_t(&v_503);
+      if (v_524) {
+         _fx_free_N14C_form__cexp_t(&v_524);
       }
-      if (v_502) {
-         _fx_free_LN14C_form__cexp_t(&v_502);
+      if (v_523) {
+         _fx_free_LN14C_form__cexp_t(&v_523);
       }
-      if (ccode_84) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_84);
+      if (ccode_87) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_87);
       }
       if (fp_exp_1) {
          _fx_free_N14C_form__cexp_t(&fp_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_501);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_522);
       if (args_11) {
          _fx_free_LN14K_form__atom_t(&args_11);
       }
-      if (ccode_83) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_83);
+      if (ccode_86) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_86);
       }
       if (cargs_4) {
          _fx_free_LN14C_form__cexp_t(&cargs_4);
       }
-      if (ccode_82) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_82);
+      if (ccode_85) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_85);
       }
       if (fp_exp_0) {
          _fx_free_N14C_form__cexp_t(&fp_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_500);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_499);
-      _fx_free_R16Ast__val_flags_t(&v_498);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_521);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_520);
+      _fx_free_R16Ast__val_flags_t(&v_519);
       if (e0_1) {
          _fx_free_N14C_form__cexp_t(&e0_1);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_497);
-      if (v_496) {
-         _fx_free_LN14C_form__cexp_t(&v_496);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_518);
+      if (v_517) {
+         _fx_free_LN14C_form__cexp_t(&v_517);
       }
-      if (v_495) {
-         _fx_free_N14C_form__cexp_t(&v_495);
+      if (v_516) {
+         _fx_free_N14C_form__cexp_t(&v_516);
       }
       if (f_exp_4) {
          _fx_free_N14C_form__cexp_t(&f_exp_4);
       }
       FX_FREE_STR(&fp_prefix_0);
-      FX_FREE_STR(&v_494);
+      FX_FREE_STR(&v_515);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 17) {
       _fx_LLT2BN14K_form__atom_t arows_0 = 0;
-      _fx_T2iN14C_form__ctyp_t v_510 = {0};
-      _fx_N14C_form__ctyp_t elem_ctyp_1 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_511 = {0};
+      _fx_T2iN14C_form__ctyp_t v_531 = {0};
+      _fx_N14C_form__ctyp_t elem_ctyp_2 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_532 = {0};
       _fx_N14C_form__cexp_t arr_exp_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_85 = 0;
-      _fx_N14C_form__ctyp_t v_512 = 0;
+      _fx_LN15C_form__cstmt_t ccode_88 = 0;
+      _fx_N14C_form__ctyp_t v_533 = 0;
       _fx_N14C_form__cexp_t scalars_exp_0 = 0;
       _fx_LN14C_form__cexp_t scalars_data_0 = 0;
       _fx_LN14C_form__cexp_t tags_data_0 = 0;
       _fx_LN14C_form__cexp_t arr_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_86 = 0;
+      _fx_LN15C_form__cstmt_t ccode_89 = 0;
       _fx_LLT2BN14K_form__atom_t arows_1 = 0;
-      _fx_LN14C_form__cexp_t v_513 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_514 = {0};
+      _fx_LN14C_form__cexp_t v_534 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_535 = {0};
       _fx_LN15C_form__cstmt_t sub_ccode_2 = 0;
-      _fx_N14C_form__cexp_t v_515 = 0;
-      _fx_LN14C_form__cexp_t v_516 = 0;
-      _fx_LN14C_form__cexp_t v_517 = 0;
+      _fx_N14C_form__cexp_t v_536 = 0;
+      _fx_LN14C_form__cexp_t v_537 = 0;
+      _fx_LN14C_form__cexp_t v_538 = 0;
       _fx_LN14C_form__cexp_t tags_data_1 = 0;
-      _fx_N14C_form__ctyp_t v_518 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_519 = {0};
+      _fx_N14C_form__ctyp_t v_539 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_540 = {0};
       _fx_N14C_form__cexp_t tags_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_3 = 0;
-      _fx_LN14C_form__cexp_t v_520 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_521 = {0};
+      _fx_LN14C_form__cexp_t v_541 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_542 = {0};
       _fx_N14C_form__cexp_t arr_data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_4 = 0;
-      _fx_N14C_form__cexp_t v_522 = 0;
-      _fx_LN14C_form__cexp_t v_523 = 0;
+      _fx_N14C_form__cexp_t v_543 = 0;
+      _fx_LN14C_form__cexp_t v_544 = 0;
       _fx_N14C_form__cexp_t sizeof_elem_exp_0 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_524 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_545 = {0};
       _fx_N14C_form__cexp_t free_f_exp_0 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_525 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_546 = {0};
       _fx_N14C_form__cexp_t copy_f_exp_0 = 0;
-      _fx_N14C_form__cexp_t v_526 = 0;
-      _fx_N14C_form__cexp_t v_527 = 0;
-      _fx_LN14C_form__cexp_t v_528 = 0;
+      _fx_N14C_form__cexp_t v_547 = 0;
+      _fx_N14C_form__cexp_t v_548 = 0;
+      _fx_LN14C_form__cexp_t v_549 = 0;
       _fx_N14C_form__cexp_t call_mkarr_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_5 = 0;
-      _fx_N15C_form__cstmt_t v_529 = 0;
-      _fx_LN15C_form__cstmt_t ccode_87 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_530 = {0};
+      _fx_N15C_form__cstmt_t v_550 = 0;
+      _fx_LN15C_form__cstmt_t ccode_90 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_551 = {0};
       _fx_N14C_form__cexp_t arr_exp_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_88 = 0;
-      _fx_LT2BN14K_form__atom_t v_531 = 0;
+      _fx_LN15C_form__cstmt_t ccode_91 = 0;
+      _fx_LT2BN14K_form__atom_t v_552 = 0;
       _fx_Li shape_0 = 0;
-      _fx_Li v_532 = 0;
+      _fx_Li v_553 = 0;
       _fx_LN14C_form__cexp_t shape_1 = 0;
       _fx_LN14C_form__cexp_t data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_89 = 0;
+      _fx_LN15C_form__cstmt_t ccode_92 = 0;
       _fx_LLT2BN14K_form__atom_t arows_2 = 0;
-      _fx_LN19C_form__ctyp_attr_t v_533 = 0;
+      _fx_LN19C_form__ctyp_attr_t v_554 = 0;
       _fx_N14C_form__ctyp_t shape_ctyp_0 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_534 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_555 = {0};
       _fx_N14C_form__cexp_t shape_arr_0 = 0;
-      _fx_R16Ast__val_flags_t v_535 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_536 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_537 = {0};
+      _fx_R16Ast__val_flags_t v_556 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_557 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_558 = {0};
       _fx_N14C_form__cexp_t shape_exp_0 = 0;
       _fx_LN15C_form__cstmt_t ccode__0 = 0;
-      _fx_LN14C_form__cexp_t v_538 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_539 = {0};
+      _fx_LN14C_form__cexp_t v_559 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_560 = {0};
       _fx_N14C_form__cexp_t data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t glob_data_ccode__0 = 0;
       _fx_R17C_form__cdefval_t data_cv_0 = {0};
       _fx_R16Ast__val_flags_t data_flags_0 = {0};
-      _fx_R16Ast__val_flags_t v_540 = {0};
-      _fx_R17C_form__cdefval_t v_541 = {0};
-      _fx_N15C_form__cinfo_t v_542 = {0};
-      _fx_Ta3N14C_form__cexp_t v_543 = {0};
+      _fx_R16Ast__val_flags_t v_561 = {0};
+      _fx_R17C_form__cdefval_t v_562 = {0};
+      _fx_N15C_form__cinfo_t v_563 = {0};
+      _fx_Ta3N14C_form__cexp_t v_564 = {0};
       _fx_N14C_form__cexp_t sizeof_elem_exp_1 = 0;
       _fx_N14C_form__cexp_t free_f_exp_1 = 0;
       _fx_N14C_form__cexp_t copy_f_exp_1 = 0;
-      _fx_N14C_form__cexp_t v_544 = 0;
-      _fx_N14C_form__cexp_t v_545 = 0;
-      _fx_LN14C_form__cexp_t v_546 = 0;
+      _fx_N14C_form__cexp_t v_565 = 0;
+      _fx_N14C_form__cexp_t v_566 = 0;
+      _fx_LN14C_form__cexp_t v_567 = 0;
       _fx_N14C_form__cexp_t call_mkarr_1 = 0;
       _fx_LN15C_form__cstmt_t ccode__1 = 0;
-      _fx_N15C_form__cstmt_t v_547 = 0;
-      _fx_LN15C_form__cstmt_t v_548 = 0;
-      _fx_LN14C_form__cexp_t v_549 = 0;
-      _fx_N14C_form__cexp_t v_550 = 0;
-      _fx_LN15C_form__cstmt_t ccode_90 = 0;
+      _fx_N15C_form__cstmt_t v_568 = 0;
+      _fx_LN15C_form__cstmt_t v_569 = 0;
+      _fx_LN14C_form__cexp_t v_570 = 0;
+      _fx_N14C_form__cexp_t v_571 = 0;
+      _fx_LN15C_form__cstmt_t ccode_93 = 0;
       _fx_T3BLLT2BN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_10 = &kexp_0->u.KExpMkArray;
       _fx_LLT2BN14K_form__atom_t arows_3 = vcase_10->t1;
       bool all_literals_0 = vcase_10->t0;
@@ -26729,20 +26968,20 @@ static int
             for (; lst_10; lst_10 = lst_10->tl) {
                _fx_T2BN14K_form__atom_t* __pat___0 = &lst_10->hd;
                if (__pat___0->t0) {
-                  __fold_result___1 = true; FX_BREAK(_fx_catch_112);
+                  __fold_result___1 = true; FX_BREAK(_fx_catch_116);
                }
 
-            _fx_catch_112: ;
+            _fx_catch_116: ;
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_113);
+               FX_CHECK_EXN(_fx_catch_117);
             }
             if (__fold_result___1) {
-               __fold_result___0 = true; FX_BREAK(_fx_catch_113);
+               __fold_result___0 = true; FX_BREAK(_fx_catch_117);
             }
 
-         _fx_catch_113: ;
+         _fx_catch_117: ;
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_129);
+            FX_CHECK_EXN(_fx_catch_133);
          }
          have_expanded_0 = __fold_result___0;
       }
@@ -26751,197 +26990,197 @@ static int
       }
       if (FX_REC_VARIANT_TAG(ctyp_0) == 19) {
          _fx_T2iN14C_form__ctyp_t* vcase_11 = &ctyp_0->u.CTypArray;
-         _fx_make_T2iN14C_form__ctyp_t(vcase_11->t0, vcase_11->t1, &v_510);
+         _fx_make_T2iN14C_form__ctyp_t(vcase_11->t0, vcase_11->t1, &v_531);
       }
       else {
-         fx_exn_t v_551 = {0};
-         fx_str_t slit_129 = FX_MAKE_STR("cgen: invalid output type of array construction expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_129, &v_551, 0), _fx_catch_114);
-         FX_THROW(&v_551, false, _fx_catch_114);
+         fx_exn_t v_572 = {0};
+         fx_str_t slit_135 = FX_MAKE_STR("cgen: invalid output type of array construction expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_135, &v_572, 0), _fx_catch_118);
+         FX_THROW(&v_572, false, _fx_catch_118);
 
-      _fx_catch_114: ;
-         fx_free_exn(&v_551);
+      _fx_catch_118: ;
+         fx_free_exn(&v_572);
       }
-      FX_CHECK_EXN(_fx_catch_129);
-      int_ dims_0 = v_510.t0;
-      FX_COPY_PTR(v_510.t1, &elem_ctyp_1);
+      FX_CHECK_EXN(_fx_catch_133);
+      int_ dims_0 = v_531.t0;
+      FX_COPY_PTR(v_531.t1, &elem_ctyp_2);
       if (have_expanded_0) {
-         fx_str_t slit_130 = FX_MAKE_STR("arr");
+         fx_str_t slit_136 = FX_MAKE_STR("arr");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_130, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_511, 0), _fx_catch_129);
-         FX_COPY_PTR(v_511.t0, &arr_exp_3);
-         FX_COPY_PTR(v_511.t1, &ccode_85);
+               dstexp_r_0, &slit_136, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_532, 0), _fx_catch_133);
+         FX_COPY_PTR(v_532.t0, &arr_exp_3);
+         FX_COPY_PTR(v_532.t1, &ccode_88);
          _fx_R9Ast__id_t scalars_id_0;
-         fx_str_t slit_131 = FX_MAKE_STR("scalars");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_131, &scalars_id_0, 0), _fx_catch_129);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_1, &v_512, 0), _fx_catch_129);
+         fx_str_t slit_137 = FX_MAKE_STR("scalars");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_137, &scalars_id_0, 0), _fx_catch_133);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_2, &v_533, 0), _fx_catch_133);
          FX_CALL(
-            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_0, v_512,
-               &kloc_0, &scalars_exp_0, 0), _fx_catch_129);
+            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_0, v_533,
+               &kloc_0, &scalars_exp_0, 0), _fx_catch_133);
          int_ nscalars_0 = 0;
-         FX_COPY_PTR(ccode_85, &ccode_86);
+         FX_COPY_PTR(ccode_88, &ccode_89);
          FX_COPY_PTR(arows_3, &arows_1);
          _fx_LLT2BN14K_form__atom_t lst_11 = arows_1;
          for (; lst_11; lst_11 = lst_11->tl) {
-            _fx_N14C_form__cexp_t v_552 = 0;
-            _fx_LN14C_form__cexp_t v_553 = 0;
+            _fx_N14C_form__cexp_t v_573 = 0;
+            _fx_LN14C_form__cexp_t v_574 = 0;
             _fx_LT2BN14K_form__atom_t arow_1 = lst_11->hd;
             _fx_LT2BN14K_form__atom_t lst_12 = arow_1;
             for (; lst_12; lst_12 = lst_12->tl) {
                _fx_N14K_form__atom_t a_4 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_554 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_575 = {0};
                _fx_N14C_form__cexp_t e_10 = 0;
                _fx_LN15C_form__cstmt_t ccode1_8 = 0;
                _fx_N14K_form__ktyp_t elem_ktyp_0 = 0;
-               _fx_N14K_form__ktyp_t v_555 = 0;
-               _fx_T2iN14C_form__cexp_t v_556 = {0};
+               _fx_N14K_form__ktyp_t v_576 = 0;
+               _fx_T2iN14C_form__cexp_t v_577 = {0};
                _fx_N14C_form__cexp_t elem_ptr_0 = 0;
-               _fx_N14C_form__cexp_t v_557 = 0;
-               _fx_LN14C_form__cexp_t v_558 = 0;
-               _fx_LN14C_form__cexp_t v_559 = 0;
-               _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_560 = {0};
+               _fx_N14C_form__cexp_t v_578 = 0;
+               _fx_LN14C_form__cexp_t v_579 = 0;
+               _fx_LN14C_form__cexp_t v_580 = 0;
+               _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_581 = {0};
                _fx_LN14C_form__cexp_t scalars_data1_0 = 0;
                _fx_N14C_form__cexp_t arr_data_elem_0 = 0;
-               _fx_N14C_form__cexp_t v_561 = 0;
-               _fx_LN14C_form__cexp_t v_562 = 0;
-               _fx_LN14C_form__cexp_t v_563 = 0;
+               _fx_N14C_form__cexp_t v_582 = 0;
+               _fx_LN14C_form__cexp_t v_583 = 0;
+               _fx_LN14C_form__cexp_t v_584 = 0;
                _fx_T2BN14K_form__atom_t* __pat___1 = &lst_12->hd;
                _fx_copy_N14K_form__atom_t(&__pat___1->t1, &a_4);
                FX_CALL(
-                  atom2cexp_0.fp(&a_4, ccode_86, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                     km_idx_0, &v_554, atom2cexp_0.fcv), _fx_catch_120);
-               FX_COPY_PTR(v_554.t0, &e_10);
-               FX_COPY_PTR(v_554.t1, &ccode1_8);
-               _fx_free_LN15C_form__cstmt_t(&ccode_86);
-               FX_COPY_PTR(ccode1_8, &ccode_86);
+                  atom2cexp_0.fp(&a_4, ccode_89, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                     km_idx_0, &v_575, atom2cexp_0.fcv), _fx_catch_124);
+               FX_COPY_PTR(v_575.t0, &e_10);
+               FX_COPY_PTR(v_575.t1, &ccode1_8);
+               _fx_free_LN15C_form__cstmt_t(&ccode_89);
+               FX_COPY_PTR(ccode1_8, &ccode_89);
                if (__pat___1->t0) {
                   FX_CALL(
                      _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_4, &kloc_0, &elem_ktyp_0,
-                        0), _fx_catch_120);
+                        0), _fx_catch_124);
                   FX_CALL(
-                     _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_0, &kloc_0, &v_555,
-                        0), _fx_catch_120);
-                  int tag_14 = FX_REC_VARIANT_TAG(v_555);
+                     _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_0, &kloc_0, &v_576,
+                        0), _fx_catch_124);
+                  int tag_14 = FX_REC_VARIANT_TAG(v_576);
                   if (tag_14 == 17) {
-                     _fx_N14C_form__cexp_t v_564 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_564, 0), _fx_catch_115);
-                     _fx_make_T2iN14C_form__cexp_t(v_555->u.KTypArray.t0, v_564, &v_556);
+                     _fx_N14C_form__cexp_t v_585 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_585, 0), _fx_catch_119);
+                     _fx_make_T2iN14C_form__cexp_t(v_576->u.KTypArray.t0, v_585, &v_577);
 
-                  _fx_catch_115: ;
-                     if (v_564) {
-                        _fx_free_N14C_form__cexp_t(&v_564);
+                  _fx_catch_119: ;
+                     if (v_585) {
+                        _fx_free_N14C_form__cexp_t(&v_585);
                      }
                   }
                   else if (tag_14 == 20) {
-                     _fx_make_T2iN14C_form__cexp_t(100, e_10, &v_556);
+                     _fx_make_T2iN14C_form__cexp_t(100, e_10, &v_577);
                   }
                   else if (tag_14 == 18) {
-                     _fx_N14C_form__cexp_t v_565 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_565, 0), _fx_catch_116);
-                     _fx_make_T2iN14C_form__cexp_t(110, v_565, &v_556);
+                     _fx_N14C_form__cexp_t v_586 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_586, 0), _fx_catch_120);
+                     _fx_make_T2iN14C_form__cexp_t(110, v_586, &v_577);
 
-                  _fx_catch_116: ;
-                     if (v_565) {
-                        _fx_free_N14C_form__cexp_t(&v_565);
+                  _fx_catch_120: ;
+                     if (v_586) {
+                        _fx_free_N14C_form__cexp_t(&v_586);
                      }
                   }
                   else {
-                     fx_str_t v_566 = {0};
-                     fx_str_t v_567 = {0};
-                     fx_str_t v_568 = {0};
-                     fx_exn_t v_569 = {0};
-                     FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_4, &v_566, 0), _fx_catch_117);
-                     FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_566, &v_567, 0), _fx_catch_117);
-                     fx_str_t slit_132 = FX_MAKE_STR("cgen: the expanded structure ");
-                     fx_str_t slit_133 = FX_MAKE_STR(" is not an array, rrbvec or list");
+                     fx_str_t v_587 = {0};
+                     fx_str_t v_588 = {0};
+                     fx_str_t v_589 = {0};
+                     fx_exn_t v_590 = {0};
+                     FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_4, &v_587, 0), _fx_catch_121);
+                     FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_587, &v_588, 0), _fx_catch_121);
+                     fx_str_t slit_138 = FX_MAKE_STR("cgen: the expanded structure ");
+                     fx_str_t slit_139 = FX_MAKE_STR(" is not an array, rrbvec or list");
                      {
-                        const fx_str_t strs_28[] = { slit_132, v_567, slit_133 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_28, 3, &v_568), _fx_catch_117);
+                        const fx_str_t strs_30[] = { slit_138, v_588, slit_139 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_30, 3, &v_589), _fx_catch_121);
                      }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_568, &v_569, 0), _fx_catch_117);
-                     FX_THROW(&v_569, false, _fx_catch_117);
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_589, &v_590, 0), _fx_catch_121);
+                     FX_THROW(&v_590, false, _fx_catch_121);
 
-                  _fx_catch_117: ;
-                     fx_free_exn(&v_569);
-                     FX_FREE_STR(&v_568);
-                     FX_FREE_STR(&v_567);
-                     FX_FREE_STR(&v_566);
+                  _fx_catch_121: ;
+                     fx_free_exn(&v_590);
+                     FX_FREE_STR(&v_589);
+                     FX_FREE_STR(&v_588);
+                     FX_FREE_STR(&v_587);
                   }
-                  FX_CHECK_EXN(_fx_catch_120);
-                  int_ tag_15 = v_556.t0;
-                  FX_COPY_PTR(v_556.t1, &elem_ptr_0);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_15, &kloc_0, &v_557, 0),
-                     _fx_catch_120);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_557, tags_data_0, true, &v_558), _fx_catch_120);
+                  FX_CHECK_EXN(_fx_catch_124);
+                  int_ tag_15 = v_577.t0;
+                  FX_COPY_PTR(v_577.t1, &elem_ptr_0);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_15, &kloc_0, &v_578, 0),
+                     _fx_catch_124);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_578, tags_data_0, true, &v_579), _fx_catch_124);
                   _fx_free_LN14C_form__cexp_t(&tags_data_0);
-                  FX_COPY_PTR(v_558, &tags_data_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_0, arr_data_0, true, &v_559), _fx_catch_120);
+                  FX_COPY_PTR(v_579, &tags_data_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_0, arr_data_0, true, &v_580), _fx_catch_124);
                   _fx_free_LN14C_form__cexp_t(&arr_data_0);
-                  FX_COPY_PTR(v_559, &arr_data_0);
+                  FX_COPY_PTR(v_580, &arr_data_0);
                }
                else {
                   if (FX_REC_VARIANT_TAG(e_10) == 1) {
-                     _fx_N14C_form__cexp_t v_570 = 0;
-                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_570, 0), _fx_catch_118);
-                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0, scalars_data_0, v_570, &v_560);
+                     _fx_N14C_form__cexp_t v_591 = 0;
+                     FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_10, &v_591, 0), _fx_catch_122);
+                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0, scalars_data_0, v_591, &v_581);
 
-                  _fx_catch_118: ;
-                     if (v_570) {
-                        _fx_free_N14C_form__cexp_t(&v_570);
+                  _fx_catch_122: ;
+                     if (v_591) {
+                        _fx_free_N14C_form__cexp_t(&v_591);
                      }
                   }
                   else {
-                     _fx_LN14C_form__cexp_t v_571 = 0;
-                     _fx_N14C_form__cexp_t v_572 = 0;
-                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_573 = {0};
-                     _fx_N14C_form__cexp_t v_574 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(e_10, scalars_data_0, true, &v_571), _fx_catch_119);
-                     FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_0, &kloc_0, &v_572, 0),
-                        _fx_catch_119);
-                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_573);
+                     _fx_LN14C_form__cexp_t v_592 = 0;
+                     _fx_N14C_form__cexp_t v_593 = 0;
+                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_594 = {0};
+                     _fx_N14C_form__cexp_t v_595 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(e_10, scalars_data_0, true, &v_592), _fx_catch_123);
+                     FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_0, &kloc_0, &v_593, 0),
+                        _fx_catch_123);
+                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_594);
                      FX_CALL(
                         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g18C_gen_code__COpAdd, scalars_exp_0, v_572, &v_573, &v_574), _fx_catch_119);
-                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0 + 1, v_571, v_574, &v_560);
+                           &_fx_g18C_gen_code__COpAdd, scalars_exp_0, v_593, &v_594, &v_595), _fx_catch_123);
+                     _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_0 + 1, v_592, v_595, &v_581);
 
-                  _fx_catch_119: ;
-                     if (v_574) {
-                        _fx_free_N14C_form__cexp_t(&v_574);
+                  _fx_catch_123: ;
+                     if (v_595) {
+                        _fx_free_N14C_form__cexp_t(&v_595);
                      }
-                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_573);
-                     if (v_572) {
-                        _fx_free_N14C_form__cexp_t(&v_572);
+                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_594);
+                     if (v_593) {
+                        _fx_free_N14C_form__cexp_t(&v_593);
                      }
-                     if (v_571) {
-                        _fx_free_LN14C_form__cexp_t(&v_571);
+                     if (v_592) {
+                        _fx_free_LN14C_form__cexp_t(&v_592);
                      }
                   }
-                  FX_CHECK_EXN(_fx_catch_120);
-                  int_ nscalars1_0 = v_560.t0;
-                  FX_COPY_PTR(v_560.t1, &scalars_data1_0);
-                  FX_COPY_PTR(v_560.t2, &arr_data_elem_0);
+                  FX_CHECK_EXN(_fx_catch_124);
+                  int_ nscalars1_0 = v_581.t0;
+                  FX_COPY_PTR(v_581.t1, &scalars_data1_0);
+                  FX_COPY_PTR(v_581.t2, &arr_data_elem_0);
                   nscalars_0 = nscalars1_0;
                   _fx_free_LN14C_form__cexp_t(&scalars_data_0);
                   FX_COPY_PTR(scalars_data1_0, &scalars_data_0);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_561, 0), _fx_catch_120);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_561, tags_data_0, true, &v_562), _fx_catch_120);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_582, 0), _fx_catch_124);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_582, tags_data_0, true, &v_583), _fx_catch_124);
                   _fx_free_LN14C_form__cexp_t(&tags_data_0);
-                  FX_COPY_PTR(v_562, &tags_data_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_elem_0, arr_data_0, true, &v_563), _fx_catch_120);
+                  FX_COPY_PTR(v_583, &tags_data_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_elem_0, arr_data_0, true, &v_584), _fx_catch_124);
                   _fx_free_LN14C_form__cexp_t(&arr_data_0);
-                  FX_COPY_PTR(v_563, &arr_data_0);
+                  FX_COPY_PTR(v_584, &arr_data_0);
                }
 
-            _fx_catch_120: ;
-               if (v_563) {
-                  _fx_free_LN14C_form__cexp_t(&v_563);
+            _fx_catch_124: ;
+               if (v_584) {
+                  _fx_free_LN14C_form__cexp_t(&v_584);
                }
-               if (v_562) {
-                  _fx_free_LN14C_form__cexp_t(&v_562);
+               if (v_583) {
+                  _fx_free_LN14C_form__cexp_t(&v_583);
                }
-               if (v_561) {
-                  _fx_free_N14C_form__cexp_t(&v_561);
+               if (v_582) {
+                  _fx_free_N14C_form__cexp_t(&v_582);
                }
                if (arr_data_elem_0) {
                   _fx_free_N14C_form__cexp_t(&arr_data_elem_0);
@@ -26949,22 +27188,22 @@ static int
                if (scalars_data1_0) {
                   _fx_free_LN14C_form__cexp_t(&scalars_data1_0);
                }
-               _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_560);
-               if (v_559) {
-                  _fx_free_LN14C_form__cexp_t(&v_559);
+               _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_581);
+               if (v_580) {
+                  _fx_free_LN14C_form__cexp_t(&v_580);
                }
-               if (v_558) {
-                  _fx_free_LN14C_form__cexp_t(&v_558);
+               if (v_579) {
+                  _fx_free_LN14C_form__cexp_t(&v_579);
                }
-               if (v_557) {
-                  _fx_free_N14C_form__cexp_t(&v_557);
+               if (v_578) {
+                  _fx_free_N14C_form__cexp_t(&v_578);
                }
                if (elem_ptr_0) {
                   _fx_free_N14C_form__cexp_t(&elem_ptr_0);
                }
-               _fx_free_T2iN14C_form__cexp_t(&v_556);
-               if (v_555) {
-                  _fx_free_N14K_form__ktyp_t(&v_555);
+               _fx_free_T2iN14C_form__cexp_t(&v_577);
+               if (v_576) {
+                  _fx_free_N14K_form__ktyp_t(&v_576);
                }
                if (elem_ktyp_0) {
                   _fx_free_N14K_form__ktyp_t(&elem_ktyp_0);
@@ -26975,152 +27214,152 @@ static int
                if (e_10) {
                   _fx_free_N14C_form__cexp_t(&e_10);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_554);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_575);
                _fx_free_N14K_form__atom_t(&a_4);
-               FX_CHECK_EXN(_fx_catch_121);
+               FX_CHECK_EXN(_fx_catch_125);
             }
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(127, &kloc_0, &v_552, 0), _fx_catch_121);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_552, tags_data_0, true, &v_553), _fx_catch_121);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(127, &kloc_0, &v_573, 0), _fx_catch_125);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_573, tags_data_0, true, &v_574), _fx_catch_125);
             _fx_free_LN14C_form__cexp_t(&tags_data_0);
-            FX_COPY_PTR(v_553, &tags_data_0);
-
-         _fx_catch_121: ;
-            if (v_553) {
-               _fx_free_LN14C_form__cexp_t(&v_553);
-            }
-            if (v_552) {
-               _fx_free_N14C_form__cexp_t(&v_552);
-            }
-            FX_CHECK_EXN(_fx_catch_129);
-         }
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_0, &v_513, 0), _fx_catch_129);
-         FX_CALL(
-            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &scalars_id_0, elem_ctyp_1, v_513, 0, &kloc_0, &v_514, 0), _fx_catch_129);
-         FX_COPY_PTR(v_514.t1, &sub_ccode_2);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_515, 0), _fx_catch_129);
-         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_0, &v_516, 0), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_515, v_516, true, &v_517), _fx_catch_129);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_517, &tags_data_1, 0), _fx_catch_129);
-         _fx_R9Ast__id_t v_575;
-         fx_str_t slit_134 = FX_MAKE_STR("tags");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_134, &v_575, 0), _fx_catch_129);
-         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_518), _fx_catch_129);
-         FX_CALL(
-            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_575, v_518, tags_data_1, sub_ccode_2, &kloc_0, &v_519, 0), _fx_catch_129);
-         FX_COPY_PTR(v_519.t0, &tags_exp_0);
-         FX_COPY_PTR(v_519.t1, &sub_ccode_3);
-         _fx_R9Ast__id_t v_576;
-         fx_str_t slit_135 = FX_MAKE_STR("parts");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_135, &v_576, 0), _fx_catch_129);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(arr_data_0, &v_520, 0), _fx_catch_129);
-         FX_CALL(
-            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_576, _fx_g23C_form__std_CTypVoidPtr, v_520, sub_ccode_3, &kloc_0, &v_521, 0), _fx_catch_129);
-         FX_COPY_PTR(v_521.t0, &arr_data_exp_0);
-         FX_COPY_PTR(v_521.t1, &sub_ccode_4);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_1, &kloc_0, &v_522),
-            _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_522, 0, true, &v_523), _fx_catch_129);
-         FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g18C_form__std_sizeof, v_523, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_0, 0),
-            _fx_catch_129);
-         FX_CALL(
-            _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_1, true,
-               false, &kloc_0, &v_524, 0), _fx_catch_129);
-         _fx_Nt6option1N14C_form__cexp_t* v_577 = &v_524.t1;
-         if (v_577->tag == 2) {
-            FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_577->u.Some,
-                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_0), _fx_catch_122);
-
-         _fx_catch_122: ;
-         }
-         else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_0, 0), _fx_catch_123);
-
-         _fx_catch_123: ;
-         }
-         FX_CHECK_EXN(_fx_catch_129);
-         FX_CALL(
-            _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_1, true,
-               false, &kloc_0, &v_525, 0), _fx_catch_129);
-         _fx_Nt6option1N14C_form__cexp_t* v_578 = &v_525.t1;
-         if (v_578->tag == 2) {
-            FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_578->u.Some,
-                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_0), _fx_catch_124);
-
-         _fx_catch_124: ;
-         }
-         else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_0, 0), _fx_catch_125);
+            FX_COPY_PTR(v_574, &tags_data_0);
 
          _fx_catch_125: ;
+            if (v_574) {
+               _fx_free_LN14C_form__cexp_t(&v_574);
+            }
+            if (v_573) {
+               _fx_free_N14C_form__cexp_t(&v_573);
+            }
+            FX_CHECK_EXN(_fx_catch_133);
          }
-         FX_CHECK_EXN(_fx_catch_129);
-         _fx_R9Ast__id_t v_579;
-         fx_str_t slit_136 = FX_MAKE_STR("fx_compose_arr");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_136, &v_579, 0), _fx_catch_129);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_0, &kloc_0, &v_526, 0), _fx_catch_129);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_3, &v_527, 0), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_527, 0, true, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_exp_0, v_528, false, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_0, v_528, false, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_0, v_528, false, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_0, v_528, false, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_0, v_528, false, &v_528), _fx_catch_129);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_526, v_528, false, &v_528), _fx_catch_129);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_0, &v_534, 0), _fx_catch_133);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_579, v_528,
-               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_0, 0), _fx_catch_129);
+            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+               &scalars_id_0, elem_ctyp_2, v_534, 0, &kloc_0, &v_535, 0), _fx_catch_133);
+         FX_COPY_PTR(v_535.t1, &sub_ccode_2);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_536, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_0, &v_537, 0), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_536, v_537, true, &v_538), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_538, &tags_data_1, 0), _fx_catch_133);
+         _fx_R9Ast__id_t v_596;
+         fx_str_t slit_140 = FX_MAKE_STR("tags");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_140, &v_596, 0), _fx_catch_133);
+         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_539), _fx_catch_133);
          FX_CALL(
-            _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-               call_mkarr_0, sub_ccode_4, &kloc_0, block_stack_ref_0, &sub_ccode_5, 0), _fx_catch_129);
+            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+               &v_596, v_539, tags_data_1, sub_ccode_2, &kloc_0, &v_540, 0), _fx_catch_133);
+         FX_COPY_PTR(v_540.t0, &tags_exp_0);
+         FX_COPY_PTR(v_540.t1, &sub_ccode_3);
+         _fx_R9Ast__id_t v_597;
+         fx_str_t slit_141 = FX_MAKE_STR("parts");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_141, &v_597, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(arr_data_0, &v_541, 0), _fx_catch_133);
          FX_CALL(
-            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_5, &kloc_0, &v_529, 0),
-            _fx_catch_129);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_529, ccode_86, true, &ccode_87), _fx_catch_129);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_3, ccode_87, &v_1);
-      }
-      else {
-         fx_str_t slit_137 = FX_MAKE_STR("arr");
+            _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+               &v_597, _fx_g23C_form__std_CTypVoidPtr, v_541, sub_ccode_3, &kloc_0, &v_542, 0), _fx_catch_133);
+         FX_COPY_PTR(v_542.t0, &arr_data_exp_0);
+         FX_COPY_PTR(v_542.t1, &sub_ccode_4);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2, &kloc_0, &v_543),
+            _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_543, 0, true, &v_544), _fx_catch_133);
          FX_CALL(
-            _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_137, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_530, 0), _fx_catch_129);
-         FX_COPY_PTR(v_530.t0, &arr_exp_4);
-         FX_COPY_PTR(v_530.t1, &ccode_88);
-         int_ nrows_0;
-         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LLT2BN14K_form__atom_t(arows_3, &nrows_0, 0), _fx_catch_129);
-         FX_CALL(_fx_M10C_gen_codeFM2hdLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(arows_3, &v_531, 0), _fx_catch_129);
-         int_ ncols_0;
-         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2BN14K_form__atom_t(v_531, &ncols_0, 0), _fx_catch_129);
-         if (nrows_0 > 1) {
-            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &v_532), _fx_catch_129);
-            FX_CALL(_fx_cons_Li(nrows_0, v_532, true, &shape_0), _fx_catch_129);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+               &_fx_g18C_form__std_sizeof, v_544, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_0, 0),
+            _fx_catch_133);
+         FX_CALL(
+            _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
+               false, &kloc_0, &v_545, 0), _fx_catch_133);
+         _fx_Nt6option1N14C_form__cexp_t* v_598 = &v_545.t1;
+         if (v_598->tag == 2) {
+            FX_CALL(
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_598->u.Some,
+                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_0), _fx_catch_126);
+
+         _fx_catch_126: ;
          }
          else {
-            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &shape_0), _fx_catch_129);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_0, 0), _fx_catch_127);
+
+         _fx_catch_127: ;
+         }
+         FX_CHECK_EXN(_fx_catch_133);
+         FX_CALL(
+            _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
+               false, &kloc_0, &v_546, 0), _fx_catch_133);
+         _fx_Nt6option1N14C_form__cexp_t* v_599 = &v_546.t1;
+         if (v_599->tag == 2) {
+            FX_CALL(
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_599->u.Some,
+                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_0), _fx_catch_128);
+
+         _fx_catch_128: ;
+         }
+         else {
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_0, 0), _fx_catch_129);
+
+         _fx_catch_129: ;
+         }
+         FX_CHECK_EXN(_fx_catch_133);
+         _fx_R9Ast__id_t v_600;
+         fx_str_t slit_142 = FX_MAKE_STR("fx_compose_arr");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_142, &v_600, 0), _fx_catch_133);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_0, &kloc_0, &v_547, 0), _fx_catch_133);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_3, &v_548, 0), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_548, 0, true, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_data_exp_0, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_0, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_0, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_0, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_0, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_547, v_549, false, &v_549), _fx_catch_133);
+         FX_CALL(
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_600, v_549,
+               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_0, 0), _fx_catch_133);
+         FX_CALL(
+            _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+               call_mkarr_0, sub_ccode_4, &kloc_0, block_stack_ref_0, &sub_ccode_5, 0), _fx_catch_133);
+         FX_CALL(
+            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_5, &kloc_0, &v_550, 0),
+            _fx_catch_133);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_550, ccode_89, true, &ccode_90), _fx_catch_133);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_3, ccode_90, &v_1);
+      }
+      else {
+         fx_str_t slit_143 = FX_MAKE_STR("arr");
+         FX_CALL(
+            _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+               dstexp_r_0, &slit_143, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_551, 0), _fx_catch_133);
+         FX_COPY_PTR(v_551.t0, &arr_exp_4);
+         FX_COPY_PTR(v_551.t1, &ccode_91);
+         int_ nrows_0;
+         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LLT2BN14K_form__atom_t(arows_3, &nrows_0, 0), _fx_catch_133);
+         FX_CALL(_fx_M10C_gen_codeFM2hdLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(arows_3, &v_552, 0), _fx_catch_133);
+         int_ ncols_0;
+         FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2BN14K_form__atom_t(v_552, &ncols_0, 0), _fx_catch_133);
+         if (nrows_0 > 1) {
+            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &v_553), _fx_catch_133);
+            FX_CALL(_fx_cons_Li(nrows_0, v_553, true, &shape_0), _fx_catch_133);
+         }
+         else {
+            FX_CALL(_fx_cons_Li(ncols_0, 0, true, &shape_0), _fx_catch_133);
          }
          _fx_LN14C_form__cexp_t lstend_0 = 0;
          _fx_Li lst_13 = shape_0;
          for (; lst_13; lst_13 = lst_13->tl) {
             _fx_N14C_form__cexp_t res_18 = 0;
             int_ i_5 = lst_13->hd;
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(i_5, &kloc_0, &res_18, 0), _fx_catch_126);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(i_5, &kloc_0, &res_18, 0), _fx_catch_130);
             _fx_LN14C_form__cexp_t node_0 = 0;
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_18, 0, false, &node_0), _fx_catch_126);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_18, 0, false, &node_0), _fx_catch_130);
             FX_LIST_APPEND(shape_1, lstend_0, node_0);
 
-         _fx_catch_126: ;
+         _fx_catch_130: ;
             if (res_18) {
                _fx_free_N14C_form__cexp_t(&res_18);
             }
-            FX_CHECK_EXN(_fx_catch_129);
+            FX_CHECK_EXN(_fx_catch_133);
          }
-         FX_COPY_PTR(ccode_88, &ccode_89);
+         FX_COPY_PTR(ccode_91, &ccode_92);
          FX_COPY_PTR(arows_3, &arows_2);
          _fx_LLT2BN14K_form__atom_t lst_14 = arows_2;
          for (; lst_14; lst_14 = lst_14->tl) {
@@ -27128,26 +27367,26 @@ static int
             _fx_LT2BN14K_form__atom_t lst_15 = arow_2;
             for (; lst_15; lst_15 = lst_15->tl) {
                _fx_N14K_form__atom_t a_5 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_580 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_601 = {0};
                _fx_N14C_form__cexp_t e_11 = 0;
                _fx_LN15C_form__cstmt_t ccode1_9 = 0;
-               _fx_LN14C_form__cexp_t v_581 = 0;
+               _fx_LN14C_form__cexp_t v_602 = 0;
                _fx_T2BN14K_form__atom_t* __pat___2 = &lst_15->hd;
                _fx_copy_N14K_form__atom_t(&__pat___2->t1, &a_5);
                FX_CALL(
-                  atom2cexp_0.fp(&a_5, ccode_89, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                     km_idx_0, &v_580, atom2cexp_0.fcv), _fx_catch_127);
-               FX_COPY_PTR(v_580.t0, &e_11);
-               FX_COPY_PTR(v_580.t1, &ccode1_9);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(e_11, data_0, true, &v_581), _fx_catch_127);
+                  atom2cexp_0.fp(&a_5, ccode_92, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                     km_idx_0, &v_601, atom2cexp_0.fcv), _fx_catch_131);
+               FX_COPY_PTR(v_601.t0, &e_11);
+               FX_COPY_PTR(v_601.t1, &ccode1_9);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(e_11, data_0, true, &v_602), _fx_catch_131);
                _fx_free_LN14C_form__cexp_t(&data_0);
-               FX_COPY_PTR(v_581, &data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_89);
-               FX_COPY_PTR(ccode1_9, &ccode_89);
+               FX_COPY_PTR(v_602, &data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_92);
+               FX_COPY_PTR(ccode1_9, &ccode_92);
 
-            _fx_catch_127: ;
-               if (v_581) {
-                  _fx_free_LN14C_form__cexp_t(&v_581);
+            _fx_catch_131: ;
+               if (v_602) {
+                  _fx_free_LN14C_form__cexp_t(&v_602);
                }
                if (ccode1_9) {
                   _fx_free_LN15C_form__cstmt_t(&ccode1_9);
@@ -27155,112 +27394,112 @@ static int
                if (e_11) {
                   _fx_free_N14C_form__cexp_t(&e_11);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_580);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_601);
                _fx_free_N14K_form__atom_t(&a_5);
-               FX_CHECK_EXN(_fx_catch_128);
+               FX_CHECK_EXN(_fx_catch_132);
             }
 
-         _fx_catch_128: ;
-            FX_CHECK_EXN(_fx_catch_129);
+         _fx_catch_132: ;
+            FX_CHECK_EXN(_fx_catch_133);
          }
          if (all_literals_0) {
             int_ dims_1;
-            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14C_form__cexp_t(shape_1, &dims_1, 0), _fx_catch_129);
-            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_533), _fx_catch_129);
+            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN14C_form__cexp_t(shape_1, &dims_1, 0), _fx_catch_133);
+            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_554), _fx_catch_133);
             FX_CALL(
-               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_533,
-                  _fx_g19C_gen_code__CTypInt, &shape_ctyp_0), _fx_catch_129);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(shape_ctyp_0, &kloc_0, &v_534);
+               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_554,
+                  _fx_g19C_gen_code__CTypInt, &shape_ctyp_0), _fx_catch_133);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(shape_ctyp_0, &kloc_0, &v_555);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(shape_1, &v_534,
-                  &shape_arr_0), _fx_catch_129);
-            _fx_R9Ast__id_t v_582;
-            fx_str_t slit_138 = FX_MAKE_STR("shape");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_138, &v_582, 0), _fx_catch_129);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_535, 0), _fx_catch_129);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(shape_arr_0, &v_536);
-            fx_str_t slit_139 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(shape_1, &v_555,
+                  &shape_arr_0), _fx_catch_133);
+            _fx_R9Ast__id_t v_603;
+            fx_str_t slit_144 = FX_MAKE_STR("shape");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_144, &v_603, 0), _fx_catch_133);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_556, 0), _fx_catch_133);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(shape_arr_0, &v_557);
+            fx_str_t slit_145 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_582, shape_ctyp_0, &v_535, &slit_139, &v_536, 0, &kloc_0, &v_537, 0), _fx_catch_129);
-            FX_COPY_PTR(v_537.t0, &shape_exp_0);
-            FX_COPY_PTR(v_537.t1, &ccode__0);
+                  &v_603, shape_ctyp_0, &v_556, &slit_145, &v_557, 0, &kloc_0, &v_558, 0), _fx_catch_133);
+            FX_COPY_PTR(v_558.t0, &shape_exp_0);
+            FX_COPY_PTR(v_558.t1, &ccode__0);
             _fx_R9Ast__id_t data_id_0;
-            fx_str_t slit_140 = FX_MAKE_STR("data");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_140, &data_id_0, 0), _fx_catch_129);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_538, 0), _fx_catch_129);
+            fx_str_t slit_146 = FX_MAKE_STR("data");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_146, &data_id_0, 0), _fx_catch_133);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_559, 0), _fx_catch_133);
             FX_CALL(
                _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &data_id_0, elem_ctyp_1, v_538, *glob_data_ccode_0, &kloc_0, &v_539, 0), _fx_catch_129);
-            FX_COPY_PTR(v_539.t0, &data_exp_0);
-            FX_COPY_PTR(v_539.t1, &glob_data_ccode__0);
+                  &data_id_0, elem_ctyp_2, v_559, *glob_data_ccode_0, &kloc_0, &v_560, 0), _fx_catch_133);
+            FX_COPY_PTR(v_560.t0, &data_exp_0);
+            FX_COPY_PTR(v_560.t1, &glob_data_ccode__0);
             FX_CALL(_fx_M6C_formFM8get_cvalRM9cdefval_t2R9Ast__id_tR10Ast__loc_t(&data_id_0, &kloc_0, &data_cv_0, 0),
-               _fx_catch_129);
+               _fx_catch_133);
             _fx_copy_R16Ast__val_flags_t(&data_cv_0.cv_flags, &data_flags_0);
             _fx_make_R16Ast__val_flags_t(data_flags_0.val_flag_arg, data_flags_0.val_flag_mutable, data_flags_0.val_flag_temp,
                data_flags_0.val_flag_tempref, true, data_flags_0.val_flag_subarray, data_flags_0.val_flag_instance,
-               &data_flags_0.val_flag_method, data_flags_0.val_flag_ctor, data_flags_0.val_flag_global, &v_540);
-            _fx_make_R17C_form__cdefval_t(&data_cv_0.cv_name, data_cv_0.cv_typ, &data_cv_0.cv_cname, &v_540, &data_cv_0.cv_loc,
-               &v_541);
-            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&v_541, &v_542);
-            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(&data_id_0, &v_542, 0), _fx_catch_129);
+               &data_flags_0.val_flag_method, data_flags_0.val_flag_ctor, data_flags_0.val_flag_global, &v_561);
+            _fx_make_R17C_form__cdefval_t(&data_cv_0.cv_name, data_cv_0.cv_typ, &data_cv_0.cv_cname, &v_561, &data_cv_0.cv_loc,
+               &v_562);
+            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&v_562, &v_563);
+            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(&data_id_0, &v_563, 0), _fx_catch_133);
             _fx_free_LN15C_form__cstmt_t(glob_data_ccode_0);
             FX_COPY_PTR(glob_data_ccode__0, glob_data_ccode_0);
             FX_CALL(
-               _fx_M10C_gen_codeFM23get_elem_size_free_copyTa3N14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_1,
-                  &kloc_0, &v_543, 0), _fx_catch_129);
-            FX_COPY_PTR(v_543.t0, &sizeof_elem_exp_1);
-            FX_COPY_PTR(v_543.t1, &free_f_exp_1);
-            FX_COPY_PTR(v_543.t2, &copy_f_exp_1);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_1, &kloc_0, &v_544, 0), _fx_catch_129);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_4, &v_545, 0), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_545, 0, true, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(data_exp_0, v_546, false, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_1, v_546, false, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_1, v_546, false, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_1, v_546, false, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(shape_exp_0, v_546, false, &v_546), _fx_catch_129);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_544, v_546, false, &v_546), _fx_catch_129);
+               _fx_M10C_gen_codeFM23get_elem_size_free_copyTa3N14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2,
+                  &kloc_0, &v_564, 0), _fx_catch_133);
+            FX_COPY_PTR(v_564.t0, &sizeof_elem_exp_1);
+            FX_COPY_PTR(v_564.t1, &free_f_exp_1);
+            FX_COPY_PTR(v_564.t2, &copy_f_exp_1);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dims_1, &kloc_0, &v_565, 0), _fx_catch_133);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_4, &v_566, 0), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_566, 0, true, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(data_exp_0, v_567, false, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_1, v_567, false, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_1, v_567, false, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_1, v_567, false, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(shape_exp_0, v_567, false, &v_567), _fx_catch_133);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_565, v_567, false, &v_567), _fx_catch_133);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g23C_form__std_fx_make_arr, v_546, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_1, 0),
-               _fx_catch_129);
+                  &_fx_g23C_form__std_fx_make_arr, v_567, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkarr_1, 0),
+               _fx_catch_133);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_mkarr_1, ccode__0, &kloc_0, block_stack_ref_0, &ccode__1, 0), _fx_catch_129);
+                  call_mkarr_1, ccode__0, &kloc_0, block_stack_ref_0, &ccode__1, 0), _fx_catch_133);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode__1, &kloc_0, &v_547, 0),
-               _fx_catch_129);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_547, ccode_89, true, &v_548), _fx_catch_129);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, v_548, &v_1);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(ccode__1, &kloc_0, &v_568, 0),
+               _fx_catch_133);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_568, ccode_92, true, &v_569), _fx_catch_133);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, v_569, &v_1);
          }
          else {
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_549, 0), _fx_catch_129);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_0, &v_570, 0), _fx_catch_133);
             FX_CALL(
                _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0,
-                  block_stack_ref_0, &v_550, 0), _fx_catch_129);
+                  block_stack_ref_0, &v_571, 0), _fx_catch_133);
             FX_CALL(
                _fx_M10C_gen_codeFM18make_make_arr_callLN15C_form__cstmt_t7N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_ti(
-                  arr_exp_4, shape_1, v_549, ccode_89, v_550, &kloc_0, km_idx_0, &ccode_90, 0), _fx_catch_129);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, ccode_90, &v_1);
+                  arr_exp_4, shape_1, v_570, ccode_92, v_571, &kloc_0, km_idx_0, &ccode_93, 0), _fx_catch_133);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, arr_exp_4, ccode_93, &v_1);
          }
       }
 
-   _fx_catch_129: ;
-      if (ccode_90) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_90);
+   _fx_catch_133: ;
+      if (ccode_93) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_93);
       }
-      if (v_550) {
-         _fx_free_N14C_form__cexp_t(&v_550);
+      if (v_571) {
+         _fx_free_N14C_form__cexp_t(&v_571);
       }
-      if (v_549) {
-         _fx_free_LN14C_form__cexp_t(&v_549);
+      if (v_570) {
+         _fx_free_LN14C_form__cexp_t(&v_570);
       }
-      if (v_548) {
-         _fx_free_LN15C_form__cstmt_t(&v_548);
+      if (v_569) {
+         _fx_free_LN15C_form__cstmt_t(&v_569);
       }
-      if (v_547) {
-         _fx_free_N15C_form__cstmt_t(&v_547);
+      if (v_568) {
+         _fx_free_N15C_form__cstmt_t(&v_568);
       }
       if (ccode__1) {
          _fx_free_LN15C_form__cstmt_t(&ccode__1);
@@ -27268,14 +27507,14 @@ static int
       if (call_mkarr_1) {
          _fx_free_N14C_form__cexp_t(&call_mkarr_1);
       }
-      if (v_546) {
-         _fx_free_LN14C_form__cexp_t(&v_546);
+      if (v_567) {
+         _fx_free_LN14C_form__cexp_t(&v_567);
       }
-      if (v_545) {
-         _fx_free_N14C_form__cexp_t(&v_545);
+      if (v_566) {
+         _fx_free_N14C_form__cexp_t(&v_566);
       }
-      if (v_544) {
-         _fx_free_N14C_form__cexp_t(&v_544);
+      if (v_565) {
+         _fx_free_N14C_form__cexp_t(&v_565);
       }
       if (copy_f_exp_1) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_1);
@@ -27286,10 +27525,10 @@ static int
       if (sizeof_elem_exp_1) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_1);
       }
-      _fx_free_Ta3N14C_form__cexp_t(&v_543);
-      _fx_free_N15C_form__cinfo_t(&v_542);
-      _fx_free_R17C_form__cdefval_t(&v_541);
-      _fx_free_R16Ast__val_flags_t(&v_540);
+      _fx_free_Ta3N14C_form__cexp_t(&v_564);
+      _fx_free_N15C_form__cinfo_t(&v_563);
+      _fx_free_R17C_form__cdefval_t(&v_562);
+      _fx_free_R16Ast__val_flags_t(&v_561);
       _fx_free_R16Ast__val_flags_t(&data_flags_0);
       _fx_free_R17C_form__cdefval_t(&data_cv_0);
       if (glob_data_ccode__0) {
@@ -27298,9 +27537,9 @@ static int
       if (data_exp_0) {
          _fx_free_N14C_form__cexp_t(&data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_539);
-      if (v_538) {
-         _fx_free_LN14C_form__cexp_t(&v_538);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_560);
+      if (v_559) {
+         _fx_free_LN14C_form__cexp_t(&v_559);
       }
       if (ccode__0) {
          _fx_free_LN15C_form__cstmt_t(&ccode__0);
@@ -27308,22 +27547,22 @@ static int
       if (shape_exp_0) {
          _fx_free_N14C_form__cexp_t(&shape_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_537);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_536);
-      _fx_free_R16Ast__val_flags_t(&v_535);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_558);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_557);
+      _fx_free_R16Ast__val_flags_t(&v_556);
       if (shape_arr_0) {
          _fx_free_N14C_form__cexp_t(&shape_arr_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_534);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_555);
       if (shape_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&shape_ctyp_0);
       }
-      FX_FREE_LIST_SIMPLE(&v_533);
+      FX_FREE_LIST_SIMPLE(&v_554);
       if (arows_2) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_2);
       }
-      if (ccode_89) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_89);
+      if (ccode_92) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_92);
       }
       if (data_0) {
          _fx_free_LN14C_form__cexp_t(&data_0);
@@ -27331,23 +27570,23 @@ static int
       if (shape_1) {
          _fx_free_LN14C_form__cexp_t(&shape_1);
       }
-      FX_FREE_LIST_SIMPLE(&v_532);
+      FX_FREE_LIST_SIMPLE(&v_553);
       FX_FREE_LIST_SIMPLE(&shape_0);
-      if (v_531) {
-         _fx_free_LT2BN14K_form__atom_t(&v_531);
+      if (v_552) {
+         _fx_free_LT2BN14K_form__atom_t(&v_552);
       }
-      if (ccode_88) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_88);
+      if (ccode_91) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_91);
       }
       if (arr_exp_4) {
          _fx_free_N14C_form__cexp_t(&arr_exp_4);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_530);
-      if (ccode_87) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_87);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_551);
+      if (ccode_90) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_90);
       }
-      if (v_529) {
-         _fx_free_N15C_form__cstmt_t(&v_529);
+      if (v_550) {
+         _fx_free_N15C_form__cstmt_t(&v_550);
       }
       if (sub_ccode_5) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_5);
@@ -27355,31 +27594,31 @@ static int
       if (call_mkarr_0) {
          _fx_free_N14C_form__cexp_t(&call_mkarr_0);
       }
-      if (v_528) {
-         _fx_free_LN14C_form__cexp_t(&v_528);
+      if (v_549) {
+         _fx_free_LN14C_form__cexp_t(&v_549);
       }
-      if (v_527) {
-         _fx_free_N14C_form__cexp_t(&v_527);
+      if (v_548) {
+         _fx_free_N14C_form__cexp_t(&v_548);
       }
-      if (v_526) {
-         _fx_free_N14C_form__cexp_t(&v_526);
+      if (v_547) {
+         _fx_free_N14C_form__cexp_t(&v_547);
       }
       if (copy_f_exp_0) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_0);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_525);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_546);
       if (free_f_exp_0) {
          _fx_free_N14C_form__cexp_t(&free_f_exp_0);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_524);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_545);
       if (sizeof_elem_exp_0) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_0);
       }
-      if (v_523) {
-         _fx_free_LN14C_form__cexp_t(&v_523);
+      if (v_544) {
+         _fx_free_LN14C_form__cexp_t(&v_544);
       }
-      if (v_522) {
-         _fx_free_N14C_form__cexp_t(&v_522);
+      if (v_543) {
+         _fx_free_N14C_form__cexp_t(&v_543);
       }
       if (sub_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_4);
@@ -27387,9 +27626,9 @@ static int
       if (arr_data_exp_0) {
          _fx_free_N14C_form__cexp_t(&arr_data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_521);
-      if (v_520) {
-         _fx_free_LN14C_form__cexp_t(&v_520);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_542);
+      if (v_541) {
+         _fx_free_LN14C_form__cexp_t(&v_541);
       }
       if (sub_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_3);
@@ -27397,34 +27636,34 @@ static int
       if (tags_exp_0) {
          _fx_free_N14C_form__cexp_t(&tags_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_519);
-      if (v_518) {
-         _fx_free_N14C_form__ctyp_t(&v_518);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_540);
+      if (v_539) {
+         _fx_free_N14C_form__ctyp_t(&v_539);
       }
       if (tags_data_1) {
          _fx_free_LN14C_form__cexp_t(&tags_data_1);
       }
-      if (v_517) {
-         _fx_free_LN14C_form__cexp_t(&v_517);
+      if (v_538) {
+         _fx_free_LN14C_form__cexp_t(&v_538);
       }
-      if (v_516) {
-         _fx_free_LN14C_form__cexp_t(&v_516);
+      if (v_537) {
+         _fx_free_LN14C_form__cexp_t(&v_537);
       }
-      if (v_515) {
-         _fx_free_N14C_form__cexp_t(&v_515);
+      if (v_536) {
+         _fx_free_N14C_form__cexp_t(&v_536);
       }
       if (sub_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_514);
-      if (v_513) {
-         _fx_free_LN14C_form__cexp_t(&v_513);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_535);
+      if (v_534) {
+         _fx_free_LN14C_form__cexp_t(&v_534);
       }
       if (arows_1) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_1);
       }
-      if (ccode_86) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_86);
+      if (ccode_89) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_89);
       }
       if (arr_data_0) {
          _fx_free_LN14C_form__cexp_t(&arr_data_0);
@@ -27438,20 +27677,20 @@ static int
       if (scalars_exp_0) {
          _fx_free_N14C_form__cexp_t(&scalars_exp_0);
       }
-      if (v_512) {
-         _fx_free_N14C_form__ctyp_t(&v_512);
+      if (v_533) {
+         _fx_free_N14C_form__ctyp_t(&v_533);
       }
-      if (ccode_85) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_85);
+      if (ccode_88) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_88);
       }
       if (arr_exp_3) {
          _fx_free_N14C_form__cexp_t(&arr_exp_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_511);
-      if (elem_ctyp_1) {
-         _fx_free_N14C_form__ctyp_t(&elem_ctyp_1);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_532);
+      if (elem_ctyp_2) {
+         _fx_free_N14C_form__ctyp_t(&elem_ctyp_2);
       }
-      _fx_free_T2iN14C_form__ctyp_t(&v_510);
+      _fx_free_T2iN14C_form__ctyp_t(&v_531);
       if (arows_0) {
          _fx_free_LLT2BN14K_form__atom_t(&arows_0);
       }
@@ -27459,58 +27698,58 @@ static int
    }
    if (tag_0 == 18) {
       _fx_LT2BN14K_form__atom_t elems_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_583 = {0};
-      _fx_N14C_form__cexp_t vec_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_91 = 0;
-      _fx_N14C_form__ctyp_t elem_ctyp_2 = 0;
-      _fx_N14C_form__ctyp_t v_584 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_604 = {0};
+      _fx_N14C_form__cexp_t vec_exp_2 = 0;
+      _fx_LN15C_form__cstmt_t ccode_94 = 0;
+      _fx_N14C_form__ctyp_t elem_ctyp_3 = 0;
+      _fx_N14C_form__ctyp_t v_605 = 0;
       _fx_N14C_form__cexp_t scalars_exp_1 = 0;
       _fx_LN14C_form__cexp_t scalars_data_1 = 0;
       _fx_LN14C_form__cexp_t tags_data_2 = 0;
       _fx_LN14C_form__cexp_t vec_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_92 = 0;
+      _fx_LN15C_form__cstmt_t ccode_95 = 0;
       _fx_LT2BN14K_form__atom_t elems_1 = 0;
       _fx_LN14C_form__cexp_t scalars_data_2 = 0;
       _fx_LN14C_form__cexp_t tags_data_3 = 0;
       _fx_LN14C_form__cexp_t vec_data_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_93 = 0;
-      _fx_LN14C_form__cexp_t v_585 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_586 = {0};
+      _fx_LN15C_form__cstmt_t ccode_96 = 0;
+      _fx_LN14C_form__cexp_t v_606 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_607 = {0};
       _fx_LN15C_form__cstmt_t sub_ccode_6 = 0;
-      _fx_N14C_form__cexp_t v_587 = 0;
-      _fx_LN14C_form__cexp_t v_588 = 0;
-      _fx_LN14C_form__cexp_t v_589 = 0;
+      _fx_N14C_form__cexp_t v_608 = 0;
+      _fx_LN14C_form__cexp_t v_609 = 0;
+      _fx_LN14C_form__cexp_t v_610 = 0;
       _fx_LN14C_form__cexp_t tags_data_4 = 0;
-      _fx_N14C_form__ctyp_t v_590 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_591 = {0};
+      _fx_N14C_form__ctyp_t v_611 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_612 = {0};
       _fx_N14C_form__cexp_t tags_exp_1 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_7 = 0;
-      _fx_LN14C_form__cexp_t v_592 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_593 = {0};
+      _fx_LN14C_form__cexp_t v_613 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_614 = {0};
       _fx_N14C_form__cexp_t vec_data_exp_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_8 = 0;
-      _fx_N14C_form__cexp_t v_594 = 0;
-      _fx_LN14C_form__cexp_t v_595 = 0;
+      _fx_N14C_form__cexp_t v_615 = 0;
+      _fx_LN14C_form__cexp_t v_616 = 0;
       _fx_N14C_form__cexp_t sizeof_elem_exp_2 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_596 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_617 = {0};
       _fx_N14C_form__cexp_t free_f_exp_2 = 0;
-      _fx_T2BNt6option1N14C_form__cexp_t v_597 = {0};
+      _fx_T2BNt6option1N14C_form__cexp_t v_618 = {0};
       _fx_N14C_form__cexp_t copy_f_exp_2 = 0;
-      _fx_N14C_form__cexp_t v_598 = 0;
-      _fx_LN14C_form__cexp_t v_599 = 0;
+      _fx_N14C_form__cexp_t v_619 = 0;
+      _fx_LN14C_form__cexp_t v_620 = 0;
       _fx_N14C_form__cexp_t call_mkvec_0 = 0;
       _fx_LN15C_form__cstmt_t sub_ccode_9 = 0;
-      _fx_N15C_form__cstmt_t v_600 = 0;
-      _fx_LN15C_form__cstmt_t ccode_94 = 0;
-      _fx_LN14C_form__cexp_t data_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_95 = 0;
-      _fx_LT2BN14K_form__atom_t elems_2 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_601 = {0};
-      _fx_N14C_form__cexp_t vec_exp_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_96 = 0;
-      _fx_LN14C_form__cexp_t v_602 = 0;
-      _fx_N14C_form__cexp_t v_603 = 0;
+      _fx_N15C_form__cstmt_t v_621 = 0;
       _fx_LN15C_form__cstmt_t ccode_97 = 0;
+      _fx_LN14C_form__cexp_t data_1 = 0;
+      _fx_LN15C_form__cstmt_t ccode_98 = 0;
+      _fx_LT2BN14K_form__atom_t elems_2 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_622 = {0};
+      _fx_N14C_form__cexp_t vec_exp_3 = 0;
+      _fx_LN15C_form__cstmt_t ccode_99 = 0;
+      _fx_LN14C_form__cexp_t v_623 = 0;
+      _fx_N14C_form__cexp_t v_624 = 0;
+      _fx_LN15C_form__cstmt_t ccode_100 = 0;
       _fx_LT2BN14K_form__atom_t elems_3 = kexp_0->u.KExpMkVector.t0;
       bool __fold_result___2 = false;
       FX_COPY_PTR(elems_3, &elems_0);
@@ -27518,200 +27757,200 @@ static int
       for (; lst_16; lst_16 = lst_16->tl) {
          _fx_T2BN14K_form__atom_t* __pat___3 = &lst_16->hd;
          if (__pat___3->t0) {
-            __fold_result___2 = true; FX_BREAK(_fx_catch_130);
+            __fold_result___2 = true; FX_BREAK(_fx_catch_134);
          }
 
-      _fx_catch_130: ;
+      _fx_catch_134: ;
          FX_CHECK_BREAK();
-         FX_CHECK_EXN(_fx_catch_143);
+         FX_CHECK_EXN(_fx_catch_147);
       }
       bool have_expanded_1 = __fold_result___2;
       if (have_expanded_1) {
-         fx_str_t slit_141 = FX_MAKE_STR("vec");
+         fx_str_t slit_147 = FX_MAKE_STR("vec");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_141, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_583, 0), _fx_catch_143);
-         FX_COPY_PTR(v_583.t0, &vec_exp_0);
-         FX_COPY_PTR(v_583.t1, &ccode_91);
+               dstexp_r_0, &slit_147, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_604, 0), _fx_catch_147);
+         FX_COPY_PTR(v_604.t0, &vec_exp_2);
+         FX_COPY_PTR(v_604.t1, &ccode_94);
          if (FX_REC_VARIANT_TAG(ctyp_0) == 20) {
-            FX_COPY_PTR(ctyp_0->u.CTypRRBVec, &elem_ctyp_2);
+            FX_COPY_PTR(ctyp_0->u.CTypRRBVec, &elem_ctyp_3);
          }
          else {
-            fx_exn_t v_604 = {0};
-            fx_str_t slit_142 = FX_MAKE_STR("cgen: invalid output type of rrbvec construction expression");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_142, &v_604, 0), _fx_catch_131);
-            FX_THROW(&v_604, false, _fx_catch_131);
+            fx_exn_t v_625 = {0};
+            fx_str_t slit_148 = FX_MAKE_STR("cgen: invalid output type of rrbvec construction expression");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_148, &v_625, 0), _fx_catch_135);
+            FX_THROW(&v_625, false, _fx_catch_135);
 
-         _fx_catch_131: ;
-            fx_free_exn(&v_604);
+         _fx_catch_135: ;
+            fx_free_exn(&v_625);
          }
-         FX_CHECK_EXN(_fx_catch_143);
+         FX_CHECK_EXN(_fx_catch_147);
          _fx_R9Ast__id_t scalars_id_1;
-         fx_str_t slit_143 = FX_MAKE_STR("scalars");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_143, &scalars_id_1, 0), _fx_catch_143);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_2, &v_584, 0), _fx_catch_143);
+         fx_str_t slit_149 = FX_MAKE_STR("scalars");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_149, &scalars_id_1, 0), _fx_catch_147);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elem_ctyp_3, &v_605, 0), _fx_catch_147);
          FX_CALL(
-            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_1, v_584,
-               &kloc_0, &scalars_exp_1, 0), _fx_catch_143);
+            _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&scalars_id_1, v_605,
+               &kloc_0, &scalars_exp_1, 0), _fx_catch_147);
          int_ nscalars_1 = 0;
-         FX_COPY_PTR(ccode_91, &ccode_92);
+         FX_COPY_PTR(ccode_94, &ccode_95);
          FX_COPY_PTR(elems_3, &elems_1);
          _fx_LT2BN14K_form__atom_t lst_17 = elems_1;
          for (; lst_17; lst_17 = lst_17->tl) {
             _fx_N14K_form__atom_t a_6 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_605 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_626 = {0};
             _fx_N14C_form__cexp_t e_12 = 0;
             _fx_LN15C_form__cstmt_t ccode1_10 = 0;
             _fx_N14K_form__ktyp_t elem_ktyp_1 = 0;
-            _fx_N14K_form__ktyp_t v_606 = 0;
-            _fx_T2iN14C_form__cexp_t v_607 = {0};
+            _fx_N14K_form__ktyp_t v_627 = 0;
+            _fx_T2iN14C_form__cexp_t v_628 = {0};
             _fx_N14C_form__cexp_t elem_ptr_1 = 0;
-            _fx_N14C_form__cexp_t v_608 = 0;
-            _fx_LN14C_form__cexp_t v_609 = 0;
-            _fx_LN14C_form__cexp_t v_610 = 0;
-            _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_611 = {0};
+            _fx_N14C_form__cexp_t v_629 = 0;
+            _fx_LN14C_form__cexp_t v_630 = 0;
+            _fx_LN14C_form__cexp_t v_631 = 0;
+            _fx_T3iLN14C_form__cexp_tN14C_form__cexp_t v_632 = {0};
             _fx_LN14C_form__cexp_t scalars_data1_1 = 0;
             _fx_N14C_form__cexp_t vec_data_elem_0 = 0;
-            _fx_N14C_form__cexp_t v_612 = 0;
-            _fx_LN14C_form__cexp_t v_613 = 0;
-            _fx_LN14C_form__cexp_t v_614 = 0;
+            _fx_N14C_form__cexp_t v_633 = 0;
+            _fx_LN14C_form__cexp_t v_634 = 0;
+            _fx_LN14C_form__cexp_t v_635 = 0;
             _fx_T2BN14K_form__atom_t* __pat___4 = &lst_17->hd;
             _fx_copy_N14K_form__atom_t(&__pat___4->t1, &a_6);
             FX_CALL(
-               atom2cexp_0.fp(&a_6, ccode_92, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_605, atom2cexp_0.fcv), _fx_catch_137);
-            FX_COPY_PTR(v_605.t0, &e_12);
-            FX_COPY_PTR(v_605.t1, &ccode1_10);
+               atom2cexp_0.fp(&a_6, ccode_95, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_626, atom2cexp_0.fcv), _fx_catch_141);
+            FX_COPY_PTR(v_626.t0, &e_12);
+            FX_COPY_PTR(v_626.t1, &ccode1_10);
             if (__pat___4->t0) {
                FX_CALL(
                   _fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_6, &kloc_0, &elem_ktyp_1, 0),
-                  _fx_catch_137);
+                  _fx_catch_141);
                FX_CALL(
-                  _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_1, &kloc_0, &v_606, 0),
-                  _fx_catch_137);
-               int tag_16 = FX_REC_VARIANT_TAG(v_606);
+                  _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(elem_ktyp_1, &kloc_0, &v_627, 0),
+                  _fx_catch_141);
+               int tag_16 = FX_REC_VARIANT_TAG(v_627);
                if (tag_16 == 17) {
-                  _fx_N14C_form__cexp_t v_615 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_615, 0), _fx_catch_132);
-                  _fx_make_T2iN14C_form__cexp_t(v_606->u.KTypArray.t0, v_615, &v_607);
+                  _fx_N14C_form__cexp_t v_636 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_636, 0), _fx_catch_136);
+                  _fx_make_T2iN14C_form__cexp_t(v_627->u.KTypArray.t0, v_636, &v_628);
 
-               _fx_catch_132: ;
-                  if (v_615) {
-                     _fx_free_N14C_form__cexp_t(&v_615);
+               _fx_catch_136: ;
+                  if (v_636) {
+                     _fx_free_N14C_form__cexp_t(&v_636);
                   }
                }
                else if (tag_16 == 20) {
-                  _fx_make_T2iN14C_form__cexp_t(100, e_12, &v_607);
+                  _fx_make_T2iN14C_form__cexp_t(100, e_12, &v_628);
                }
                else if (tag_16 == 18) {
-                  _fx_N14C_form__cexp_t v_616 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_616, 0), _fx_catch_133);
-                  _fx_make_T2iN14C_form__cexp_t(110, v_616, &v_607);
+                  _fx_N14C_form__cexp_t v_637 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_637, 0), _fx_catch_137);
+                  _fx_make_T2iN14C_form__cexp_t(110, v_637, &v_628);
 
-               _fx_catch_133: ;
-                  if (v_616) {
-                     _fx_free_N14C_form__cexp_t(&v_616);
+               _fx_catch_137: ;
+                  if (v_637) {
+                     _fx_free_N14C_form__cexp_t(&v_637);
                   }
                }
                else {
-                  fx_str_t v_617 = {0};
-                  fx_str_t v_618 = {0};
-                  fx_str_t v_619 = {0};
-                  fx_exn_t v_620 = {0};
-                  FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_6, &v_617, 0), _fx_catch_134);
-                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_617, &v_618, 0), _fx_catch_134);
-                  fx_str_t slit_144 = FX_MAKE_STR("cgen: the expanded structure ");
-                  fx_str_t slit_145 = FX_MAKE_STR(" is not an array, rrbvec or list");
+                  fx_str_t v_638 = {0};
+                  fx_str_t v_639 = {0};
+                  fx_str_t v_640 = {0};
+                  fx_exn_t v_641 = {0};
+                  FX_CALL(_fx_M6K_formFM8atom2strS1N14K_form__atom_t(&a_6, &v_638, 0), _fx_catch_138);
+                  FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_638, &v_639, 0), _fx_catch_138);
+                  fx_str_t slit_150 = FX_MAKE_STR("cgen: the expanded structure ");
+                  fx_str_t slit_151 = FX_MAKE_STR(" is not an array, rrbvec or list");
                   {
-                     const fx_str_t strs_29[] = { slit_144, v_618, slit_145 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_29, 3, &v_619), _fx_catch_134);
+                     const fx_str_t strs_31[] = { slit_150, v_639, slit_151 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_31, 3, &v_640), _fx_catch_138);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_619, &v_620, 0), _fx_catch_134);
-                  FX_THROW(&v_620, false, _fx_catch_134);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_640, &v_641, 0), _fx_catch_138);
+                  FX_THROW(&v_641, false, _fx_catch_138);
 
-               _fx_catch_134: ;
-                  fx_free_exn(&v_620);
-                  FX_FREE_STR(&v_619);
-                  FX_FREE_STR(&v_618);
-                  FX_FREE_STR(&v_617);
+               _fx_catch_138: ;
+                  fx_free_exn(&v_641);
+                  FX_FREE_STR(&v_640);
+                  FX_FREE_STR(&v_639);
+                  FX_FREE_STR(&v_638);
                }
-               FX_CHECK_EXN(_fx_catch_137);
-               int_ tag_17 = v_607.t0;
-               FX_COPY_PTR(v_607.t1, &elem_ptr_1);
-               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_17, &kloc_0, &v_608, 0), _fx_catch_137);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_608, tags_data_2, true, &v_609), _fx_catch_137);
+               FX_CHECK_EXN(_fx_catch_141);
+               int_ tag_17 = v_628.t0;
+               FX_COPY_PTR(v_628.t1, &elem_ptr_1);
+               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(tag_17, &kloc_0, &v_629, 0), _fx_catch_141);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_629, tags_data_2, true, &v_630), _fx_catch_141);
                _fx_free_LN14C_form__cexp_t(&tags_data_2);
-               FX_COPY_PTR(v_609, &tags_data_2);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_1, vec_data_0, true, &v_610), _fx_catch_137);
+               FX_COPY_PTR(v_630, &tags_data_2);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(elem_ptr_1, vec_data_0, true, &v_631), _fx_catch_141);
                _fx_free_LN14C_form__cexp_t(&vec_data_0);
-               FX_COPY_PTR(v_610, &vec_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_92);
-               FX_COPY_PTR(ccode1_10, &ccode_92);
+               FX_COPY_PTR(v_631, &vec_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_95);
+               FX_COPY_PTR(ccode1_10, &ccode_95);
             }
             else {
                if (FX_REC_VARIANT_TAG(e_12) == 1) {
-                  _fx_N14C_form__cexp_t v_621 = 0;
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_621, 0), _fx_catch_135);
-                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1, scalars_data_1, v_621, &v_611);
+                  _fx_N14C_form__cexp_t v_642 = 0;
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_12, &v_642, 0), _fx_catch_139);
+                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1, scalars_data_1, v_642, &v_632);
 
-               _fx_catch_135: ;
-                  if (v_621) {
-                     _fx_free_N14C_form__cexp_t(&v_621);
+               _fx_catch_139: ;
+                  if (v_642) {
+                     _fx_free_N14C_form__cexp_t(&v_642);
                   }
                }
                else {
-                  _fx_LN14C_form__cexp_t v_622 = 0;
-                  _fx_N14C_form__cexp_t v_623 = 0;
-                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_624 = {0};
-                  _fx_N14C_form__cexp_t v_625 = 0;
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(e_12, scalars_data_1, true, &v_622), _fx_catch_136);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_1, &kloc_0, &v_623, 0),
-                     _fx_catch_136);
-                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_624);
+                  _fx_LN14C_form__cexp_t v_643 = 0;
+                  _fx_N14C_form__cexp_t v_644 = 0;
+                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_645 = {0};
+                  _fx_N14C_form__cexp_t v_646 = 0;
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(e_12, scalars_data_1, true, &v_643), _fx_catch_140);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(nscalars_1, &kloc_0, &v_644, 0),
+                     _fx_catch_140);
+                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_645);
                   FX_CALL(
                      _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g18C_gen_code__COpAdd, scalars_exp_1, v_623, &v_624, &v_625), _fx_catch_136);
-                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1 + 1, v_622, v_625, &v_611);
+                        &_fx_g18C_gen_code__COpAdd, scalars_exp_1, v_644, &v_645, &v_646), _fx_catch_140);
+                  _fx_make_T3iLN14C_form__cexp_tN14C_form__cexp_t(nscalars_1 + 1, v_643, v_646, &v_632);
 
-               _fx_catch_136: ;
-                  if (v_625) {
-                     _fx_free_N14C_form__cexp_t(&v_625);
+               _fx_catch_140: ;
+                  if (v_646) {
+                     _fx_free_N14C_form__cexp_t(&v_646);
                   }
-                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_624);
-                  if (v_623) {
-                     _fx_free_N14C_form__cexp_t(&v_623);
+                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_645);
+                  if (v_644) {
+                     _fx_free_N14C_form__cexp_t(&v_644);
                   }
-                  if (v_622) {
-                     _fx_free_LN14C_form__cexp_t(&v_622);
+                  if (v_643) {
+                     _fx_free_LN14C_form__cexp_t(&v_643);
                   }
                }
-               FX_CHECK_EXN(_fx_catch_137);
-               int_ nscalars1_1 = v_611.t0;
-               FX_COPY_PTR(v_611.t1, &scalars_data1_1);
-               FX_COPY_PTR(v_611.t2, &vec_data_elem_0);
+               FX_CHECK_EXN(_fx_catch_141);
+               int_ nscalars1_1 = v_632.t0;
+               FX_COPY_PTR(v_632.t1, &scalars_data1_1);
+               FX_COPY_PTR(v_632.t2, &vec_data_elem_0);
                nscalars_1 = nscalars1_1;
                _fx_free_LN14C_form__cexp_t(&scalars_data_1);
                FX_COPY_PTR(scalars_data1_1, &scalars_data_1);
-               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_612, 0), _fx_catch_137);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_612, tags_data_2, true, &v_613), _fx_catch_137);
+               FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_633, 0), _fx_catch_141);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(v_633, tags_data_2, true, &v_634), _fx_catch_141);
                _fx_free_LN14C_form__cexp_t(&tags_data_2);
-               FX_COPY_PTR(v_613, &tags_data_2);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_elem_0, vec_data_0, true, &v_614), _fx_catch_137);
+               FX_COPY_PTR(v_634, &tags_data_2);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_elem_0, vec_data_0, true, &v_635), _fx_catch_141);
                _fx_free_LN14C_form__cexp_t(&vec_data_0);
-               FX_COPY_PTR(v_614, &vec_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_92);
-               FX_COPY_PTR(ccode1_10, &ccode_92);
+               FX_COPY_PTR(v_635, &vec_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_95);
+               FX_COPY_PTR(ccode1_10, &ccode_95);
             }
 
-         _fx_catch_137: ;
-            if (v_614) {
-               _fx_free_LN14C_form__cexp_t(&v_614);
+         _fx_catch_141: ;
+            if (v_635) {
+               _fx_free_LN14C_form__cexp_t(&v_635);
             }
-            if (v_613) {
-               _fx_free_LN14C_form__cexp_t(&v_613);
+            if (v_634) {
+               _fx_free_LN14C_form__cexp_t(&v_634);
             }
-            if (v_612) {
-               _fx_free_N14C_form__cexp_t(&v_612);
+            if (v_633) {
+               _fx_free_N14C_form__cexp_t(&v_633);
             }
             if (vec_data_elem_0) {
                _fx_free_N14C_form__cexp_t(&vec_data_elem_0);
@@ -27719,22 +27958,22 @@ static int
             if (scalars_data1_1) {
                _fx_free_LN14C_form__cexp_t(&scalars_data1_1);
             }
-            _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_611);
-            if (v_610) {
-               _fx_free_LN14C_form__cexp_t(&v_610);
+            _fx_free_T3iLN14C_form__cexp_tN14C_form__cexp_t(&v_632);
+            if (v_631) {
+               _fx_free_LN14C_form__cexp_t(&v_631);
             }
-            if (v_609) {
-               _fx_free_LN14C_form__cexp_t(&v_609);
+            if (v_630) {
+               _fx_free_LN14C_form__cexp_t(&v_630);
             }
-            if (v_608) {
-               _fx_free_N14C_form__cexp_t(&v_608);
+            if (v_629) {
+               _fx_free_N14C_form__cexp_t(&v_629);
             }
             if (elem_ptr_1) {
                _fx_free_N14C_form__cexp_t(&elem_ptr_1);
             }
-            _fx_free_T2iN14C_form__cexp_t(&v_607);
-            if (v_606) {
-               _fx_free_N14K_form__ktyp_t(&v_606);
+            _fx_free_T2iN14C_form__cexp_t(&v_628);
+            if (v_627) {
+               _fx_free_N14K_form__ktyp_t(&v_627);
             }
             if (elem_ktyp_1) {
                _fx_free_N14K_form__ktyp_t(&elem_ktyp_1);
@@ -27745,130 +27984,130 @@ static int
             if (e_12) {
                _fx_free_N14C_form__cexp_t(&e_12);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_605);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_626);
             _fx_free_N14K_form__atom_t(&a_6);
-            FX_CHECK_EXN(_fx_catch_143);
+            FX_CHECK_EXN(_fx_catch_147);
          }
          FX_COPY_PTR(scalars_data_1, &scalars_data_2);
          FX_COPY_PTR(tags_data_2, &tags_data_3);
          FX_COPY_PTR(vec_data_0, &vec_data_1);
-         FX_COPY_PTR(ccode_92, &ccode_93);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_2, &v_585, 0), _fx_catch_143);
+         FX_COPY_PTR(ccode_95, &ccode_96);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(scalars_data_2, &v_606, 0), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &scalars_id_1, elem_ctyp_2, v_585, 0, &kloc_0, &v_586, 0), _fx_catch_143);
-         FX_COPY_PTR(v_586.t1, &sub_ccode_6);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_587, 0), _fx_catch_143);
-         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_3, &v_588, 0), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_587, v_588, true, &v_589), _fx_catch_143);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_589, &tags_data_4, 0), _fx_catch_143);
-         _fx_R9Ast__id_t v_626;
-         fx_str_t slit_146 = FX_MAKE_STR("tags");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_146, &v_626, 0), _fx_catch_143);
-         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_590), _fx_catch_143);
+               &scalars_id_1, elem_ctyp_3, v_606, 0, &kloc_0, &v_607, 0), _fx_catch_147);
+         FX_COPY_PTR(v_607.t1, &sub_ccode_6);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(-1, &kloc_0, &v_608, 0), _fx_catch_147);
+         FX_CALL(_fx_M10C_gen_codeFM2tlLN14C_form__cexp_t1LN14C_form__cexp_t(tags_data_3, &v_609, 0), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_608, v_609, true, &v_610), _fx_catch_147);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(v_610, &tags_data_4, 0), _fx_catch_147);
+         _fx_R9Ast__id_t v_647;
+         fx_str_t slit_152 = FX_MAKE_STR("tags");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_152, &v_647, 0), _fx_catch_147);
+         FX_CALL(_fx_M6C_formFM8CTypSIntN14C_form__ctyp_t1i(8, &v_611), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_626, v_590, tags_data_4, sub_ccode_6, &kloc_0, &v_591, 0), _fx_catch_143);
-         FX_COPY_PTR(v_591.t0, &tags_exp_1);
-         FX_COPY_PTR(v_591.t1, &sub_ccode_7);
-         _fx_R9Ast__id_t v_627;
-         fx_str_t slit_147 = FX_MAKE_STR("parts");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_147, &v_627, 0), _fx_catch_143);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(vec_data_1, &v_592, 0), _fx_catch_143);
+               &v_647, v_611, tags_data_4, sub_ccode_6, &kloc_0, &v_612, 0), _fx_catch_147);
+         FX_COPY_PTR(v_612.t0, &tags_exp_1);
+         FX_COPY_PTR(v_612.t1, &sub_ccode_7);
+         _fx_R9Ast__id_t v_648;
+         fx_str_t slit_153 = FX_MAKE_STR("parts");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_153, &v_648, 0), _fx_catch_147);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(vec_data_1, &v_613, 0), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM14decl_plain_arrT2N14C_form__cexp_tLN15C_form__cstmt_t5R9Ast__id_tN14C_form__ctyp_tLN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_627, _fx_g23C_form__std_CTypVoidPtr, v_592, sub_ccode_7, &kloc_0, &v_593, 0), _fx_catch_143);
-         FX_COPY_PTR(v_593.t0, &vec_data_exp_0);
-         FX_COPY_PTR(v_593.t1, &sub_ccode_8);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_2, &kloc_0, &v_594),
-            _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_594, 0, true, &v_595), _fx_catch_143);
+               &v_648, _fx_g23C_form__std_CTypVoidPtr, v_613, sub_ccode_7, &kloc_0, &v_614, 0), _fx_catch_147);
+         FX_COPY_PTR(v_614.t0, &vec_data_exp_0);
+         FX_COPY_PTR(v_614.t1, &sub_ccode_8);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elem_ctyp_3, &kloc_0, &v_615),
+            _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_615, 0, true, &v_616), _fx_catch_147);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g18C_form__std_sizeof, v_595, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_2, 0),
-            _fx_catch_143);
+               &_fx_g18C_form__std_sizeof, v_616, _fx_g22C_gen_code__CTypSize_t, &kloc_0, &sizeof_elem_exp_2, 0),
+            _fx_catch_147);
          FX_CALL(
-            _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
-               false, &kloc_0, &v_596, 0), _fx_catch_143);
-         _fx_Nt6option1N14C_form__cexp_t* v_628 = &v_596.t1;
-         if (v_628->tag == 2) {
+            _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_3, true,
+               false, &kloc_0, &v_617, 0), _fx_catch_147);
+         _fx_Nt6option1N14C_form__cexp_t* v_649 = &v_617.t1;
+         if (v_649->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_628->u.Some,
-                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_2), _fx_catch_138);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_649->u.Some,
+                  _fx_g21C_form__std_fx_free_t, &kloc_0, &free_f_exp_2), _fx_catch_142);
 
-         _fx_catch_138: ;
+         _fx_catch_142: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_2, 0), _fx_catch_139);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &free_f_exp_2, 0), _fx_catch_143);
 
-         _fx_catch_139: ;
+         _fx_catch_143: ;
          }
-         FX_CHECK_EXN(_fx_catch_143);
+         FX_CHECK_EXN(_fx_catch_147);
          FX_CALL(
-            _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_2, true,
-               false, &kloc_0, &v_597, 0), _fx_catch_143);
-         _fx_Nt6option1N14C_form__cexp_t* v_629 = &v_597.t1;
-         if (v_629->tag == 2) {
+            _fx_M11C_gen_typesFM10get_copy_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(elem_ctyp_3, true,
+               false, &kloc_0, &v_618, 0), _fx_catch_147);
+         _fx_Nt6option1N14C_form__cexp_t* v_650 = &v_618.t1;
+         if (v_650->tag == 2) {
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_629->u.Some,
-                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_2), _fx_catch_140);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_650->u.Some,
+                  _fx_g21C_form__std_fx_copy_t, &kloc_0, &copy_f_exp_2), _fx_catch_144);
 
-         _fx_catch_140: ;
+         _fx_catch_144: ;
          }
          else {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_2, 0), _fx_catch_141);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &copy_f_exp_2, 0), _fx_catch_145);
 
-         _fx_catch_141: ;
+         _fx_catch_145: ;
          }
-         FX_CHECK_EXN(_fx_catch_143);
-         _fx_R9Ast__id_t v_630;
-         fx_str_t slit_148 = FX_MAKE_STR("fx_compose_vec");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_148, &v_630, 0), _fx_catch_143);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(vec_exp_0, &v_598, 0), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_598, 0, true, &v_599), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_exp_0, v_599, false, &v_599), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_1, v_599, false, &v_599), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_2, v_599, false, &v_599), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_2, v_599, false, &v_599), _fx_catch_143);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_2, v_599, false, &v_599), _fx_catch_143);
+         FX_CHECK_EXN(_fx_catch_147);
+         _fx_R9Ast__id_t v_651;
+         fx_str_t slit_154 = FX_MAKE_STR("fx_compose_vec");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_154, &v_651, 0), _fx_catch_147);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(vec_exp_2, &v_619, 0), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_619, 0, true, &v_620), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(vec_data_exp_0, v_620, false, &v_620), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(tags_exp_1, v_620, false, &v_620), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_2, v_620, false, &v_620), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_2, v_620, false, &v_620), _fx_catch_147);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_2, v_620, false, &v_620), _fx_catch_147);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_630, v_599,
-               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkvec_0, 0), _fx_catch_143);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_651, v_620,
+               _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_mkvec_0, 0), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-               call_mkvec_0, sub_ccode_8, &kloc_0, block_stack_ref_0, &sub_ccode_9, 0), _fx_catch_143);
+               call_mkvec_0, sub_ccode_8, &kloc_0, block_stack_ref_0, &sub_ccode_9, 0), _fx_catch_147);
          FX_CALL(
-            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_9, &kloc_0, &v_600, 0),
-            _fx_catch_143);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_600, ccode_93, true, &ccode_94), _fx_catch_143);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_0, ccode_94, &v_1);
+            _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_9, &kloc_0, &v_621, 0),
+            _fx_catch_147);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_621, ccode_96, true, &ccode_97), _fx_catch_147);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_2, ccode_97, &v_1);
       }
       else {
-         FX_COPY_PTR(ccode_0, &ccode_95);
+         FX_COPY_PTR(ccode_0, &ccode_98);
          FX_COPY_PTR(elems_3, &elems_2);
          _fx_LT2BN14K_form__atom_t lst_18 = elems_2;
          for (; lst_18; lst_18 = lst_18->tl) {
             _fx_N14K_form__atom_t a_7 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_631 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_652 = {0};
             _fx_N14C_form__cexp_t e_13 = 0;
             _fx_LN15C_form__cstmt_t ccode1_11 = 0;
-            _fx_LN14C_form__cexp_t v_632 = 0;
+            _fx_LN14C_form__cexp_t v_653 = 0;
             _fx_T2BN14K_form__atom_t* __pat___5 = &lst_18->hd;
             _fx_copy_N14K_form__atom_t(&__pat___5->t1, &a_7);
             FX_CALL(
-               atom2cexp_0.fp(&a_7, ccode_95, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                  km_idx_0, &v_631, atom2cexp_0.fcv), _fx_catch_142);
-            FX_COPY_PTR(v_631.t0, &e_13);
-            FX_COPY_PTR(v_631.t1, &ccode1_11);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_13, data_1, true, &v_632), _fx_catch_142);
+               atom2cexp_0.fp(&a_7, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                  km_idx_0, &v_652, atom2cexp_0.fcv), _fx_catch_146);
+            FX_COPY_PTR(v_652.t0, &e_13);
+            FX_COPY_PTR(v_652.t1, &ccode1_11);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_13, data_1, true, &v_653), _fx_catch_146);
             _fx_free_LN14C_form__cexp_t(&data_1);
-            FX_COPY_PTR(v_632, &data_1);
-            _fx_free_LN15C_form__cstmt_t(&ccode_95);
-            FX_COPY_PTR(ccode1_11, &ccode_95);
+            FX_COPY_PTR(v_653, &data_1);
+            _fx_free_LN15C_form__cstmt_t(&ccode_98);
+            FX_COPY_PTR(ccode1_11, &ccode_98);
 
-         _fx_catch_142: ;
-            if (v_632) {
-               _fx_free_LN14C_form__cexp_t(&v_632);
+         _fx_catch_146: ;
+            if (v_653) {
+               _fx_free_LN14C_form__cexp_t(&v_653);
             }
             if (ccode1_11) {
                _fx_free_LN15C_form__cstmt_t(&ccode1_11);
@@ -27876,57 +28115,57 @@ static int
             if (e_13) {
                _fx_free_N14C_form__cexp_t(&e_13);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_631);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_652);
             _fx_free_N14K_form__atom_t(&a_7);
-            FX_CHECK_EXN(_fx_catch_143);
+            FX_CHECK_EXN(_fx_catch_147);
          }
-         fx_str_t slit_149 = FX_MAKE_STR("vec");
+         fx_str_t slit_155 = FX_MAKE_STR("vec");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_149, ctyp_0, ccode_95, &kloc_0, block_stack_ref_0, km_idx_0, &v_601, 0), _fx_catch_143);
-         FX_COPY_PTR(v_601.t0, &vec_exp_1);
-         FX_COPY_PTR(v_601.t1, &ccode_96);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_1, &v_602, 0), _fx_catch_143);
+               dstexp_r_0, &slit_155, ctyp_0, ccode_98, &kloc_0, block_stack_ref_0, km_idx_0, &v_622, 0), _fx_catch_147);
+         FX_COPY_PTR(v_622.t0, &vec_exp_3);
+         FX_COPY_PTR(v_622.t1, &ccode_99);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(data_1, &v_623, 0), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &v_603, 0), _fx_catch_143);
+               &v_624, 0), _fx_catch_147);
          FX_CALL(
             _fx_M10C_gen_codeFM18make_make_vec_callLN15C_form__cstmt_t6N14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_ti(
-               vec_exp_1, v_602, ccode_96, v_603, &kloc_0, km_idx_0, &ccode_97, 0), _fx_catch_143);
-         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_1, ccode_97, &v_1);
+               vec_exp_3, v_623, ccode_99, v_624, &kloc_0, km_idx_0, &ccode_100, 0), _fx_catch_147);
+         _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, vec_exp_3, ccode_100, &v_1);
       }
 
-   _fx_catch_143: ;
-      if (ccode_97) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_97);
+   _fx_catch_147: ;
+      if (ccode_100) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_100);
       }
-      if (v_603) {
-         _fx_free_N14C_form__cexp_t(&v_603);
+      if (v_624) {
+         _fx_free_N14C_form__cexp_t(&v_624);
       }
-      if (v_602) {
-         _fx_free_LN14C_form__cexp_t(&v_602);
+      if (v_623) {
+         _fx_free_LN14C_form__cexp_t(&v_623);
       }
-      if (ccode_96) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_96);
+      if (ccode_99) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_99);
       }
-      if (vec_exp_1) {
-         _fx_free_N14C_form__cexp_t(&vec_exp_1);
+      if (vec_exp_3) {
+         _fx_free_N14C_form__cexp_t(&vec_exp_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_601);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_622);
       if (elems_2) {
          _fx_free_LT2BN14K_form__atom_t(&elems_2);
       }
-      if (ccode_95) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_95);
+      if (ccode_98) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_98);
       }
       if (data_1) {
          _fx_free_LN14C_form__cexp_t(&data_1);
       }
-      if (ccode_94) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_94);
+      if (ccode_97) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_97);
       }
-      if (v_600) {
-         _fx_free_N15C_form__cstmt_t(&v_600);
+      if (v_621) {
+         _fx_free_N15C_form__cstmt_t(&v_621);
       }
       if (sub_ccode_9) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_9);
@@ -27934,28 +28173,28 @@ static int
       if (call_mkvec_0) {
          _fx_free_N14C_form__cexp_t(&call_mkvec_0);
       }
-      if (v_599) {
-         _fx_free_LN14C_form__cexp_t(&v_599);
+      if (v_620) {
+         _fx_free_LN14C_form__cexp_t(&v_620);
       }
-      if (v_598) {
-         _fx_free_N14C_form__cexp_t(&v_598);
+      if (v_619) {
+         _fx_free_N14C_form__cexp_t(&v_619);
       }
       if (copy_f_exp_2) {
          _fx_free_N14C_form__cexp_t(&copy_f_exp_2);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_597);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_618);
       if (free_f_exp_2) {
          _fx_free_N14C_form__cexp_t(&free_f_exp_2);
       }
-      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_596);
+      _fx_free_T2BNt6option1N14C_form__cexp_t(&v_617);
       if (sizeof_elem_exp_2) {
          _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_2);
       }
-      if (v_595) {
-         _fx_free_LN14C_form__cexp_t(&v_595);
+      if (v_616) {
+         _fx_free_LN14C_form__cexp_t(&v_616);
       }
-      if (v_594) {
-         _fx_free_N14C_form__cexp_t(&v_594);
+      if (v_615) {
+         _fx_free_N14C_form__cexp_t(&v_615);
       }
       if (sub_ccode_8) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_8);
@@ -27963,9 +28202,9 @@ static int
       if (vec_data_exp_0) {
          _fx_free_N14C_form__cexp_t(&vec_data_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_593);
-      if (v_592) {
-         _fx_free_LN14C_form__cexp_t(&v_592);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_614);
+      if (v_613) {
+         _fx_free_LN14C_form__cexp_t(&v_613);
       }
       if (sub_ccode_7) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_7);
@@ -27973,31 +28212,31 @@ static int
       if (tags_exp_1) {
          _fx_free_N14C_form__cexp_t(&tags_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_591);
-      if (v_590) {
-         _fx_free_N14C_form__ctyp_t(&v_590);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_612);
+      if (v_611) {
+         _fx_free_N14C_form__ctyp_t(&v_611);
       }
       if (tags_data_4) {
          _fx_free_LN14C_form__cexp_t(&tags_data_4);
       }
-      if (v_589) {
-         _fx_free_LN14C_form__cexp_t(&v_589);
+      if (v_610) {
+         _fx_free_LN14C_form__cexp_t(&v_610);
       }
-      if (v_588) {
-         _fx_free_LN14C_form__cexp_t(&v_588);
+      if (v_609) {
+         _fx_free_LN14C_form__cexp_t(&v_609);
       }
-      if (v_587) {
-         _fx_free_N14C_form__cexp_t(&v_587);
+      if (v_608) {
+         _fx_free_N14C_form__cexp_t(&v_608);
       }
       if (sub_ccode_6) {
          _fx_free_LN15C_form__cstmt_t(&sub_ccode_6);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_586);
-      if (v_585) {
-         _fx_free_LN14C_form__cexp_t(&v_585);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_607);
+      if (v_606) {
+         _fx_free_LN14C_form__cexp_t(&v_606);
       }
-      if (ccode_93) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_93);
+      if (ccode_96) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_96);
       }
       if (vec_data_1) {
          _fx_free_LN14C_form__cexp_t(&vec_data_1);
@@ -28011,8 +28250,8 @@ static int
       if (elems_1) {
          _fx_free_LT2BN14K_form__atom_t(&elems_1);
       }
-      if (ccode_92) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_92);
+      if (ccode_95) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_95);
       }
       if (vec_data_0) {
          _fx_free_LN14C_form__cexp_t(&vec_data_0);
@@ -28026,751 +28265,751 @@ static int
       if (scalars_exp_1) {
          _fx_free_N14C_form__cexp_t(&scalars_exp_1);
       }
-      if (v_584) {
-         _fx_free_N14C_form__ctyp_t(&v_584);
+      if (v_605) {
+         _fx_free_N14C_form__ctyp_t(&v_605);
       }
-      if (elem_ctyp_2) {
-         _fx_free_N14C_form__ctyp_t(&elem_ctyp_2);
+      if (elem_ctyp_3) {
+         _fx_free_N14C_form__ctyp_t(&elem_ctyp_3);
       }
-      if (ccode_91) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_91);
+      if (ccode_94) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_94);
       }
-      if (vec_exp_0) {
-         _fx_free_N14C_form__cexp_t(&vec_exp_0);
+      if (vec_exp_2) {
+         _fx_free_N14C_form__cexp_t(&vec_exp_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_583);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_604);
       if (elems_0) {
          _fx_free_LT2BN14K_form__atom_t(&elems_0);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 19) {
-      fx_exn_t v_633 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_634 = {0};
+      fx_exn_t v_654 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_655 = {0};
       _fx_N14C_form__cexp_t arr_exp_5 = 0;
-      _fx_LN15C_form__cstmt_t ccode_98 = 0;
-      _fx_N14C_form__cexp_t lbl_5 = 0;
+      _fx_LN15C_form__cstmt_t ccode_101 = 0;
+      _fx_N14C_form__cexp_t lbl_7 = 0;
       _fx_N14C_form__ctyp_t arr_ctyp_0 = 0;
       _fx_T5N14K_form__atom_tN13Ast__border_tN18Ast__interpolate_tLN13K_form__dom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_12 =
          &kexp_0->u.KExpAt;
       _fx_LN13K_form__dom_t idxs_1 = vcase_12->t3;
       _fx_N13Ast__border_t* border_0 = &vcase_12->t1;
       if (vcase_12->t2.tag != 1) {
-         fx_str_t slit_150 = FX_MAKE_STR("cgen: inter-element interpolation is not supported yet");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_150, &v_633, 0), _fx_catch_203);
-         FX_THROW(&v_633, false, _fx_catch_203);
+         fx_str_t slit_156 = FX_MAKE_STR("cgen: inter-element interpolation is not supported yet");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_156, &v_654, 0), _fx_catch_207);
+         FX_THROW(&v_654, false, _fx_catch_207);
       }
-      FX_CALL(atom2cexp__0.fp(&vcase_12->t0, false, ccode_0, &kloc_0, &v_634, atom2cexp__0.fcv), _fx_catch_203);
-      FX_COPY_PTR(v_634.t0, &arr_exp_5);
-      FX_COPY_PTR(v_634.t1, &ccode_98);
+      FX_CALL(atom2cexp__0.fp(&vcase_12->t0, false, ccode_0, &kloc_0, &v_655, atom2cexp__0.fcv), _fx_catch_207);
+      FX_COPY_PTR(v_655.t0, &arr_exp_5);
+      FX_COPY_PTR(v_655.t1, &ccode_101);
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_5, 0), _fx_catch_203);
-      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(arr_exp_5, &arr_ctyp_0, 0), _fx_catch_203);
+            &lbl_7, 0), _fx_catch_207);
+      FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(arr_exp_5, &arr_ctyp_0, 0), _fx_catch_207);
       int tag_18 = FX_REC_VARIANT_TAG(arr_ctyp_0);
       if (tag_18 == 12) {
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_635 = &idxs_1->hd;
-               if (v_635->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_636 = {0};
+               _fx_N13K_form__dom_t* v_656 = &idxs_1->hd;
+               if (v_656->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_657 = {0};
                   _fx_N14C_form__cexp_t i_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_99 = 0;
-                  _fx_LN14C_form__cexp_t v_637 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_102 = 0;
+                  _fx_LN14C_form__cexp_t v_658 = 0;
                   _fx_N14C_form__cexp_t get_elem_exp_1 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&v_635->u.DomainFast, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_636, atom2cexp_0.fcv), _fx_catch_144);
-                  FX_COPY_PTR(v_636.t0, &i_exp_2);
-                  FX_COPY_PTR(v_636.t1, &ccode_99);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_2, 0, true, &v_637), _fx_catch_144);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_637, false, &v_637), _fx_catch_144);
+                     atom2cexp_0.fp(&v_656->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_657, atom2cexp_0.fcv), _fx_catch_148);
+                  FX_COPY_PTR(v_657.t0, &i_exp_2);
+                  FX_COPY_PTR(v_657.t1, &ccode_102);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_2, 0, true, &v_658), _fx_catch_148);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_658, false, &v_658), _fx_catch_148);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g23C_form__std_FX_STR_ELEM, v_637, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &get_elem_exp_1, 0),
-                     _fx_catch_144);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_1, ccode_99, &v_1);
+                        &_fx_g23C_form__std_FX_STR_ELEM, v_658, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &get_elem_exp_1, 0),
+                     _fx_catch_148);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_1, ccode_102, &v_1);
 
-               _fx_catch_144: ;
+               _fx_catch_148: ;
                   if (get_elem_exp_1) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_1);
                   }
-                  if (v_637) {
-                     _fx_free_LN14C_form__cexp_t(&v_637);
+                  if (v_658) {
+                     _fx_free_LN14C_form__cexp_t(&v_658);
                   }
-                  if (ccode_99) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_99);
+                  if (ccode_102) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_102);
                   }
                   if (i_exp_2) {
                      _fx_free_N14C_form__cexp_t(&i_exp_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_636);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_657);
                   goto _fx_endmatch_19;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_638 = &idxs_1->hd;
-               if (v_638->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_639 = {0};
+               _fx_N13K_form__dom_t* v_659 = &idxs_1->hd;
+               if (v_659->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_660 = {0};
                   _fx_N14C_form__cexp_t i_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_100 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_640 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_103 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_661 = {0};
                   _fx_N14C_form__cexp_t get_elem_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_101 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_638->u.DomainElem, true, ccode_98, &kloc_0, &v_639, atom2cexp__0.fcv),
-                     _fx_catch_149);
-                  FX_COPY_PTR(v_639.t0, &i_exp_3);
-                  FX_COPY_PTR(v_639.t1, &ccode_100);
+                  _fx_LN15C_form__cstmt_t ccode_104 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_659->u.DomainElem, true, ccode_101, &kloc_0, &v_660, atom2cexp__0.fcv),
+                     _fx_catch_153);
+                  FX_COPY_PTR(v_660.t0, &i_exp_3);
+                  FX_COPY_PTR(v_660.t1, &ccode_103);
                   int tag_19 = border_0->tag;
                   if (tag_19 == 1) {
-                     _fx_LN14C_form__cexp_t v_641 = 0;
+                     _fx_LN14C_form__cexp_t v_662 = 0;
                      _fx_N14C_form__cexp_t chk_exp_0 = 0;
-                     _fx_LN14C_form__cexp_t v_642 = 0;
-                     _fx_N14C_form__cexp_t v_643 = 0;
-                     _fx_N15C_form__cstmt_t v_644 = 0;
-                     _fx_LN15C_form__cstmt_t v_645 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_5, 0, true, &v_641), _fx_catch_145);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, v_641, false, &v_641), _fx_catch_145);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_641, false, &v_641), _fx_catch_145);
+                     _fx_LN14C_form__cexp_t v_663 = 0;
+                     _fx_N14C_form__cexp_t v_664 = 0;
+                     _fx_N15C_form__cstmt_t v_665 = 0;
+                     _fx_LN15C_form__cstmt_t v_666 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_662), _fx_catch_149);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, v_662, false, &v_662), _fx_catch_149);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_662, false, &v_662), _fx_catch_149);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g25C_form__std_FX_STR_CHKIDX, v_641, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_0, 0),
-                        _fx_catch_145);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_642), _fx_catch_145);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_642, false, &v_642), _fx_catch_145);
+                           &_fx_g25C_form__std_FX_STR_CHKIDX, v_662, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_0, 0),
+                        _fx_catch_149);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_663), _fx_catch_149);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_663, false, &v_663), _fx_catch_149);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g23C_form__std_FX_STR_ELEM, v_642, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_643, 0),
-                        _fx_catch_145);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_0, &v_644), _fx_catch_145);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_644, ccode_100, true, &v_645), _fx_catch_145);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_643, v_645, &v_640);
+                           &_fx_g23C_form__std_FX_STR_ELEM, v_663, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_664, 0),
+                        _fx_catch_149);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_0, &v_665), _fx_catch_149);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_665, ccode_103, true, &v_666), _fx_catch_149);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_664, v_666, &v_661);
 
-                  _fx_catch_145: ;
-                     if (v_645) {
-                        _fx_free_LN15C_form__cstmt_t(&v_645);
+                  _fx_catch_149: ;
+                     if (v_666) {
+                        _fx_free_LN15C_form__cstmt_t(&v_666);
                      }
-                     if (v_644) {
-                        _fx_free_N15C_form__cstmt_t(&v_644);
+                     if (v_665) {
+                        _fx_free_N15C_form__cstmt_t(&v_665);
                      }
-                     if (v_643) {
-                        _fx_free_N14C_form__cexp_t(&v_643);
+                     if (v_664) {
+                        _fx_free_N14C_form__cexp_t(&v_664);
                      }
-                     if (v_642) {
-                        _fx_free_LN14C_form__cexp_t(&v_642);
+                     if (v_663) {
+                        _fx_free_LN14C_form__cexp_t(&v_663);
                      }
                      if (chk_exp_0) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_0);
                      }
-                     if (v_641) {
-                        _fx_free_LN14C_form__cexp_t(&v_641);
+                     if (v_662) {
+                        _fx_free_LN14C_form__cexp_t(&v_662);
                      }
                   }
                   else if (tag_19 == 2) {
-                     _fx_LN14C_form__cexp_t v_646 = 0;
-                     _fx_N14C_form__cexp_t v_647 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_646), _fx_catch_146);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_646, false, &v_646), _fx_catch_146);
+                     _fx_LN14C_form__cexp_t v_667 = 0;
+                     _fx_N14C_form__cexp_t v_668 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_667), _fx_catch_150);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_667, false, &v_667), _fx_catch_150);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_CLIP, v_646, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_647, 0),
-                        _fx_catch_146);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_647, ccode_100, &v_640);
+                           &_fx_g28C_form__std_FX_STR_ELEM_CLIP, v_667, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_668, 0),
+                        _fx_catch_150);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_668, ccode_103, &v_661);
 
-                  _fx_catch_146: ;
-                     if (v_647) {
-                        _fx_free_N14C_form__cexp_t(&v_647);
+                  _fx_catch_150: ;
+                     if (v_668) {
+                        _fx_free_N14C_form__cexp_t(&v_668);
                      }
-                     if (v_646) {
-                        _fx_free_LN14C_form__cexp_t(&v_646);
+                     if (v_667) {
+                        _fx_free_LN14C_form__cexp_t(&v_667);
                      }
                   }
                   else if (tag_19 == 3) {
-                     _fx_LN14C_form__cexp_t v_648 = 0;
-                     _fx_N14C_form__cexp_t v_649 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_648), _fx_catch_147);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_648, false, &v_648), _fx_catch_147);
+                     _fx_LN14C_form__cexp_t v_669 = 0;
+                     _fx_N14C_form__cexp_t v_670 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_669), _fx_catch_151);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_669, false, &v_669), _fx_catch_151);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_WRAP, v_648, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_649, 0),
-                        _fx_catch_147);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_649, ccode_100, &v_640);
+                           &_fx_g28C_form__std_FX_STR_ELEM_WRAP, v_669, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_670, 0),
+                        _fx_catch_151);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_670, ccode_103, &v_661);
 
-                  _fx_catch_147: ;
-                     if (v_649) {
-                        _fx_free_N14C_form__cexp_t(&v_649);
+                  _fx_catch_151: ;
+                     if (v_670) {
+                        _fx_free_N14C_form__cexp_t(&v_670);
                      }
-                     if (v_648) {
-                        _fx_free_LN14C_form__cexp_t(&v_648);
+                     if (v_669) {
+                        _fx_free_LN14C_form__cexp_t(&v_669);
                      }
                   }
                   else if (tag_19 == 4) {
-                     _fx_LN14C_form__cexp_t v_650 = 0;
-                     _fx_N14C_form__cexp_t v_651 = 0;
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_650), _fx_catch_148);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_650, false, &v_650), _fx_catch_148);
+                     _fx_LN14C_form__cexp_t v_671 = 0;
+                     _fx_N14C_form__cexp_t v_672 = 0;
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_3, 0, true, &v_671), _fx_catch_152);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_671, false, &v_671), _fx_catch_152);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g28C_form__std_FX_STR_ELEM_ZERO, v_650, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_651, 0),
-                        _fx_catch_148);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_651, ccode_100, &v_640);
+                           &_fx_g28C_form__std_FX_STR_ELEM_ZERO, v_671, _fx_g23C_gen_code__CTypUniChar, &kloc_0, &v_672, 0),
+                        _fx_catch_152);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_672, ccode_103, &v_661);
 
-                  _fx_catch_148: ;
-                     if (v_651) {
-                        _fx_free_N14C_form__cexp_t(&v_651);
+                  _fx_catch_152: ;
+                     if (v_672) {
+                        _fx_free_N14C_form__cexp_t(&v_672);
                      }
-                     if (v_650) {
-                        _fx_free_LN14C_form__cexp_t(&v_650);
+                     if (v_671) {
+                        _fx_free_LN14C_form__cexp_t(&v_671);
                      }
                   }
                   else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_149);
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_153);
                   }
-                  FX_CHECK_EXN(_fx_catch_149);
-                  FX_COPY_PTR(v_640.t0, &get_elem_exp_2);
-                  FX_COPY_PTR(v_640.t1, &ccode_101);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_2, ccode_101, &v_1);
+                  FX_CHECK_EXN(_fx_catch_153);
+                  FX_COPY_PTR(v_661.t0, &get_elem_exp_2);
+                  FX_COPY_PTR(v_661.t1, &ccode_104);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_2, ccode_104, &v_1);
 
-               _fx_catch_149: ;
-                  if (ccode_101) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_101);
+               _fx_catch_153: ;
+                  if (ccode_104) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_104);
                   }
                   if (get_elem_exp_2) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_640);
-                  if (ccode_100) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_100);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_661);
+                  if (ccode_103) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_103);
                   }
                   if (i_exp_3) {
                      _fx_free_N14C_form__cexp_t(&i_exp_3);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_639);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_660);
                   goto _fx_endmatch_19;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_652 = &idxs_1->hd;
-               if (v_652->tag == 3) {
-                  fx_exn_t v_653 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_654 = {0};
+               _fx_N13K_form__dom_t* v_673 = &idxs_1->hd;
+               if (v_673->tag == 3) {
+                  fx_exn_t v_674 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_675 = {0};
                   _fx_N14C_form__cexp_t a_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_102 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_655 = {0};
-                  _fx_N14C_form__cexp_t b_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_103 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_656 = {0};
-                  _fx_N14C_form__cexp_t delta_exp_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_104 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_657 = {0};
-                  _fx_N14C_form__cexp_t substr_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode_105 = 0;
-                  _fx_N14C_form__cexp_t v_658 = 0;
-                  _fx_N14C_form__cexp_t v_659 = 0;
-                  _fx_N14C_form__cexp_t v_660 = 0;
-                  _fx_LN14C_form__cexp_t v_661 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_676 = {0};
+                  _fx_N14C_form__cexp_t b_exp_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_106 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_677 = {0};
+                  _fx_N14C_form__cexp_t delta_exp_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_107 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_678 = {0};
+                  _fx_N14C_form__cexp_t substr_exp_0 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_108 = 0;
+                  _fx_N14C_form__cexp_t v_679 = 0;
+                  _fx_N14C_form__cexp_t v_680 = 0;
+                  _fx_N14C_form__cexp_t v_681 = 0;
+                  _fx_LN14C_form__cexp_t v_682 = 0;
                   _fx_N14C_form__cexp_t call_substr_0 = 0;
-                  _fx_LN15C_form__cstmt_t v_662 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_13 = &v_652->u.DomainRange;
+                  _fx_LN15C_form__cstmt_t v_683 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_13 = &v_673->u.DomainRange;
                   _fx_N14K_form__atom_t* b_0 = &vcase_13->t1;
                   _fx_N14K_form__atom_t* a_8 = &vcase_13->t0;
                   if (border_0->tag != 1) {
-                     fx_str_t slit_151 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_151, &v_653, 0), _fx_catch_154);
-                     FX_THROW(&v_653, false, _fx_catch_154);
+                     fx_str_t slit_157 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_157, &v_674, 0), _fx_catch_158);
+                     FX_THROW(&v_674, false, _fx_catch_158);
                   }
                   if (a_8->tag == 2) {
                      if (a_8->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_663 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_664 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_663, 0),
-                           _fx_catch_150);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_663, ccode_98, &v_664);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_664, &v_654);
+                        _fx_N14C_form__cexp_t v_684 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_685 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_684, 0),
+                           _fx_catch_154);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_684, ccode_101, &v_685);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_685, &v_675);
 
-                     _fx_catch_150: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_664);
-                        if (v_663) {
-                           _fx_free_N14C_form__cexp_t(&v_663);
+                     _fx_catch_154: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_685);
+                        if (v_684) {
+                           _fx_free_N14C_form__cexp_t(&v_684);
                         }
                         goto _fx_endmatch_17;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_665 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_686 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(a_8, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_665, atom2cexp_0.fcv), _fx_catch_151);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_665, &v_654);
+                     atom2cexp_0.fp(a_8, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_686, atom2cexp_0.fcv), _fx_catch_155);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_686, &v_675);
 
-               _fx_catch_151: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_665);
+               _fx_catch_155: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_686);
 
                _fx_endmatch_17: ;
-                  FX_CHECK_EXN(_fx_catch_154);
-                  int_ mask_0 = v_654.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_666 = &v_654.t1;
-                  FX_COPY_PTR(v_666->t0, &a_exp_1);
-                  FX_COPY_PTR(v_666->t1, &ccode_102);
+                  FX_CHECK_EXN(_fx_catch_158);
+                  int_ mask_0 = v_675.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_687 = &v_675.t1;
+                  FX_COPY_PTR(v_687->t0, &a_exp_1);
+                  FX_COPY_PTR(v_687->t1, &ccode_105);
                   if (b_0->tag == 2) {
                      if (b_0->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_667 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_668 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_667, 0),
-                           _fx_catch_152);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_667, ccode_102, &v_668);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_0, &v_668, &v_655);
+                        _fx_N14C_form__cexp_t v_688 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_689 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_688, 0),
+                           _fx_catch_156);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_688, ccode_105, &v_689);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_0, &v_689, &v_676);
 
-                     _fx_catch_152: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_668);
-                        if (v_667) {
-                           _fx_free_N14C_form__cexp_t(&v_667);
+                     _fx_catch_156: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_689);
+                        if (v_688) {
+                           _fx_free_N14C_form__cexp_t(&v_688);
                         }
                         goto _fx_endmatch_18;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_669 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_690 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(b_0, ccode_102, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_669, atom2cexp_0.fcv), _fx_catch_153);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_0, &v_669, &v_655);
+                     atom2cexp_0.fp(b_0, ccode_105, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_690, atom2cexp_0.fcv), _fx_catch_157);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_0, &v_690, &v_676);
 
-               _fx_catch_153: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_669);
+               _fx_catch_157: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_690);
 
                _fx_endmatch_18: ;
-                  FX_CHECK_EXN(_fx_catch_154);
-                  int_ mask_1 = v_655.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_670 = &v_655.t1;
-                  FX_COPY_PTR(v_670->t0, &b_exp_1);
-                  FX_COPY_PTR(v_670->t1, &ccode_103);
+                  FX_CHECK_EXN(_fx_catch_158);
+                  int_ mask_1 = v_676.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_691 = &v_676.t1;
+                  FX_COPY_PTR(v_691->t0, &b_exp_1);
+                  FX_COPY_PTR(v_691->t1, &ccode_106);
                   FX_CALL(
-                     atom2cexp_0.fp(&vcase_13->t2, ccode_103, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_656, atom2cexp_0.fcv), _fx_catch_154);
-                  FX_COPY_PTR(v_656.t0, &delta_exp_1);
-                  FX_COPY_PTR(v_656.t1, &ccode_104);
-                  fx_str_t slit_152 = FX_MAKE_STR("substr");
+                     atom2cexp_0.fp(&vcase_13->t2, ccode_106, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_677, atom2cexp_0.fcv), _fx_catch_158);
+                  FX_COPY_PTR(v_677.t0, &delta_exp_1);
+                  FX_COPY_PTR(v_677.t1, &ccode_107);
+                  fx_str_t slit_158 = FX_MAKE_STR("substr");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_152, ctyp_0, ccode_104, &kloc_0, block_stack_ref_0, km_idx_0, &v_657, 0),
-                     _fx_catch_154);
-                  FX_COPY_PTR(v_657.t0, &substr_exp_0);
-                  FX_COPY_PTR(v_657.t1, &ccode_105);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_658, 0),
-                     _fx_catch_154);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_1, &kloc_0, &v_659, 0),
-                     _fx_catch_154);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(substr_exp_0, &v_660, 0),
-                     _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_660, 0, true, &v_661), _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_659, v_661, false, &v_661), _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_1, v_661, false, &v_661), _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_1, v_661, false, &v_661), _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_1, v_661, false, &v_661), _fx_catch_154);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_658, v_661, false, &v_661), _fx_catch_154);
+                        dstexp_r_0, &slit_158, ctyp_0, ccode_107, &kloc_0, block_stack_ref_0, km_idx_0, &v_678, 0),
+                     _fx_catch_158);
+                  FX_COPY_PTR(v_678.t0, &substr_exp_0);
+                  FX_COPY_PTR(v_678.t1, &ccode_108);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_679, 0),
+                     _fx_catch_158);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_1, &kloc_0, &v_680, 0),
+                     _fx_catch_158);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(substr_exp_0, &v_681, 0),
+                     _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_681, 0, true, &v_682), _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_680, v_682, false, &v_682), _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_1, v_682, false, &v_682), _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_1, v_682, false, &v_682), _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_1, v_682, false, &v_682), _fx_catch_158);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_679, v_682, false, &v_682), _fx_catch_158);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g21C_form__std_fx_substr, v_661, _fx_g22C_gen_code__CTypString, &kloc_0, &call_substr_0, 0),
-                     _fx_catch_154);
+                        &_fx_g21C_form__std_fx_substr, v_682, _fx_g22C_gen_code__CTypString, &kloc_0, &call_substr_0, 0),
+                     _fx_catch_158);
                   FX_CALL(
                      _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_substr_0, ccode_105, &kloc_0, block_stack_ref_0, &v_662, 0), _fx_catch_154);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, substr_exp_0, v_662, &v_1);
+                        call_substr_0, ccode_108, &kloc_0, block_stack_ref_0, &v_683, 0), _fx_catch_158);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, substr_exp_0, v_683, &v_1);
 
-               _fx_catch_154: ;
-                  if (v_662) {
-                     _fx_free_LN15C_form__cstmt_t(&v_662);
+               _fx_catch_158: ;
+                  if (v_683) {
+                     _fx_free_LN15C_form__cstmt_t(&v_683);
                   }
                   if (call_substr_0) {
                      _fx_free_N14C_form__cexp_t(&call_substr_0);
                   }
-                  if (v_661) {
-                     _fx_free_LN14C_form__cexp_t(&v_661);
+                  if (v_682) {
+                     _fx_free_LN14C_form__cexp_t(&v_682);
                   }
-                  if (v_660) {
-                     _fx_free_N14C_form__cexp_t(&v_660);
+                  if (v_681) {
+                     _fx_free_N14C_form__cexp_t(&v_681);
                   }
-                  if (v_659) {
-                     _fx_free_N14C_form__cexp_t(&v_659);
+                  if (v_680) {
+                     _fx_free_N14C_form__cexp_t(&v_680);
                   }
-                  if (v_658) {
-                     _fx_free_N14C_form__cexp_t(&v_658);
+                  if (v_679) {
+                     _fx_free_N14C_form__cexp_t(&v_679);
                   }
-                  if (ccode_105) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_105);
+                  if (ccode_108) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_108);
                   }
                   if (substr_exp_0) {
                      _fx_free_N14C_form__cexp_t(&substr_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_657);
-                  if (ccode_104) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_104);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_678);
+                  if (ccode_107) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_107);
                   }
                   if (delta_exp_1) {
                      _fx_free_N14C_form__cexp_t(&delta_exp_1);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_656);
-                  if (ccode_103) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_103);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_677);
+                  if (ccode_106) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_106);
                   }
                   if (b_exp_1) {
                      _fx_free_N14C_form__cexp_t(&b_exp_1);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_655);
-                  if (ccode_102) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_102);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_676);
+                  if (ccode_105) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_105);
                   }
                   if (a_exp_1) {
                      _fx_free_N14C_form__cexp_t(&a_exp_1);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_654);
-                  fx_free_exn(&v_653);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_675);
+                  fx_free_exn(&v_674);
                   goto _fx_endmatch_19;
                }
             }
          }
-         fx_exn_t v_671 = {0};
-         fx_str_t slit_153 =
+         fx_exn_t v_692 = {0};
+         fx_str_t slit_159 =
             FX_MAKE_STR("cgen: unexpected index type when accessing string (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_153, &v_671, 0), _fx_catch_155);
-         FX_THROW(&v_671, false, _fx_catch_155);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_159, &v_692, 0), _fx_catch_159);
+         FX_THROW(&v_692, false, _fx_catch_159);
 
-      _fx_catch_155: ;
-         fx_free_exn(&v_671);
+      _fx_catch_159: ;
+         fx_free_exn(&v_692);
 
       _fx_endmatch_19: ;
-         FX_CHECK_EXN(_fx_catch_156);
+         FX_CHECK_EXN(_fx_catch_160);
 
-      _fx_catch_156: ;
+      _fx_catch_160: ;
       }
       else if (tag_18 == 20) {
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_672 = &idxs_1->hd;
-               if (v_672->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_673 = {0};
+               _fx_N13K_form__dom_t* v_693 = &idxs_1->hd;
+               if (v_693->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_694 = {0};
                   _fx_N14C_form__cexp_t i_exp_4 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_106 = 0;
-                  _fx_N14C_form__cexp_t v_674 = 0;
-                  _fx_LN14C_form__cexp_t v_675 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_109 = 0;
+                  _fx_N14C_form__cexp_t v_695 = 0;
+                  _fx_LN14C_form__cexp_t v_696 = 0;
                   _fx_N14C_form__cexp_t get_elem_exp_3 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&v_672->u.DomainFast, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_673, atom2cexp_0.fcv), _fx_catch_157);
-                  FX_COPY_PTR(v_673.t0, &i_exp_4);
-                  FX_COPY_PTR(v_673.t1, &ccode_106);
-                  _fx_R9Ast__id_t v_676;
-                  fx_str_t slit_154 = FX_MAKE_STR("FX_RRB_ELEM");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_154, &v_676, 0), _fx_catch_157);
-                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_674),
-                     _fx_catch_157);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_4, 0, true, &v_675), _fx_catch_157);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_675, false, &v_675), _fx_catch_157);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_674, v_675, false, &v_675), _fx_catch_157);
+                     atom2cexp_0.fp(&v_693->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_694, atom2cexp_0.fcv), _fx_catch_161);
+                  FX_COPY_PTR(v_694.t0, &i_exp_4);
+                  FX_COPY_PTR(v_694.t1, &ccode_109);
+                  _fx_R9Ast__id_t v_697;
+                  fx_str_t slit_160 = FX_MAKE_STR("FX_RRB_ELEM");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_160, &v_697, 0), _fx_catch_161);
+                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_695),
+                     _fx_catch_161);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_4, 0, true, &v_696), _fx_catch_161);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_696, false, &v_696), _fx_catch_161);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_695, v_696, false, &v_696), _fx_catch_161);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_676, v_675, ctyp_0, &kloc_0, &get_elem_exp_3, 0), _fx_catch_157);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_3, ccode_106, &v_1);
+                        &v_697, v_696, ctyp_0, &kloc_0, &get_elem_exp_3, 0), _fx_catch_161);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_3, ccode_109, &v_1);
 
-               _fx_catch_157: ;
+               _fx_catch_161: ;
                   if (get_elem_exp_3) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_3);
                   }
-                  if (v_675) {
-                     _fx_free_LN14C_form__cexp_t(&v_675);
+                  if (v_696) {
+                     _fx_free_LN14C_form__cexp_t(&v_696);
                   }
-                  if (v_674) {
-                     _fx_free_N14C_form__cexp_t(&v_674);
+                  if (v_695) {
+                     _fx_free_N14C_form__cexp_t(&v_695);
                   }
-                  if (ccode_106) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_106);
+                  if (ccode_109) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_109);
                   }
                   if (i_exp_4) {
                      _fx_free_N14C_form__cexp_t(&i_exp_4);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_673);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_694);
                   goto _fx_endmatch_24;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_677 = &idxs_1->hd;
-               if (v_677->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_678 = {0};
+               _fx_N13K_form__dom_t* v_698 = &idxs_1->hd;
+               if (v_698->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_699 = {0};
                   _fx_N14C_form__cexp_t i_exp_5 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_107 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_679 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_110 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_700 = {0};
                   _fx_N14C_form__cexp_t get_elem_exp_4 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_108 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_677->u.DomainElem, true, ccode_98, &kloc_0, &v_678, atom2cexp__0.fcv),
-                     _fx_catch_162);
-                  FX_COPY_PTR(v_678.t0, &i_exp_5);
-                  FX_COPY_PTR(v_678.t1, &ccode_107);
+                  _fx_LN15C_form__cstmt_t ccode_111 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_698->u.DomainElem, true, ccode_101, &kloc_0, &v_699, atom2cexp__0.fcv),
+                     _fx_catch_166);
+                  FX_COPY_PTR(v_699.t0, &i_exp_5);
+                  FX_COPY_PTR(v_699.t1, &ccode_110);
                   int tag_20 = border_0->tag;
                   if (tag_20 == 1) {
-                     _fx_LN14C_form__cexp_t v_680 = 0;
+                     _fx_LN14C_form__cexp_t v_701 = 0;
                      _fx_N14C_form__cexp_t chk_exp_1 = 0;
-                     _fx_N14C_form__cexp_t v_681 = 0;
-                     _fx_LN14C_form__cexp_t v_682 = 0;
+                     _fx_N14C_form__cexp_t v_702 = 0;
+                     _fx_LN14C_form__cexp_t v_703 = 0;
                      _fx_N14C_form__cexp_t get_elem_exp_5 = 0;
-                     _fx_N15C_form__cstmt_t v_683 = 0;
-                     _fx_LN15C_form__cstmt_t v_684 = 0;
-                     _fx_R9Ast__id_t v_685;
-                     fx_str_t slit_155 = FX_MAKE_STR("FX_RRB_CHKIDX");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_155, &v_685, 0), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_5, 0, true, &v_680), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, v_680, false, &v_680), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_680, false, &v_680), _fx_catch_158);
+                     _fx_N15C_form__cstmt_t v_704 = 0;
+                     _fx_LN15C_form__cstmt_t v_705 = 0;
+                     _fx_R9Ast__id_t v_706;
+                     fx_str_t slit_161 = FX_MAKE_STR("FX_RRB_CHKIDX");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_161, &v_706, 0), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_701), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, v_701, false, &v_701), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_701, false, &v_701), _fx_catch_162);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_685, v_680, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_1, 0), _fx_catch_158);
-                     _fx_R9Ast__id_t v_686;
-                     fx_str_t slit_156 = FX_MAKE_STR("FX_RRB_ELEM");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_156, &v_686, 0), _fx_catch_158);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_681),
-                        _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_682), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_682, false, &v_682), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_681, v_682, false, &v_682), _fx_catch_158);
+                           &v_706, v_701, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_1, 0), _fx_catch_162);
+                     _fx_R9Ast__id_t v_707;
+                     fx_str_t slit_162 = FX_MAKE_STR("FX_RRB_ELEM");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_162, &v_707, 0), _fx_catch_162);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_702),
+                        _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_703), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_703, false, &v_703), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_702, v_703, false, &v_703), _fx_catch_162);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_686, v_682, ctyp_0, &kloc_0, &get_elem_exp_5, 0), _fx_catch_158);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_1, &v_683), _fx_catch_158);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_683, ccode_107, true, &v_684), _fx_catch_158);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_5, v_684, &v_679);
+                           &v_707, v_703, ctyp_0, &kloc_0, &get_elem_exp_5, 0), _fx_catch_162);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_1, &v_704), _fx_catch_162);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_704, ccode_110, true, &v_705), _fx_catch_162);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_5, v_705, &v_700);
 
-                  _fx_catch_158: ;
-                     if (v_684) {
-                        _fx_free_LN15C_form__cstmt_t(&v_684);
+                  _fx_catch_162: ;
+                     if (v_705) {
+                        _fx_free_LN15C_form__cstmt_t(&v_705);
                      }
-                     if (v_683) {
-                        _fx_free_N15C_form__cstmt_t(&v_683);
+                     if (v_704) {
+                        _fx_free_N15C_form__cstmt_t(&v_704);
                      }
                      if (get_elem_exp_5) {
                         _fx_free_N14C_form__cexp_t(&get_elem_exp_5);
                      }
-                     if (v_682) {
-                        _fx_free_LN14C_form__cexp_t(&v_682);
+                     if (v_703) {
+                        _fx_free_LN14C_form__cexp_t(&v_703);
                      }
-                     if (v_681) {
-                        _fx_free_N14C_form__cexp_t(&v_681);
+                     if (v_702) {
+                        _fx_free_N14C_form__cexp_t(&v_702);
                      }
                      if (chk_exp_1) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_1);
                      }
-                     if (v_680) {
-                        _fx_free_LN14C_form__cexp_t(&v_680);
+                     if (v_701) {
+                        _fx_free_LN14C_form__cexp_t(&v_701);
                      }
                   }
                   else if (tag_20 == 2) {
-                     _fx_N14C_form__cexp_t v_687 = 0;
-                     _fx_LN14C_form__cexp_t v_688 = 0;
+                     _fx_N14C_form__cexp_t v_708 = 0;
+                     _fx_LN14C_form__cexp_t v_709 = 0;
                      _fx_N14C_form__cexp_t get_elem_exp_6 = 0;
-                     _fx_R9Ast__id_t v_689;
-                     fx_str_t slit_157 = FX_MAKE_STR("FX_RRB_ELEM_CLIP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_157, &v_689, 0), _fx_catch_159);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_687),
-                        _fx_catch_159);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_688), _fx_catch_159);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_688, false, &v_688), _fx_catch_159);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_687, v_688, false, &v_688), _fx_catch_159);
+                     _fx_R9Ast__id_t v_710;
+                     fx_str_t slit_163 = FX_MAKE_STR("FX_RRB_ELEM_CLIP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_163, &v_710, 0), _fx_catch_163);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_708),
+                        _fx_catch_163);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_709), _fx_catch_163);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_709, false, &v_709), _fx_catch_163);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_708, v_709, false, &v_709), _fx_catch_163);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_689, v_688, ctyp_0, &kloc_0, &get_elem_exp_6, 0), _fx_catch_159);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_6, ccode_107, &v_679);
+                           &v_710, v_709, ctyp_0, &kloc_0, &get_elem_exp_6, 0), _fx_catch_163);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_6, ccode_110, &v_700);
 
-                  _fx_catch_159: ;
+                  _fx_catch_163: ;
                      if (get_elem_exp_6) {
                         _fx_free_N14C_form__cexp_t(&get_elem_exp_6);
                      }
-                     if (v_688) {
-                        _fx_free_LN14C_form__cexp_t(&v_688);
+                     if (v_709) {
+                        _fx_free_LN14C_form__cexp_t(&v_709);
                      }
-                     if (v_687) {
-                        _fx_free_N14C_form__cexp_t(&v_687);
+                     if (v_708) {
+                        _fx_free_N14C_form__cexp_t(&v_708);
                      }
                   }
                   else if (tag_20 == 3) {
-                     _fx_N14C_form__cexp_t v_690 = 0;
-                     _fx_LN14C_form__cexp_t v_691 = 0;
+                     _fx_N14C_form__cexp_t v_711 = 0;
+                     _fx_LN14C_form__cexp_t v_712 = 0;
                      _fx_N14C_form__cexp_t get_elem_exp_7 = 0;
-                     _fx_R9Ast__id_t v_692;
-                     fx_str_t slit_158 = FX_MAKE_STR("FX_RRB_ELEM_WRAP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_158, &v_692, 0), _fx_catch_160);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_690),
-                        _fx_catch_160);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_691), _fx_catch_160);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_691, false, &v_691), _fx_catch_160);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_690, v_691, false, &v_691), _fx_catch_160);
+                     _fx_R9Ast__id_t v_713;
+                     fx_str_t slit_164 = FX_MAKE_STR("FX_RRB_ELEM_WRAP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_164, &v_713, 0), _fx_catch_164);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_711),
+                        _fx_catch_164);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_712), _fx_catch_164);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_712, false, &v_712), _fx_catch_164);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_711, v_712, false, &v_712), _fx_catch_164);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_692, v_691, ctyp_0, &kloc_0, &get_elem_exp_7, 0), _fx_catch_160);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_7, ccode_107, &v_679);
+                           &v_713, v_712, ctyp_0, &kloc_0, &get_elem_exp_7, 0), _fx_catch_164);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_7, ccode_110, &v_700);
 
-                  _fx_catch_160: ;
+                  _fx_catch_164: ;
                      if (get_elem_exp_7) {
                         _fx_free_N14C_form__cexp_t(&get_elem_exp_7);
                      }
-                     if (v_691) {
-                        _fx_free_LN14C_form__cexp_t(&v_691);
+                     if (v_712) {
+                        _fx_free_LN14C_form__cexp_t(&v_712);
                      }
-                     if (v_690) {
-                        _fx_free_N14C_form__cexp_t(&v_690);
+                     if (v_711) {
+                        _fx_free_N14C_form__cexp_t(&v_711);
                      }
                   }
                   else if (tag_20 == 4) {
-                     _fx_N14C_form__cexp_t v_693 = 0;
-                     _fx_LN14C_form__cexp_t v_694 = 0;
+                     _fx_N14C_form__cexp_t v_714 = 0;
+                     _fx_LN14C_form__cexp_t v_715 = 0;
                      _fx_N14C_form__cexp_t get_elem_exp_8 = 0;
-                     _fx_R9Ast__id_t v_695;
-                     fx_str_t slit_159 = FX_MAKE_STR("FX_RRB_ELEM_ZERO");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_159, &v_695, 0), _fx_catch_161);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_693),
-                        _fx_catch_161);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_694), _fx_catch_161);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_694, false, &v_694), _fx_catch_161);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_693, v_694, false, &v_694), _fx_catch_161);
+                     _fx_R9Ast__id_t v_716;
+                     fx_str_t slit_165 = FX_MAKE_STR("FX_RRB_ELEM_ZERO");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_165, &v_716, 0), _fx_catch_165);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_714),
+                        _fx_catch_165);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_5, 0, true, &v_715), _fx_catch_165);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_715, false, &v_715), _fx_catch_165);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_714, v_715, false, &v_715), _fx_catch_165);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_695, v_694, ctyp_0, &kloc_0, &get_elem_exp_8, 0), _fx_catch_161);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_8, ccode_107, &v_679);
+                           &v_716, v_715, ctyp_0, &kloc_0, &get_elem_exp_8, 0), _fx_catch_165);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_8, ccode_110, &v_700);
 
-                  _fx_catch_161: ;
+                  _fx_catch_165: ;
                      if (get_elem_exp_8) {
                         _fx_free_N14C_form__cexp_t(&get_elem_exp_8);
                      }
-                     if (v_694) {
-                        _fx_free_LN14C_form__cexp_t(&v_694);
+                     if (v_715) {
+                        _fx_free_LN14C_form__cexp_t(&v_715);
                      }
-                     if (v_693) {
-                        _fx_free_N14C_form__cexp_t(&v_693);
+                     if (v_714) {
+                        _fx_free_N14C_form__cexp_t(&v_714);
                      }
                   }
                   else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_162);
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_166);
                   }
-                  FX_CHECK_EXN(_fx_catch_162);
-                  FX_COPY_PTR(v_679.t0, &get_elem_exp_4);
-                  FX_COPY_PTR(v_679.t1, &ccode_108);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_4, ccode_108, &v_1);
+                  FX_CHECK_EXN(_fx_catch_166);
+                  FX_COPY_PTR(v_700.t0, &get_elem_exp_4);
+                  FX_COPY_PTR(v_700.t1, &ccode_111);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_4, ccode_111, &v_1);
 
-               _fx_catch_162: ;
-                  if (ccode_108) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_108);
+               _fx_catch_166: ;
+                  if (ccode_111) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_111);
                   }
                   if (get_elem_exp_4) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_4);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_679);
-                  if (ccode_107) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_107);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_700);
+                  if (ccode_110) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_110);
                   }
                   if (i_exp_5) {
                      _fx_free_N14C_form__cexp_t(&i_exp_5);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_678);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_699);
                   goto _fx_endmatch_24;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_696 = &idxs_1->hd;
-               if (v_696->tag == 3) {
-                  fx_exn_t v_697 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_698 = {0};
+               _fx_N13K_form__dom_t* v_717 = &idxs_1->hd;
+               if (v_717->tag == 3) {
+                  fx_exn_t v_718 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_719 = {0};
                   _fx_N14C_form__cexp_t a_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_109 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_699 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_112 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_720 = {0};
                   _fx_N14C_form__cexp_t b_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_110 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_700 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_113 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_721 = {0};
                   _fx_N14C_form__cexp_t slice_exp_0 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_111 = 0;
-                  _fx_N14C_form__cexp_t v_701 = 0;
-                  _fx_N14C_form__cexp_t v_702 = 0;
-                  _fx_N14C_form__cexp_t v_703 = 0;
-                  _fx_N14C_form__cexp_t v_704 = 0;
-                  _fx_LN14C_form__cexp_t v_705 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_114 = 0;
+                  _fx_N14C_form__cexp_t v_722 = 0;
+                  _fx_N14C_form__cexp_t v_723 = 0;
+                  _fx_N14C_form__cexp_t v_724 = 0;
+                  _fx_N14C_form__cexp_t v_725 = 0;
+                  _fx_LN14C_form__cexp_t v_726 = 0;
                   _fx_N14C_form__cexp_t call_slice_0 = 0;
-                  _fx_LN15C_form__cstmt_t v_706 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_14 = &v_696->u.DomainRange;
+                  _fx_LN15C_form__cstmt_t v_727 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_14 = &v_717->u.DomainRange;
                   _fx_N14K_form__atom_t* delta_0 = &vcase_14->t2;
                   _fx_N14K_form__atom_t* b_1 = &vcase_14->t1;
                   _fx_N14K_form__atom_t* a_9 = &vcase_14->t0;
                   if (border_0->tag != 1) {
-                     fx_str_t slit_160 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_160, &v_697, 0), _fx_catch_168);
-                     FX_THROW(&v_697, false, _fx_catch_168);
+                     fx_str_t slit_166 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_166, &v_718, 0), _fx_catch_172);
+                     FX_THROW(&v_718, false, _fx_catch_172);
                   }
                   if (a_9->tag == 2) {
                      if (a_9->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_707 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_708 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_707, 0),
-                           _fx_catch_163);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_707, ccode_98, &v_708);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_708, &v_698);
+                        _fx_N14C_form__cexp_t v_728 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_729 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_728, 0),
+                           _fx_catch_167);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_728, ccode_101, &v_729);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_729, &v_719);
 
-                     _fx_catch_163: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_708);
-                        if (v_707) {
-                           _fx_free_N14C_form__cexp_t(&v_707);
+                     _fx_catch_167: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_729);
+                        if (v_728) {
+                           _fx_free_N14C_form__cexp_t(&v_728);
                         }
                         goto _fx_endmatch_20;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_709 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_730 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(a_9, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_709, atom2cexp_0.fcv), _fx_catch_164);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_709, &v_698);
+                     atom2cexp_0.fp(a_9, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_730, atom2cexp_0.fcv), _fx_catch_168);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_730, &v_719);
 
-               _fx_catch_164: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_709);
+               _fx_catch_168: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_730);
 
                _fx_endmatch_20: ;
-                  FX_CHECK_EXN(_fx_catch_168);
-                  int_ mask_2 = v_698.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_710 = &v_698.t1;
-                  FX_COPY_PTR(v_710->t0, &a_exp_2);
-                  FX_COPY_PTR(v_710->t1, &ccode_109);
+                  FX_CHECK_EXN(_fx_catch_172);
+                  int_ mask_2 = v_719.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_731 = &v_719.t1;
+                  FX_COPY_PTR(v_731->t0, &a_exp_2);
+                  FX_COPY_PTR(v_731->t1, &ccode_112);
                   if (b_1->tag == 2) {
                      if (b_1->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_711 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_712 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_711, 0),
-                           _fx_catch_165);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_711, ccode_109, &v_712);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_2, &v_712, &v_699);
+                        _fx_N14C_form__cexp_t v_732 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_733 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_732, 0),
+                           _fx_catch_169);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_732, ccode_112, &v_733);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_2, &v_733, &v_720);
 
-                     _fx_catch_165: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_712);
-                        if (v_711) {
-                           _fx_free_N14C_form__cexp_t(&v_711);
+                     _fx_catch_169: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_733);
+                        if (v_732) {
+                           _fx_free_N14C_form__cexp_t(&v_732);
                         }
                         goto _fx_endmatch_21;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_713 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_734 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(b_1, ccode_109, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_713, atom2cexp_0.fcv), _fx_catch_166);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_2, &v_713, &v_699);
+                     atom2cexp_0.fp(b_1, ccode_112, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_734, atom2cexp_0.fcv), _fx_catch_170);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_2, &v_734, &v_720);
 
-               _fx_catch_166: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_713);
+               _fx_catch_170: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_734);
 
                _fx_endmatch_21: ;
-                  FX_CHECK_EXN(_fx_catch_168);
-                  int_ mask_3 = v_699.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_714 = &v_699.t1;
-                  FX_COPY_PTR(v_714->t0, &b_exp_2);
-                  FX_COPY_PTR(v_714->t1, &ccode_110);
+                  FX_CHECK_EXN(_fx_catch_172);
+                  int_ mask_3 = v_720.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_735 = &v_720.t1;
+                  FX_COPY_PTR(v_735->t0, &b_exp_2);
+                  FX_COPY_PTR(v_735->t1, &ccode_113);
                   int tag_21 = delta_0->tag;
                   int_ delta_1;
                   bool res_19;
@@ -28780,9 +29019,9 @@ static int
                      }
                   }
                   if (tag_21 == 2) {
-                     _fx_N14K_form__klit_t* v_715 = &delta_0->u.AtomLit;
-                     if (v_715->tag == 1) {
-                        if (v_715->u.KLitInt == 1LL) {
+                     _fx_N14K_form__klit_t* v_736 = &delta_0->u.AtomLit;
+                     if (v_736->tag == 1) {
+                        if (v_736->u.KLitInt == 1LL) {
                            res_19 = true; goto _fx_endmatch_22;
                         }
                      }
@@ -28790,609 +29029,609 @@ static int
                   res_19 = false;
 
                _fx_endmatch_22: ;
-                  FX_CHECK_EXN(_fx_catch_168);
+                  FX_CHECK_EXN(_fx_catch_172);
                   if (res_19) {
                      delta_1 = 1; goto _fx_endmatch_23;
                   }
                   if (tag_21 == 2) {
-                     _fx_N14K_form__klit_t* v_716 = &delta_0->u.AtomLit;
-                     if (v_716->tag == 1) {
-                        if (v_716->u.KLitInt == -1LL) {
+                     _fx_N14K_form__klit_t* v_737 = &delta_0->u.AtomLit;
+                     if (v_737->tag == 1) {
+                        if (v_737->u.KLitInt == -1LL) {
                            delta_1 = -1; goto _fx_endmatch_23;
                         }
                      }
                   }
-                  fx_exn_t v_717 = {0};
-                  fx_str_t slit_161 = FX_MAKE_STR("cgen: rrbvec slicing only supports stride == ±1");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_161, &v_717, 0), _fx_catch_167);
-                  FX_THROW(&v_717, false, _fx_catch_167);
+                  fx_exn_t v_738 = {0};
+                  fx_str_t slit_167 = FX_MAKE_STR("cgen: rrbvec slicing only supports stride == ±1");
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_167, &v_738, 0), _fx_catch_171);
+                  FX_THROW(&v_738, false, _fx_catch_171);
 
-               _fx_catch_167: ;
-                  fx_free_exn(&v_717);
+               _fx_catch_171: ;
+                  fx_free_exn(&v_738);
 
                _fx_endmatch_23: ;
-                  FX_CHECK_EXN(_fx_catch_168);
-                  fx_str_t slit_162 = FX_MAKE_STR("slice");
+                  FX_CHECK_EXN(_fx_catch_172);
+                  fx_str_t slit_168 = FX_MAKE_STR("slice");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_162, ctyp_0, ccode_110, &kloc_0, block_stack_ref_0, km_idx_0, &v_700, 0),
-                     _fx_catch_168);
-                  FX_COPY_PTR(v_700.t0, &slice_exp_0);
-                  FX_COPY_PTR(v_700.t1, &ccode_111);
-                  _fx_R9Ast__id_t v_718;
-                  fx_str_t slit_163 = FX_MAKE_STR("fx_rrb_slice");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_163, &v_718, 0), _fx_catch_168);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_701, 0),
-                     _fx_catch_168);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(delta_1, &kloc_0, &v_702, 0),
-                     _fx_catch_168);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_3, &kloc_0, &v_703, 0),
-                     _fx_catch_168);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_0, &v_704, 0),
-                     _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_704, 0, true, &v_705), _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_703, v_705, false, &v_705), _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_702, v_705, false, &v_705), _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_2, v_705, false, &v_705), _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_2, v_705, false, &v_705), _fx_catch_168);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_701, v_705, false, &v_705), _fx_catch_168);
+                        dstexp_r_0, &slit_168, ctyp_0, ccode_113, &kloc_0, block_stack_ref_0, km_idx_0, &v_721, 0),
+                     _fx_catch_172);
+                  FX_COPY_PTR(v_721.t0, &slice_exp_0);
+                  FX_COPY_PTR(v_721.t1, &ccode_114);
+                  _fx_R9Ast__id_t v_739;
+                  fx_str_t slit_169 = FX_MAKE_STR("fx_rrb_slice");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_169, &v_739, 0), _fx_catch_172);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_722, 0),
+                     _fx_catch_172);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(delta_1, &kloc_0, &v_723, 0),
+                     _fx_catch_172);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_3, &kloc_0, &v_724, 0),
+                     _fx_catch_172);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_0, &v_725, 0),
+                     _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_725, 0, true, &v_726), _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_724, v_726, false, &v_726), _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_723, v_726, false, &v_726), _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_2, v_726, false, &v_726), _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_2, v_726, false, &v_726), _fx_catch_172);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_722, v_726, false, &v_726), _fx_catch_172);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_718, v_705, ctyp_0, &kloc_0, &call_slice_0, 0), _fx_catch_168);
+                        &v_739, v_726, ctyp_0, &kloc_0, &call_slice_0, 0), _fx_catch_172);
                   FX_CALL(
                      _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_slice_0, ccode_111, &kloc_0, block_stack_ref_0, &v_706, 0), _fx_catch_168);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_0, v_706, &v_1);
+                        call_slice_0, ccode_114, &kloc_0, block_stack_ref_0, &v_727, 0), _fx_catch_172);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_0, v_727, &v_1);
 
-               _fx_catch_168: ;
-                  if (v_706) {
-                     _fx_free_LN15C_form__cstmt_t(&v_706);
+               _fx_catch_172: ;
+                  if (v_727) {
+                     _fx_free_LN15C_form__cstmt_t(&v_727);
                   }
                   if (call_slice_0) {
                      _fx_free_N14C_form__cexp_t(&call_slice_0);
                   }
-                  if (v_705) {
-                     _fx_free_LN14C_form__cexp_t(&v_705);
+                  if (v_726) {
+                     _fx_free_LN14C_form__cexp_t(&v_726);
                   }
-                  if (v_704) {
-                     _fx_free_N14C_form__cexp_t(&v_704);
+                  if (v_725) {
+                     _fx_free_N14C_form__cexp_t(&v_725);
                   }
-                  if (v_703) {
-                     _fx_free_N14C_form__cexp_t(&v_703);
-                  }
-                  if (v_702) {
-                     _fx_free_N14C_form__cexp_t(&v_702);
-                  }
-                  if (v_701) {
-                     _fx_free_N14C_form__cexp_t(&v_701);
-                  }
-                  if (ccode_111) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_111);
-                  }
-                  if (slice_exp_0) {
-                     _fx_free_N14C_form__cexp_t(&slice_exp_0);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_700);
-                  if (ccode_110) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_110);
-                  }
-                  if (b_exp_2) {
-                     _fx_free_N14C_form__cexp_t(&b_exp_2);
-                  }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_699);
-                  if (ccode_109) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_109);
-                  }
-                  if (a_exp_2) {
-                     _fx_free_N14C_form__cexp_t(&a_exp_2);
-                  }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_698);
-                  fx_free_exn(&v_697);
-                  goto _fx_endmatch_24;
-               }
-            }
-         }
-         fx_exn_t v_719 = {0};
-         fx_str_t slit_164 =
-            FX_MAKE_STR("cgen: unexpected index type when accessing rrbvec (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_164, &v_719, 0), _fx_catch_169);
-         FX_THROW(&v_719, false, _fx_catch_169);
-
-      _fx_catch_169: ;
-         fx_free_exn(&v_719);
-
-      _fx_endmatch_24: ;
-         FX_CHECK_EXN(_fx_catch_170);
-
-      _fx_catch_170: ;
-      }
-      else if (tag_18 == 21) {
-         if (idxs_1 != 0) {
-            if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_720 = &idxs_1->hd;
-               if (v_720->tag == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_721 = {0};
-                  _fx_N14C_form__cexp_t i_exp_6 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_112 = 0;
-                  _fx_N14C_form__cexp_t v_722 = 0;
-                  _fx_LN14C_form__cexp_t v_723 = 0;
-                  _fx_N14C_form__cexp_t get_elem_exp_9 = 0;
-                  FX_CALL(
-                     atom2cexp_0.fp(&v_720->u.DomainFast, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_721, atom2cexp_0.fcv), _fx_catch_171);
-                  FX_COPY_PTR(v_721.t0, &i_exp_6);
-                  FX_COPY_PTR(v_721.t1, &ccode_112);
-                  _fx_R9Ast__id_t v_724;
-                  fx_str_t slit_165 = FX_MAKE_STR("FX_VEC_ELEM");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_165, &v_724, 0), _fx_catch_171);
-                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_722),
-                     _fx_catch_171);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_6, 0, true, &v_723), _fx_catch_171);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_723, false, &v_723), _fx_catch_171);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_722, v_723, false, &v_723), _fx_catch_171);
-                  FX_CALL(
-                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_724, v_723, ctyp_0, &kloc_0, &get_elem_exp_9, 0), _fx_catch_171);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_9, ccode_112, &v_1);
-
-               _fx_catch_171: ;
-                  if (get_elem_exp_9) {
-                     _fx_free_N14C_form__cexp_t(&get_elem_exp_9);
+                  if (v_724) {
+                     _fx_free_N14C_form__cexp_t(&v_724);
                   }
                   if (v_723) {
-                     _fx_free_LN14C_form__cexp_t(&v_723);
+                     _fx_free_N14C_form__cexp_t(&v_723);
                   }
                   if (v_722) {
                      _fx_free_N14C_form__cexp_t(&v_722);
                   }
+                  if (ccode_114) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_114);
+                  }
+                  if (slice_exp_0) {
+                     _fx_free_N14C_form__cexp_t(&slice_exp_0);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_721);
+                  if (ccode_113) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_113);
+                  }
+                  if (b_exp_2) {
+                     _fx_free_N14C_form__cexp_t(&b_exp_2);
+                  }
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_720);
                   if (ccode_112) {
                      _fx_free_LN15C_form__cstmt_t(&ccode_112);
+                  }
+                  if (a_exp_2) {
+                     _fx_free_N14C_form__cexp_t(&a_exp_2);
+                  }
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_719);
+                  fx_free_exn(&v_718);
+                  goto _fx_endmatch_24;
+               }
+            }
+         }
+         fx_exn_t v_740 = {0};
+         fx_str_t slit_170 =
+            FX_MAKE_STR("cgen: unexpected index type when accessing rrbvec (should be a single scalar index or range)");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_170, &v_740, 0), _fx_catch_173);
+         FX_THROW(&v_740, false, _fx_catch_173);
+
+      _fx_catch_173: ;
+         fx_free_exn(&v_740);
+
+      _fx_endmatch_24: ;
+         FX_CHECK_EXN(_fx_catch_174);
+
+      _fx_catch_174: ;
+      }
+      else if (tag_18 == 21) {
+         if (idxs_1 != 0) {
+            if (idxs_1->tl == 0) {
+               _fx_N13K_form__dom_t* v_741 = &idxs_1->hd;
+               if (v_741->tag == 2) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_742 = {0};
+                  _fx_N14C_form__cexp_t i_exp_6 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_115 = 0;
+                  _fx_N14C_form__cexp_t v_743 = 0;
+                  _fx_LN14C_form__cexp_t v_744 = 0;
+                  _fx_N14C_form__cexp_t get_elem_exp_9 = 0;
+                  FX_CALL(
+                     atom2cexp_0.fp(&v_741->u.DomainFast, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_742, atom2cexp_0.fcv), _fx_catch_175);
+                  FX_COPY_PTR(v_742.t0, &i_exp_6);
+                  FX_COPY_PTR(v_742.t1, &ccode_115);
+                  _fx_R9Ast__id_t v_745;
+                  fx_str_t slit_171 = FX_MAKE_STR("FX_VEC_ELEM");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_171, &v_745, 0), _fx_catch_175);
+                  FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_743),
+                     _fx_catch_175);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_6, 0, true, &v_744), _fx_catch_175);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_744, false, &v_744), _fx_catch_175);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_743, v_744, false, &v_744), _fx_catch_175);
+                  FX_CALL(
+                     _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
+                        &v_745, v_744, ctyp_0, &kloc_0, &get_elem_exp_9, 0), _fx_catch_175);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_9, ccode_115, &v_1);
+
+               _fx_catch_175: ;
+                  if (get_elem_exp_9) {
+                     _fx_free_N14C_form__cexp_t(&get_elem_exp_9);
+                  }
+                  if (v_744) {
+                     _fx_free_LN14C_form__cexp_t(&v_744);
+                  }
+                  if (v_743) {
+                     _fx_free_N14C_form__cexp_t(&v_743);
+                  }
+                  if (ccode_115) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_115);
                   }
                   if (i_exp_6) {
                      _fx_free_N14C_form__cexp_t(&i_exp_6);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_721);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_742);
                   goto _fx_endmatch_28;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_725 = &idxs_1->hd;
-               if (v_725->tag == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_726 = {0};
+               _fx_N13K_form__dom_t* v_746 = &idxs_1->hd;
+               if (v_746->tag == 1) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_747 = {0};
                   _fx_N14C_form__cexp_t i_exp_7 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_113 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_727 = {0};
+                  _fx_LN15C_form__cstmt_t ccode_116 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_748 = {0};
                   _fx_N14C_form__cexp_t get_elem_exp_10 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_114 = 0;
-                  FX_CALL(atom2cexp__0.fp(&v_725->u.DomainElem, true, ccode_98, &kloc_0, &v_726, atom2cexp__0.fcv),
-                     _fx_catch_176);
-                  FX_COPY_PTR(v_726.t0, &i_exp_7);
-                  FX_COPY_PTR(v_726.t1, &ccode_113);
+                  _fx_LN15C_form__cstmt_t ccode_117 = 0;
+                  FX_CALL(atom2cexp__0.fp(&v_746->u.DomainElem, true, ccode_101, &kloc_0, &v_747, atom2cexp__0.fcv),
+                     _fx_catch_180);
+                  FX_COPY_PTR(v_747.t0, &i_exp_7);
+                  FX_COPY_PTR(v_747.t1, &ccode_116);
                   int tag_22 = border_0->tag;
                   if (tag_22 == 1) {
-                     _fx_LN14C_form__cexp_t v_728 = 0;
+                     _fx_LN14C_form__cexp_t v_749 = 0;
                      _fx_N14C_form__cexp_t chk_exp_2 = 0;
-                     _fx_N14C_form__cexp_t v_729 = 0;
-                     _fx_LN14C_form__cexp_t v_730 = 0;
+                     _fx_N14C_form__cexp_t v_750 = 0;
+                     _fx_LN14C_form__cexp_t v_751 = 0;
                      _fx_N14C_form__cexp_t get_elem_exp_11 = 0;
-                     _fx_N15C_form__cstmt_t v_731 = 0;
-                     _fx_LN15C_form__cstmt_t v_732 = 0;
-                     _fx_R9Ast__id_t v_733;
-                     fx_str_t slit_166 = FX_MAKE_STR("FX_VEC_CHKIDX");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_166, &v_733, 0), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_5, 0, true, &v_728), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, v_728, false, &v_728), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_728, false, &v_728), _fx_catch_172);
+                     _fx_N15C_form__cstmt_t v_752 = 0;
+                     _fx_LN15C_form__cstmt_t v_753 = 0;
+                     _fx_R9Ast__id_t v_754;
+                     fx_str_t slit_172 = FX_MAKE_STR("FX_VEC_CHKIDX");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_172, &v_754, 0), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_749), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, v_749, false, &v_749), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_749, false, &v_749), _fx_catch_176);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_733, v_728, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_2, 0), _fx_catch_172);
-                     _fx_R9Ast__id_t v_734;
-                     fx_str_t slit_167 = FX_MAKE_STR("FX_VEC_ELEM");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_167, &v_734, 0), _fx_catch_172);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_729),
-                        _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_730), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_730, false, &v_730), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_729, v_730, false, &v_730), _fx_catch_172);
+                           &v_754, v_749, _fx_g20C_gen_code__CTypVoid, &kloc_0, &chk_exp_2, 0), _fx_catch_176);
+                     _fx_R9Ast__id_t v_755;
+                     fx_str_t slit_173 = FX_MAKE_STR("FX_VEC_ELEM");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_173, &v_755, 0), _fx_catch_176);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_750),
+                        _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_751), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_751, false, &v_751), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_750, v_751, false, &v_751), _fx_catch_176);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_734, v_730, ctyp_0, &kloc_0, &get_elem_exp_11, 0), _fx_catch_172);
-                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_2, &v_731), _fx_catch_172);
-                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_731, ccode_113, true, &v_732), _fx_catch_172);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_11, v_732, &v_727);
+                           &v_755, v_751, ctyp_0, &kloc_0, &get_elem_exp_11, 0), _fx_catch_176);
+                     FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(chk_exp_2, &v_752), _fx_catch_176);
+                     FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_752, ccode_116, true, &v_753), _fx_catch_176);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(get_elem_exp_11, v_753, &v_748);
 
-                  _fx_catch_172: ;
-                     if (v_732) {
-                        _fx_free_LN15C_form__cstmt_t(&v_732);
+                  _fx_catch_176: ;
+                     if (v_753) {
+                        _fx_free_LN15C_form__cstmt_t(&v_753);
                      }
-                     if (v_731) {
-                        _fx_free_N15C_form__cstmt_t(&v_731);
+                     if (v_752) {
+                        _fx_free_N15C_form__cstmt_t(&v_752);
                      }
                      if (get_elem_exp_11) {
                         _fx_free_N14C_form__cexp_t(&get_elem_exp_11);
                      }
-                     if (v_730) {
-                        _fx_free_LN14C_form__cexp_t(&v_730);
+                     if (v_751) {
+                        _fx_free_LN14C_form__cexp_t(&v_751);
                      }
-                     if (v_729) {
-                        _fx_free_N14C_form__cexp_t(&v_729);
+                     if (v_750) {
+                        _fx_free_N14C_form__cexp_t(&v_750);
                      }
                      if (chk_exp_2) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_2);
                      }
-                     if (v_728) {
-                        _fx_free_LN14C_form__cexp_t(&v_728);
+                     if (v_749) {
+                        _fx_free_LN14C_form__cexp_t(&v_749);
                      }
                   }
                   else if (tag_22 == 2) {
-                     _fx_N14C_form__cexp_t v_735 = 0;
-                     _fx_LN14C_form__cexp_t v_736 = 0;
-                     _fx_N14C_form__cexp_t v_737 = 0;
-                     _fx_R9Ast__id_t v_738;
-                     fx_str_t slit_168 = FX_MAKE_STR("FX_VEC_ELEM_CLIP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_168, &v_738, 0), _fx_catch_173);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_735),
-                        _fx_catch_173);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_736), _fx_catch_173);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_736, false, &v_736), _fx_catch_173);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_735, v_736, false, &v_736), _fx_catch_173);
+                     _fx_N14C_form__cexp_t v_756 = 0;
+                     _fx_LN14C_form__cexp_t v_757 = 0;
+                     _fx_N14C_form__cexp_t v_758 = 0;
+                     _fx_R9Ast__id_t v_759;
+                     fx_str_t slit_174 = FX_MAKE_STR("FX_VEC_ELEM_CLIP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_174, &v_759, 0), _fx_catch_177);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_756),
+                        _fx_catch_177);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_757), _fx_catch_177);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_757, false, &v_757), _fx_catch_177);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_756, v_757, false, &v_757), _fx_catch_177);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_738, v_736, ctyp_0, &kloc_0, &v_737, 0), _fx_catch_173);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_737, ccode_113, &v_727);
+                           &v_759, v_757, ctyp_0, &kloc_0, &v_758, 0), _fx_catch_177);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_758, ccode_116, &v_748);
 
-                  _fx_catch_173: ;
-                     if (v_737) {
-                        _fx_free_N14C_form__cexp_t(&v_737);
+                  _fx_catch_177: ;
+                     if (v_758) {
+                        _fx_free_N14C_form__cexp_t(&v_758);
                      }
-                     if (v_736) {
-                        _fx_free_LN14C_form__cexp_t(&v_736);
+                     if (v_757) {
+                        _fx_free_LN14C_form__cexp_t(&v_757);
                      }
-                     if (v_735) {
-                        _fx_free_N14C_form__cexp_t(&v_735);
+                     if (v_756) {
+                        _fx_free_N14C_form__cexp_t(&v_756);
                      }
                   }
                   else if (tag_22 == 3) {
-                     _fx_N14C_form__cexp_t v_739 = 0;
-                     _fx_LN14C_form__cexp_t v_740 = 0;
-                     _fx_N14C_form__cexp_t v_741 = 0;
-                     _fx_R9Ast__id_t v_742;
-                     fx_str_t slit_169 = FX_MAKE_STR("FX_VEC_ELEM_WRAP");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_169, &v_742, 0), _fx_catch_174);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_739),
-                        _fx_catch_174);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_740), _fx_catch_174);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_740, false, &v_740), _fx_catch_174);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_739, v_740, false, &v_740), _fx_catch_174);
+                     _fx_N14C_form__cexp_t v_760 = 0;
+                     _fx_LN14C_form__cexp_t v_761 = 0;
+                     _fx_N14C_form__cexp_t v_762 = 0;
+                     _fx_R9Ast__id_t v_763;
+                     fx_str_t slit_175 = FX_MAKE_STR("FX_VEC_ELEM_WRAP");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_175, &v_763, 0), _fx_catch_178);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_760),
+                        _fx_catch_178);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_761), _fx_catch_178);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_761, false, &v_761), _fx_catch_178);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_760, v_761, false, &v_761), _fx_catch_178);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_742, v_740, ctyp_0, &kloc_0, &v_741, 0), _fx_catch_174);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_741, ccode_113, &v_727);
+                           &v_763, v_761, ctyp_0, &kloc_0, &v_762, 0), _fx_catch_178);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_762, ccode_116, &v_748);
 
-                  _fx_catch_174: ;
-                     if (v_741) {
-                        _fx_free_N14C_form__cexp_t(&v_741);
+                  _fx_catch_178: ;
+                     if (v_762) {
+                        _fx_free_N14C_form__cexp_t(&v_762);
                      }
-                     if (v_740) {
-                        _fx_free_LN14C_form__cexp_t(&v_740);
+                     if (v_761) {
+                        _fx_free_LN14C_form__cexp_t(&v_761);
                      }
-                     if (v_739) {
-                        _fx_free_N14C_form__cexp_t(&v_739);
+                     if (v_760) {
+                        _fx_free_N14C_form__cexp_t(&v_760);
                      }
                   }
                   else if (tag_22 == 4) {
-                     _fx_N14C_form__cexp_t v_743 = 0;
-                     _fx_LN14C_form__cexp_t v_744 = 0;
-                     _fx_N14C_form__cexp_t v_745 = 0;
-                     _fx_R9Ast__id_t v_746;
-                     fx_str_t slit_170 = FX_MAKE_STR("FX_VEC_ELEM_ZERO");
-                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_170, &v_746, 0), _fx_catch_175);
-                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_743),
-                        _fx_catch_175);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_744), _fx_catch_175);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_744, false, &v_744), _fx_catch_175);
-                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_743, v_744, false, &v_744), _fx_catch_175);
+                     _fx_N14C_form__cexp_t v_764 = 0;
+                     _fx_LN14C_form__cexp_t v_765 = 0;
+                     _fx_N14C_form__cexp_t v_766 = 0;
+                     _fx_R9Ast__id_t v_767;
+                     fx_str_t slit_176 = FX_MAKE_STR("FX_VEC_ELEM_ZERO");
+                     FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_176, &v_767, 0), _fx_catch_179);
+                     FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_764),
+                        _fx_catch_179);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_7, 0, true, &v_765), _fx_catch_179);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_765, false, &v_765), _fx_catch_179);
+                     FX_CALL(_fx_cons_LN14C_form__cexp_t(v_764, v_765, false, &v_765), _fx_catch_179);
                      FX_CALL(
                         _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                           &v_746, v_744, ctyp_0, &kloc_0, &v_745, 0), _fx_catch_175);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_745, ccode_113, &v_727);
+                           &v_767, v_765, ctyp_0, &kloc_0, &v_766, 0), _fx_catch_179);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_766, ccode_116, &v_748);
 
-                  _fx_catch_175: ;
-                     if (v_745) {
-                        _fx_free_N14C_form__cexp_t(&v_745);
+                  _fx_catch_179: ;
+                     if (v_766) {
+                        _fx_free_N14C_form__cexp_t(&v_766);
                      }
-                     if (v_744) {
-                        _fx_free_LN14C_form__cexp_t(&v_744);
+                     if (v_765) {
+                        _fx_free_LN14C_form__cexp_t(&v_765);
                      }
-                     if (v_743) {
-                        _fx_free_N14C_form__cexp_t(&v_743);
+                     if (v_764) {
+                        _fx_free_N14C_form__cexp_t(&v_764);
                      }
                   }
                   else {
-                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_176);
+                     FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_180);
                   }
-                  FX_CHECK_EXN(_fx_catch_176);
-                  FX_COPY_PTR(v_727.t0, &get_elem_exp_10);
-                  FX_COPY_PTR(v_727.t1, &ccode_114);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_10, ccode_114, &v_1);
+                  FX_CHECK_EXN(_fx_catch_180);
+                  FX_COPY_PTR(v_748.t0, &get_elem_exp_10);
+                  FX_COPY_PTR(v_748.t1, &ccode_117);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, get_elem_exp_10, ccode_117, &v_1);
 
-               _fx_catch_176: ;
-                  if (ccode_114) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_114);
+               _fx_catch_180: ;
+                  if (ccode_117) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_117);
                   }
                   if (get_elem_exp_10) {
                      _fx_free_N14C_form__cexp_t(&get_elem_exp_10);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_727);
-                  if (ccode_113) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_113);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_748);
+                  if (ccode_116) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_116);
                   }
                   if (i_exp_7) {
                      _fx_free_N14C_form__cexp_t(&i_exp_7);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_726);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_747);
                   goto _fx_endmatch_28;
                }
             }
          }
          if (idxs_1 != 0) {
             if (idxs_1->tl == 0) {
-               _fx_N13K_form__dom_t* v_747 = &idxs_1->hd;
-               if (v_747->tag == 3) {
-                  fx_exn_t v_748 = {0};
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_749 = {0};
+               _fx_N13K_form__dom_t* v_768 = &idxs_1->hd;
+               if (v_768->tag == 3) {
+                  fx_exn_t v_769 = {0};
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_770 = {0};
                   _fx_N14C_form__cexp_t a_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_115 = 0;
-                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_750 = {0};
-                  _fx_N14C_form__cexp_t b_exp_3 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_116 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_751 = {0};
-                  _fx_N14C_form__cexp_t delta_exp_2 = 0;
-                  _fx_LN15C_form__cstmt_t ccode_117 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_752 = {0};
-                  _fx_N14C_form__cexp_t slice_exp_1 = 0;
                   _fx_LN15C_form__cstmt_t ccode_118 = 0;
-                  _fx_N14C_form__cexp_t v_753 = 0;
-                  _fx_N14C_form__cexp_t v_754 = 0;
-                  _fx_LN14C_form__cexp_t v_755 = 0;
+                  _fx_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t v_771 = {0};
+                  _fx_N14C_form__cexp_t b_exp_3 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_119 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_772 = {0};
+                  _fx_N14C_form__cexp_t delta_exp_2 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_120 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_773 = {0};
+                  _fx_N14C_form__cexp_t slice_exp_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode_121 = 0;
+                  _fx_N14C_form__cexp_t v_774 = 0;
+                  _fx_N14C_form__cexp_t v_775 = 0;
+                  _fx_LN14C_form__cexp_t v_776 = 0;
                   _fx_N14C_form__cexp_t call_slice_1 = 0;
-                  _fx_LN15C_form__cstmt_t v_756 = 0;
-                  _fx_Ta3N14K_form__atom_t* vcase_15 = &v_747->u.DomainRange;
+                  _fx_LN15C_form__cstmt_t v_777 = 0;
+                  _fx_Ta3N14K_form__atom_t* vcase_15 = &v_768->u.DomainRange;
                   _fx_N14K_form__atom_t* delta_2 = &vcase_15->t2;
                   _fx_N14K_form__atom_t* b_2 = &vcase_15->t1;
                   _fx_N14K_form__atom_t* a_10 = &vcase_15->t0;
                   if (border_0->tag != 1) {
-                     fx_str_t slit_171 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported for vectors");
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_171, &v_748, 0), _fx_catch_183);
-                     FX_THROW(&v_748, false, _fx_catch_183);
+                     fx_str_t slit_177 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported for vectors");
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_177, &v_769, 0), _fx_catch_187);
+                     FX_THROW(&v_769, false, _fx_catch_187);
                   }
                   if (a_10->tag == 2) {
                      if (a_10->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_757 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_758 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_757, 0),
-                           _fx_catch_177);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_757, ccode_98, &v_758);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_758, &v_749);
+                        _fx_N14C_form__cexp_t v_778 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_779 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_778, 0),
+                           _fx_catch_181);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_778, ccode_101, &v_779);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(1, &v_779, &v_770);
 
-                     _fx_catch_177: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_758);
-                        if (v_757) {
-                           _fx_free_N14C_form__cexp_t(&v_757);
+                     _fx_catch_181: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_779);
+                        if (v_778) {
+                           _fx_free_N14C_form__cexp_t(&v_778);
                         }
                         goto _fx_endmatch_25;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_759 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_780 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(a_10, ccode_98, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_759, atom2cexp_0.fcv), _fx_catch_178);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_759, &v_749);
+                     atom2cexp_0.fp(a_10, ccode_101, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_780, atom2cexp_0.fcv), _fx_catch_182);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(0, &v_780, &v_770);
 
-               _fx_catch_178: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_759);
+               _fx_catch_182: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_780);
 
                _fx_endmatch_25: ;
-                  FX_CHECK_EXN(_fx_catch_183);
-                  int_ mask_4 = v_749.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_760 = &v_749.t1;
-                  FX_COPY_PTR(v_760->t0, &a_exp_3);
-                  FX_COPY_PTR(v_760->t1, &ccode_115);
+                  FX_CHECK_EXN(_fx_catch_187);
+                  int_ mask_4 = v_770.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_781 = &v_770.t1;
+                  FX_COPY_PTR(v_781->t0, &a_exp_3);
+                  FX_COPY_PTR(v_781->t1, &ccode_118);
                   if (b_2->tag == 2) {
                      if (b_2->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_761 = 0;
-                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_762 = {0};
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_761, 0),
-                           _fx_catch_179);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_761, ccode_115, &v_762);
-                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_4, &v_762, &v_750);
+                        _fx_N14C_form__cexp_t v_782 = 0;
+                        _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_783 = {0};
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_782, 0),
+                           _fx_catch_183);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_782, ccode_118, &v_783);
+                        _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(2 + mask_4, &v_783, &v_771);
 
-                     _fx_catch_179: ;
-                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_762);
-                        if (v_761) {
-                           _fx_free_N14C_form__cexp_t(&v_761);
+                     _fx_catch_183: ;
+                        _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_783);
+                        if (v_782) {
+                           _fx_free_N14C_form__cexp_t(&v_782);
                         }
                         goto _fx_endmatch_26;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_763 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_784 = {0};
                   FX_CALL(
-                     atom2cexp_0.fp(b_2, ccode_115, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_763, atom2cexp_0.fcv), _fx_catch_180);
-                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_4, &v_763, &v_750);
+                     atom2cexp_0.fp(b_2, ccode_118, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+                        km_idx_0, &v_784, atom2cexp_0.fcv), _fx_catch_184);
+                  _fx_make_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(mask_4, &v_784, &v_771);
 
-               _fx_catch_180: ;
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_763);
+               _fx_catch_184: ;
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_784);
 
                _fx_endmatch_26: ;
-                  FX_CHECK_EXN(_fx_catch_183);
-                  int_ mask_5 = v_750.t0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_764 = &v_750.t1;
-                  FX_COPY_PTR(v_764->t0, &b_exp_3);
-                  FX_COPY_PTR(v_764->t1, &ccode_116);
+                  FX_CHECK_EXN(_fx_catch_187);
+                  int_ mask_5 = v_771.t0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* v_785 = &v_771.t1;
+                  FX_COPY_PTR(v_785->t0, &b_exp_3);
+                  FX_COPY_PTR(v_785->t1, &ccode_119);
                   if (delta_2->tag == 2) {
                      if (delta_2->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_765 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_765, 0),
-                           _fx_catch_181);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_765, ccode_116, &v_751);
+                        _fx_N14C_form__cexp_t v_786 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_786, 0),
+                           _fx_catch_185);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_786, ccode_119, &v_772);
 
-                     _fx_catch_181: ;
-                        if (v_765) {
-                           _fx_free_N14C_form__cexp_t(&v_765);
+                     _fx_catch_185: ;
+                        if (v_786) {
+                           _fx_free_N14C_form__cexp_t(&v_786);
                         }
                         goto _fx_endmatch_27;
                      }
                   }
                   FX_CALL(
-                     atom2cexp_0.fp(delta_2, ccode_116, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_751, atom2cexp_0.fcv), _fx_catch_182);
+                     atom2cexp_0.fp(delta_2, ccode_119, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_772, atom2cexp_0.fcv), _fx_catch_186);
 
-               _fx_catch_182: ;
+               _fx_catch_186: ;
 
                _fx_endmatch_27: ;
-                  FX_CHECK_EXN(_fx_catch_183);
-                  FX_COPY_PTR(v_751.t0, &delta_exp_2);
-                  FX_COPY_PTR(v_751.t1, &ccode_117);
-                  fx_str_t slit_172 = FX_MAKE_STR("slice");
+                  FX_CHECK_EXN(_fx_catch_187);
+                  FX_COPY_PTR(v_772.t0, &delta_exp_2);
+                  FX_COPY_PTR(v_772.t1, &ccode_120);
+                  fx_str_t slit_178 = FX_MAKE_STR("slice");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_172, ctyp_0, ccode_117, &kloc_0, block_stack_ref_0, km_idx_0, &v_752, 0),
-                     _fx_catch_183);
-                  FX_COPY_PTR(v_752.t0, &slice_exp_1);
-                  FX_COPY_PTR(v_752.t1, &ccode_118);
-                  _fx_R9Ast__id_t v_766;
-                  fx_str_t slit_173 = FX_MAKE_STR("fx_vec_slice");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_173, &v_766, 0), _fx_catch_183);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_5, &kloc_0, &v_753, 0),
-                     _fx_catch_183);
-                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_1, &v_754, 0),
-                     _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_754, 0, true, &v_755), _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_753, v_755, false, &v_755), _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_2, v_755, false, &v_755), _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_3, v_755, false, &v_755), _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_3, v_755, false, &v_755), _fx_catch_183);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_755, false, &v_755), _fx_catch_183);
+                        dstexp_r_0, &slit_178, ctyp_0, ccode_120, &kloc_0, block_stack_ref_0, km_idx_0, &v_773, 0),
+                     _fx_catch_187);
+                  FX_COPY_PTR(v_773.t0, &slice_exp_1);
+                  FX_COPY_PTR(v_773.t1, &ccode_121);
+                  _fx_R9Ast__id_t v_787;
+                  fx_str_t slit_179 = FX_MAKE_STR("fx_vec_slice");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_179, &v_787, 0), _fx_catch_187);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(mask_5, &kloc_0, &v_774, 0),
+                     _fx_catch_187);
+                  FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(slice_exp_1, &v_775, 0),
+                     _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_775, 0, true, &v_776), _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_774, v_776, false, &v_776), _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(delta_exp_2, v_776, false, &v_776), _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_3, v_776, false, &v_776), _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_3, v_776, false, &v_776), _fx_catch_187);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_776, false, &v_776), _fx_catch_187);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_766, v_755, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_slice_1, 0), _fx_catch_183);
+                        &v_787, v_776, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_slice_1, 0), _fx_catch_187);
                   FX_CALL(
                      _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        call_slice_1, ccode_118, &kloc_0, block_stack_ref_0, &v_756, 0), _fx_catch_183);
-                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_1, v_756, &v_1);
+                        call_slice_1, ccode_121, &kloc_0, block_stack_ref_0, &v_777, 0), _fx_catch_187);
+                  _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, slice_exp_1, v_777, &v_1);
 
-               _fx_catch_183: ;
-                  if (v_756) {
-                     _fx_free_LN15C_form__cstmt_t(&v_756);
+               _fx_catch_187: ;
+                  if (v_777) {
+                     _fx_free_LN15C_form__cstmt_t(&v_777);
                   }
                   if (call_slice_1) {
                      _fx_free_N14C_form__cexp_t(&call_slice_1);
                   }
-                  if (v_755) {
-                     _fx_free_LN14C_form__cexp_t(&v_755);
+                  if (v_776) {
+                     _fx_free_LN14C_form__cexp_t(&v_776);
                   }
-                  if (v_754) {
-                     _fx_free_N14C_form__cexp_t(&v_754);
+                  if (v_775) {
+                     _fx_free_N14C_form__cexp_t(&v_775);
                   }
-                  if (v_753) {
-                     _fx_free_N14C_form__cexp_t(&v_753);
+                  if (v_774) {
+                     _fx_free_N14C_form__cexp_t(&v_774);
                   }
-                  if (ccode_118) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_118);
+                  if (ccode_121) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_121);
                   }
                   if (slice_exp_1) {
                      _fx_free_N14C_form__cexp_t(&slice_exp_1);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_752);
-                  if (ccode_117) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_117);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_773);
+                  if (ccode_120) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_120);
                   }
                   if (delta_exp_2) {
                      _fx_free_N14C_form__cexp_t(&delta_exp_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_751);
-                  if (ccode_116) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_116);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_772);
+                  if (ccode_119) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_119);
                   }
                   if (b_exp_3) {
                      _fx_free_N14C_form__cexp_t(&b_exp_3);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_750);
-                  if (ccode_115) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode_115);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_771);
+                  if (ccode_118) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode_118);
                   }
                   if (a_exp_3) {
                      _fx_free_N14C_form__cexp_t(&a_exp_3);
                   }
-                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_749);
-                  fx_free_exn(&v_748);
+                  _fx_free_T2iT2N14C_form__cexp_tLN15C_form__cstmt_t(&v_770);
+                  fx_free_exn(&v_769);
                   goto _fx_endmatch_28;
                }
             }
          }
-         fx_exn_t v_767 = {0};
-         fx_str_t slit_174 =
+         fx_exn_t v_788 = {0};
+         fx_str_t slit_180 =
             FX_MAKE_STR("cgen: unexpected index type when accessing vector (should be a single scalar index or range)");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_174, &v_767, 0), _fx_catch_184);
-         FX_THROW(&v_767, false, _fx_catch_184);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_180, &v_788, 0), _fx_catch_188);
+         FX_THROW(&v_788, false, _fx_catch_188);
 
-      _fx_catch_184: ;
-         fx_free_exn(&v_767);
+      _fx_catch_188: ;
+         fx_free_exn(&v_788);
 
       _fx_endmatch_28: ;
-         FX_CHECK_EXN(_fx_catch_185);
+         FX_CHECK_EXN(_fx_catch_189);
 
-      _fx_catch_185: ;
+      _fx_catch_189: ;
       }
       else if (tag_18 == 19) {
          _fx_LN13K_form__dom_t idxs_2 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_768 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_789 = {0};
          _fx_N14C_form__cexp_t subarr_exp_0 = 0;
-         _fx_N14C_form__cexp_t v_769 = 0;
-         _fx_N14C_form__cexp_t v_770 = 0;
-         _fx_LN14C_form__cexp_t v_771 = 0;
+         _fx_N14C_form__cexp_t v_790 = 0;
+         _fx_N14C_form__cexp_t v_791 = 0;
+         _fx_LN14C_form__cexp_t v_792 = 0;
          _fx_N14C_form__cexp_t call_flatten_0 = 0;
-         _fx_LN15C_form__cstmt_t v_772 = 0;
-         fx_exn_t v_773 = {0};
+         _fx_LN15C_form__cstmt_t v_793 = 0;
+         fx_exn_t v_794 = {0};
          _fx_LN14C_form__cexp_t range_data_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_119 = 0;
+         _fx_LN15C_form__cstmt_t ccode_122 = 0;
          _fx_LN13K_form__dom_t idxs_3 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_774 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_795 = {0};
          _fx_N14C_form__cexp_t subarr_exp_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_120 = 0;
-         _fx_LN19C_form__ctyp_attr_t v_775 = 0;
+         _fx_LN15C_form__cstmt_t ccode_123 = 0;
+         _fx_LN19C_form__ctyp_attr_t v_796 = 0;
          _fx_N14C_form__ctyp_t rdata_ctyp_0 = 0;
-         _fx_LN14C_form__cexp_t v_776 = 0;
-         _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_777 = {0};
+         _fx_LN14C_form__cexp_t v_797 = 0;
+         _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_798 = {0};
          _fx_N14C_form__cexp_t rdata_arr_0 = 0;
-         _fx_R16Ast__val_flags_t v_778 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_779 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_780 = {0};
+         _fx_R16Ast__val_flags_t v_799 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_800 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_801 = {0};
          _fx_N14C_form__cexp_t rdata_exp_0 = 0;
          _fx_LN15C_form__cstmt_t sub_ccode_10 = 0;
-         _fx_N14C_form__cexp_t v_781 = 0;
-         _fx_N14C_form__cexp_t v_782 = 0;
-         _fx_LN14C_form__cexp_t v_783 = 0;
+         _fx_N14C_form__cexp_t v_802 = 0;
+         _fx_N14C_form__cexp_t v_803 = 0;
+         _fx_LN14C_form__cexp_t v_804 = 0;
          _fx_N14C_form__cexp_t call_subarr_0 = 0;
          _fx_LN15C_form__cstmt_t sub_ccode_11 = 0;
-         _fx_N15C_form__cstmt_t v_784 = 0;
-         _fx_LN15C_form__cstmt_t ccode_121 = 0;
+         _fx_N15C_form__cstmt_t v_805 = 0;
+         _fx_LN15C_form__cstmt_t ccode_124 = 0;
          _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_0 = {0};
          _fx_LN14C_form__cexp_t i_exps_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_122 = 0;
+         _fx_LN15C_form__cstmt_t ccode_125 = 0;
          _fx_LN13K_form__dom_t idxs_4 = 0;
          _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_1 = {0};
-         _fx_LN15C_form__cstmt_t ccode_123 = 0;
+         _fx_LN15C_form__cstmt_t ccode_126 = 0;
          _fx_LR9Ast__id_t access_op_0 = 0;
-         _fx_N14C_form__cexp_t v_785 = 0;
-         _fx_LN14C_form__cexp_t v_786 = 0;
-         _fx_LN14C_form__cexp_t v_787 = 0;
-         _fx_N14C_form__ctyp_t v_788 = 0;
+         _fx_N14C_form__cexp_t v_806 = 0;
+         _fx_LN14C_form__cexp_t v_807 = 0;
+         _fx_LN14C_form__cexp_t v_808 = 0;
+         _fx_N14C_form__ctyp_t v_809 = 0;
          _fx_N14C_form__cexp_t get_elem_exp_12 = 0;
-         _fx_N14C_form__cexp_t v_789 = 0;
+         _fx_N14C_form__cexp_t v_810 = 0;
          bool __fold_result___3 = false;
          FX_COPY_PTR(idxs_1, &idxs_2);
          _fx_LN13K_form__dom_t lst_19 = idxs_2;
@@ -29405,14 +29644,14 @@ static int
             else {
                res_20 = false;
             }
-            FX_CHECK_EXN(_fx_catch_186);
+            FX_CHECK_EXN(_fx_catch_190);
             if (res_20) {
-               __fold_result___3 = true; FX_BREAK(_fx_catch_186);
+               __fold_result___3 = true; FX_BREAK(_fx_catch_190);
             }
 
-         _fx_catch_186: ;
+         _fx_catch_190: ;
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_201);
+            FX_CHECK_EXN(_fx_catch_205);
          }
          bool need_subarr_0 = __fold_result___3;
          bool need_flatten_0;
@@ -29420,18 +29659,18 @@ static int
             bool res_21;
             if (idxs_1 != 0) {
                if (idxs_1->tl == 0) {
-                  _fx_N13K_form__dom_t* v_790 = &idxs_1->hd;
-                  if (v_790->tag == 3) {
-                     _fx_Ta3N14K_form__atom_t* vcase_16 = &v_790->u.DomainRange;
-                     _fx_N14K_form__atom_t* v_791 = &vcase_16->t0;
-                     if (v_791->tag == 2) {
-                        _fx_N14K_form__atom_t* v_792 = &vcase_16->t1;
-                        if (v_792->tag == 2) {
-                           _fx_N14K_form__atom_t* v_793 = &vcase_16->t2;
-                           if (v_793->tag == 2) {
-                              if (v_791->u.AtomLit.tag == 8) {
-                                 if (v_792->u.AtomLit.tag == 8) {
-                                    if (v_793->u.AtomLit.tag == 8) {
+                  _fx_N13K_form__dom_t* v_811 = &idxs_1->hd;
+                  if (v_811->tag == 3) {
+                     _fx_Ta3N14K_form__atom_t* vcase_16 = &v_811->u.DomainRange;
+                     _fx_N14K_form__atom_t* v_812 = &vcase_16->t0;
+                     if (v_812->tag == 2) {
+                        _fx_N14K_form__atom_t* v_813 = &vcase_16->t1;
+                        if (v_813->tag == 2) {
+                           _fx_N14K_form__atom_t* v_814 = &vcase_16->t2;
+                           if (v_814->tag == 2) {
+                              if (v_812->u.AtomLit.tag == 8) {
+                                 if (v_813->u.AtomLit.tag == 8) {
+                                    if (v_814->u.AtomLit.tag == 8) {
                                        res_21 = true; goto _fx_endmatch_29;
                                     }
                                  }
@@ -29444,20 +29683,20 @@ static int
             }
             if (idxs_1 != 0) {
                if (idxs_1->tl == 0) {
-                  _fx_N13K_form__dom_t* v_794 = &idxs_1->hd;
-                  if (v_794->tag == 3) {
-                     _fx_Ta3N14K_form__atom_t* vcase_17 = &v_794->u.DomainRange;
-                     _fx_N14K_form__atom_t* v_795 = &vcase_17->t0;
-                     if (v_795->tag == 2) {
-                        _fx_N14K_form__atom_t* v_796 = &vcase_17->t1;
-                        if (v_796->tag == 2) {
-                           _fx_N14K_form__atom_t* v_797 = &vcase_17->t2;
-                           if (v_797->tag == 2) {
-                              if (v_795->u.AtomLit.tag == 8) {
-                                 if (v_796->u.AtomLit.tag == 8) {
-                                    _fx_N14K_form__klit_t* v_798 = &v_797->u.AtomLit;
-                                    if (v_798->tag == 1) {
-                                       if (v_798->u.KLitInt == 1LL) {
+                  _fx_N13K_form__dom_t* v_815 = &idxs_1->hd;
+                  if (v_815->tag == 3) {
+                     _fx_Ta3N14K_form__atom_t* vcase_17 = &v_815->u.DomainRange;
+                     _fx_N14K_form__atom_t* v_816 = &vcase_17->t0;
+                     if (v_816->tag == 2) {
+                        _fx_N14K_form__atom_t* v_817 = &vcase_17->t1;
+                        if (v_817->tag == 2) {
+                           _fx_N14K_form__atom_t* v_818 = &vcase_17->t2;
+                           if (v_818->tag == 2) {
+                              if (v_816->u.AtomLit.tag == 8) {
+                                 if (v_817->u.AtomLit.tag == 8) {
+                                    _fx_N14K_form__klit_t* v_819 = &v_818->u.AtomLit;
+                                    if (v_819->tag == 1) {
+                                       if (v_819->u.KLitInt == 1LL) {
                                           res_21 = true; goto _fx_endmatch_29;
                                        }
                                     }
@@ -29472,76 +29711,76 @@ static int
             res_21 = false;
 
          _fx_endmatch_29: ;
-            FX_CHECK_EXN(_fx_catch_201);
+            FX_CHECK_EXN(_fx_catch_205);
             if (res_21) {
                need_flatten_0 = true; goto _fx_endmatch_30;
             }
             need_flatten_0 = false;
 
          _fx_endmatch_30: ;
-            FX_CHECK_EXN(_fx_catch_201);
+            FX_CHECK_EXN(_fx_catch_205);
          }
          else {
             need_flatten_0 = false;
          }
          if (need_flatten_0) {
-            fx_str_t slit_175 = FX_MAKE_STR("arr");
+            fx_str_t slit_181 = FX_MAKE_STR("arr");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_175, ctyp_0, ccode_98, &kloc_0, block_stack_ref_0, km_idx_0, &v_768, 0), _fx_catch_201);
-            FX_COPY_PTR(v_768.t0, &subarr_exp_0);
-            _fx_R9Ast__id_t v_799;
-            fx_str_t slit_176 = FX_MAKE_STR("fx_flatten_arr");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_176, &v_799, 0), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_769, 0), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_0, &v_770, 0), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_770, 0, true, &v_771), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_769, v_771, false, &v_771), _fx_catch_201);
+                  dstexp_r_0, &slit_181, ctyp_0, ccode_101, &kloc_0, block_stack_ref_0, km_idx_0, &v_789, 0), _fx_catch_205);
+            FX_COPY_PTR(v_789.t0, &subarr_exp_0);
+            _fx_R9Ast__id_t v_820;
+            fx_str_t slit_182 = FX_MAKE_STR("fx_flatten_arr");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_182, &v_820, 0), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_790, 0), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_0, &v_791, 0), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_791, 0, true, &v_792), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_790, v_792, false, &v_792), _fx_catch_205);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_799,
-                  v_771, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_flatten_0, 0), _fx_catch_201);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_820,
+                  v_792, _fx_g20C_gen_code__CTypCInt, &kloc_0, &call_flatten_0, 0), _fx_catch_205);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_flatten_0, ccode_98, &kloc_0, block_stack_ref_0, &v_772, 0), _fx_catch_201);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_0, v_772, &v_1);
+                  call_flatten_0, ccode_101, &kloc_0, block_stack_ref_0, &v_793, 0), _fx_catch_205);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_0, v_793, &v_1);
          }
          else if (need_subarr_0) {
             if (border_0->tag != 1) {
-               fx_str_t slit_177 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_177, &v_773, 0), _fx_catch_201);
-               FX_THROW(&v_773, false, _fx_catch_201);
+               fx_str_t slit_183 = FX_MAKE_STR("cgen: border extrapolation with ranges is not supported yet");
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_183, &v_794, 0), _fx_catch_205);
+               FX_THROW(&v_794, false, _fx_catch_205);
             }
-            FX_COPY_PTR(ccode_98, &ccode_119);
+            FX_COPY_PTR(ccode_101, &ccode_122);
             FX_COPY_PTR(idxs_1, &idxs_3);
             _fx_LN13K_form__dom_t lst_20 = idxs_3;
             for (; lst_20; lst_20 = lst_20->tl) {
                _fx_N13K_form__dom_t* d_1 = &lst_20->hd;
                int tag_23 = d_1->tag;
                if (tag_23 == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_800 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_821 = {0};
                   _fx_N14C_form__cexp_t i_exp_8 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_12 = 0;
-                  _fx_N14C_form__cexp_t v_801 = 0;
-                  _fx_LN14C_form__cexp_t v_802 = 0;
+                  _fx_N14C_form__cexp_t v_822 = 0;
+                  _fx_LN14C_form__cexp_t v_823 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_1->u.DomainElem, ccode_119, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_800, atom2cexp_0.fcv), _fx_catch_187);
-                  FX_COPY_PTR(v_800.t0, &i_exp_8);
-                  FX_COPY_PTR(v_800.t1, &ccode1_12);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_801, 0), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_801, range_data_0, true, &v_802), _fx_catch_187);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_8, v_802, false, &v_802), _fx_catch_187);
+                     atom2cexp_0.fp(&d_1->u.DomainElem, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_821, atom2cexp_0.fcv), _fx_catch_191);
+                  FX_COPY_PTR(v_821.t0, &i_exp_8);
+                  FX_COPY_PTR(v_821.t1, &ccode1_12);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_822, 0), _fx_catch_191);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_822, range_data_0, true, &v_823), _fx_catch_191);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_8, v_823, false, &v_823), _fx_catch_191);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_802, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_119);
-                  FX_COPY_PTR(ccode1_12, &ccode_119);
+                  FX_COPY_PTR(v_823, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
+                  FX_COPY_PTR(ccode1_12, &ccode_122);
 
-               _fx_catch_187: ;
-                  if (v_802) {
-                     _fx_free_LN14C_form__cexp_t(&v_802);
+               _fx_catch_191: ;
+                  if (v_823) {
+                     _fx_free_LN14C_form__cexp_t(&v_823);
                   }
-                  if (v_801) {
-                     _fx_free_N14C_form__cexp_t(&v_801);
+                  if (v_822) {
+                     _fx_free_N14C_form__cexp_t(&v_822);
                   }
                   if (ccode1_12) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_12);
@@ -29549,33 +29788,33 @@ static int
                   if (i_exp_8) {
                      _fx_free_N14C_form__cexp_t(&i_exp_8);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_800);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_821);
                }
                else if (tag_23 == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_803 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_824 = {0};
                   _fx_N14C_form__cexp_t i_exp_9 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_13 = 0;
-                  _fx_N14C_form__cexp_t v_804 = 0;
-                  _fx_LN14C_form__cexp_t v_805 = 0;
+                  _fx_N14C_form__cexp_t v_825 = 0;
+                  _fx_LN14C_form__cexp_t v_826 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_1->u.DomainFast, ccode_119, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_803, atom2cexp_0.fcv), _fx_catch_188);
-                  FX_COPY_PTR(v_803.t0, &i_exp_9);
-                  FX_COPY_PTR(v_803.t1, &ccode1_13);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_804, 0), _fx_catch_188);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_804, range_data_0, true, &v_805), _fx_catch_188);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_9, v_805, false, &v_805), _fx_catch_188);
+                     atom2cexp_0.fp(&d_1->u.DomainFast, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_824, atom2cexp_0.fcv), _fx_catch_192);
+                  FX_COPY_PTR(v_824.t0, &i_exp_9);
+                  FX_COPY_PTR(v_824.t1, &ccode1_13);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_825, 0), _fx_catch_192);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_825, range_data_0, true, &v_826), _fx_catch_192);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_9, v_826, false, &v_826), _fx_catch_192);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_805, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_119);
-                  FX_COPY_PTR(ccode1_13, &ccode_119);
+                  FX_COPY_PTR(v_826, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
+                  FX_COPY_PTR(ccode1_13, &ccode_122);
 
-               _fx_catch_188: ;
-                  if (v_805) {
-                     _fx_free_LN14C_form__cexp_t(&v_805);
+               _fx_catch_192: ;
+                  if (v_826) {
+                     _fx_free_LN14C_form__cexp_t(&v_826);
                   }
-                  if (v_804) {
-                     _fx_free_N14C_form__cexp_t(&v_804);
+                  if (v_825) {
+                     _fx_free_N14C_form__cexp_t(&v_825);
                   }
                   if (ccode1_13) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_13);
@@ -29583,89 +29822,89 @@ static int
                   if (i_exp_9) {
                      _fx_free_N14C_form__cexp_t(&i_exp_9);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_803);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_824);
                }
                else if (tag_23 == 3) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_806 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_827 = {0};
                   _fx_N14C_form__cexp_t a_exp_4 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_14 = 0;
-                  _fx_T2LN14C_form__cexp_tLN15C_form__cstmt_t v_807 = {0};
+                  _fx_T2LN14C_form__cexp_tLN15C_form__cstmt_t v_828 = {0};
                   _fx_LN14C_form__cexp_t range_delta_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_1 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_808 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_829 = {0};
                   _fx_N14C_form__cexp_t d_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode3_0 = 0;
-                  _fx_LN14C_form__cexp_t v_809 = 0;
-                  _fx_LN14C_form__cexp_t v_810 = 0;
+                  _fx_LN14C_form__cexp_t v_830 = 0;
+                  _fx_LN14C_form__cexp_t v_831 = 0;
                   _fx_Ta3N14K_form__atom_t* vcase_18 = &d_1->u.DomainRange;
                   _fx_N14K_form__atom_t* b_3 = &vcase_18->t1;
                   _fx_N14K_form__atom_t* a_11 = &vcase_18->t0;
                   if (a_11->tag == 2) {
                      if (a_11->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_811 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_811, 0),
-                           _fx_catch_189);
-                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_811, ccode_119, &v_806);
+                        _fx_N14C_form__cexp_t v_832 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_832, 0),
+                           _fx_catch_193);
+                        _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_832, ccode_122, &v_827);
 
-                     _fx_catch_189: ;
-                        if (v_811) {
-                           _fx_free_N14C_form__cexp_t(&v_811);
+                     _fx_catch_193: ;
+                        if (v_832) {
+                           _fx_free_N14C_form__cexp_t(&v_832);
                         }
                         goto _fx_endmatch_31;
                      }
                   }
                   FX_CALL(
-                     atom2cexp_0.fp(a_11, ccode_119, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_806, atom2cexp_0.fcv), _fx_catch_190);
+                     atom2cexp_0.fp(a_11, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
+                        i2e_ref_0, km_idx_0, &v_827, atom2cexp_0.fcv), _fx_catch_194);
 
-               _fx_catch_190: ;
+               _fx_catch_194: ;
 
                _fx_endmatch_31: ;
-                  FX_CHECK_EXN(_fx_catch_193);
-                  FX_COPY_PTR(v_806.t0, &a_exp_4);
-                  FX_COPY_PTR(v_806.t1, &ccode1_14);
+                  FX_CHECK_EXN(_fx_catch_197);
+                  FX_COPY_PTR(v_827.t0, &a_exp_4);
+                  FX_COPY_PTR(v_827.t1, &ccode1_14);
                   if (b_3->tag == 2) {
                      if (b_3->u.AtomLit.tag == 8) {
-                        _fx_N14C_form__cexp_t v_812 = 0;
-                        _fx_LN14C_form__cexp_t v_813 = 0;
-                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(2, &kloc_0, &v_812, 0),
-                           _fx_catch_191);
-                        FX_CALL(_fx_cons_LN14C_form__cexp_t(v_812, 0, true, &v_813), _fx_catch_191);
-                        FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_813, false, &v_813), _fx_catch_191);
-                        _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_813, ccode1_14, &v_807);
+                        _fx_N14C_form__cexp_t v_833 = 0;
+                        _fx_LN14C_form__cexp_t v_834 = 0;
+                        FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(2, &kloc_0, &v_833, 0),
+                           _fx_catch_195);
+                        FX_CALL(_fx_cons_LN14C_form__cexp_t(v_833, 0, true, &v_834), _fx_catch_195);
+                        FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_834, false, &v_834), _fx_catch_195);
+                        _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_834, ccode1_14, &v_828);
 
-                     _fx_catch_191: ;
-                        if (v_813) {
-                           _fx_free_LN14C_form__cexp_t(&v_813);
+                     _fx_catch_195: ;
+                        if (v_834) {
+                           _fx_free_LN14C_form__cexp_t(&v_834);
                         }
-                        if (v_812) {
-                           _fx_free_N14C_form__cexp_t(&v_812);
+                        if (v_833) {
+                           _fx_free_N14C_form__cexp_t(&v_833);
                         }
                         goto _fx_endmatch_32;
                      }
                   }
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_814 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_835 = {0};
                   _fx_N14C_form__cexp_t b_exp_4 = 0;
                   _fx_LN15C_form__cstmt_t ccode__2 = 0;
-                  _fx_N14C_form__cexp_t v_815 = 0;
-                  _fx_LN14C_form__cexp_t v_816 = 0;
+                  _fx_N14C_form__cexp_t v_836 = 0;
+                  _fx_LN14C_form__cexp_t v_837 = 0;
                   FX_CALL(
                      atom2cexp_0.fp(b_3, ccode1_14, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-                        km_idx_0, &v_814, atom2cexp_0.fcv), _fx_catch_192);
-                  FX_COPY_PTR(v_814.t0, &b_exp_4);
-                  FX_COPY_PTR(v_814.t1, &ccode__2);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_815, 0), _fx_catch_192);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_815, 0, true, &v_816), _fx_catch_192);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_816, false, &v_816), _fx_catch_192);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_4, v_816, false, &v_816), _fx_catch_192);
-                  _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_816, ccode__2, &v_807);
+                        km_idx_0, &v_835, atom2cexp_0.fcv), _fx_catch_196);
+                  FX_COPY_PTR(v_835.t0, &b_exp_4);
+                  FX_COPY_PTR(v_835.t1, &ccode__2);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &v_836, 0), _fx_catch_196);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_836, 0, true, &v_837), _fx_catch_196);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(a_exp_4, v_837, false, &v_837), _fx_catch_196);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(b_exp_4, v_837, false, &v_837), _fx_catch_196);
+                  _fx_make_T2LN14C_form__cexp_tLN15C_form__cstmt_t(v_837, ccode__2, &v_828);
 
-               _fx_catch_192: ;
-                  if (v_816) {
-                     _fx_free_LN14C_form__cexp_t(&v_816);
+               _fx_catch_196: ;
+                  if (v_837) {
+                     _fx_free_LN14C_form__cexp_t(&v_837);
                   }
-                  if (v_815) {
-                     _fx_free_N14C_form__cexp_t(&v_815);
+                  if (v_836) {
+                     _fx_free_N14C_form__cexp_t(&v_836);
                   }
                   if (ccode__2) {
                      _fx_free_LN15C_form__cstmt_t(&ccode__2);
@@ -29673,32 +29912,32 @@ static int
                   if (b_exp_4) {
                      _fx_free_N14C_form__cexp_t(&b_exp_4);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_814);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_835);
 
                _fx_endmatch_32: ;
-                  FX_CHECK_EXN(_fx_catch_193);
-                  FX_COPY_PTR(v_807.t0, &range_delta_0);
-                  FX_COPY_PTR(v_807.t1, &ccode2_1);
+                  FX_CHECK_EXN(_fx_catch_197);
+                  FX_COPY_PTR(v_828.t0, &range_delta_0);
+                  FX_COPY_PTR(v_828.t1, &ccode2_1);
                   FX_CALL(
                      atom2cexp_0.fp(&vcase_18->t2, ccode2_1, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0,
-                        i2e_ref_0, km_idx_0, &v_808, atom2cexp_0.fcv), _fx_catch_193);
-                  FX_COPY_PTR(v_808.t0, &d_exp_0);
-                  FX_COPY_PTR(v_808.t1, &ccode3_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(d_exp_0, range_delta_0, true, &v_809), _fx_catch_193);
+                        i2e_ref_0, km_idx_0, &v_829, atom2cexp_0.fcv), _fx_catch_197);
+                  FX_COPY_PTR(v_829.t0, &d_exp_0);
+                  FX_COPY_PTR(v_829.t1, &ccode3_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(d_exp_0, range_delta_0, true, &v_830), _fx_catch_197);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_809, range_data_0,
-                        &v_810, 0), _fx_catch_193);
+                     _fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(v_830, range_data_0,
+                        &v_831, 0), _fx_catch_197);
                   _fx_free_LN14C_form__cexp_t(&range_data_0);
-                  FX_COPY_PTR(v_810, &range_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_119);
-                  FX_COPY_PTR(ccode3_0, &ccode_119);
+                  FX_COPY_PTR(v_831, &range_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
+                  FX_COPY_PTR(ccode3_0, &ccode_122);
 
-               _fx_catch_193: ;
-                  if (v_810) {
-                     _fx_free_LN14C_form__cexp_t(&v_810);
+               _fx_catch_197: ;
+                  if (v_831) {
+                     _fx_free_LN14C_form__cexp_t(&v_831);
                   }
-                  if (v_809) {
-                     _fx_free_LN14C_form__cexp_t(&v_809);
+                  if (v_830) {
+                     _fx_free_LN14C_form__cexp_t(&v_830);
                   }
                   if (ccode3_0) {
                      _fx_free_LN15C_form__cstmt_t(&ccode3_0);
@@ -29706,76 +29945,76 @@ static int
                   if (d_exp_0) {
                      _fx_free_N14C_form__cexp_t(&d_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_808);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_829);
                   if (ccode2_1) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_1);
                   }
                   if (range_delta_0) {
                      _fx_free_LN14C_form__cexp_t(&range_delta_0);
                   }
-                  _fx_free_T2LN14C_form__cexp_tLN15C_form__cstmt_t(&v_807);
+                  _fx_free_T2LN14C_form__cexp_tLN15C_form__cstmt_t(&v_828);
                   if (ccode1_14) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_14);
                   }
                   if (a_exp_4) {
                      _fx_free_N14C_form__cexp_t(&a_exp_4);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_806);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_827);
                }
                else {
-                  FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_194);
+                  FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_198);
                }
-               FX_CHECK_EXN(_fx_catch_194);
+               FX_CHECK_EXN(_fx_catch_198);
 
-            _fx_catch_194: ;
-               FX_CHECK_EXN(_fx_catch_201);
+            _fx_catch_198: ;
+               FX_CHECK_EXN(_fx_catch_205);
             }
-            fx_str_t slit_178 = FX_MAKE_STR("arr");
+            fx_str_t slit_184 = FX_MAKE_STR("arr");
             FX_CALL(
                _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                  dstexp_r_0, &slit_178, ctyp_0, ccode_119, &kloc_0, block_stack_ref_0, km_idx_0, &v_774, 0), _fx_catch_201);
-            FX_COPY_PTR(v_774.t0, &subarr_exp_1);
-            FX_COPY_PTR(v_774.t1, &ccode_120);
-            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_775), _fx_catch_201);
+                  dstexp_r_0, &slit_184, ctyp_0, ccode_122, &kloc_0, block_stack_ref_0, km_idx_0, &v_795, 0), _fx_catch_205);
+            FX_COPY_PTR(v_795.t0, &subarr_exp_1);
+            FX_COPY_PTR(v_795.t1, &ccode_123);
+            FX_CALL(_fx_cons_LN19C_form__ctyp_attr_t(&_fx_g21C_gen_code__CTypConst, 0, true, &v_796), _fx_catch_205);
             FX_CALL(
-               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_775,
-                  _fx_g19C_gen_code__CTypInt, &rdata_ctyp_0), _fx_catch_201);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(range_data_0, &v_776, 0), _fx_catch_201);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(rdata_ctyp_0, &kloc_0, &v_777);
+               _fx_M6C_formFM12CTypRawArrayN14C_form__ctyp_t2LN19C_form__ctyp_attr_tN14C_form__ctyp_t(v_796,
+                  _fx_g19C_gen_code__CTypInt, &rdata_ctyp_0), _fx_catch_205);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(range_data_0, &v_797, 0), _fx_catch_205);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(rdata_ctyp_0, &kloc_0, &v_798);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_776, &v_777,
-                  &rdata_arr_0), _fx_catch_201);
-            _fx_R9Ast__id_t v_817;
-            fx_str_t slit_179 = FX_MAKE_STR("ranges");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_179, &v_817, 0), _fx_catch_201);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_778, 0), _fx_catch_201);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(rdata_arr_0, &v_779);
-            fx_str_t slit_180 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_797, &v_798,
+                  &rdata_arr_0), _fx_catch_205);
+            _fx_R9Ast__id_t v_838;
+            fx_str_t slit_185 = FX_MAKE_STR("ranges");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_185, &v_838, 0), _fx_catch_205);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_799, 0), _fx_catch_205);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(rdata_arr_0, &v_800);
+            fx_str_t slit_186 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_817, rdata_ctyp_0, &v_778, &slit_180, &v_779, 0, &kloc_0, &v_780, 0), _fx_catch_201);
-            FX_COPY_PTR(v_780.t0, &rdata_exp_0);
-            FX_COPY_PTR(v_780.t1, &sub_ccode_10);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_781, 0), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_1, &v_782, 0), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_782, 0, true, &v_783), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(rdata_exp_0, v_783, false, &v_783), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_781, v_783, false, &v_783), _fx_catch_201);
+                  &v_838, rdata_ctyp_0, &v_799, &slit_186, &v_800, 0, &kloc_0, &v_801, 0), _fx_catch_205);
+            FX_COPY_PTR(v_801.t0, &rdata_exp_0);
+            FX_COPY_PTR(v_801.t1, &sub_ccode_10);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(arr_exp_5, &v_802, 0), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(subarr_exp_1, &v_803, 0), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_803, 0, true, &v_804), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(rdata_exp_0, v_804, false, &v_804), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_802, v_804, false, &v_804), _fx_catch_205);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g21C_form__std_fx_subarr, v_783, _fx_g19C_gen_code__CTypInt, &kloc_0, &call_subarr_0, 0), _fx_catch_201);
+                  &_fx_g21C_form__std_fx_subarr, v_804, _fx_g19C_gen_code__CTypInt, &kloc_0, &call_subarr_0, 0), _fx_catch_205);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_subarr_0, sub_ccode_10, &kloc_0, block_stack_ref_0, &sub_ccode_11, 0), _fx_catch_201);
+                  call_subarr_0, sub_ccode_10, &kloc_0, block_stack_ref_0, &sub_ccode_11, 0), _fx_catch_205);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_11, &kloc_0, &v_784, 0),
-               _fx_catch_201);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_784, ccode_120, true, &ccode_121), _fx_catch_201);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_1, ccode_121, &v_1);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(sub_ccode_11, &kloc_0, &v_805, 0),
+               _fx_catch_205);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_805, ccode_123, true, &ccode_124), _fx_catch_205);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, subarr_exp_1, ccode_124, &v_1);
          }
          else {
             _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &chk_exp_opt_0);
-            FX_COPY_PTR(ccode_98, &ccode_122);
+            FX_COPY_PTR(ccode_101, &ccode_125);
             int_ dim_0 = 0;
             FX_COPY_PTR(idxs_1, &idxs_4);
             _fx_LN13K_form__dom_t lst_21 = idxs_4;
@@ -29792,28 +30031,28 @@ static int
                   else {
                      _fx_copy_N13K_form__dom_t(d_3, &d_2);
                   }
-                  FX_CHECK_EXN(_fx_catch_199);
+                  FX_CHECK_EXN(_fx_catch_203);
                }
                int tag_24 = d_2.tag;
                if (tag_24 == 2) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_818 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_839 = {0};
                   _fx_N14C_form__cexp_t i_exp_10 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_15 = 0;
-                  _fx_LN14C_form__cexp_t v_819 = 0;
+                  _fx_LN14C_form__cexp_t v_840 = 0;
                   FX_CALL(
-                     atom2cexp_0.fp(&d_2.u.DomainFast, ccode_122, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
-                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_818, atom2cexp_0.fcv), _fx_catch_195);
-                  FX_COPY_PTR(v_818.t0, &i_exp_10);
-                  FX_COPY_PTR(v_818.t1, &ccode1_15);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_10, i_exps_2, true, &v_819), _fx_catch_195);
+                     atom2cexp_0.fp(&d_2.u.DomainFast, ccode_125, &kloc_0, block_stack_ref_0, defined_syms_ref_0,
+                        fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_839, atom2cexp_0.fcv), _fx_catch_199);
+                  FX_COPY_PTR(v_839.t0, &i_exp_10);
+                  FX_COPY_PTR(v_839.t1, &ccode1_15);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_10, i_exps_2, true, &v_840), _fx_catch_199);
                   _fx_free_LN14C_form__cexp_t(&i_exps_2);
-                  FX_COPY_PTR(v_819, &i_exps_2);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
-                  FX_COPY_PTR(ccode1_15, &ccode_122);
+                  FX_COPY_PTR(v_840, &i_exps_2);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_125);
+                  FX_COPY_PTR(ccode1_15, &ccode_125);
 
-               _fx_catch_195: ;
-                  if (v_819) {
-                     _fx_free_LN14C_form__cexp_t(&v_819);
+               _fx_catch_199: ;
+                  if (v_840) {
+                     _fx_free_LN14C_form__cexp_t(&v_840);
                   }
                   if (ccode1_15) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_15);
@@ -29821,74 +30060,74 @@ static int
                   if (i_exp_10) {
                      _fx_free_N14C_form__cexp_t(&i_exp_10);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_818);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_839);
                }
                else if (tag_24 == 1) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_820 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_841 = {0};
                   _fx_N14C_form__cexp_t i_exp_11 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_16 = 0;
-                  _fx_N14C_form__cexp_t v_821 = 0;
-                  _fx_LN14C_form__cexp_t v_822 = 0;
+                  _fx_N14C_form__cexp_t v_842 = 0;
+                  _fx_LN14C_form__cexp_t v_843 = 0;
                   _fx_N14C_form__cexp_t chk_exp1_0 = 0;
                   _fx_Nt6option1N14C_form__cexp_t chk_exp_opt_2 = {0};
-                  _fx_Nt6option1N14C_form__cexp_t v_823 = {0};
-                  _fx_LN14C_form__cexp_t v_824 = 0;
-                  FX_CALL(atom2cexp__0.fp(&d_2.u.DomainElem, true, ccode_122, &kloc_0, &v_820, atom2cexp__0.fcv),
-                     _fx_catch_197);
-                  FX_COPY_PTR(v_820.t0, &i_exp_11);
-                  FX_COPY_PTR(v_820.t1, &ccode1_16);
-                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dim_0, &kloc_0, &v_821, 0),
-                     _fx_catch_197);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, 0, true, &v_822), _fx_catch_197);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_821, v_822, false, &v_822), _fx_catch_197);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_822, false, &v_822), _fx_catch_197);
+                  _fx_Nt6option1N14C_form__cexp_t v_844 = {0};
+                  _fx_LN14C_form__cexp_t v_845 = 0;
+                  FX_CALL(atom2cexp__0.fp(&d_2.u.DomainElem, true, ccode_125, &kloc_0, &v_841, atom2cexp__0.fcv),
+                     _fx_catch_201);
+                  FX_COPY_PTR(v_841.t0, &i_exp_11);
+                  FX_COPY_PTR(v_841.t1, &ccode1_16);
+                  FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(dim_0, &kloc_0, &v_842, 0),
+                     _fx_catch_201);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, 0, true, &v_843), _fx_catch_201);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_842, v_843, false, &v_843), _fx_catch_201);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_843, false, &v_843), _fx_catch_201);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g22C_form__std_FX_CHKIDX1, v_822, _fx_g20C_gen_code__CTypBool, &kloc_0, &chk_exp1_0, 0),
-                     _fx_catch_197);
+                        &_fx_g22C_form__std_FX_CHKIDX1, v_843, _fx_g20C_gen_code__CTypBool, &kloc_0, &chk_exp1_0, 0),
+                     _fx_catch_201);
                   _fx_copy_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0, &chk_exp_opt_2);
                   if (chk_exp_opt_2.tag == 2) {
-                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_825 = {0};
+                     _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_846 = {0};
                      _fx_N14C_form__cexp_t chk_exp_3 = 0;
-                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &kloc_0, &v_825);
+                     _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &kloc_0, &v_846);
                      FX_CALL(
                         _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                           &_fx_g23C_gen_code__COpLogicAnd, chk_exp_opt_2.u.Some, chk_exp1_0, &v_825, &chk_exp_3),
-                        _fx_catch_196);
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp_3, &v_823);
+                           &_fx_g23C_gen_code__COpLogicAnd, chk_exp_opt_2.u.Some, chk_exp1_0, &v_846, &chk_exp_3),
+                        _fx_catch_200);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp_3, &v_844);
 
-                  _fx_catch_196: ;
+                  _fx_catch_200: ;
                      if (chk_exp_3) {
                         _fx_free_N14C_form__cexp_t(&chk_exp_3);
                      }
-                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_825);
+                     _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_846);
                   }
                   else {
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp1_0, &v_823);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_exp1_0, &v_844);
                   }
-                  FX_CHECK_EXN(_fx_catch_197);
+                  FX_CHECK_EXN(_fx_catch_201);
                   _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0);
-                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_823, &chk_exp_opt_0);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, i_exps_2, true, &v_824), _fx_catch_197);
+                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_844, &chk_exp_opt_0);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_11, i_exps_2, true, &v_845), _fx_catch_201);
                   _fx_free_LN14C_form__cexp_t(&i_exps_2);
-                  FX_COPY_PTR(v_824, &i_exps_2);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_122);
-                  FX_COPY_PTR(ccode1_16, &ccode_122);
+                  FX_COPY_PTR(v_845, &i_exps_2);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_125);
+                  FX_COPY_PTR(ccode1_16, &ccode_125);
 
-               _fx_catch_197: ;
-                  if (v_824) {
-                     _fx_free_LN14C_form__cexp_t(&v_824);
+               _fx_catch_201: ;
+                  if (v_845) {
+                     _fx_free_LN14C_form__cexp_t(&v_845);
                   }
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_823);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_844);
                   _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_2);
                   if (chk_exp1_0) {
                      _fx_free_N14C_form__cexp_t(&chk_exp1_0);
                   }
-                  if (v_822) {
-                     _fx_free_LN14C_form__cexp_t(&v_822);
+                  if (v_843) {
+                     _fx_free_LN14C_form__cexp_t(&v_843);
                   }
-                  if (v_821) {
-                     _fx_free_N14C_form__cexp_t(&v_821);
+                  if (v_842) {
+                     _fx_free_N14C_form__cexp_t(&v_842);
                   }
                   if (ccode1_16) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_16);
@@ -29896,54 +30135,54 @@ static int
                   if (i_exp_11) {
                      _fx_free_N14C_form__cexp_t(&i_exp_11);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_820);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_841);
                }
                else {
-                  fx_exn_t v_826 = {0};
-                  fx_str_t slit_181 = FX_MAKE_STR("cgen: unexpected index type");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_181, &v_826, 0), _fx_catch_198);
-                  FX_THROW(&v_826, false, _fx_catch_198);
+                  fx_exn_t v_847 = {0};
+                  fx_str_t slit_187 = FX_MAKE_STR("cgen: unexpected index type");
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_187, &v_847, 0), _fx_catch_202);
+                  FX_THROW(&v_847, false, _fx_catch_202);
 
-               _fx_catch_198: ;
-                  fx_free_exn(&v_826);
+               _fx_catch_202: ;
+                  fx_free_exn(&v_847);
                }
-               FX_CHECK_EXN(_fx_catch_199);
+               FX_CHECK_EXN(_fx_catch_203);
 
-            _fx_catch_199: ;
+            _fx_catch_203: ;
                _fx_free_N13K_form__dom_t(&d_2);
-               FX_CHECK_EXN(_fx_catch_201);
+               FX_CHECK_EXN(_fx_catch_205);
             }
             _fx_copy_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0, &chk_exp_opt_1);
             if (chk_exp_opt_1.tag == 2) {
-               _fx_LN14C_form__cexp_t v_827 = 0;
+               _fx_LN14C_form__cexp_t v_848 = 0;
                _fx_N14C_form__cexp_t call_chkidx_0 = 0;
-               _fx_N15C_form__cstmt_t v_828 = 0;
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_5, 0, true, &v_827), _fx_catch_200);
-               FX_CALL(_fx_cons_LN14C_form__cexp_t(chk_exp_opt_1.u.Some, v_827, false, &v_827), _fx_catch_200);
+               _fx_N15C_form__cstmt_t v_849 = 0;
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_848), _fx_catch_204);
+               FX_CALL(_fx_cons_LN14C_form__cexp_t(chk_exp_opt_1.u.Some, v_848, false, &v_848), _fx_catch_204);
                FX_CALL(
                   _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                     &_fx_g21C_form__std_FX_CHKIDX, v_827, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_chkidx_0, 0),
-                  _fx_catch_200);
-               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_chkidx_0, &v_828), _fx_catch_200);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_828, ccode_122, true, &ccode_123), _fx_catch_200);
+                     &_fx_g21C_form__std_FX_CHKIDX, v_848, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_chkidx_0, 0),
+                  _fx_catch_204);
+               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_chkidx_0, &v_849), _fx_catch_204);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_849, ccode_125, true, &ccode_126), _fx_catch_204);
 
-            _fx_catch_200: ;
-               if (v_828) {
-                  _fx_free_N15C_form__cstmt_t(&v_828);
+            _fx_catch_204: ;
+               if (v_849) {
+                  _fx_free_N15C_form__cstmt_t(&v_849);
                }
                if (call_chkidx_0) {
                   _fx_free_N14C_form__cexp_t(&call_chkidx_0);
                }
-               if (v_827) {
-                  _fx_free_LN14C_form__cexp_t(&v_827);
+               if (v_848) {
+                  _fx_free_LN14C_form__cexp_t(&v_848);
                }
             }
             else {
-               FX_COPY_PTR(ccode_122, &ccode_123);
+               FX_COPY_PTR(ccode_125, &ccode_126);
             }
-            FX_CHECK_EXN(_fx_catch_201);
+            FX_CHECK_EXN(_fx_catch_205);
             int_ ndims_2;
-            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN13K_form__dom_t(idxs_1, &ndims_2, 0), _fx_catch_201);
+            FX_CALL(_fx_M10C_gen_codeFM8length1_i1LN13K_form__dom_t(idxs_1, &ndims_2, 0), _fx_catch_205);
             int tag_25 = border_0->tag;
             if (tag_25 == 1) {
                FX_COPY_PTR(_fx_g21C_form__std_FX_PTR_xD, &access_op_0);
@@ -29958,63 +30197,63 @@ static int
                FX_COPY_PTR(_fx_g26C_form__std_FX_PTR_xD_ZERO, &access_op_0);
             }
             else {
-               FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_201);
+               FX_FAST_THROW(FX_EXN_NoMatchError, _fx_catch_205);
             }
-            FX_CHECK_EXN(_fx_catch_201);
-            _fx_R9Ast__id_t v_829;
-            FX_CALL(_fx_M10C_gen_codeFM3nthR9Ast__id_t2LR9Ast__id_ti(access_op_0, ndims_2 - 1, &v_829, 0), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_785),
-               _fx_catch_201);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(i_exps_2, &v_786, 0), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_786, true, &v_787), _fx_catch_201);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_785, v_787, false, &v_787), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ctyp_0, &v_788, 0), _fx_catch_201);
+            FX_CHECK_EXN(_fx_catch_205);
+            _fx_R9Ast__id_t v_850;
+            FX_CALL(_fx_M10C_gen_codeFM3nthR9Ast__id_t2LR9Ast__id_ti(access_op_0, ndims_2 - 1, &v_850, 0), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_806),
+               _fx_catch_205);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN14C_form__cexp_t1LN14C_form__cexp_t(i_exps_2, &v_807, 0), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(arr_exp_5, v_807, true, &v_808), _fx_catch_205);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_806, v_808, false, &v_808), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ctyp_0, &v_809, 0), _fx_catch_205);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_829,
-                  v_787, v_788, &kloc_0, &get_elem_exp_12, 0), _fx_catch_201);
-            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(get_elem_exp_12, &v_789, 0), _fx_catch_201);
-            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_789, ccode_123, &v_1);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_850,
+                  v_808, v_809, &kloc_0, &get_elem_exp_12, 0), _fx_catch_205);
+            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(get_elem_exp_12, &v_810, 0), _fx_catch_205);
+            _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_810, ccode_126, &v_1);
          }
 
-      _fx_catch_201: ;
-         if (v_789) {
-            _fx_free_N14C_form__cexp_t(&v_789);
+      _fx_catch_205: ;
+         if (v_810) {
+            _fx_free_N14C_form__cexp_t(&v_810);
          }
          if (get_elem_exp_12) {
             _fx_free_N14C_form__cexp_t(&get_elem_exp_12);
          }
-         if (v_788) {
-            _fx_free_N14C_form__ctyp_t(&v_788);
+         if (v_809) {
+            _fx_free_N14C_form__ctyp_t(&v_809);
          }
-         if (v_787) {
-            _fx_free_LN14C_form__cexp_t(&v_787);
+         if (v_808) {
+            _fx_free_LN14C_form__cexp_t(&v_808);
          }
-         if (v_786) {
-            _fx_free_LN14C_form__cexp_t(&v_786);
+         if (v_807) {
+            _fx_free_LN14C_form__cexp_t(&v_807);
          }
-         if (v_785) {
-            _fx_free_N14C_form__cexp_t(&v_785);
+         if (v_806) {
+            _fx_free_N14C_form__cexp_t(&v_806);
          }
          FX_FREE_LIST_SIMPLE(&access_op_0);
-         if (ccode_123) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_123);
+         if (ccode_126) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_126);
          }
          _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_1);
          if (idxs_4) {
             _fx_free_LN13K_form__dom_t(&idxs_4);
          }
-         if (ccode_122) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_122);
+         if (ccode_125) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_125);
          }
          if (i_exps_2) {
             _fx_free_LN14C_form__cexp_t(&i_exps_2);
          }
          _fx_free_Nt6option1N14C_form__cexp_t(&chk_exp_opt_0);
-         if (ccode_121) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_121);
+         if (ccode_124) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_124);
          }
-         if (v_784) {
-            _fx_free_N15C_form__cstmt_t(&v_784);
+         if (v_805) {
+            _fx_free_N15C_form__cstmt_t(&v_805);
          }
          if (sub_ccode_11) {
             _fx_free_LN15C_form__cstmt_t(&sub_ccode_11);
@@ -30022,14 +30261,14 @@ static int
          if (call_subarr_0) {
             _fx_free_N14C_form__cexp_t(&call_subarr_0);
          }
-         if (v_783) {
-            _fx_free_LN14C_form__cexp_t(&v_783);
+         if (v_804) {
+            _fx_free_LN14C_form__cexp_t(&v_804);
          }
-         if (v_782) {
-            _fx_free_N14C_form__cexp_t(&v_782);
+         if (v_803) {
+            _fx_free_N14C_form__cexp_t(&v_803);
          }
-         if (v_781) {
-            _fx_free_N14C_form__cexp_t(&v_781);
+         if (v_802) {
+            _fx_free_N14C_form__cexp_t(&v_802);
          }
          if (sub_ccode_10) {
             _fx_free_LN15C_form__cstmt_t(&sub_ccode_10);
@@ -30037,119 +30276,119 @@ static int
          if (rdata_exp_0) {
             _fx_free_N14C_form__cexp_t(&rdata_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_780);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_779);
-         _fx_free_R16Ast__val_flags_t(&v_778);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_801);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_800);
+         _fx_free_R16Ast__val_flags_t(&v_799);
          if (rdata_arr_0) {
             _fx_free_N14C_form__cexp_t(&rdata_arr_0);
          }
-         _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_777);
-         if (v_776) {
-            _fx_free_LN14C_form__cexp_t(&v_776);
+         _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_798);
+         if (v_797) {
+            _fx_free_LN14C_form__cexp_t(&v_797);
          }
          if (rdata_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&rdata_ctyp_0);
          }
-         FX_FREE_LIST_SIMPLE(&v_775);
-         if (ccode_120) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_120);
+         FX_FREE_LIST_SIMPLE(&v_796);
+         if (ccode_123) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_123);
          }
          if (subarr_exp_1) {
             _fx_free_N14C_form__cexp_t(&subarr_exp_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_774);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_795);
          if (idxs_3) {
             _fx_free_LN13K_form__dom_t(&idxs_3);
          }
-         if (ccode_119) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_119);
+         if (ccode_122) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_122);
          }
          if (range_data_0) {
             _fx_free_LN14C_form__cexp_t(&range_data_0);
          }
-         fx_free_exn(&v_773);
-         if (v_772) {
-            _fx_free_LN15C_form__cstmt_t(&v_772);
+         fx_free_exn(&v_794);
+         if (v_793) {
+            _fx_free_LN15C_form__cstmt_t(&v_793);
          }
          if (call_flatten_0) {
             _fx_free_N14C_form__cexp_t(&call_flatten_0);
          }
-         if (v_771) {
-            _fx_free_LN14C_form__cexp_t(&v_771);
+         if (v_792) {
+            _fx_free_LN14C_form__cexp_t(&v_792);
          }
-         if (v_770) {
-            _fx_free_N14C_form__cexp_t(&v_770);
+         if (v_791) {
+            _fx_free_N14C_form__cexp_t(&v_791);
          }
-         if (v_769) {
-            _fx_free_N14C_form__cexp_t(&v_769);
+         if (v_790) {
+            _fx_free_N14C_form__cexp_t(&v_790);
          }
          if (subarr_exp_0) {
             _fx_free_N14C_form__cexp_t(&subarr_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_768);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_789);
          if (idxs_2) {
             _fx_free_LN13K_form__dom_t(&idxs_2);
          }
       }
       else {
-         fx_exn_t v_830 = {0};
-         fx_str_t slit_182 =
+         fx_exn_t v_851 = {0};
+         fx_str_t slit_188 =
             FX_MAKE_STR(
                "cgen: unknown/unsupported type of the container, it should be CTypArray _ or CTypRRBVec _ or CTypString");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_182, &v_830, 0), _fx_catch_202);
-         FX_THROW(&v_830, false, _fx_catch_202);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_188, &v_851, 0), _fx_catch_206);
+         FX_THROW(&v_851, false, _fx_catch_206);
 
-      _fx_catch_202: ;
-         fx_free_exn(&v_830);
+      _fx_catch_206: ;
+         fx_free_exn(&v_851);
       }
-      FX_CHECK_EXN(_fx_catch_203);
+      FX_CHECK_EXN(_fx_catch_207);
 
-   _fx_catch_203: ;
+   _fx_catch_207: ;
       if (arr_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&arr_ctyp_0);
       }
-      if (lbl_5) {
-         _fx_free_N14C_form__cexp_t(&lbl_5);
+      if (lbl_7) {
+         _fx_free_N14C_form__cexp_t(&lbl_7);
       }
-      if (ccode_98) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_98);
+      if (ccode_101) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_101);
       }
       if (arr_exp_5) {
          _fx_free_N14C_form__cexp_t(&arr_exp_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_634);
-      fx_free_exn(&v_633);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_655);
+      fx_free_exn(&v_654);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 20) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_831 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_852 = {0};
       _fx_N14C_form__cexp_t ce1_7 = 0;
-      _fx_LN15C_form__cstmt_t ccode_124 = 0;
-      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_832 = {0};
+      _fx_LN15C_form__cstmt_t ccode_127 = 0;
+      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_853 = {0};
       _fx_N14C_form__cexp_t ce1_8 = 0;
       _fx_LT2R9Ast__id_tN14C_form__ctyp_t relems_0 = 0;
-      fx_str_t v_833 = {0};
-      fx_str_t v_834 = {0};
-      fx_str_t v_835 = {0};
-      fx_exn_t v_836 = {0};
-      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_837 = {0};
-      _fx_N14C_form__cexp_t v_838 = 0;
+      fx_str_t v_854 = {0};
+      fx_str_t v_855 = {0};
+      fx_str_t v_856 = {0};
+      fx_exn_t v_857 = {0};
+      _fx_T2R9Ast__id_tN14C_form__ctyp_t v_858 = {0};
+      _fx_N14C_form__cexp_t v_859 = 0;
       _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_19 = &kexp_0->u.KExpMem;
       int_ n_1 = vcase_19->t1;
       FX_CALL(
          _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
             &vcase_19->t0, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-            km_idx_0, &v_831, 0), _fx_catch_204);
-      FX_COPY_PTR(v_831.t0, &ce1_7);
-      FX_COPY_PTR(v_831.t1, &ccode_124);
+            km_idx_0, &v_852, 0), _fx_catch_208);
+      FX_COPY_PTR(v_852.t0, &ce1_7);
+      FX_COPY_PTR(v_852.t1, &ccode_127);
       FX_CALL(
          _fx_M10C_gen_codeFM10get_structT4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti1N14C_form__cexp_t(ce1_7,
-            &v_832, 0), _fx_catch_204);
-      FX_COPY_PTR(v_832.t1, &ce1_8);
-      FX_COPY_PTR(v_832.t2, &relems_0);
-      int_ ofs_0 = v_832.t3;
+            &v_853, 0), _fx_catch_208);
+      FX_COPY_PTR(v_853.t1, &ce1_8);
+      FX_COPY_PTR(v_853.t2, &relems_0);
+      int_ ofs_0 = v_853.t3;
       int_ nelems_0;
-      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2R9Ast__id_tN14C_form__ctyp_t(relems_0, &nelems_0, 0), _fx_catch_204);
+      FX_CALL(_fx_M10C_gen_codeFM8length1_i1LT2R9Ast__id_tN14C_form__ctyp_t(relems_0, &nelems_0, 0), _fx_catch_208);
       bool t_11;
       if (n_1 < 0) {
          t_11 = true;
@@ -30158,189 +30397,189 @@ static int
          t_11 = n_1 + ofs_0 >= nelems_0;
       }
       if (t_11) {
-         FX_CALL(_fx_F6stringS1i(n_1, &v_833, 0), _fx_catch_204);
-         FX_CALL(_fx_F6stringS1i(nelems_0, &v_834, 0), _fx_catch_204);
-         fx_str_t slit_183 = FX_MAKE_STR("cgen: the tuple/record element index ");
-         fx_str_t slit_184 = FX_MAKE_STR(" is out of range [0, ");
-         fx_str_t slit_185 = FX_MAKE_STR("]");
+         FX_CALL(_fx_F6stringS1i(n_1, &v_854, 0), _fx_catch_208);
+         FX_CALL(_fx_F6stringS1i(nelems_0, &v_855, 0), _fx_catch_208);
+         fx_str_t slit_189 = FX_MAKE_STR("cgen: the tuple/record element index ");
+         fx_str_t slit_190 = FX_MAKE_STR(" is out of range [0, ");
+         fx_str_t slit_191 = FX_MAKE_STR("]");
          {
-            const fx_str_t strs_30[] = { slit_183, v_833, slit_184, v_834, slit_185 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_30, 5, &v_835), _fx_catch_204);
+            const fx_str_t strs_32[] = { slit_189, v_854, slit_190, v_855, slit_191 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_856), _fx_catch_208);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_835, &v_836, 0), _fx_catch_204);
-         FX_THROW(&v_836, false, _fx_catch_204);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_856, &v_857, 0), _fx_catch_208);
+         FX_THROW(&v_857, false, _fx_catch_208);
       }
       FX_CALL(
-         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(relems_0, n_1 + ofs_0, &v_837,
-            0), _fx_catch_204);
-      _fx_R9Ast__id_t n_id_1 = v_837.t0;
+         _fx_M10C_gen_codeFM3nthT2R9Ast__id_tN14C_form__ctyp_t2LT2R9Ast__id_tN14C_form__ctyp_ti(relems_0, n_1 + ofs_0, &v_858,
+            0), _fx_catch_208);
+      _fx_R9Ast__id_t n_id_1 = v_858.t0;
       FX_CALL(
-         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(ce1_8, &n_id_1, ctyp_0, &v_838,
-            0), _fx_catch_204);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_838, ccode_124, &v_1);
+         _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(ce1_8, &n_id_1, ctyp_0, &v_859,
+            0), _fx_catch_208);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_859, ccode_127, &v_1);
 
-   _fx_catch_204: ;
-      if (v_838) {
-         _fx_free_N14C_form__cexp_t(&v_838);
+   _fx_catch_208: ;
+      if (v_859) {
+         _fx_free_N14C_form__cexp_t(&v_859);
       }
-      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_837);
-      fx_free_exn(&v_836);
-      FX_FREE_STR(&v_835);
-      FX_FREE_STR(&v_834);
-      FX_FREE_STR(&v_833);
+      _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(&v_858);
+      fx_free_exn(&v_857);
+      FX_FREE_STR(&v_856);
+      FX_FREE_STR(&v_855);
+      FX_FREE_STR(&v_854);
       if (relems_0) {
          _fx_free_LT2R9Ast__id_tN14C_form__ctyp_t(&relems_0);
       }
       if (ce1_8) {
          _fx_free_N14C_form__cexp_t(&ce1_8);
       }
-      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_832);
-      if (ccode_124) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_124);
+      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_853);
+      if (ccode_127) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_127);
       }
       if (ce1_7) {
          _fx_free_N14C_form__cexp_t(&ce1_7);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_831);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_852);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 21) {
       _fx_N14K_form__ktyp_t ktyp_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_125 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_839 = {0};
-      _fx_N14C_form__cexp_t i_exp_12 = 0;
-      _fx_LN15C_form__cstmt_t ccode_126 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_840 = {0};
-      _fx_N14C_form__cexp_t e_exp_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_127 = 0;
-      _fx_N14C_form__ctyp_t ctyp_2 = 0;
-      _fx_N14C_form__cexp_t v_841 = 0;
-      _fx_N14C_form__cexp_t v_842 = 0;
-      _fx_N14C_form__cexp_t v_843 = 0;
-      _fx_LN14C_form__cexp_t v_844 = 0;
-      _fx_N14C_form__cexp_t copy_arr_data_0 = 0;
       _fx_LN15C_form__cstmt_t ccode_128 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_845 = {0};
-      _fx_N14C_form__cexp_t i_exp_13 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_860 = {0};
+      _fx_N14C_form__cexp_t i_exp_12 = 0;
       _fx_LN15C_form__cstmt_t ccode_129 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_846 = {0};
-      _fx_N14C_form__cexp_t a_exp_5 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_861 = {0};
+      _fx_N14C_form__cexp_t e_exp_0 = 0;
       _fx_LN15C_form__cstmt_t ccode_130 = 0;
+      _fx_N14C_form__ctyp_t ctyp_2 = 0;
+      _fx_N14C_form__cexp_t v_862 = 0;
+      _fx_N14C_form__cexp_t v_863 = 0;
+      _fx_N14C_form__cexp_t v_864 = 0;
+      _fx_LN14C_form__cexp_t v_865 = 0;
+      _fx_N14C_form__cexp_t copy_arr_data_0 = 0;
+      _fx_LN15C_form__cstmt_t ccode_131 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_866 = {0};
+      _fx_N14C_form__cexp_t i_exp_13 = 0;
+      _fx_LN15C_form__cstmt_t ccode_132 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_867 = {0};
+      _fx_N14C_form__cexp_t a_exp_5 = 0;
+      _fx_LN15C_form__cstmt_t ccode_133 = 0;
       _fx_T3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t* vcase_20 = &kexp_0->u.KExpAssign;
       _fx_N14K_form__atom_t* a_12 = &vcase_20->t1;
       _fx_R9Ast__id_t* i_6 = &vcase_20->t0;
-      FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &ktyp_2, 0), _fx_catch_205);
-      _fx_R17K_form__ktprops_t v_847;
-      FX_CALL(_fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_2, &kloc_0, &v_847, 0),
-         _fx_catch_205);
-      bool ktp_complex_0 = v_847.ktp_complex;
-      if (ktp_complex_0) {
+      FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &ktyp_2, 0), _fx_catch_209);
+      _fx_R17K_form__ktprops_t v_868;
+      FX_CALL(_fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_2, &kloc_0, &v_868, 0),
+         _fx_catch_209);
+      bool ktp_complex_2 = v_868.ktp_complex;
+      if (ktp_complex_2) {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_6, true, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_839, 0), _fx_catch_205);
-         FX_COPY_PTR(v_839.t0, &i_exp_12);
-         FX_COPY_PTR(v_839.t1, &ccode_126);
-         FX_CALL(atom2cexp__0.fp(a_12, true, ccode_126, &kloc_0, &v_840, atom2cexp__0.fcv), _fx_catch_205);
-         FX_COPY_PTR(v_840.t0, &e_exp_0);
-         FX_COPY_PTR(v_840.t1, &ccode_127);
-         FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(i_exp_12, &ctyp_2, 0), _fx_catch_205);
-         bool v_848;
-         FX_CALL(_fx_M6K_formFM11is_subarrayB2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &v_848, 0), _fx_catch_205);
-         if (v_848) {
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_exp_0, &v_841, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_12, &v_842, 0), _fx_catch_205);
-            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(true, &kloc_0, &v_843, 0), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_843, 0, true, &v_844), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_842, v_844, false, &v_844), _fx_catch_205);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_841, v_844, false, &v_844), _fx_catch_205);
+               &v_860, 0), _fx_catch_209);
+         FX_COPY_PTR(v_860.t0, &i_exp_12);
+         FX_COPY_PTR(v_860.t1, &ccode_129);
+         FX_CALL(atom2cexp__0.fp(a_12, true, ccode_129, &kloc_0, &v_861, atom2cexp__0.fcv), _fx_catch_209);
+         FX_COPY_PTR(v_861.t0, &e_exp_0);
+         FX_COPY_PTR(v_861.t1, &ccode_130);
+         FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(i_exp_12, &ctyp_2, 0), _fx_catch_209);
+         bool v_869;
+         FX_CALL(_fx_M6K_formFM11is_subarrayB2R9Ast__id_tR10Ast__loc_t(i_6, &kloc_0, &v_869, 0), _fx_catch_209);
+         if (v_869) {
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(e_exp_0, &v_862, 0), _fx_catch_209);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_12, &v_863, 0), _fx_catch_209);
+            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(true, &kloc_0, &v_864, 0), _fx_catch_209);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_864, 0, true, &v_865), _fx_catch_209);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_863, v_865, false, &v_865), _fx_catch_209);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_862, v_865, false, &v_865), _fx_catch_209);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g28C_form__std_fx_copy_arr_data, v_844, _fx_g19C_gen_code__CTypInt, &kloc_0, &copy_arr_data_0, 0),
-               _fx_catch_205);
+                  &_fx_g28C_form__std_fx_copy_arr_data, v_865, _fx_g19C_gen_code__CTypInt, &kloc_0, &copy_arr_data_0, 0),
+               _fx_catch_209);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  copy_arr_data_0, ccode_127, &kloc_0, block_stack_ref_0, &ccode_125, 0), _fx_catch_205);
+                  copy_arr_data_0, ccode_130, &kloc_0, block_stack_ref_0, &ccode_128, 0), _fx_catch_209);
          }
          else {
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_free_codeLN15C_form__cstmt_t6N14C_form__cexp_tN14C_form__ctyp_tBBLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_exp_12, ctyp_2, true, false, ccode_127, &kloc_0, &ccode_128, 0), _fx_catch_205);
+                  i_exp_12, ctyp_2, true, false, ccode_130, &kloc_0, &ccode_131, 0), _fx_catch_209);
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  e_exp_0, i_exp_12, ctyp_2, ccode_128, &kloc_0, &ccode_125, 0), _fx_catch_205);
+                  e_exp_0, i_exp_12, ctyp_2, ccode_131, &kloc_0, &ccode_128, 0), _fx_catch_209);
          }
       }
       else {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_6, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_845, 0), _fx_catch_205);
-         FX_COPY_PTR(v_845.t0, &i_exp_13);
-         FX_COPY_PTR(v_845.t1, &ccode_129);
+               &v_866, 0), _fx_catch_209);
+         FX_COPY_PTR(v_866.t0, &i_exp_13);
+         FX_COPY_PTR(v_866.t1, &ccode_132);
          FX_CALL(
-            atom2cexp_0.fp(a_12, ccode_129, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
-               km_idx_0, &v_846, atom2cexp_0.fcv), _fx_catch_205);
-         FX_COPY_PTR(v_846.t0, &a_exp_5);
-         FX_COPY_PTR(v_846.t1, &ccode_130);
+            atom2cexp_0.fp(a_12, ccode_132, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0,
+               km_idx_0, &v_867, atom2cexp_0.fcv), _fx_catch_209);
+         FX_COPY_PTR(v_867.t0, &a_exp_5);
+         FX_COPY_PTR(v_867.t1, &ccode_133);
          FX_CALL(
             _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               a_exp_5, i_exp_13, ctyp_0, ccode_130, &kloc_0, &ccode_125, 0), _fx_catch_205);
+               a_exp_5, i_exp_13, ctyp_0, ccode_133, &kloc_0, &ccode_128, 0), _fx_catch_209);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_125, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_128, &v_1);
 
-   _fx_catch_205: ;
-      if (ccode_130) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_130);
+   _fx_catch_209: ;
+      if (ccode_133) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_133);
       }
       if (a_exp_5) {
          _fx_free_N14C_form__cexp_t(&a_exp_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_846);
-      if (ccode_129) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_129);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_867);
+      if (ccode_132) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_132);
       }
       if (i_exp_13) {
          _fx_free_N14C_form__cexp_t(&i_exp_13);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_845);
-      if (ccode_128) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_128);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_866);
+      if (ccode_131) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_131);
       }
       if (copy_arr_data_0) {
          _fx_free_N14C_form__cexp_t(&copy_arr_data_0);
       }
-      if (v_844) {
-         _fx_free_LN14C_form__cexp_t(&v_844);
+      if (v_865) {
+         _fx_free_LN14C_form__cexp_t(&v_865);
       }
-      if (v_843) {
-         _fx_free_N14C_form__cexp_t(&v_843);
+      if (v_864) {
+         _fx_free_N14C_form__cexp_t(&v_864);
       }
-      if (v_842) {
-         _fx_free_N14C_form__cexp_t(&v_842);
+      if (v_863) {
+         _fx_free_N14C_form__cexp_t(&v_863);
       }
-      if (v_841) {
-         _fx_free_N14C_form__cexp_t(&v_841);
+      if (v_862) {
+         _fx_free_N14C_form__cexp_t(&v_862);
       }
       if (ctyp_2) {
          _fx_free_N14C_form__ctyp_t(&ctyp_2);
       }
-      if (ccode_127) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_127);
+      if (ccode_130) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_130);
       }
       if (e_exp_0) {
          _fx_free_N14C_form__cexp_t(&e_exp_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_840);
-      if (ccode_126) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_126);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_861);
+      if (ccode_129) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_129);
       }
       if (i_exp_12) {
          _fx_free_N14C_form__cexp_t(&i_exp_12);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_839);
-      if (ccode_125) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_125);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_860);
+      if (ccode_128) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_128);
       }
       if (ktyp_2) {
          _fx_free_N14K_form__ktyp_t(&ktyp_2);
@@ -30348,95 +30587,95 @@ static int
       goto _fx_endmatch_55;
    }
    if (tag_0 == 22) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_849 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_870 = {0};
       _fx_N14C_form__cexp_t dst_exp_14 = 0;
-      _fx_LN15C_form__cstmt_t ccode_131 = 0;
-      _fx_LN15C_form__cstmt_t ccode_132 = 0;
-      fx_str_t slit_186 = FX_MAKE_STR("res");
+      _fx_LN15C_form__cstmt_t ccode_134 = 0;
+      _fx_LN15C_form__cstmt_t ccode_135 = 0;
+      fx_str_t slit_192 = FX_MAKE_STR("res");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_186, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_849, 0), _fx_catch_206);
-      FX_COPY_PTR(v_849.t0, &dst_exp_14);
-      FX_COPY_PTR(v_849.t1, &ccode_131);
+            dstexp_r_0, &slit_192, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_870, 0), _fx_catch_210);
+      FX_COPY_PTR(v_870.t0, &dst_exp_14);
+      FX_COPY_PTR(v_870.t1, &ccode_134);
       FX_CALL(
-         process_cases_0.fp(kexp_0->u.KExpMatch.t0, dstexp_r_0, ccode_131, false, &kloc_0, block_stack_ref_0,
+         process_cases_0.fp(kexp_0->u.KExpMatch.t0, dstexp_r_0, ccode_134, false, &kloc_0, block_stack_ref_0,
             defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0,
             i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0,
-            &ccode_132, process_cases_0.fcv), _fx_catch_206);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_14, ccode_132, &v_1);
+            &ccode_135, process_cases_0.fcv), _fx_catch_210);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_14, ccode_135, &v_1);
 
-   _fx_catch_206: ;
-      if (ccode_132) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_132);
+   _fx_catch_210: ;
+      if (ccode_135) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_135);
       }
-      if (ccode_131) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_131);
+      if (ccode_134) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_134);
       }
       if (dst_exp_14) {
          _fx_free_N14C_form__cexp_t(&dst_exp_14);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_849);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_870);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 23) {
-      _fx_Ta2N14K_form__kexp_t v_850 = {0};
+      _fx_Ta2N14K_form__kexp_t v_871 = {0};
       _fx_N14K_form__kexp_t pop_exn_0 = 0;
       _fx_N14K_form__kexp_t catch_e_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_851 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_872 = {0};
       _fx_N14C_form__cexp_t dst_exp_15 = 0;
-      _fx_LN15C_form__cstmt_t ccode_133 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_852 = {0};
+      _fx_LN15C_form__cstmt_t ccode_136 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_873 = {0};
       _fx_LN15C_form__cstmt_t try_ccode_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t bctx_try_0 = 0;
       _fx_LN15C_form__cstmt_t bctx_cleanup_1 = 0;
       _fx_LN15C_form__cstmt_t bctx_prologue_1 = 0;
       _fx_LN15C_form__cstmt_t epilogue_1 = 0;
-      _fx_N15C_form__cstmt_t v_853 = 0;
-      _fx_LN15C_form__cstmt_t v_854 = 0;
-      _fx_LN15C_form__cstmt_t v_855 = 0;
-      _fx_LN15C_form__cstmt_t v_856 = 0;
-      _fx_LN15C_form__cstmt_t ccode_134 = 0;
+      _fx_N15C_form__cstmt_t v_874 = 0;
+      _fx_LN15C_form__cstmt_t v_875 = 0;
+      _fx_LN15C_form__cstmt_t v_876 = 0;
+      _fx_LN15C_form__cstmt_t v_877 = 0;
+      _fx_LN15C_form__cstmt_t ccode_137 = 0;
       _fx_N14C_form__cexp_t fx_status_exp_1 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_857 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_858 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_878 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_879 = {0};
       _fx_LN15C_form__cstmt_t catch_ccode_0 = 0;
-      _fx_N14C_form__cexp_t v_859 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_860 = {0};
-      _fx_N14C_form__cexp_t v_861 = 0;
-      _fx_N15C_form__cstmt_t v_862 = 0;
+      _fx_N14C_form__cexp_t v_880 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_881 = {0};
+      _fx_N14C_form__cexp_t v_882 = 0;
+      _fx_N15C_form__cstmt_t v_883 = 0;
       _fx_LN15C_form__cstmt_t catch_ccode_1 = 0;
       _fx_LN15C_form__cstmt_t catch_ccode_2 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_863 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_884 = {0};
       _fx_LN15C_form__cstmt_t catch_ccode_3 = 0;
-      _fx_N14C_form__cexp_t v_864 = 0;
-      _fx_N14C_form__cexp_t v_865 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_866 = {0};
+      _fx_N14C_form__cexp_t v_885 = 0;
+      _fx_N14C_form__cexp_t v_886 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_887 = {0};
       _fx_N14C_form__cexp_t check_neg_status_0 = 0;
-      _fx_N15C_form__cstmt_t v_867 = 0;
-      _fx_N15C_form__cstmt_t v_868 = 0;
+      _fx_N15C_form__cstmt_t v_888 = 0;
+      _fx_N15C_form__cstmt_t v_889 = 0;
       _fx_N15C_form__cstmt_t catch_clause_0 = 0;
-      _fx_LN15C_form__cstmt_t v_869 = 0;
+      _fx_LN15C_form__cstmt_t v_890 = 0;
       _fx_T3N14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_21 = &kexp_0->u.KExpTryCatch;
       _fx_N14K_form__kexp_t catch_e_1 = vcase_21->t1;
       _fx_N14K_form__kexp_t try_e_0 = vcase_21->t0;
       int tag_26 = FX_REC_VARIANT_TAG(catch_e_1);
       if (tag_26 == 10) {
-         _fx_LN14K_form__kexp_t v_870 = catch_e_1->u.KExpSeq.t0;
-         if (v_870 != 0) {
-            _fx_N14K_form__kexp_t pop_exn_1 = v_870->hd;
+         _fx_LN14K_form__kexp_t v_891 = catch_e_1->u.KExpSeq.t0;
+         if (v_891 != 0) {
+            _fx_N14K_form__kexp_t pop_exn_1 = v_891->hd;
             if (FX_REC_VARIANT_TAG(pop_exn_1) == 31) {
-               _fx_N14K_form__kexp_t v_871 = pop_exn_1->u.KDefVal.t1;
-               if (FX_REC_VARIANT_TAG(v_871) == 8) {
-                  if (v_871->u.KExpIntrin.t0.tag == 1) {
-                     _fx_N14K_form__kexp_t v_872 = 0;
+               _fx_N14K_form__kexp_t v_892 = pop_exn_1->u.KDefVal.t1;
+               if (FX_REC_VARIANT_TAG(v_892) == 8) {
+                  if (v_892->u.KExpIntrin.t0.tag == 1) {
+                     _fx_N14K_form__kexp_t v_893 = 0;
                      FX_CALL(
-                        _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_870->tl, &kloc_0, &v_872,
-                           0), _fx_catch_207);
-                     _fx_make_Ta2N14K_form__kexp_t(pop_exn_1, v_872, &v_850);
+                        _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_891->tl, &kloc_0, &v_893,
+                           0), _fx_catch_211);
+                     _fx_make_Ta2N14K_form__kexp_t(pop_exn_1, v_893, &v_871);
 
-                  _fx_catch_207: ;
-                     if (v_872) {
-                        _fx_free_N14K_form__kexp_t(&v_872);
+                  _fx_catch_211: ;
+                     if (v_893) {
+                        _fx_free_N14K_form__kexp_t(&v_893);
                      }
                      goto _fx_endmatch_33;
                   }
@@ -30445,210 +30684,210 @@ static int
          }
       }
       if (tag_26 == 10) {
-         _fx_LN14K_form__kexp_t v_873 = catch_e_1->u.KExpSeq.t0;
-         if (v_873 != 0) {
-            _fx_N14K_form__kexp_t pop_exn_2 = v_873->hd;
+         _fx_LN14K_form__kexp_t v_894 = catch_e_1->u.KExpSeq.t0;
+         if (v_894 != 0) {
+            _fx_N14K_form__kexp_t pop_exn_2 = v_894->hd;
             if (FX_REC_VARIANT_TAG(pop_exn_2) == 8) {
                if (pop_exn_2->u.KExpIntrin.t0.tag == 1) {
-                  _fx_N14K_form__kexp_t v_874 = 0;
+                  _fx_N14K_form__kexp_t v_895 = 0;
                   FX_CALL(
-                     _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_873->tl, &kloc_0, &v_874, 0),
-                     _fx_catch_208);
-                  _fx_make_Ta2N14K_form__kexp_t(pop_exn_2, v_874, &v_850);
+                     _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_894->tl, &kloc_0, &v_895, 0),
+                     _fx_catch_212);
+                  _fx_make_Ta2N14K_form__kexp_t(pop_exn_2, v_895, &v_871);
 
-               _fx_catch_208: ;
-                  if (v_874) {
-                     _fx_free_N14K_form__kexp_t(&v_874);
+               _fx_catch_212: ;
+                  if (v_895) {
+                     _fx_free_N14K_form__kexp_t(&v_895);
                   }
                   goto _fx_endmatch_33;
                }
             }
          }
       }
-      fx_exn_t v_875 = {0};
-      fx_str_t slit_187 = FX_MAKE_STR("catch part in KExpTryCatch() should be a sequence starting with \'val x = pop_exn()\'");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_187, &v_875, 0), _fx_catch_209);
-      FX_THROW(&v_875, false, _fx_catch_209);
+      fx_exn_t v_896 = {0};
+      fx_str_t slit_193 = FX_MAKE_STR("catch part in KExpTryCatch() should be a sequence starting with \'val x = pop_exn()\'");
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_193, &v_896, 0), _fx_catch_213);
+      FX_THROW(&v_896, false, _fx_catch_213);
 
-   _fx_catch_209: ;
-      fx_free_exn(&v_875);
+   _fx_catch_213: ;
+      fx_free_exn(&v_896);
 
    _fx_endmatch_33: ;
-      FX_CHECK_EXN(_fx_catch_211);
-      FX_COPY_PTR(v_850.t0, &pop_exn_0);
-      FX_COPY_PTR(v_850.t1, &catch_e_0);
-      fx_str_t slit_188 = FX_MAKE_STR("res");
+      FX_CHECK_EXN(_fx_catch_215);
+      FX_COPY_PTR(v_871.t0, &pop_exn_0);
+      FX_COPY_PTR(v_871.t1, &catch_e_0);
+      fx_str_t slit_194 = FX_MAKE_STR("res");
       FX_CALL(
          _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-            dstexp_r_0, &slit_188, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_851, 0), _fx_catch_211);
-      FX_COPY_PTR(v_851.t0, &dst_exp_15);
-      FX_COPY_PTR(v_851.t1, &ccode_133);
+            dstexp_r_0, &slit_194, ctyp_0, ccode_0, &kloc_0, block_stack_ref_0, km_idx_0, &v_872, 0), _fx_catch_215);
+      FX_COPY_PTR(v_872.t0, &dst_exp_15);
+      FX_COPY_PTR(v_872.t1, &ccode_136);
       _fx_R10Ast__loc_t try_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(try_e_0, &try_loc_0, 0), _fx_catch_211);
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(try_e_0, &try_loc_0, 0), _fx_catch_215);
       _fx_R10Ast__loc_t try_end_loc_0;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&try_loc_0, &try_end_loc_0, 0), _fx_catch_211);
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&try_loc_0, &try_end_loc_0, 0), _fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g25C_gen_code__BlockKind_Try, &try_loc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_211);
+            &_fx_g25C_gen_code__BlockKind_Try, &try_loc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             try_e_0, dstexp_r_0, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_852, fx_fv), _fx_catch_211);
-      FX_COPY_PTR(v_852.t1, &try_ccode_0);
+            top_inline_ccode_ref_0, u1vals_0, &v_873, fx_fv), _fx_catch_215);
+      FX_COPY_PTR(v_873.t1, &try_ccode_0);
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_try_0, 0), _fx_catch_211);
-      _fx_R23C_gen_code__block_ctx_t* v_876 = &bctx_try_0->data;
-      int_ bctx_label_used_1 = v_876->bctx_label_used;
-      _fx_R9Ast__id_t bctx_label_1 = v_876->bctx_label;
-      FX_COPY_PTR(v_876->bctx_cleanup, &bctx_cleanup_1);
-      FX_COPY_PTR(v_876->bctx_prologue, &bctx_prologue_1);
+            &bctx_try_0, 0), _fx_catch_215);
+      _fx_R23C_gen_code__block_ctx_t* v_897 = &bctx_try_0->data;
+      int_ bctx_label_used_1 = v_897->bctx_label_used;
+      _fx_R9Ast__id_t bctx_label_1 = v_897->bctx_label;
+      FX_COPY_PTR(v_897->bctx_cleanup, &bctx_cleanup_1);
+      FX_COPY_PTR(v_897->bctx_prologue, &bctx_prologue_1);
       if (bctx_label_used_1 == 0) {
          FX_COPY_PTR(bctx_cleanup_1, &epilogue_1);
       }
       else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_1, &try_end_loc_0, &v_853),
-            _fx_catch_211);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_853, 0, true, &v_854), _fx_catch_211);
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_1, &try_end_loc_0, &v_874),
+            _fx_catch_215);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_874, 0, true, &v_875), _fx_catch_215);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_1, v_854,
-               &epilogue_1, 0), _fx_catch_211);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_1, v_875,
+               &epilogue_1, 0), _fx_catch_215);
       }
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_prologue_1, ccode_133,
-            &v_855, 0), _fx_catch_211);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_prologue_1, ccode_136,
+            &v_876, 0), _fx_catch_215);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(try_ccode_0, v_855, &v_856, 0),
-         _fx_catch_211);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(try_ccode_0, v_876, &v_877, 0),
+         _fx_catch_215);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_1, v_856, &ccode_134,
-            0), _fx_catch_211);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_1, v_877, &ccode_137,
+            0), _fx_catch_215);
       FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&try_end_loc_0, block_stack_ref_0, 0),
-         _fx_catch_211);
+         _fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0,
-            &fx_status_exp_1, 0), _fx_catch_211);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_857), _fx_catch_211);
+            &fx_status_exp_1, 0), _fx_catch_215);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_878), _fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            pop_exn_0, v_857, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
+            pop_exn_0, v_878, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0,
             fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0, return_used_ref_0,
-            top_inline_ccode_ref_0, u1vals_0, &v_858, fx_fv), _fx_catch_211);
-      FX_COPY_PTR(v_858.t1, &catch_ccode_0);
-      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_859, 0), _fx_catch_211);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypVoid, &try_end_loc_0, &v_860);
+            top_inline_ccode_ref_0, u1vals_0, &v_879, fx_fv), _fx_catch_215);
+      FX_COPY_PTR(v_879.t1, &catch_ccode_0);
+      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_880, 0), _fx_catch_215);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypVoid, &try_end_loc_0, &v_881);
       FX_CALL(
          _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g21C_gen_code__COpAssign, fx_status_exp_1, v_859, &v_860, &v_861), _fx_catch_211);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_861, &v_862), _fx_catch_211);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_862, catch_ccode_0, true, &catch_ccode_1), _fx_catch_211);
+            &_fx_g21C_gen_code__COpAssign, fx_status_exp_1, v_880, &v_881, &v_882), _fx_catch_215);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_882, &v_883), _fx_catch_215);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_883, catch_ccode_0, true, &catch_ccode_1), _fx_catch_215);
       if (FX_REC_VARIANT_TAG(ctyp_0) == 8) {
          FX_COPY_PTR(catch_ccode_1, &catch_ccode_2);
       }
       else {
          FX_CALL(
             _fx_M11C_gen_typesFM13gen_free_codeLN15C_form__cstmt_t6N14C_form__cexp_tN14C_form__ctyp_tBBLN15C_form__cstmt_tR10Ast__loc_t(
-               dst_exp_15, ctyp_0, true, true, catch_ccode_1, &try_end_loc_0, &catch_ccode_2, 0), _fx_catch_210);
+               dst_exp_15, ctyp_0, true, true, catch_ccode_1, &try_end_loc_0, &catch_ccode_2, 0), _fx_catch_214);
 
-      _fx_catch_210: ;
+      _fx_catch_214: ;
       }
-      FX_CHECK_EXN(_fx_catch_211);
+      FX_CHECK_EXN(_fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
             catch_e_0, dstexp_r_0, catch_ccode_2, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_863, fx_fv), _fx_catch_211);
-      FX_COPY_PTR(v_863.t1, &catch_ccode_3);
-      _fx_N17C_form__cbinary_t v_877;
-      _fx_M6C_formFM6COpCmpN17C_form__cbinary_t1N12Ast__cmpop_t(&_fx_g17C_gen_code__CmpLT, &v_877);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_884, fx_fv), _fx_catch_215);
+      FX_COPY_PTR(v_884.t1, &catch_ccode_3);
+      _fx_N17C_form__cbinary_t v_898;
+      _fx_M6C_formFM6COpCmpN17C_form__cbinary_t1N12Ast__cmpop_t(&_fx_g17C_gen_code__CmpLT, &v_898);
       FX_CALL(
-         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0, &v_864, 0),
-         _fx_catch_211);
-      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_865, 0), _fx_catch_211);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &try_end_loc_0, &v_866);
+         _fx_M10C_gen_codeFM14make_fx_statusN14C_form__cexp_t2R10Ast__loc_tR9Ast__id_t(&try_end_loc_0, fx_status__0, &v_885, 0),
+         _fx_catch_215);
+      FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &try_end_loc_0, &v_886, 0), _fx_catch_215);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &try_end_loc_0, &v_887);
       FX_CALL(
          _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &v_877, v_864, v_865, &v_866, &check_neg_status_0), _fx_catch_211);
+            &v_898, v_885, v_886, &v_887, &check_neg_status_0), _fx_catch_215);
       _fx_R10Ast__loc_t catch_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(catch_e_0, &catch_loc_0, 0), _fx_catch_211);
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(catch_e_0, &catch_loc_0, 0), _fx_catch_215);
       FX_CALL(
-         _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(catch_ccode_3, &catch_loc_0, &v_867, 0),
-         _fx_catch_211);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&try_end_loc_0, &v_868), _fx_catch_211);
+         _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(catch_ccode_3, &catch_loc_0, &v_888, 0),
+         _fx_catch_215);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&try_end_loc_0, &v_889), _fx_catch_215);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            check_neg_status_0, v_867, v_868, &catch_loc_0, &catch_clause_0, 0), _fx_catch_211);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(catch_clause_0, ccode_134, true, &v_869), _fx_catch_211);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_15, v_869, &v_1);
+            check_neg_status_0, v_888, v_889, &catch_loc_0, &catch_clause_0, 0), _fx_catch_215);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(catch_clause_0, ccode_137, true, &v_890), _fx_catch_215);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dst_exp_15, v_890, &v_1);
 
-   _fx_catch_211: ;
-      if (v_869) {
-         _fx_free_LN15C_form__cstmt_t(&v_869);
+   _fx_catch_215: ;
+      if (v_890) {
+         _fx_free_LN15C_form__cstmt_t(&v_890);
       }
       if (catch_clause_0) {
          _fx_free_N15C_form__cstmt_t(&catch_clause_0);
       }
-      if (v_868) {
-         _fx_free_N15C_form__cstmt_t(&v_868);
+      if (v_889) {
+         _fx_free_N15C_form__cstmt_t(&v_889);
       }
-      if (v_867) {
-         _fx_free_N15C_form__cstmt_t(&v_867);
+      if (v_888) {
+         _fx_free_N15C_form__cstmt_t(&v_888);
       }
       if (check_neg_status_0) {
          _fx_free_N14C_form__cexp_t(&check_neg_status_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_866);
-      if (v_865) {
-         _fx_free_N14C_form__cexp_t(&v_865);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_887);
+      if (v_886) {
+         _fx_free_N14C_form__cexp_t(&v_886);
       }
-      if (v_864) {
-         _fx_free_N14C_form__cexp_t(&v_864);
+      if (v_885) {
+         _fx_free_N14C_form__cexp_t(&v_885);
       }
       if (catch_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_863);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_884);
       if (catch_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_2);
       }
       if (catch_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_1);
       }
-      if (v_862) {
-         _fx_free_N15C_form__cstmt_t(&v_862);
+      if (v_883) {
+         _fx_free_N15C_form__cstmt_t(&v_883);
       }
-      if (v_861) {
-         _fx_free_N14C_form__cexp_t(&v_861);
+      if (v_882) {
+         _fx_free_N14C_form__cexp_t(&v_882);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_860);
-      if (v_859) {
-         _fx_free_N14C_form__cexp_t(&v_859);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_881);
+      if (v_880) {
+         _fx_free_N14C_form__cexp_t(&v_880);
       }
       if (catch_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&catch_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_858);
-      if (v_857) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_857);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_879);
+      if (v_878) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_878);
       }
       if (fx_status_exp_1) {
          _fx_free_N14C_form__cexp_t(&fx_status_exp_1);
       }
-      if (ccode_134) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_134);
+      if (ccode_137) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_137);
       }
-      if (v_856) {
-         _fx_free_LN15C_form__cstmt_t(&v_856);
+      if (v_877) {
+         _fx_free_LN15C_form__cstmt_t(&v_877);
       }
-      if (v_855) {
-         _fx_free_LN15C_form__cstmt_t(&v_855);
+      if (v_876) {
+         _fx_free_LN15C_form__cstmt_t(&v_876);
       }
-      if (v_854) {
-         _fx_free_LN15C_form__cstmt_t(&v_854);
+      if (v_875) {
+         _fx_free_LN15C_form__cstmt_t(&v_875);
       }
-      if (v_853) {
-         _fx_free_N15C_form__cstmt_t(&v_853);
+      if (v_874) {
+         _fx_free_N15C_form__cstmt_t(&v_874);
       }
       if (epilogue_1) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_1);
@@ -30665,250 +30904,250 @@ static int
       if (try_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&try_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_852);
-      if (ccode_133) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_133);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_873);
+      if (ccode_136) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_136);
       }
       if (dst_exp_15) {
          _fx_free_N14C_form__cexp_t(&dst_exp_15);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_851);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_872);
       if (catch_e_0) {
          _fx_free_N14K_form__kexp_t(&catch_e_0);
       }
       if (pop_exn_0) {
          _fx_free_N14K_form__kexp_t(&pop_exn_0);
       }
-      _fx_free_Ta2N14K_form__kexp_t(&v_850);
+      _fx_free_Ta2N14K_form__kexp_t(&v_871);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 24) {
-      _fx_N14C_form__cexp_t lbl_6 = 0;
-      _fx_LN15C_form__cstmt_t ccode_135 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_878 = {0};
+      _fx_N14C_form__cexp_t lbl_8 = 0;
+      _fx_LN15C_form__cstmt_t ccode_138 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_899 = {0};
       _fx_N14C_form__cexp_t i_exp_14 = 0;
-      _fx_LN15C_form__cstmt_t ccode_136 = 0;
-      _fx_N14C_form__cexp_t v_879 = 0;
-      _fx_LN14C_form__cexp_t v_880 = 0;
+      _fx_LN15C_form__cstmt_t ccode_139 = 0;
+      _fx_N14C_form__cexp_t v_900 = 0;
+      _fx_LN14C_form__cexp_t v_901 = 0;
       _fx_N14C_form__cexp_t throw_exp_0 = 0;
-      _fx_N15C_form__cstmt_t v_881 = 0;
+      _fx_N15C_form__cstmt_t v_902 = 0;
       _fx_T3R9Ast__id_tBR10Ast__loc_t* vcase_22 = &kexp_0->u.KExpThrow;
       _fx_R9Ast__id_t* i_7 = &vcase_22->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_6, 0), _fx_catch_216);
+            &lbl_8, 0), _fx_catch_220);
       if (vcase_22->t1) {
          FX_CALL(
             _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                i_7, false, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-               &v_878, 0), _fx_catch_216);
-         FX_COPY_PTR(v_878.t0, &i_exp_14);
-         FX_COPY_PTR(v_878.t1, &ccode_136);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_14, &v_879, 0), _fx_catch_216);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_6, 0, true, &v_880), _fx_catch_216);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_879, v_880, false, &v_880), _fx_catch_216);
+               &v_899, 0), _fx_catch_220);
+         FX_COPY_PTR(v_899.t0, &i_exp_14);
+         FX_COPY_PTR(v_899.t1, &ccode_139);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_14, &v_900, 0), _fx_catch_220);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_901), _fx_catch_220);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_900, v_901, false, &v_901), _fx_catch_220);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g22C_form__std_FX_RETHROW, v_880, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_0, 0), _fx_catch_216);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_0, &v_881), _fx_catch_216);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_881, ccode_136, true, &ccode_135), _fx_catch_216);
+               &_fx_g22C_form__std_FX_RETHROW, v_901, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_0, 0), _fx_catch_220);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_0, &v_902), _fx_catch_220);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_902, ccode_139, true, &ccode_138), _fx_catch_220);
       }
       else {
-         _fx_Nt6option1R9Ast__id_t v_882;
+         _fx_Nt6option1R9Ast__id_t v_903;
          FX_CALL(
             _fx_M10C_gen_codeFM8find_optNt6option1R9Ast__id_t2Rt6Map__t2R9Ast__id_tR9Ast__id_tR9Ast__id_t(
-               &_fx_g23Ast__builtin_exceptions, i_7, &v_882, 0), _fx_catch_216);
-         if (v_882.tag == 2) {
-            fx_str_t v_883 = {0};
-            fx_str_t v_884 = {0};
+               &_fx_g23Ast__builtin_exceptions, i_7, &v_903, 0), _fx_catch_220);
+         if (v_903.tag == 2) {
+            fx_str_t v_904 = {0};
+            fx_str_t v_905 = {0};
             _fx_N14C_form__cexp_t i_exp_15 = 0;
-            _fx_LN14C_form__cexp_t v_885 = 0;
+            _fx_LN14C_form__cexp_t v_906 = 0;
             _fx_N14C_form__cexp_t throw_exp_1 = 0;
-            _fx_N15C_form__cstmt_t v_886 = 0;
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_7, &v_883, 0), _fx_catch_212);
-            fx_str_t slit_189 = FX_MAKE_STR("FX_EXN_");
+            _fx_N15C_form__cstmt_t v_907 = 0;
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_7, &v_904, 0), _fx_catch_216);
+            fx_str_t slit_195 = FX_MAKE_STR("FX_EXN_");
             {
-               const fx_str_t strs_31[] = { slit_189, v_883 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_31, 2, &v_884), _fx_catch_212);
+               const fx_str_t strs_33[] = { slit_195, v_904 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_33, 2, &v_905), _fx_catch_216);
             }
             _fx_R9Ast__id_t i_8;
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_884, &i_8, 0), _fx_catch_212);
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_905, &i_8, 0), _fx_catch_216);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&i_8,
-                  _fx_g20C_gen_code__CTypCInt, &kloc_0, &i_exp_15, 0), _fx_catch_212);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_6, 0, true, &v_885), _fx_catch_212);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_15, v_885, false, &v_885), _fx_catch_212);
+                  _fx_g20C_gen_code__CTypCInt, &kloc_0, &i_exp_15, 0), _fx_catch_216);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_906), _fx_catch_216);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(i_exp_15, v_906, false, &v_906), _fx_catch_216);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g25C_form__std_FX_FAST_THROW, v_885, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_1, 0),
-               _fx_catch_212);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_1, &v_886), _fx_catch_212);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_886, ccode_0, true, &ccode_135), _fx_catch_212);
+                  &_fx_g25C_form__std_FX_FAST_THROW, v_906, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_1, 0),
+               _fx_catch_216);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_1, &v_907), _fx_catch_216);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_907, ccode_0, true, &ccode_138), _fx_catch_216);
 
-         _fx_catch_212: ;
-            if (v_886) {
-               _fx_free_N15C_form__cstmt_t(&v_886);
+         _fx_catch_216: ;
+            if (v_907) {
+               _fx_free_N15C_form__cstmt_t(&v_907);
             }
             if (throw_exp_1) {
                _fx_free_N14C_form__cexp_t(&throw_exp_1);
             }
-            if (v_885) {
-               _fx_free_LN14C_form__cexp_t(&v_885);
+            if (v_906) {
+               _fx_free_LN14C_form__cexp_t(&v_906);
             }
             if (i_exp_15) {
                _fx_free_N14C_form__cexp_t(&i_exp_15);
             }
-            FX_FREE_STR(&v_884);
-            FX_FREE_STR(&v_883);
+            FX_FREE_STR(&v_905);
+            FX_FREE_STR(&v_904);
          }
          else {
-            _fx_N15K_form__kinfo_t v_887 = {0};
-            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_888 = {0};
+            _fx_N15K_form__kinfo_t v_908 = {0};
+            _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_909 = {0};
             _fx_N14C_form__cexp_t i_exp_16 = 0;
-            _fx_LN15C_form__cstmt_t ccode_137 = 0;
-            _fx_N14C_form__cexp_t v_889 = 0;
-            _fx_N14C_form__cexp_t v_890 = 0;
-            _fx_LN14C_form__cexp_t v_891 = 0;
+            _fx_LN15C_form__cstmt_t ccode_140 = 0;
+            _fx_N14C_form__cexp_t v_910 = 0;
+            _fx_N14C_form__cexp_t v_911 = 0;
+            _fx_LN14C_form__cexp_t v_912 = 0;
             _fx_N14C_form__cexp_t throw_exp_2 = 0;
-            _fx_N15C_form__cstmt_t v_892 = 0;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_7, &kloc_0, &v_887, 0), _fx_catch_215);
-            int tag_27 = v_887.tag;
+            _fx_N15C_form__cstmt_t v_913 = 0;
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_7, &kloc_0, &v_908, 0), _fx_catch_219);
+            int tag_27 = v_908.tag;
             bool move_f_0;
             if (tag_27 == 4) {
                move_f_0 = false; goto _fx_endmatch_34;
             }
             if (tag_27 == 2) {
-               if (FX_REC_VARIANT_TAG(v_887.u.KVal.kv_typ) == 22) {
+               if (FX_REC_VARIANT_TAG(v_908.u.KVal.kv_typ) == 22) {
                   FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_7, &move_f_0, 0),
-                     _fx_catch_213);
+                     _fx_catch_217);
 
-               _fx_catch_213: ;
+               _fx_catch_217: ;
                   goto _fx_endmatch_34;
                }
             }
-            fx_exn_t v_893 = {0};
-            fx_str_t slit_190 = FX_MAKE_STR("cgen: throw is applied to neither exception nor value of \'exn\' type");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_190, &v_893, 0), _fx_catch_214);
-            FX_THROW(&v_893, false, _fx_catch_214);
+            fx_exn_t v_914 = {0};
+            fx_str_t slit_196 = FX_MAKE_STR("cgen: throw is applied to neither exception nor value of \'exn\' type");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_196, &v_914, 0), _fx_catch_218);
+            FX_THROW(&v_914, false, _fx_catch_218);
 
-         _fx_catch_214: ;
-            fx_free_exn(&v_893);
+         _fx_catch_218: ;
+            fx_free_exn(&v_914);
 
          _fx_endmatch_34: ;
-            FX_CHECK_EXN(_fx_catch_215);
+            FX_CHECK_EXN(_fx_catch_219);
             FX_CALL(
                _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                   i_7, move_f_0, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-                  &v_888, 0), _fx_catch_215);
-            FX_COPY_PTR(v_888.t0, &i_exp_16);
-            FX_COPY_PTR(v_888.t1, &ccode_137);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_16, &v_889, 0), _fx_catch_215);
-            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(move_f_0, &kloc_0, &v_890, 0), _fx_catch_215);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_6, 0, true, &v_891), _fx_catch_215);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_890, v_891, false, &v_891), _fx_catch_215);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_889, v_891, false, &v_891), _fx_catch_215);
+                  &v_909, 0), _fx_catch_219);
+            FX_COPY_PTR(v_909.t0, &i_exp_16);
+            FX_COPY_PTR(v_909.t1, &ccode_140);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(i_exp_16, &v_910, 0), _fx_catch_219);
+            FX_CALL(_fx_M6C_formFM13make_bool_expN14C_form__cexp_t2BR10Ast__loc_t(move_f_0, &kloc_0, &v_911, 0), _fx_catch_219);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_8, 0, true, &v_912), _fx_catch_219);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_911, v_912, false, &v_912), _fx_catch_219);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_910, v_912, false, &v_912), _fx_catch_219);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g20C_form__std_FX_THROW, v_891, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_2, 0), _fx_catch_215);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_2, &v_892), _fx_catch_215);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_892, ccode_137, true, &ccode_135), _fx_catch_215);
+                  &_fx_g20C_form__std_FX_THROW, v_912, _fx_g20C_gen_code__CTypVoid, &kloc_0, &throw_exp_2, 0), _fx_catch_219);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(throw_exp_2, &v_913), _fx_catch_219);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_913, ccode_140, true, &ccode_138), _fx_catch_219);
 
-         _fx_catch_215: ;
-            if (v_892) {
-               _fx_free_N15C_form__cstmt_t(&v_892);
+         _fx_catch_219: ;
+            if (v_913) {
+               _fx_free_N15C_form__cstmt_t(&v_913);
             }
             if (throw_exp_2) {
                _fx_free_N14C_form__cexp_t(&throw_exp_2);
             }
-            if (v_891) {
-               _fx_free_LN14C_form__cexp_t(&v_891);
+            if (v_912) {
+               _fx_free_LN14C_form__cexp_t(&v_912);
             }
-            if (v_890) {
-               _fx_free_N14C_form__cexp_t(&v_890);
+            if (v_911) {
+               _fx_free_N14C_form__cexp_t(&v_911);
             }
-            if (v_889) {
-               _fx_free_N14C_form__cexp_t(&v_889);
+            if (v_910) {
+               _fx_free_N14C_form__cexp_t(&v_910);
             }
-            if (ccode_137) {
-               _fx_free_LN15C_form__cstmt_t(&ccode_137);
+            if (ccode_140) {
+               _fx_free_LN15C_form__cstmt_t(&ccode_140);
             }
             if (i_exp_16) {
                _fx_free_N14C_form__cexp_t(&i_exp_16);
             }
-            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_888);
-            _fx_free_N15K_form__kinfo_t(&v_887);
+            _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_909);
+            _fx_free_N15K_form__kinfo_t(&v_908);
          }
-         FX_CHECK_EXN(_fx_catch_216);
+         FX_CHECK_EXN(_fx_catch_220);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_135, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_138, &v_1);
 
-   _fx_catch_216: ;
-      if (v_881) {
-         _fx_free_N15C_form__cstmt_t(&v_881);
+   _fx_catch_220: ;
+      if (v_902) {
+         _fx_free_N15C_form__cstmt_t(&v_902);
       }
       if (throw_exp_0) {
          _fx_free_N14C_form__cexp_t(&throw_exp_0);
       }
-      if (v_880) {
-         _fx_free_LN14C_form__cexp_t(&v_880);
+      if (v_901) {
+         _fx_free_LN14C_form__cexp_t(&v_901);
       }
-      if (v_879) {
-         _fx_free_N14C_form__cexp_t(&v_879);
+      if (v_900) {
+         _fx_free_N14C_form__cexp_t(&v_900);
       }
-      if (ccode_136) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_136);
+      if (ccode_139) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_139);
       }
       if (i_exp_14) {
          _fx_free_N14C_form__cexp_t(&i_exp_14);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_878);
-      if (ccode_135) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_135);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_899);
+      if (ccode_138) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_138);
       }
-      if (lbl_6) {
-         _fx_free_N14C_form__cexp_t(&lbl_6);
+      if (lbl_8) {
+         _fx_free_N14C_form__cexp_t(&lbl_8);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 25) {
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_894 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_915 = {0};
       _fx_N14C_form__cexp_t ce1_9 = 0;
-      _fx_LN15C_form__cstmt_t ccode_138 = 0;
+      _fx_LN15C_form__cstmt_t ccode_141 = 0;
       _fx_N14K_form__ktyp_t atyp_0 = 0;
       _fx_N14C_form__ctyp_t ctyp_3 = 0;
-      _fx_N14C_form__cexp_t v_895 = 0;
+      _fx_N14C_form__cexp_t v_916 = 0;
       _fx_T3N14K_form__atom_tN14K_form__ktyp_tR10Ast__loc_t* vcase_23 = &kexp_0->u.KExpCast;
       _fx_N14K_form__atom_t* a1_2 = &vcase_23->t0;
       FX_CALL(
          atom2cexp_0.fp(a1_2, ccode_0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-            &v_894, atom2cexp_0.fcv), _fx_catch_226);
-      FX_COPY_PTR(v_894.t0, &ce1_9);
-      FX_COPY_PTR(v_894.t1, &ccode_138);
+            &v_915, atom2cexp_0.fcv), _fx_catch_230);
+      FX_COPY_PTR(v_915.t0, &ce1_9);
+      FX_COPY_PTR(v_915.t1, &ccode_141);
       FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(a1_2, &kloc_0, &atyp_0, 0),
-         _fx_catch_226);
+         _fx_catch_230);
       FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(vcase_23->t1, &kloc_0, &ctyp_3, 0),
-         _fx_catch_226);
+         _fx_catch_230);
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 32) {
-                  _fx_LN14C_form__cexp_t v_896 = 0;
-                  _fx_N14C_form__ctyp_t v_897 = 0;
-                  _fx_R9Ast__id_t v_898;
-                  fx_str_t slit_191 = FX_MAKE_STR("FX_F16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_191, &v_898, 0), _fx_catch_217);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_896), _fx_catch_217);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_897), _fx_catch_217);
+                  _fx_LN14C_form__cexp_t v_917 = 0;
+                  _fx_N14C_form__ctyp_t v_918 = 0;
+                  _fx_R9Ast__id_t v_919;
+                  fx_str_t slit_197 = FX_MAKE_STR("FX_F16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_197, &v_919, 0), _fx_catch_221);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_917), _fx_catch_221);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_918), _fx_catch_221);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_898, v_896, v_897, &kloc_0, &v_895, 0), _fx_catch_217);
+                        &v_919, v_917, v_918, &kloc_0, &v_916, 0), _fx_catch_221);
 
-               _fx_catch_217: ;
-                  if (v_897) {
-                     _fx_free_N14C_form__ctyp_t(&v_897);
+               _fx_catch_221: ;
+                  if (v_918) {
+                     _fx_free_N14C_form__ctyp_t(&v_918);
                   }
-                  if (v_896) {
-                     _fx_free_LN14C_form__cexp_t(&v_896);
+                  if (v_917) {
+                     _fx_free_LN14C_form__cexp_t(&v_917);
                   }
                   goto _fx_endmatch_36;
                }
@@ -30919,23 +31158,23 @@ static int
          if (atyp_0->u.KTypFloat == 17) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 32) {
-                  _fx_LN14C_form__cexp_t v_899 = 0;
-                  _fx_N14C_form__ctyp_t v_900 = 0;
-                  _fx_R9Ast__id_t v_901;
-                  fx_str_t slit_192 = FX_MAKE_STR("FX_BF16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_192, &v_901, 0), _fx_catch_218);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_899), _fx_catch_218);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_900), _fx_catch_218);
+                  _fx_LN14C_form__cexp_t v_920 = 0;
+                  _fx_N14C_form__ctyp_t v_921 = 0;
+                  _fx_R9Ast__id_t v_922;
+                  fx_str_t slit_198 = FX_MAKE_STR("FX_BF16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_198, &v_922, 0), _fx_catch_222);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_920), _fx_catch_222);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_921), _fx_catch_222);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_901, v_899, v_900, &kloc_0, &v_895, 0), _fx_catch_218);
+                        &v_922, v_920, v_921, &kloc_0, &v_916, 0), _fx_catch_222);
 
-               _fx_catch_218: ;
-                  if (v_900) {
-                     _fx_free_N14C_form__ctyp_t(&v_900);
+               _fx_catch_222: ;
+                  if (v_921) {
+                     _fx_free_N14C_form__ctyp_t(&v_921);
                   }
-                  if (v_899) {
-                     _fx_free_LN14C_form__cexp_t(&v_899);
+                  if (v_920) {
+                     _fx_free_LN14C_form__cexp_t(&v_920);
                   }
                   goto _fx_endmatch_36;
                }
@@ -30964,51 +31203,51 @@ static int
       res_22 = false;
 
    _fx_endmatch_35: ;
-      FX_CHECK_EXN(_fx_catch_226);
+      FX_CHECK_EXN(_fx_catch_230);
       if (res_22) {
-         FX_COPY_PTR(ce1_9, &v_895); goto _fx_endmatch_36;
+         FX_COPY_PTR(ce1_9, &v_916); goto _fx_endmatch_36;
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 17) {
-                  _fx_LN14C_form__cexp_t v_902 = 0;
-                  _fx_N14C_form__ctyp_t v_903 = 0;
-                  _fx_N14C_form__cexp_t v_904 = 0;
-                  _fx_LN14C_form__cexp_t v_905 = 0;
-                  _fx_N14C_form__ctyp_t v_906 = 0;
-                  _fx_R9Ast__id_t v_907;
-                  fx_str_t slit_193 = FX_MAKE_STR("FX_F32TOBF16");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_193, &v_907, 0), _fx_catch_219);
-                  _fx_R9Ast__id_t v_908;
-                  fx_str_t slit_194 = FX_MAKE_STR("FX_F16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_194, &v_908, 0), _fx_catch_219);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_902), _fx_catch_219);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_903), _fx_catch_219);
+                  _fx_LN14C_form__cexp_t v_923 = 0;
+                  _fx_N14C_form__ctyp_t v_924 = 0;
+                  _fx_N14C_form__cexp_t v_925 = 0;
+                  _fx_LN14C_form__cexp_t v_926 = 0;
+                  _fx_N14C_form__ctyp_t v_927 = 0;
+                  _fx_R9Ast__id_t v_928;
+                  fx_str_t slit_199 = FX_MAKE_STR("FX_F32TOBF16");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_199, &v_928, 0), _fx_catch_223);
+                  _fx_R9Ast__id_t v_929;
+                  fx_str_t slit_200 = FX_MAKE_STR("FX_F16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_200, &v_929, 0), _fx_catch_223);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_923), _fx_catch_223);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_924), _fx_catch_223);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_908, v_902, v_903, &kloc_0, &v_904, 0), _fx_catch_219);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_904, 0, true, &v_905), _fx_catch_219);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_906), _fx_catch_219);
+                        &v_929, v_923, v_924, &kloc_0, &v_925, 0), _fx_catch_223);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_925, 0, true, &v_926), _fx_catch_223);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_927), _fx_catch_223);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_907, v_905, v_906, &kloc_0, &v_895, 0), _fx_catch_219);
+                        &v_928, v_926, v_927, &kloc_0, &v_916, 0), _fx_catch_223);
 
-               _fx_catch_219: ;
-                  if (v_906) {
-                     _fx_free_N14C_form__ctyp_t(&v_906);
+               _fx_catch_223: ;
+                  if (v_927) {
+                     _fx_free_N14C_form__ctyp_t(&v_927);
                   }
-                  if (v_905) {
-                     _fx_free_LN14C_form__cexp_t(&v_905);
+                  if (v_926) {
+                     _fx_free_LN14C_form__cexp_t(&v_926);
                   }
-                  if (v_904) {
-                     _fx_free_N14C_form__cexp_t(&v_904);
+                  if (v_925) {
+                     _fx_free_N14C_form__cexp_t(&v_925);
                   }
-                  if (v_903) {
-                     _fx_free_N14C_form__ctyp_t(&v_903);
+                  if (v_924) {
+                     _fx_free_N14C_form__ctyp_t(&v_924);
                   }
-                  if (v_902) {
-                     _fx_free_LN14C_form__cexp_t(&v_902);
+                  if (v_923) {
+                     _fx_free_LN14C_form__cexp_t(&v_923);
                   }
                   goto _fx_endmatch_36;
                }
@@ -31019,43 +31258,43 @@ static int
          if (atyp_0->u.KTypFloat == 17) {
             if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
                if (ctyp_3->u.CTypFloat == 16) {
-                  _fx_LN14C_form__cexp_t v_909 = 0;
-                  _fx_N14C_form__ctyp_t v_910 = 0;
-                  _fx_N14C_form__cexp_t v_911 = 0;
-                  _fx_LN14C_form__cexp_t v_912 = 0;
-                  _fx_N14C_form__ctyp_t v_913 = 0;
-                  _fx_R9Ast__id_t v_914;
-                  fx_str_t slit_195 = FX_MAKE_STR("FX_F32TOF16");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_195, &v_914, 0), _fx_catch_220);
-                  _fx_R9Ast__id_t v_915;
-                  fx_str_t slit_196 = FX_MAKE_STR("FX_BF16TOF32");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_196, &v_915, 0), _fx_catch_220);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_909), _fx_catch_220);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_910), _fx_catch_220);
+                  _fx_LN14C_form__cexp_t v_930 = 0;
+                  _fx_N14C_form__ctyp_t v_931 = 0;
+                  _fx_N14C_form__cexp_t v_932 = 0;
+                  _fx_LN14C_form__cexp_t v_933 = 0;
+                  _fx_N14C_form__ctyp_t v_934 = 0;
+                  _fx_R9Ast__id_t v_935;
+                  fx_str_t slit_201 = FX_MAKE_STR("FX_F32TOF16");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_201, &v_935, 0), _fx_catch_224);
+                  _fx_R9Ast__id_t v_936;
+                  fx_str_t slit_202 = FX_MAKE_STR("FX_BF16TOF32");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_202, &v_936, 0), _fx_catch_224);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_930), _fx_catch_224);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_931), _fx_catch_224);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_915, v_909, v_910, &kloc_0, &v_911, 0), _fx_catch_220);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_911, 0, true, &v_912), _fx_catch_220);
-                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_913), _fx_catch_220);
+                        &v_936, v_930, v_931, &kloc_0, &v_932, 0), _fx_catch_224);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_932, 0, true, &v_933), _fx_catch_224);
+                  FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_934), _fx_catch_224);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_914, v_912, v_913, &kloc_0, &v_895, 0), _fx_catch_220);
+                        &v_935, v_933, v_934, &kloc_0, &v_916, 0), _fx_catch_224);
 
-               _fx_catch_220: ;
-                  if (v_913) {
-                     _fx_free_N14C_form__ctyp_t(&v_913);
+               _fx_catch_224: ;
+                  if (v_934) {
+                     _fx_free_N14C_form__ctyp_t(&v_934);
                   }
-                  if (v_912) {
-                     _fx_free_LN14C_form__cexp_t(&v_912);
+                  if (v_933) {
+                     _fx_free_LN14C_form__cexp_t(&v_933);
                   }
-                  if (v_911) {
-                     _fx_free_N14C_form__cexp_t(&v_911);
+                  if (v_932) {
+                     _fx_free_N14C_form__cexp_t(&v_932);
                   }
-                  if (v_910) {
-                     _fx_free_N14C_form__ctyp_t(&v_910);
+                  if (v_931) {
+                     _fx_free_N14C_form__ctyp_t(&v_931);
                   }
-                  if (v_909) {
-                     _fx_free_LN14C_form__cexp_t(&v_909);
+                  if (v_930) {
+                     _fx_free_LN14C_form__cexp_t(&v_930);
                   }
                   goto _fx_endmatch_36;
                }
@@ -31064,123 +31303,123 @@ static int
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 16) {
-            _fx_LN14C_form__cexp_t v_916 = 0;
-            _fx_N14C_form__ctyp_t v_917 = 0;
-            _fx_N14C_form__cexp_t v_918 = 0;
-            _fx_R9Ast__id_t v_919;
-            fx_str_t slit_197 = FX_MAKE_STR("FX_F16TOF32");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_197, &v_919, 0), _fx_catch_221);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_916), _fx_catch_221);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_917), _fx_catch_221);
+            _fx_LN14C_form__cexp_t v_937 = 0;
+            _fx_N14C_form__ctyp_t v_938 = 0;
+            _fx_N14C_form__cexp_t v_939 = 0;
+            _fx_R9Ast__id_t v_940;
+            fx_str_t slit_203 = FX_MAKE_STR("FX_F16TOF32");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_203, &v_940, 0), _fx_catch_225);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_937), _fx_catch_225);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_938), _fx_catch_225);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_919,
-                  v_916, v_917, &kloc_0, &v_918, 0), _fx_catch_221);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_940,
+                  v_937, v_938, &kloc_0, &v_939, 0), _fx_catch_225);
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_918, ctyp_3, &kloc_0,
-                  &v_895), _fx_catch_221);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_939, ctyp_3, &kloc_0,
+                  &v_916), _fx_catch_225);
 
-         _fx_catch_221: ;
-            if (v_918) {
-               _fx_free_N14C_form__cexp_t(&v_918);
+         _fx_catch_225: ;
+            if (v_939) {
+               _fx_free_N14C_form__cexp_t(&v_939);
             }
-            if (v_917) {
-               _fx_free_N14C_form__ctyp_t(&v_917);
+            if (v_938) {
+               _fx_free_N14C_form__ctyp_t(&v_938);
             }
-            if (v_916) {
-               _fx_free_LN14C_form__cexp_t(&v_916);
+            if (v_937) {
+               _fx_free_LN14C_form__cexp_t(&v_937);
             }
             goto _fx_endmatch_36;
          }
       }
       if (FX_REC_VARIANT_TAG(atyp_0) == 5) {
          if (atyp_0->u.KTypFloat == 17) {
-            _fx_LN14C_form__cexp_t v_920 = 0;
-            _fx_N14C_form__ctyp_t v_921 = 0;
-            _fx_N14C_form__cexp_t v_922 = 0;
-            _fx_R9Ast__id_t v_923;
-            fx_str_t slit_198 = FX_MAKE_STR("FX_BF16TOF32");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_198, &v_923, 0), _fx_catch_222);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_920), _fx_catch_222);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_921), _fx_catch_222);
+            _fx_LN14C_form__cexp_t v_941 = 0;
+            _fx_N14C_form__ctyp_t v_942 = 0;
+            _fx_N14C_form__cexp_t v_943 = 0;
+            _fx_R9Ast__id_t v_944;
+            fx_str_t slit_204 = FX_MAKE_STR("FX_BF16TOF32");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_204, &v_944, 0), _fx_catch_226);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_941), _fx_catch_226);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(32, &v_942), _fx_catch_226);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_923,
-                  v_920, v_921, &kloc_0, &v_922, 0), _fx_catch_222);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_944,
+                  v_941, v_942, &kloc_0, &v_943, 0), _fx_catch_226);
             FX_CALL(
-               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_922, ctyp_3, &kloc_0,
-                  &v_895), _fx_catch_222);
+               _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_943, ctyp_3, &kloc_0,
+                  &v_916), _fx_catch_226);
 
-         _fx_catch_222: ;
-            if (v_922) {
-               _fx_free_N14C_form__cexp_t(&v_922);
+         _fx_catch_226: ;
+            if (v_943) {
+               _fx_free_N14C_form__cexp_t(&v_943);
             }
-            if (v_921) {
-               _fx_free_N14C_form__ctyp_t(&v_921);
+            if (v_942) {
+               _fx_free_N14C_form__ctyp_t(&v_942);
             }
-            if (v_920) {
-               _fx_free_LN14C_form__cexp_t(&v_920);
+            if (v_941) {
+               _fx_free_LN14C_form__cexp_t(&v_941);
             }
             goto _fx_endmatch_36;
          }
       }
       if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
          if (ctyp_3->u.CTypFloat == 16) {
-            _fx_LN14C_form__cexp_t v_924 = 0;
-            _fx_N14C_form__ctyp_t v_925 = 0;
-            _fx_R9Ast__id_t v_926;
-            fx_str_t slit_199 = FX_MAKE_STR("FX_F32TOF16");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_199, &v_926, 0), _fx_catch_223);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_924), _fx_catch_223);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_925), _fx_catch_223);
+            _fx_LN14C_form__cexp_t v_945 = 0;
+            _fx_N14C_form__ctyp_t v_946 = 0;
+            _fx_R9Ast__id_t v_947;
+            fx_str_t slit_205 = FX_MAKE_STR("FX_F32TOF16");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_205, &v_947, 0), _fx_catch_227);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_945), _fx_catch_227);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(16, &v_946), _fx_catch_227);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_926,
-                  v_924, v_925, &kloc_0, &v_895, 0), _fx_catch_223);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_947,
+                  v_945, v_946, &kloc_0, &v_916, 0), _fx_catch_227);
 
-         _fx_catch_223: ;
-            if (v_925) {
-               _fx_free_N14C_form__ctyp_t(&v_925);
+         _fx_catch_227: ;
+            if (v_946) {
+               _fx_free_N14C_form__ctyp_t(&v_946);
             }
-            if (v_924) {
-               _fx_free_LN14C_form__cexp_t(&v_924);
+            if (v_945) {
+               _fx_free_LN14C_form__cexp_t(&v_945);
             }
             goto _fx_endmatch_36;
          }
       }
       if (FX_REC_VARIANT_TAG(ctyp_3) == 7) {
          if (ctyp_3->u.CTypFloat == 17) {
-            _fx_LN14C_form__cexp_t v_927 = 0;
-            _fx_N14C_form__ctyp_t v_928 = 0;
-            _fx_R9Ast__id_t v_929;
-            fx_str_t slit_200 = FX_MAKE_STR("FX_F32TOBF16");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_200, &v_929, 0), _fx_catch_224);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_927), _fx_catch_224);
-            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_928), _fx_catch_224);
+            _fx_LN14C_form__cexp_t v_948 = 0;
+            _fx_N14C_form__ctyp_t v_949 = 0;
+            _fx_R9Ast__id_t v_950;
+            fx_str_t slit_206 = FX_MAKE_STR("FX_F32TOBF16");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_206, &v_950, 0), _fx_catch_228);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(ce1_9, 0, true, &v_948), _fx_catch_228);
+            FX_CALL(_fx_M6C_formFM9CTypFloatN14C_form__ctyp_t1i(17, &v_949), _fx_catch_228);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_929,
-                  v_927, v_928, &kloc_0, &v_895, 0), _fx_catch_224);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_950,
+                  v_948, v_949, &kloc_0, &v_916, 0), _fx_catch_228);
 
-         _fx_catch_224: ;
-            if (v_928) {
-               _fx_free_N14C_form__ctyp_t(&v_928);
+         _fx_catch_228: ;
+            if (v_949) {
+               _fx_free_N14C_form__ctyp_t(&v_949);
             }
-            if (v_927) {
-               _fx_free_LN14C_form__cexp_t(&v_927);
+            if (v_948) {
+               _fx_free_LN14C_form__cexp_t(&v_948);
             }
             goto _fx_endmatch_36;
          }
       }
       FX_CALL(
          _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(ce1_9, ctyp_3, &kloc_0,
-            &v_895), _fx_catch_225);
+            &v_916), _fx_catch_229);
 
-   _fx_catch_225: ;
+   _fx_catch_229: ;
 
    _fx_endmatch_36: ;
-      FX_CHECK_EXN(_fx_catch_226);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_895, ccode_138, &v_1);
+      FX_CHECK_EXN(_fx_catch_230);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(true, v_916, ccode_141, &v_1);
 
-   _fx_catch_226: ;
-      if (v_895) {
-         _fx_free_N14C_form__cexp_t(&v_895);
+   _fx_catch_230: ;
+      if (v_916) {
+         _fx_free_N14C_form__cexp_t(&v_916);
       }
       if (ctyp_3) {
          _fx_free_N14C_form__ctyp_t(&ctyp_3);
@@ -31188,13 +31427,13 @@ static int
       if (atyp_0) {
          _fx_free_N14K_form__ktyp_t(&atyp_0);
       }
-      if (ccode_138) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_138);
+      if (ccode_141) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_141);
       }
       if (ce1_9) {
          _fx_free_N14C_form__cexp_t(&ce1_9);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_894);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_915);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 26) {
@@ -31204,66 +31443,66 @@ static int
       _fx_ri ndims_ref_0 = 0;
       _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t e_idoml_l_1 = 0;
       _fx_N14C_form__cexp_t glob_status_0 = 0;
-      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_930 = {0};
-      _fx_R16Ast__val_flags_t v_931 = {0};
-      _fx_N14C_form__cexp_t v_932 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_933 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_934 = {0};
+      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_951 = {0};
+      _fx_R16Ast__val_flags_t v_952 = {0};
+      _fx_N14C_form__cexp_t v_953 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_954 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_955 = {0};
       _fx_N14C_form__cexp_t par_status_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_139 = 0;
-      _fx_R16Ast__val_flags_t v_935 = {0};
-      _fx_N14C_form__cexp_t v_936 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_937 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_938 = {0};
+      _fx_LN15C_form__cstmt_t ccode_142 = 0;
+      _fx_R16Ast__val_flags_t v_956 = {0};
+      _fx_N14C_form__cexp_t v_957 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_958 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_959 = {0};
       _fx_N14C_form__cexp_t nested_status_0 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_0 = 0;
-      _fx_N14C_form__cexp_t v_939 = 0;
+      _fx_N14C_form__cexp_t v_960 = 0;
       _fx_N14C_form__cexp_t par_status_1 = 0;
-      _fx_LN15C_form__cstmt_t ccode_140 = 0;
+      _fx_LN15C_form__cstmt_t ccode_143 = 0;
       _fx_N14C_form__cexp_t nested_status_1 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_1 = 0;
-      _fx_N14K_form__ktyp_t v_940 = 0;
+      _fx_N14K_form__ktyp_t v_961 = 0;
       _fx_LN14K_form__ktyp_t coll_typs_0 = 0;
       _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t dst_data_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_141 = 0;
+      _fx_LN15C_form__cstmt_t ccode_144 = 0;
       _fx_LN15C_form__cstmt_t finalize_ccode_0 = 0;
       _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t dst_data_1 = 0;
       _fx_FPTa2LN15C_form__cstmt_t36LN15C_form__cstmt_tiLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14C_form__cexp_tLN14C_form__cexp_trLrR23C_gen_code__block_ctx_tLN15C_form__cstmt_trNt10Hashset__t1R9Ast__id_tLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_tN15Ast__for_make_tLSR10Ast__loc_trrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tBR10Ast__loc_tiN14C_form__cexp_tLN12Ast__scope_trLN15C_form__cstmt_triBBBN14C_form__cexp_tiN14C_form__cexp_tBrirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_tB
          form_map_0 = {0};
-      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_941 = {0};
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_942 = 0;
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_943 = 0;
-      _fx_Ta2LN15C_form__cstmt_t v_944 = {0};
+      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_962 = {0};
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_963 = 0;
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_964 = 0;
+      _fx_Ta2LN15C_form__cstmt_t v_965 = {0};
       _fx_LN15C_form__cstmt_t pre_map_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_1 = 0;
-      _fx_LN14C_form__cexp_t v_945 = 0;
+      _fx_LN14C_form__cexp_t v_966 = 0;
       _fx_N14C_form__cexp_t update_exn_parallel_0 = 0;
-      _fx_N15C_form__cstmt_t v_946 = 0;
+      _fx_N15C_form__cstmt_t v_967 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_2 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_3 = 0;
       _fx_LN14C_form__cexp_t cargs_5 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_947 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_968 = {0};
       _fx_N14C_form__cexp_t t_exp_2 = 0;
       _fx_LN15C_form__cstmt_t map_ccode_4 = 0;
-      _fx_N14C_form__cexp_t v_948 = 0;
-      _fx_LN14C_form__cexp_t v_949 = 0;
-      _fx_LN14C_form__cexp_t v_950 = 0;
+      _fx_N14C_form__cexp_t v_969 = 0;
+      _fx_LN14C_form__cexp_t v_970 = 0;
+      _fx_LN14C_form__cexp_t v_971 = 0;
       _fx_N14C_form__cexp_t call_mktup_1 = 0;
-      _fx_N15C_form__cstmt_t v_951 = 0;
-      _fx_LN15C_form__cstmt_t v_952 = 0;
-      _fx_LN15C_form__cstmt_t v_953 = 0;
+      _fx_N15C_form__cstmt_t v_972 = 0;
+      _fx_LN15C_form__cstmt_t v_973 = 0;
+      _fx_LN15C_form__cstmt_t v_974 = 0;
       _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
          vcase_24 = &kexp_0->u.KExpMap;
       _fx_R16Ast__for_flags_t* flags_0 = &vcase_24->t2;
       _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t e_idoml_l_2 = vcase_24->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &map_lbl_0, 0), _fx_catch_242);
+            &map_lbl_0, 0), _fx_catch_246);
       _fx_R10Ast__loc_t for_loc_0;
-      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_0, 0), _fx_catch_242);
+      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_0, 0), _fx_catch_246);
       _fx_R10Ast__loc_t end_for_loc_0;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_0, 0), _fx_catch_242);
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_0, 0), _fx_catch_246);
       _fx_N15Ast__for_make_t for_flag_make_0 = flags_0->for_flag_make;
       bool need_make_array_0 = for_flag_make_0.tag == 2;
       bool need_make_vec_0 = for_flag_make_0.tag == 5;
@@ -31278,13 +31517,13 @@ static int
       int_ nfors_0;
       FX_CALL(
          _fx_M10C_gen_codeFM8length1_i1LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(e_idoml_l_2, &nfors_0, 0),
-         _fx_catch_242);
+         _fx_catch_246);
       bool pre_alloc_array_0;
       if (!need_make_array_0) {
          pre_alloc_array_0 = false;
       }
       else {
-         FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(256, &decl_inside_for_0, 0), _fx_catch_242);
+         FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(256, &decl_inside_for_0, 0), _fx_catch_246);
          bool __fold_result___4 = true;
          FX_COPY_PTR(e_idoml_l_2, &e_idoml_l_0);
          _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t lst_22 = e_idoml_l_0;
@@ -31292,26 +31531,26 @@ static int
             _fx_N14K_form__kexp_t e_14 = 0;
             _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_0 = 0;
             _fx_LR9Ast__id_t idxl_0 = 0;
-            _fx_LN14K_form__kexp_t v_954 = 0;
-            _fx_Nt10Hashset__t1R9Ast__id_t v_955 = 0;
+            _fx_LN14K_form__kexp_t v_975 = 0;
+            _fx_Nt10Hashset__t1R9Ast__id_t v_976 = 0;
             _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t* __pat___6 = &lst_22->hd;
             FX_COPY_PTR(__pat___6->t0, &e_14);
             FX_COPY_PTR(__pat___6->t1, &idoml_0);
             FX_COPY_PTR(__pat___6->t2, &idxl_0);
-            FX_CALL(_fx_cons_LN14K_form__kexp_t(e_14, 0, true, &v_954), _fx_catch_231);
-            FX_CALL(_fx_M6K_formFM8declaredNt10Hashset__t1R9Ast__id_t2LN14K_form__kexp_ti(v_954, 256, &v_955, 0),
-               _fx_catch_231);
+            FX_CALL(_fx_cons_LN14K_form__kexp_t(e_14, 0, true, &v_975), _fx_catch_235);
+            FX_CALL(_fx_M6K_formFM8declaredNt10Hashset__t1R9Ast__id_t2LN14K_form__kexp_ti(v_975, 256, &v_976, 0),
+               _fx_catch_235);
             FX_CALL(
-               _fx_M10C_gen_codeFM5unionv2Nt10Hashset__t1R9Ast__id_tNt10Hashset__t1R9Ast__id_t(decl_inside_for_0, v_955, 0),
-               _fx_catch_231);
+               _fx_M10C_gen_codeFM5unionv2Nt10Hashset__t1R9Ast__id_tNt10Hashset__t1R9Ast__id_t(decl_inside_for_0, v_976, 0),
+               _fx_catch_235);
             _fx_LR9Ast__id_t lst_23 = idxl_0;
             for (; lst_23; lst_23 = lst_23->tl) {
                _fx_R9Ast__id_t* i_9 = &lst_23->hd;
                FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, i_9, 0),
-                  _fx_catch_227);
+                  _fx_catch_231);
 
-            _fx_catch_227: ;
-               FX_CHECK_EXN(_fx_catch_231);
+            _fx_catch_231: ;
+               FX_CHECK_EXN(_fx_catch_235);
             }
             bool __fold_result___5 = true;
             _fx_LT2R9Ast__id_tN13K_form__dom_t lst_24 = idoml_0;
@@ -31321,20 +31560,20 @@ static int
                _fx_R9Ast__id_t i_10 = __pat___7->t0;
                _fx_copy_N13K_form__dom_t(&__pat___7->t1, &dom_0);
                FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, &i_10, 0),
-                  _fx_catch_230);
+                  _fx_catch_234);
                int tag_28 = dom_0.tag;
-               bool v_956;
+               bool v_977;
                if (tag_28 == 1) {
-                  _fx_N14K_form__atom_t* v_957 = &dom_0.u.DomainElem;
-                  if (v_957->tag == 1) {
-                     _fx_R17K_form__kdefval_t v_958 = {0};
+                  _fx_N14K_form__atom_t* v_978 = &dom_0.u.DomainElem;
+                  if (v_978->tag == 1) {
+                     _fx_R17K_form__kdefval_t v_979 = {0};
                      _fx_R16Ast__val_flags_t kv_flags_0 = {0};
                      _fx_N14K_form__ktyp_t kv_typ_0 = 0;
-                     _fx_R9Ast__id_t* col_0 = &v_957->u.AtomId;
-                     FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(col_0, &kloc_0, &v_958, 0),
-                        _fx_catch_228);
-                     _fx_copy_R16Ast__val_flags_t(&v_958.kv_flags, &kv_flags_0);
-                     FX_COPY_PTR(v_958.kv_typ, &kv_typ_0);
+                     _fx_R9Ast__id_t* col_0 = &v_978->u.AtomId;
+                     FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(col_0, &kloc_0, &v_979, 0),
+                        _fx_catch_232);
+                     _fx_copy_R16Ast__val_flags_t(&v_979.kv_flags, &kv_flags_0);
+                     FX_COPY_PTR(v_979.kv_typ, &kv_typ_0);
                      bool t_12;
                      if (!kv_flags_0.val_flag_mutable) {
                         int tag_29 = FX_REC_VARIANT_TAG(kv_typ_0);
@@ -31348,43 +31587,43 @@ static int
                         else {
                            res_23 = false;
                         }
-                        FX_CHECK_EXN(_fx_catch_228);
+                        FX_CHECK_EXN(_fx_catch_232);
                         if (res_23) {
                            t_12 = true; goto _fx_endmatch_37;
                         }
                         t_12 = false;
 
                      _fx_endmatch_37: ;
-                        FX_CHECK_EXN(_fx_catch_228);
+                        FX_CHECK_EXN(_fx_catch_232);
                      }
                      else {
                         t_12 = false;
                      }
                      if (t_12) {
-                        bool v_959;
+                        bool v_980;
                         FX_CALL(
-                           _fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, col_0, &v_959, 0),
-                           _fx_catch_228);
-                        v_956 = !v_959;
+                           _fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(decl_inside_for_0, col_0, &v_980, 0),
+                           _fx_catch_232);
+                        v_977 = !v_980;
                      }
                      else {
-                        v_956 = false;
+                        v_977 = false;
                      }
 
-                  _fx_catch_228: ;
+                  _fx_catch_232: ;
                      if (kv_typ_0) {
                         _fx_free_N14K_form__ktyp_t(&kv_typ_0);
                      }
                      _fx_free_R16Ast__val_flags_t(&kv_flags_0);
-                     _fx_free_R17K_form__kdefval_t(&v_958);
+                     _fx_free_R17K_form__kdefval_t(&v_979);
                      goto _fx_endmatch_38;
                   }
                }
                if (tag_28 == 1) {
-                  _fx_N14K_form__atom_t* v_960 = &dom_0.u.DomainElem;
-                  if (v_960->tag == 2) {
-                     if (v_960->u.AtomLit.tag == 5) {
-                        v_956 = true; goto _fx_endmatch_38;
+                  _fx_N14K_form__atom_t* v_981 = &dom_0.u.DomainElem;
+                  if (v_981->tag == 2) {
+                     if (v_981->u.AtomLit.tag == 5) {
+                        v_977 = true; goto _fx_endmatch_38;
                      }
                   }
                }
@@ -31393,12 +31632,12 @@ static int
                   bool res_24;
                   FX_CALL(
                      _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                        &vcase_25->t0, decl_inside_for_0, &kloc_0, &res_24, 0), _fx_catch_229);
+                        &vcase_25->t0, decl_inside_for_0, &kloc_0, &res_24, 0), _fx_catch_233);
                   bool t_13;
                   if (res_24) {
                      FX_CALL(
                         _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                           &vcase_25->t1, decl_inside_for_0, &kloc_0, &t_13, 0), _fx_catch_229);
+                           &vcase_25->t1, decl_inside_for_0, &kloc_0, &t_13, 0), _fx_catch_233);
                   }
                   else {
                      t_13 = false;
@@ -31406,38 +31645,38 @@ static int
                   if (t_13) {
                      FX_CALL(
                         _fx_M10C_gen_codeFM16check_range_elemB3N14K_form__atom_tNt10Hashset__t1R9Ast__id_tR10Ast__loc_t(
-                           &vcase_25->t2, decl_inside_for_0, &kloc_0, &v_956, 0), _fx_catch_229);
+                           &vcase_25->t2, decl_inside_for_0, &kloc_0, &v_977, 0), _fx_catch_233);
                   }
                   else {
-                     v_956 = false;
+                     v_977 = false;
                   }
 
-               _fx_catch_229: ;
+               _fx_catch_233: ;
                   goto _fx_endmatch_38;
                }
-               v_956 = false;
+               v_977 = false;
 
             _fx_endmatch_38: ;
-               FX_CHECK_EXN(_fx_catch_230);
-               if (!v_956) {
-                  __fold_result___5 = false; FX_BREAK(_fx_catch_230);
+               FX_CHECK_EXN(_fx_catch_234);
+               if (!v_977) {
+                  __fold_result___5 = false; FX_BREAK(_fx_catch_234);
                }
 
-            _fx_catch_230: ;
+            _fx_catch_234: ;
                _fx_free_N13K_form__dom_t(&dom_0);
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_231);
+               FX_CHECK_EXN(_fx_catch_235);
             }
             if (!__fold_result___5) {
-               __fold_result___4 = false; FX_BREAK(_fx_catch_231);
+               __fold_result___4 = false; FX_BREAK(_fx_catch_235);
             }
 
-         _fx_catch_231: ;
-            if (v_955) {
-               _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_955);
+         _fx_catch_235: ;
+            if (v_976) {
+               _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_976);
             }
-            if (v_954) {
-               _fx_free_LN14K_form__kexp_t(&v_954);
+            if (v_975) {
+               _fx_free_LN14K_form__kexp_t(&v_975);
             }
             FX_FREE_LIST_SIMPLE(&idxl_0);
             if (idoml_0) {
@@ -31447,11 +31686,11 @@ static int
                _fx_free_N14K_form__kexp_t(&e_14);
             }
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_242);
+            FX_CHECK_EXN(_fx_catch_246);
          }
          pre_alloc_array_0 = __fold_result___4;
       }
-      FX_CALL(_fx_make_ri(0, &ndims_ref_0), _fx_catch_242);
+      FX_CALL(_fx_make_ri(0, &ndims_ref_0), _fx_catch_246);
       int_* ndims_3 = &ndims_ref_0->data;
       int_ for_idx_0 = 0;
       FX_COPY_PTR(e_idoml_l_2, &e_idoml_l_1);
@@ -31463,14 +31702,14 @@ static int
          int_ ndims_i_0;
          FX_CALL(
             _fx_M10C_gen_codeFM17compute_for_ndimsi4iiLT2R9Ast__id_tN13K_form__dom_tR10Ast__loc_t(for_idx_0, nfors_0, idoml_1,
-               &for_loc_0, &ndims_i_0, 0), _fx_catch_232);
+               &for_loc_0, &ndims_i_0, 0), _fx_catch_236);
          *ndims_3 = *ndims_3 + ndims_i_0;
 
-      _fx_catch_232: ;
+      _fx_catch_236: ;
          if (idoml_1) {
             _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idoml_1);
          }
-         FX_CHECK_EXN(_fx_catch_242);
+         FX_CHECK_EXN(_fx_catch_246);
       }
       bool is_parallel_map_0;
       if (pre_alloc_array_0) {
@@ -31481,328 +31720,183 @@ static int
       }
       FX_CALL(
          _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(fx_status__0,
-            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_0, 0), _fx_catch_242);
+            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_0, 0), _fx_catch_246);
       if (is_parallel_map_0) {
-         _fx_R9Ast__id_t v_961;
-         fx_str_t slit_201 = FX_MAKE_STR("par_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_201, &v_961, 0), _fx_catch_242);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_931, 0), _fx_catch_242);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_932, 0), _fx_catch_242);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_932, &v_933);
-         fx_str_t slit_202 = FX_MAKE_STR("");
+         _fx_R9Ast__id_t v_982;
+         fx_str_t slit_207 = FX_MAKE_STR("par_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_207, &v_982, 0), _fx_catch_246);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_952, 0), _fx_catch_246);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_953, 0), _fx_catch_246);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_953, &v_954);
+         fx_str_t slit_208 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_961, _fx_g20C_gen_code__CTypCInt, &v_931, &slit_202, &v_933, ccode_0, &kloc_0, &v_934, 0), _fx_catch_242);
-         FX_COPY_PTR(v_934.t0, &par_status_0);
-         FX_COPY_PTR(v_934.t1, &ccode_139);
-         _fx_R9Ast__id_t v_962;
-         fx_str_t slit_203 = FX_MAKE_STR("status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_203, &v_962, 0), _fx_catch_242);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_935, 0), _fx_catch_242);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_936, 0), _fx_catch_242);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_936, &v_937);
-         fx_str_t slit_204 = FX_MAKE_STR("fx_status");
+               &v_982, _fx_g20C_gen_code__CTypCInt, &v_952, &slit_208, &v_954, ccode_0, &kloc_0, &v_955, 0), _fx_catch_246);
+         FX_COPY_PTR(v_955.t0, &par_status_0);
+         FX_COPY_PTR(v_955.t1, &ccode_142);
+         _fx_R9Ast__id_t v_983;
+         fx_str_t slit_209 = FX_MAKE_STR("status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_209, &v_983, 0), _fx_catch_246);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_956, 0), _fx_catch_246);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_957, 0), _fx_catch_246);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_957, &v_958);
+         fx_str_t slit_210 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_962, _fx_g20C_gen_code__CTypCInt, &v_935, &slit_204, &v_937, 0, &kloc_0, &v_938, 0), _fx_catch_242);
-         FX_COPY_PTR(v_938.t0, &nested_status_0);
-         FX_COPY_PTR(v_938.t1, &decl_nested_status_0);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_0, ccode_139,
-            nested_status_0, decl_nested_status_0, &v_930);
+               &v_983, _fx_g20C_gen_code__CTypCInt, &v_956, &slit_210, &v_958, 0, &kloc_0, &v_959, 0), _fx_catch_246);
+         FX_COPY_PTR(v_959.t0, &nested_status_0);
+         FX_COPY_PTR(v_959.t1, &decl_nested_status_0);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_0, ccode_142,
+            nested_status_0, decl_nested_status_0, &v_951);
       }
       else {
-         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_939, 0), _fx_catch_242);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_939, ccode_0, glob_status_0, 0,
-            &v_930);
+         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_960, 0), _fx_catch_246);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_960, ccode_0, glob_status_0, 0,
+            &v_951);
       }
-      FX_COPY_PTR(v_930.t0, &par_status_1);
-      FX_COPY_PTR(v_930.t1, &ccode_140);
-      FX_COPY_PTR(v_930.t2, &nested_status_1);
-      FX_COPY_PTR(v_930.t3, &decl_nested_status_1);
-      FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &for_loc_0, &v_940, 0),
-         _fx_catch_242);
+      FX_COPY_PTR(v_951.t0, &par_status_1);
+      FX_COPY_PTR(v_951.t1, &ccode_143);
+      FX_COPY_PTR(v_951.t2, &nested_status_1);
+      FX_COPY_PTR(v_951.t3, &decl_nested_status_1);
+      FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &for_loc_0, &v_961, 0),
+         _fx_catch_246);
       if (unzip_mode_0 == false) {
-         FX_CALL(_fx_cons_LN14K_form__ktyp_t(ktyp_0, 0, true, &coll_typs_0), _fx_catch_233);
+         FX_CALL(_fx_cons_LN14K_form__ktyp_t(ktyp_0, 0, true, &coll_typs_0), _fx_catch_237);
 
-      _fx_catch_233: ;
+      _fx_catch_237: ;
          goto _fx_endmatch_39;
       }
       if (unzip_mode_0 == true) {
-         if (FX_REC_VARIANT_TAG(v_940) == 14) {
-            FX_COPY_PTR(v_940->u.KTypTuple, &coll_typs_0); goto _fx_endmatch_39;
+         if (FX_REC_VARIANT_TAG(v_961) == 14) {
+            FX_COPY_PTR(v_961->u.KTypTuple, &coll_typs_0); goto _fx_endmatch_39;
          }
       }
-      fx_exn_t v_963 = {0};
-      fx_str_t slit_205 = FX_MAKE_STR("cgen: the result of @unzip comprehension should be a tuple");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_205, &v_963, 0), _fx_catch_234);
-      FX_THROW(&v_963, false, _fx_catch_234);
+      fx_exn_t v_984 = {0};
+      fx_str_t slit_211 = FX_MAKE_STR("cgen: the result of @unzip comprehension should be a tuple");
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_211, &v_984, 0), _fx_catch_238);
+      FX_THROW(&v_984, false, _fx_catch_238);
 
-   _fx_catch_234: ;
-      fx_free_exn(&v_963);
+   _fx_catch_238: ;
+      fx_free_exn(&v_984);
 
    _fx_endmatch_39: ;
-      FX_CHECK_EXN(_fx_catch_242);
-      FX_COPY_PTR(ccode_140, &ccode_141);
+      FX_CHECK_EXN(_fx_catch_246);
+      FX_COPY_PTR(ccode_143, &ccode_144);
       _fx_LN14K_form__ktyp_t lst_26 = coll_typs_0;
       for (; lst_26; lst_26 = lst_26->tl) {
          _fx_N14C_form__ctyp_t coll_ctyp_0 = 0;
-         _fx_N14K_form__ktyp_t v_964 = 0;
+         _fx_N14K_form__ktyp_t v_985 = 0;
          _fx_N14K_form__ktyp_t coll_typ_0 = lst_26->hd;
          FX_CALL(
             _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &coll_ctyp_0,
-               0), _fx_catch_240);
-         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &v_964, 0),
-            _fx_catch_240);
+               0), _fx_catch_244);
+         FX_CALL(_fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(coll_typ_0, &kloc_0, &v_985, 0),
+            _fx_catch_244);
          if (for_flag_make_0.tag == 5) {
-            if (FX_REC_VARIANT_TAG(v_964) == 19) {
+            if (FX_REC_VARIANT_TAG(v_985) == 19) {
                if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 21) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_965 = {0};
-                  _fx_R16Ast__val_flags_t v_966 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_986 = {0};
+                  _fx_R16Ast__val_flags_t v_987 = {0};
                   _fx_N14C_form__cexp_t dst_exp_16 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_17 = 0;
-                  _fx_N14C_form__ctyp_t v_967 = 0;
-                  _fx_R16Ast__val_flags_t v_968 = {0};
-                  _fx_N14C_form__cexp_t v_969 = 0;
-                  _fx_Nt6option1N14C_form__cexp_t v_970 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_971 = {0};
+                  _fx_N14C_form__ctyp_t v_988 = 0;
+                  _fx_R16Ast__val_flags_t v_989 = {0};
+                  _fx_N14C_form__cexp_t v_990 = 0;
+                  _fx_Nt6option1N14C_form__cexp_t v_991 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_992 = {0};
                   _fx_N14C_form__cexp_t dst_ptr_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_2 = 0;
-                  _fx_N14C_form__cexp_t v_972 = 0;
-                  _fx_N14C_form__ctyp_t v_973 = 0;
+                  _fx_N14C_form__cexp_t v_993 = 0;
+                  _fx_N14C_form__ctyp_t v_994 = 0;
                   _fx_N14C_form__cexp_t base_0 = 0;
-                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_974 = {0};
+                  _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_995 = {0};
                   _fx_N14C_form__cexp_t nwritten_0 = 0;
-                  _fx_N14C_form__cexp_t v_975 = 0;
+                  _fx_N14C_form__cexp_t v_996 = 0;
                   _fx_N14C_form__cexp_t set_size_0 = 0;
-                  _fx_N14C_form__cexp_t v_976 = 0;
-                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_977 = {0};
-                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_978 = 0;
-                  _fx_N15C_form__cstmt_t v_979 = 0;
-                  _fx_LN15C_form__cstmt_t v_980 = 0;
-                  _fx_N14C_form__ctyp_t elemtyp_0 = coll_ctyp_0->u.CTypVector;
-                  if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_981;
-                     fx_str_t slit_206 = FX_MAKE_STR("vec");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_206, &v_981, 0), _fx_catch_235);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_966, 0), _fx_catch_235);
-                     FX_CALL(
-                        _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_981, coll_ctyp_0, &v_966, &_fx_g18C_gen_code__None2_, ccode_141, &for_loc_0, block_stack_ref_0,
-                           &v_965, 0), _fx_catch_235);
-                  }
-                  else {
-                     fx_str_t slit_207 = FX_MAKE_STR("vec");
-                     FX_CALL(
-                        _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_207, coll_ctyp_0, ccode_141, &for_loc_0, block_stack_ref_0, km_idx_0, &v_965, 0),
-                        _fx_catch_235);
-                  }
-                  FX_COPY_PTR(v_965.t0, &dst_exp_16);
-                  FX_COPY_PTR(v_965.t1, &ccode1_17);
-                  _fx_R9Ast__id_t v_982;
-                  fx_str_t slit_208 = FX_MAKE_STR("dstptr");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_208, &v_982, 0), _fx_catch_235);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_967, 0), _fx_catch_235);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_968, 0), _fx_catch_235);
-                  FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_969, 0), _fx_catch_235);
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_969, &v_970);
-                  fx_str_t slit_209 = FX_MAKE_STR("");
-                  FX_CALL(
-                     _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_982, v_967, &v_968, &slit_209, &v_970, ccode1_17, &for_loc_0, &v_971, 0), _fx_catch_235);
-                  FX_COPY_PTR(v_971.t0, &dst_ptr_0);
-                  FX_COPY_PTR(v_971.t1, &ccode2_2);
-                  _fx_R9Ast__id_t v_983;
-                  fx_str_t slit_210 = FX_MAKE_STR("data");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_210, &v_983, 0), _fx_catch_235);
-                  FX_CALL(
-                     _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
-                        &v_983, _fx_g23C_form__std_CTypVoidPtr, &v_972, 0), _fx_catch_235);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_973, 0), _fx_catch_235);
-                  FX_CALL(
-                     _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_972, v_973,
-                        &for_loc_0, &base_0), _fx_catch_235);
-                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g19C_gen_code__CTypInt, &for_loc_0, &v_974);
-                  FX_CALL(
-                     _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                        &_fx_g18C_gen_code__COpSub, dst_ptr_0, base_0, &v_974, &nwritten_0), _fx_catch_235);
-                  _fx_R9Ast__id_t v_984;
-                  fx_str_t slit_211 = FX_MAKE_STR("size");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_211, &v_984, 0), _fx_catch_235);
-                  FX_CALL(
-                     _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
-                        &v_984, _fx_g19C_gen_code__CTypInt, &v_975, 0), _fx_catch_235);
-                  FX_CALL(
-                     _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_975, nwritten_0,
-                        &set_size_0, 0), _fx_catch_235);
-                  FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_976, 0), _fx_catch_235);
-                  _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                     elemtyp_0, dst_exp_16, dst_ptr_0, v_976, &v_977);
-                  FX_CALL(
-                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_977,
-                        dst_data_0, true, &v_978), _fx_catch_235);
-                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                     &dst_data_0);
-                  FX_COPY_PTR(v_978, &dst_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_141);
-                  FX_COPY_PTR(ccode2_2, &ccode_141);
-                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(set_size_0, &v_979), _fx_catch_235);
-                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_979, finalize_ccode_0, true, &v_980), _fx_catch_235);
-                  _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
-                  FX_COPY_PTR(v_980, &finalize_ccode_0);
-
-               _fx_catch_235: ;
-                  if (v_980) {
-                     _fx_free_LN15C_form__cstmt_t(&v_980);
-                  }
-                  if (v_979) {
-                     _fx_free_N15C_form__cstmt_t(&v_979);
-                  }
-                  if (v_978) {
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_978);
-                  }
-                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_977);
-                  if (v_976) {
-                     _fx_free_N14C_form__cexp_t(&v_976);
-                  }
-                  if (set_size_0) {
-                     _fx_free_N14C_form__cexp_t(&set_size_0);
-                  }
-                  if (v_975) {
-                     _fx_free_N14C_form__cexp_t(&v_975);
-                  }
-                  if (nwritten_0) {
-                     _fx_free_N14C_form__cexp_t(&nwritten_0);
-                  }
-                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_974);
-                  if (base_0) {
-                     _fx_free_N14C_form__cexp_t(&base_0);
-                  }
-                  if (v_973) {
-                     _fx_free_N14C_form__ctyp_t(&v_973);
-                  }
-                  if (v_972) {
-                     _fx_free_N14C_form__cexp_t(&v_972);
-                  }
-                  if (ccode2_2) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode2_2);
-                  }
-                  if (dst_ptr_0) {
-                     _fx_free_N14C_form__cexp_t(&dst_ptr_0);
-                  }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_971);
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_970);
-                  if (v_969) {
-                     _fx_free_N14C_form__cexp_t(&v_969);
-                  }
-                  _fx_free_R16Ast__val_flags_t(&v_968);
-                  if (v_967) {
-                     _fx_free_N14C_form__ctyp_t(&v_967);
-                  }
-                  if (ccode1_17) {
-                     _fx_free_LN15C_form__cstmt_t(&ccode1_17);
-                  }
-                  if (dst_exp_16) {
-                     _fx_free_N14C_form__cexp_t(&dst_exp_16);
-                  }
-                  _fx_free_R16Ast__val_flags_t(&v_966);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_965);
-                  goto _fx_endmatch_40;
-               }
-            }
-         }
-         if (for_flag_make_0.tag == 2) {
-            if (FX_REC_VARIANT_TAG(v_964) == 17) {
-               if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 19) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_985 = {0};
-                  _fx_R16Ast__val_flags_t v_986 = {0};
-                  _fx_N14C_form__cexp_t dst_exp_17 = 0;
-                  _fx_LN15C_form__cstmt_t ccode1_18 = 0;
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_987 = {0};
-                  _fx_N14C_form__cexp_t v_988 = 0;
-                  _fx_N14C_form__ctyp_t v_989 = 0;
-                  _fx_R16Ast__val_flags_t v_990 = {0};
-                  _fx_N14C_form__cexp_t v_991 = 0;
-                  _fx_Nt6option1N14C_form__cexp_t v_992 = {0};
-                  _fx_N14C_form__cexp_t dst_ptr_1 = 0;
-                  _fx_LN15C_form__cstmt_t ccode2_3 = 0;
-                  fx_str_t v_993 = {0};
-                  fx_str_t v_994 = {0};
-                  fx_str_t v_995 = {0};
-                  fx_exn_t v_996 = {0};
                   _fx_N14C_form__cexp_t v_997 = 0;
                   _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_998 = {0};
                   _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_999 = 0;
-                  _fx_T2iN14C_form__ctyp_t* vcase_26 = &coll_ctyp_0->u.CTypArray;
-                  _fx_N14C_form__ctyp_t elemtyp_1 = vcase_26->t1;
-                  int_ nd_0 = vcase_26->t0;
+                  _fx_N15C_form__cstmt_t v_1000 = 0;
+                  _fx_LN15C_form__cstmt_t v_1001 = 0;
+                  _fx_N14C_form__ctyp_t elemtyp_0 = coll_ctyp_0->u.CTypVector;
                   if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_1000;
-                     fx_str_t slit_212 = FX_MAKE_STR("arr");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_212, &v_1000, 0), _fx_catch_236);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_986, 0), _fx_catch_236);
+                     _fx_R9Ast__id_t v_1002;
+                     fx_str_t slit_212 = FX_MAKE_STR("vec");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_212, &v_1002, 0), _fx_catch_239);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_987, 0), _fx_catch_239);
                      FX_CALL(
                         _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_1000, coll_ctyp_0, &v_986, &_fx_g18C_gen_code__None2_, ccode_141, &for_loc_0, block_stack_ref_0,
-                           &v_985, 0), _fx_catch_236);
+                           &v_1002, coll_ctyp_0, &v_987, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
+                           &v_986, 0), _fx_catch_239);
                   }
                   else {
-                     fx_str_t slit_213 = FX_MAKE_STR("arr");
+                     fx_str_t slit_213 = FX_MAKE_STR("vec");
                      FX_CALL(
                         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_213, coll_ctyp_0, ccode_141, &for_loc_0, block_stack_ref_0, km_idx_0, &v_985, 0),
-                        _fx_catch_236);
+                           dstexp_r_0, &slit_213, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_986, 0),
+                        _fx_catch_239);
                   }
-                  FX_COPY_PTR(v_985.t0, &dst_exp_17);
-                  FX_COPY_PTR(v_985.t1, &ccode1_18);
-                  if (is_parallel_map_0) {
-                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_988, 0), _fx_catch_236);
-                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_988, ccode1_18, &v_987);
-                  }
-                  else {
-                     _fx_R9Ast__id_t v_1001;
-                     fx_str_t slit_214 = FX_MAKE_STR("dstptr");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_214, &v_1001, 0), _fx_catch_236);
-                     FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_1, &v_989, 0), _fx_catch_236);
-                     FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_990, 0), _fx_catch_236);
-                     FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_991, 0), _fx_catch_236);
-                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_991, &v_992);
-                     fx_str_t slit_215 = FX_MAKE_STR("");
-                     FX_CALL(
-                        _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                           &v_1001, v_989, &v_990, &slit_215, &v_992, ccode1_18, &for_loc_0, &v_987, 0), _fx_catch_236);
-                  }
-                  FX_COPY_PTR(v_987.t0, &dst_ptr_1);
-                  FX_COPY_PTR(v_987.t1, &ccode2_3);
-                  if (nd_0 != *ndims_3) {
-                     FX_CALL(_fx_F6stringS1i(*ndims_3, &v_993, 0), _fx_catch_236);
-                     FX_CALL(_fx_F6stringS1i(nd_0, &v_994, 0), _fx_catch_236);
-                     fx_str_t slit_216 = FX_MAKE_STR("cgen: invalid dimensionaly of array comprehension result (computed: ");
-                     fx_str_t slit_217 = FX_MAKE_STR(", expected: ");
-                     fx_str_t slit_218 = FX_MAKE_STR(")");
-                     {
-                        const fx_str_t strs_32[] = { slit_216, v_993, slit_217, v_994, slit_218 };
-                        FX_CALL(fx_strjoin(0, 0, 0, strs_32, 5, &v_995), _fx_catch_236);
-                     }
-                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_995, &v_996, 0), _fx_catch_236);
-                     FX_THROW(&v_996, false, _fx_catch_236);
-                  }
-                  else {
-                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_997, 0),
-                        _fx_catch_236);
-                     _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                        coll_ctyp_0, elemtyp_1, dst_exp_17, dst_ptr_1, v_997, &v_998);
-                     FX_CALL(
-                        _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                           &v_998, dst_data_0, true, &v_999), _fx_catch_236);
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-                        &dst_data_0);
-                     FX_COPY_PTR(v_999, &dst_data_0);
-                     _fx_free_LN15C_form__cstmt_t(&ccode_141);
-                     FX_COPY_PTR(ccode2_3, &ccode_141);
-                  }
+                  FX_COPY_PTR(v_986.t0, &dst_exp_16);
+                  FX_COPY_PTR(v_986.t1, &ccode1_17);
+                  _fx_R9Ast__id_t v_1003;
+                  fx_str_t slit_214 = FX_MAKE_STR("dstptr");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_214, &v_1003, 0), _fx_catch_239);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_988, 0), _fx_catch_239);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_989, 0), _fx_catch_239);
+                  FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_990, 0), _fx_catch_239);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_990, &v_991);
+                  fx_str_t slit_215 = FX_MAKE_STR("");
+                  FX_CALL(
+                     _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+                        &v_1003, v_988, &v_989, &slit_215, &v_991, ccode1_17, &for_loc_0, &v_992, 0), _fx_catch_239);
+                  FX_COPY_PTR(v_992.t0, &dst_ptr_0);
+                  FX_COPY_PTR(v_992.t1, &ccode2_2);
+                  _fx_R9Ast__id_t v_1004;
+                  fx_str_t slit_216 = FX_MAKE_STR("data");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_216, &v_1004, 0), _fx_catch_239);
+                  FX_CALL(
+                     _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
+                        &v_1004, _fx_g23C_form__std_CTypVoidPtr, &v_993, 0), _fx_catch_239);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_0, &v_994, 0), _fx_catch_239);
+                  FX_CALL(
+                     _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(v_993, v_994,
+                        &for_loc_0, &base_0), _fx_catch_239);
+                  _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g19C_gen_code__CTypInt, &for_loc_0, &v_995);
+                  FX_CALL(
+                     _fx_M6C_formFM10CExpBinaryN14C_form__cexp_t4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
+                        &_fx_g18C_gen_code__COpSub, dst_ptr_0, base_0, &v_995, &nwritten_0), _fx_catch_239);
+                  _fx_R9Ast__id_t v_1005;
+                  fx_str_t slit_217 = FX_MAKE_STR("size");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_217, &v_1005, 0), _fx_catch_239);
+                  FX_CALL(
+                     _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_16,
+                        &v_1005, _fx_g19C_gen_code__CTypInt, &v_996, 0), _fx_catch_239);
+                  FX_CALL(
+                     _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_996, nwritten_0,
+                        &set_size_0, 0), _fx_catch_239);
+                  FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_997, 0), _fx_catch_239);
+                  _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
+                     elemtyp_0, dst_exp_16, dst_ptr_0, v_997, &v_998);
+                  FX_CALL(
+                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_998,
+                        dst_data_0, true, &v_999), _fx_catch_239);
+                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                     &dst_data_0);
+                  FX_COPY_PTR(v_999, &dst_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_144);
+                  FX_COPY_PTR(ccode2_2, &ccode_144);
+                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(set_size_0, &v_1000), _fx_catch_239);
+                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1000, finalize_ccode_0, true, &v_1001), _fx_catch_239);
+                  _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
+                  FX_COPY_PTR(v_1001, &finalize_ccode_0);
 
-               _fx_catch_236: ;
+               _fx_catch_239: ;
+                  if (v_1001) {
+                     _fx_free_LN15C_form__cstmt_t(&v_1001);
+                  }
+                  if (v_1000) {
+                     _fx_free_N15C_form__cstmt_t(&v_1000);
+                  }
                   if (v_999) {
                      _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_999);
                   }
@@ -31810,178 +31904,324 @@ static int
                   if (v_997) {
                      _fx_free_N14C_form__cexp_t(&v_997);
                   }
-                  fx_free_exn(&v_996);
-                  FX_FREE_STR(&v_995);
-                  FX_FREE_STR(&v_994);
-                  FX_FREE_STR(&v_993);
+                  if (set_size_0) {
+                     _fx_free_N14C_form__cexp_t(&set_size_0);
+                  }
+                  if (v_996) {
+                     _fx_free_N14C_form__cexp_t(&v_996);
+                  }
+                  if (nwritten_0) {
+                     _fx_free_N14C_form__cexp_t(&nwritten_0);
+                  }
+                  _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_995);
+                  if (base_0) {
+                     _fx_free_N14C_form__cexp_t(&base_0);
+                  }
+                  if (v_994) {
+                     _fx_free_N14C_form__ctyp_t(&v_994);
+                  }
+                  if (v_993) {
+                     _fx_free_N14C_form__cexp_t(&v_993);
+                  }
+                  if (ccode2_2) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode2_2);
+                  }
+                  if (dst_ptr_0) {
+                     _fx_free_N14C_form__cexp_t(&dst_ptr_0);
+                  }
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_992);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_991);
+                  if (v_990) {
+                     _fx_free_N14C_form__cexp_t(&v_990);
+                  }
+                  _fx_free_R16Ast__val_flags_t(&v_989);
+                  if (v_988) {
+                     _fx_free_N14C_form__ctyp_t(&v_988);
+                  }
+                  if (ccode1_17) {
+                     _fx_free_LN15C_form__cstmt_t(&ccode1_17);
+                  }
+                  if (dst_exp_16) {
+                     _fx_free_N14C_form__cexp_t(&dst_exp_16);
+                  }
+                  _fx_free_R16Ast__val_flags_t(&v_987);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_986);
+                  goto _fx_endmatch_40;
+               }
+            }
+         }
+         if (for_flag_make_0.tag == 2) {
+            if (FX_REC_VARIANT_TAG(v_985) == 17) {
+               if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 19) {
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1006 = {0};
+                  _fx_R16Ast__val_flags_t v_1007 = {0};
+                  _fx_N14C_form__cexp_t dst_exp_17 = 0;
+                  _fx_LN15C_form__cstmt_t ccode1_18 = 0;
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1008 = {0};
+                  _fx_N14C_form__cexp_t v_1009 = 0;
+                  _fx_N14C_form__ctyp_t v_1010 = 0;
+                  _fx_R16Ast__val_flags_t v_1011 = {0};
+                  _fx_N14C_form__cexp_t v_1012 = 0;
+                  _fx_Nt6option1N14C_form__cexp_t v_1013 = {0};
+                  _fx_N14C_form__cexp_t dst_ptr_1 = 0;
+                  _fx_LN15C_form__cstmt_t ccode2_3 = 0;
+                  fx_str_t v_1014 = {0};
+                  fx_str_t v_1015 = {0};
+                  fx_str_t v_1016 = {0};
+                  fx_exn_t v_1017 = {0};
+                  _fx_N14C_form__cexp_t v_1018 = 0;
+                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1019 = {0};
+                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1020 = 0;
+                  _fx_T2iN14C_form__ctyp_t* vcase_26 = &coll_ctyp_0->u.CTypArray;
+                  _fx_N14C_form__ctyp_t elemtyp_1 = vcase_26->t1;
+                  int_ nd_0 = vcase_26->t0;
+                  if (unzip_mode_0) {
+                     _fx_R9Ast__id_t v_1021;
+                     fx_str_t slit_218 = FX_MAKE_STR("arr");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_218, &v_1021, 0), _fx_catch_240);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1007, 0), _fx_catch_240);
+                     FX_CALL(
+                        _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
+                           &v_1021, coll_ctyp_0, &v_1007, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
+                           &v_1006, 0), _fx_catch_240);
+                  }
+                  else {
+                     fx_str_t slit_219 = FX_MAKE_STR("arr");
+                     FX_CALL(
+                        _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
+                           dstexp_r_0, &slit_219, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1006, 0),
+                        _fx_catch_240);
+                  }
+                  FX_COPY_PTR(v_1006.t0, &dst_exp_17);
+                  FX_COPY_PTR(v_1006.t1, &ccode1_18);
+                  if (is_parallel_map_0) {
+                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1009, 0), _fx_catch_240);
+                     _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1009, ccode1_18, &v_1008);
+                  }
+                  else {
+                     _fx_R9Ast__id_t v_1022;
+                     fx_str_t slit_220 = FX_MAKE_STR("dstptr");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_220, &v_1022, 0), _fx_catch_240);
+                     FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_1, &v_1010, 0), _fx_catch_240);
+                     FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1011, 0), _fx_catch_240);
+                     FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1012, 0),
+                        _fx_catch_240);
+                     _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1012, &v_1013);
+                     fx_str_t slit_221 = FX_MAKE_STR("");
+                     FX_CALL(
+                        _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
+                           &v_1022, v_1010, &v_1011, &slit_221, &v_1013, ccode1_18, &for_loc_0, &v_1008, 0), _fx_catch_240);
+                  }
+                  FX_COPY_PTR(v_1008.t0, &dst_ptr_1);
+                  FX_COPY_PTR(v_1008.t1, &ccode2_3);
+                  if (nd_0 != *ndims_3) {
+                     FX_CALL(_fx_F6stringS1i(*ndims_3, &v_1014, 0), _fx_catch_240);
+                     FX_CALL(_fx_F6stringS1i(nd_0, &v_1015, 0), _fx_catch_240);
+                     fx_str_t slit_222 = FX_MAKE_STR("cgen: invalid dimensionaly of array comprehension result (computed: ");
+                     fx_str_t slit_223 = FX_MAKE_STR(", expected: ");
+                     fx_str_t slit_224 = FX_MAKE_STR(")");
+                     {
+                        const fx_str_t strs_34[] = { slit_222, v_1014, slit_223, v_1015, slit_224 };
+                        FX_CALL(fx_strjoin(0, 0, 0, strs_34, 5, &v_1016), _fx_catch_240);
+                     }
+                     FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1016, &v_1017, 0), _fx_catch_240);
+                     FX_THROW(&v_1017, false, _fx_catch_240);
+                  }
+                  else {
+                     FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1018, 0),
+                        _fx_catch_240);
+                     _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                        coll_ctyp_0, elemtyp_1, dst_exp_17, dst_ptr_1, v_1018, &v_1019);
+                     FX_CALL(
+                        _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                           &v_1019, dst_data_0, true, &v_1020), _fx_catch_240);
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
+                        &dst_data_0);
+                     FX_COPY_PTR(v_1020, &dst_data_0);
+                     _fx_free_LN15C_form__cstmt_t(&ccode_144);
+                     FX_COPY_PTR(ccode2_3, &ccode_144);
+                  }
+
+               _fx_catch_240: ;
+                  if (v_1020) {
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1020);
+                  }
+                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1019);
+                  if (v_1018) {
+                     _fx_free_N14C_form__cexp_t(&v_1018);
+                  }
+                  fx_free_exn(&v_1017);
+                  FX_FREE_STR(&v_1016);
+                  FX_FREE_STR(&v_1015);
+                  FX_FREE_STR(&v_1014);
                   if (ccode2_3) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_3);
                   }
                   if (dst_ptr_1) {
                      _fx_free_N14C_form__cexp_t(&dst_ptr_1);
                   }
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_992);
-                  if (v_991) {
-                     _fx_free_N14C_form__cexp_t(&v_991);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1013);
+                  if (v_1012) {
+                     _fx_free_N14C_form__cexp_t(&v_1012);
                   }
-                  _fx_free_R16Ast__val_flags_t(&v_990);
-                  if (v_989) {
-                     _fx_free_N14C_form__ctyp_t(&v_989);
+                  _fx_free_R16Ast__val_flags_t(&v_1011);
+                  if (v_1010) {
+                     _fx_free_N14C_form__ctyp_t(&v_1010);
                   }
-                  if (v_988) {
-                     _fx_free_N14C_form__cexp_t(&v_988);
+                  if (v_1009) {
+                     _fx_free_N14C_form__cexp_t(&v_1009);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_987);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1008);
                   if (ccode1_18) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_18);
                   }
                   if (dst_exp_17) {
                      _fx_free_N14C_form__cexp_t(&dst_exp_17);
                   }
-                  _fx_free_R16Ast__val_flags_t(&v_986);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_985);
+                  _fx_free_R16Ast__val_flags_t(&v_1007);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1006);
                   goto _fx_endmatch_40;
                }
             }
          }
          if (for_flag_make_0.tag == 4) {
-            if (FX_REC_VARIANT_TAG(v_964) == 18) {
+            if (FX_REC_VARIANT_TAG(v_985) == 18) {
                if (FX_REC_VARIANT_TAG(coll_ctyp_0) == 20) {
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1002 = {0};
-                  _fx_R16Ast__val_flags_t v_1003 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1023 = {0};
+                  _fx_R16Ast__val_flags_t v_1024 = {0};
                   _fx_N14C_form__cexp_t dst_exp_18 = 0;
                   _fx_LN15C_form__cstmt_t ccode1_19 = 0;
-                  _fx_Ta3N14C_form__cexp_t v_1004 = {0};
+                  _fx_Ta3N14C_form__cexp_t v_1025 = {0};
                   _fx_N14C_form__cexp_t sizeof_elem_exp_3 = 0;
                   _fx_N14C_form__cexp_t free_f_exp_3 = 0;
                   _fx_N14C_form__cexp_t copy_f_exp_3 = 0;
                   _fx_N14C_form__ctyp_t iter_t_0 = 0;
-                  _fx_R16Ast__val_flags_t v_1005 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1006 = {0};
+                  _fx_R16Ast__val_flags_t v_1026 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1027 = {0};
                   _fx_N14C_form__cexp_t iter_exp_0 = 0;
                   _fx_LN15C_form__cstmt_t ccode2_4 = 0;
-                  _fx_N14C_form__cexp_t v_1007 = 0;
-                  _fx_LN14C_form__cexp_t v_1008 = 0;
+                  _fx_N14C_form__cexp_t v_1028 = 0;
+                  _fx_LN14C_form__cexp_t v_1029 = 0;
                   _fx_N14C_form__cexp_t call_start_write_0 = 0;
-                  _fx_N14C_form__ctyp_t v_1009 = 0;
-                  _fx_R16Ast__val_flags_t v_1010 = {0};
-                  _fx_Nt6option1N14C_form__cexp_t v_1011 = {0};
-                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1012 = {0};
+                  _fx_N14C_form__ctyp_t v_1030 = 0;
+                  _fx_R16Ast__val_flags_t v_1031 = {0};
+                  _fx_Nt6option1N14C_form__cexp_t v_1032 = {0};
+                  _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1033 = {0};
                   _fx_N14C_form__cexp_t dst_ptr_2 = 0;
                   _fx_LN15C_form__cstmt_t ccode3_1 = 0;
-                  _fx_LN14C_form__cexp_t v_1013 = 0;
+                  _fx_LN14C_form__cexp_t v_1034 = 0;
                   _fx_N14C_form__cexp_t call_end_write_0 = 0;
-                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1014 = {0};
-                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1015 = 0;
-                  _fx_N15C_form__cstmt_t v_1016 = 0;
-                  _fx_LN15C_form__cstmt_t v_1017 = 0;
+                  _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1035 = {0};
+                  _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1036 = 0;
+                  _fx_N15C_form__cstmt_t v_1037 = 0;
+                  _fx_LN15C_form__cstmt_t v_1038 = 0;
                   _fx_N14C_form__ctyp_t elemtyp_2 = coll_ctyp_0->u.CTypRRBVec;
                   if (unzip_mode_0) {
-                     _fx_R9Ast__id_t v_1018;
-                     fx_str_t slit_219 = FX_MAKE_STR("vec");
-                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_219, &v_1018, 0), _fx_catch_237);
-                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1003, 0), _fx_catch_237);
+                     _fx_R9Ast__id_t v_1039;
+                     fx_str_t slit_225 = FX_MAKE_STR("vec");
+                     FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_225, &v_1039, 0), _fx_catch_241);
+                     FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1024, 0), _fx_catch_241);
                      FX_CALL(
                         _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                           &v_1018, coll_ctyp_0, &v_1003, &_fx_g18C_gen_code__None2_, ccode_141, &for_loc_0, block_stack_ref_0,
-                           &v_1002, 0), _fx_catch_237);
+                           &v_1039, coll_ctyp_0, &v_1024, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
+                           &v_1023, 0), _fx_catch_241);
                   }
                   else {
-                     fx_str_t slit_220 = FX_MAKE_STR("vec");
+                     fx_str_t slit_226 = FX_MAKE_STR("vec");
                      FX_CALL(
                         _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                           dstexp_r_0, &slit_220, coll_ctyp_0, ccode_141, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1002, 0),
-                        _fx_catch_237);
+                           dstexp_r_0, &slit_226, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1023, 0),
+                        _fx_catch_241);
                   }
-                  FX_COPY_PTR(v_1002.t0, &dst_exp_18);
-                  FX_COPY_PTR(v_1002.t1, &ccode1_19);
+                  FX_COPY_PTR(v_1023.t0, &dst_exp_18);
+                  FX_COPY_PTR(v_1023.t1, &ccode1_19);
                   FX_CALL(
                      _fx_M10C_gen_codeFM23get_elem_size_free_copyTa3N14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2,
-                        &for_loc_0, &v_1004, 0), _fx_catch_237);
-                  FX_COPY_PTR(v_1004.t0, &sizeof_elem_exp_3);
-                  FX_COPY_PTR(v_1004.t1, &free_f_exp_3);
-                  FX_COPY_PTR(v_1004.t2, &copy_f_exp_3);
-                  _fx_R9Ast__id_t v_1019;
-                  fx_str_t slit_221 = FX_MAKE_STR("fx_rrbiter_t");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_221, &v_1019, 0), _fx_catch_237);
-                  FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1019, &iter_t_0), _fx_catch_237);
-                  _fx_R9Ast__id_t v_1020;
-                  fx_str_t slit_222 = FX_MAKE_STR("iter");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_222, &v_1020, 0), _fx_catch_237);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1005, 0), _fx_catch_237);
-                  fx_str_t slit_223 = FX_MAKE_STR("");
+                        &for_loc_0, &v_1025, 0), _fx_catch_241);
+                  FX_COPY_PTR(v_1025.t0, &sizeof_elem_exp_3);
+                  FX_COPY_PTR(v_1025.t1, &free_f_exp_3);
+                  FX_COPY_PTR(v_1025.t2, &copy_f_exp_3);
+                  _fx_R9Ast__id_t v_1040;
+                  fx_str_t slit_227 = FX_MAKE_STR("fx_rrbiter_t");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_227, &v_1040, 0), _fx_catch_241);
+                  FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1040, &iter_t_0), _fx_catch_241);
+                  _fx_R9Ast__id_t v_1041;
+                  fx_str_t slit_228 = FX_MAKE_STR("iter");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_228, &v_1041, 0), _fx_catch_241);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1026, 0), _fx_catch_241);
+                  fx_str_t slit_229 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_1020, iter_t_0, &v_1005, &slit_223, &_fx_g18C_gen_code__None2_, ccode1_19, &for_loc_0, &v_1006, 0),
-                     _fx_catch_237);
-                  FX_COPY_PTR(v_1006.t0, &iter_exp_0);
-                  FX_COPY_PTR(v_1006.t1, &ccode2_4);
-                  _fx_R9Ast__id_t v_1021;
-                  fx_str_t slit_224 = FX_MAKE_STR("FX_RRB_START_WRITE");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_224, &v_1021, 0), _fx_catch_237);
+                        &v_1041, iter_t_0, &v_1026, &slit_229, &_fx_g18C_gen_code__None2_, ccode1_19, &for_loc_0, &v_1027, 0),
+                     _fx_catch_241);
+                  FX_COPY_PTR(v_1027.t0, &iter_exp_0);
+                  FX_COPY_PTR(v_1027.t1, &ccode2_4);
+                  _fx_R9Ast__id_t v_1042;
+                  fx_str_t slit_230 = FX_MAKE_STR("FX_RRB_START_WRITE");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_230, &v_1042, 0), _fx_catch_241);
                   FX_CALL(
-                     _fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2, &for_loc_0, &v_1007),
-                     _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, 0, true, &v_1008), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_exp_18, v_1008, false, &v_1008), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_3, v_1008, false, &v_1008), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_3, v_1008, false, &v_1008), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_3, v_1008, false, &v_1008), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1007, v_1008, false, &v_1008), _fx_catch_237);
+                     _fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(elemtyp_2, &for_loc_0, &v_1028),
+                     _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, 0, true, &v_1029), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_exp_18, v_1029, false, &v_1029), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(copy_f_exp_3, v_1029, false, &v_1029), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_3, v_1029, false, &v_1029), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(sizeof_elem_exp_3, v_1029, false, &v_1029), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1028, v_1029, false, &v_1029), _fx_catch_241);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_1021, v_1008, _fx_g23C_form__std_CTypVoidPtr, &for_loc_0, &call_start_write_0, 0), _fx_catch_237);
-                  _fx_R9Ast__id_t v_1022;
-                  fx_str_t slit_225 = FX_MAKE_STR("dstptr");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_225, &v_1022, 0), _fx_catch_237);
-                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_2, &v_1009, 0), _fx_catch_237);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1010, 0), _fx_catch_237);
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(call_start_write_0, &v_1011);
-                  fx_str_t slit_226 = FX_MAKE_STR("");
+                        &v_1042, v_1029, _fx_g23C_form__std_CTypVoidPtr, &for_loc_0, &call_start_write_0, 0), _fx_catch_241);
+                  _fx_R9Ast__id_t v_1043;
+                  fx_str_t slit_231 = FX_MAKE_STR("dstptr");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_231, &v_1043, 0), _fx_catch_241);
+                  FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(elemtyp_2, &v_1030, 0), _fx_catch_241);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1031, 0), _fx_catch_241);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(call_start_write_0, &v_1032);
+                  fx_str_t slit_232 = FX_MAKE_STR("");
                   FX_CALL(
                      _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                        &v_1022, v_1009, &v_1010, &slit_226, &v_1011, ccode2_4, &for_loc_0, &v_1012, 0), _fx_catch_237);
-                  FX_COPY_PTR(v_1012.t0, &dst_ptr_2);
-                  FX_COPY_PTR(v_1012.t1, &ccode3_1);
-                  _fx_R9Ast__id_t v_1023;
-                  fx_str_t slit_227 = FX_MAKE_STR("FX_RRB_END_WRITE");
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_227, &v_1023, 0), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_ptr_2, 0, true, &v_1013), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, v_1013, false, &v_1013), _fx_catch_237);
+                        &v_1043, v_1030, &v_1031, &slit_232, &v_1032, ccode2_4, &for_loc_0, &v_1033, 0), _fx_catch_241);
+                  FX_COPY_PTR(v_1033.t0, &dst_ptr_2);
+                  FX_COPY_PTR(v_1033.t1, &ccode3_1);
+                  _fx_R9Ast__id_t v_1044;
+                  fx_str_t slit_233 = FX_MAKE_STR("FX_RRB_END_WRITE");
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_233, &v_1044, 0), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(dst_ptr_2, 0, true, &v_1034), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN14C_form__cexp_t(iter_exp_0, v_1034, false, &v_1034), _fx_catch_241);
                   FX_CALL(
                      _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                        &v_1023, v_1013, _fx_g20C_gen_code__CTypVoid, &for_loc_0, &call_end_write_0, 0), _fx_catch_237);
+                        &v_1044, v_1034, _fx_g20C_gen_code__CTypVoid, &for_loc_0, &call_end_write_0, 0), _fx_catch_241);
                   _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                     elemtyp_2, dst_exp_18, dst_ptr_2, iter_exp_0, &v_1014);
+                     elemtyp_2, dst_exp_18, dst_ptr_2, iter_exp_0, &v_1035);
                   FX_CALL(
-                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1014,
-                        dst_data_0, true, &v_1015), _fx_catch_237);
+                     _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1035,
+                        dst_data_0, true, &v_1036), _fx_catch_241);
                   _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
                      &dst_data_0);
-                  FX_COPY_PTR(v_1015, &dst_data_0);
-                  _fx_free_LN15C_form__cstmt_t(&ccode_141);
-                  FX_COPY_PTR(ccode3_1, &ccode_141);
-                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_end_write_0, &v_1016), _fx_catch_237);
-                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1016, finalize_ccode_0, true, &v_1017), _fx_catch_237);
+                  FX_COPY_PTR(v_1036, &dst_data_0);
+                  _fx_free_LN15C_form__cstmt_t(&ccode_144);
+                  FX_COPY_PTR(ccode3_1, &ccode_144);
+                  FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_end_write_0, &v_1037), _fx_catch_241);
+                  FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1037, finalize_ccode_0, true, &v_1038), _fx_catch_241);
                   _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
-                  FX_COPY_PTR(v_1017, &finalize_ccode_0);
+                  FX_COPY_PTR(v_1038, &finalize_ccode_0);
 
-               _fx_catch_237: ;
-                  if (v_1017) {
-                     _fx_free_LN15C_form__cstmt_t(&v_1017);
+               _fx_catch_241: ;
+                  if (v_1038) {
+                     _fx_free_LN15C_form__cstmt_t(&v_1038);
                   }
-                  if (v_1016) {
-                     _fx_free_N15C_form__cstmt_t(&v_1016);
+                  if (v_1037) {
+                     _fx_free_N15C_form__cstmt_t(&v_1037);
                   }
-                  if (v_1015) {
-                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1015);
+                  if (v_1036) {
+                     _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1036);
                   }
-                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1014);
+                  _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1035);
                   if (call_end_write_0) {
                      _fx_free_N14C_form__cexp_t(&call_end_write_0);
                   }
-                  if (v_1013) {
-                     _fx_free_LN14C_form__cexp_t(&v_1013);
+                  if (v_1034) {
+                     _fx_free_LN14C_form__cexp_t(&v_1034);
                   }
                   if (ccode3_1) {
                      _fx_free_LN15C_form__cstmt_t(&ccode3_1);
@@ -31989,20 +32229,20 @@ static int
                   if (dst_ptr_2) {
                      _fx_free_N14C_form__cexp_t(&dst_ptr_2);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1012);
-                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1011);
-                  _fx_free_R16Ast__val_flags_t(&v_1010);
-                  if (v_1009) {
-                     _fx_free_N14C_form__ctyp_t(&v_1009);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1033);
+                  _fx_free_Nt6option1N14C_form__cexp_t(&v_1032);
+                  _fx_free_R16Ast__val_flags_t(&v_1031);
+                  if (v_1030) {
+                     _fx_free_N14C_form__ctyp_t(&v_1030);
                   }
                   if (call_start_write_0) {
                      _fx_free_N14C_form__cexp_t(&call_start_write_0);
                   }
-                  if (v_1008) {
-                     _fx_free_LN14C_form__cexp_t(&v_1008);
+                  if (v_1029) {
+                     _fx_free_LN14C_form__cexp_t(&v_1029);
                   }
-                  if (v_1007) {
-                     _fx_free_N14C_form__cexp_t(&v_1007);
+                  if (v_1028) {
+                     _fx_free_N14C_form__cexp_t(&v_1028);
                   }
                   if (ccode2_4) {
                      _fx_free_LN15C_form__cstmt_t(&ccode2_4);
@@ -32010,8 +32250,8 @@ static int
                   if (iter_exp_0) {
                      _fx_free_N14C_form__cexp_t(&iter_exp_0);
                   }
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1006);
-                  _fx_free_R16Ast__val_flags_t(&v_1005);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1027);
+                  _fx_free_R16Ast__val_flags_t(&v_1026);
                   if (iter_t_0) {
                      _fx_free_N14C_form__ctyp_t(&iter_t_0);
                   }
@@ -32024,87 +32264,87 @@ static int
                   if (sizeof_elem_exp_3) {
                      _fx_free_N14C_form__cexp_t(&sizeof_elem_exp_3);
                   }
-                  _fx_free_Ta3N14C_form__cexp_t(&v_1004);
+                  _fx_free_Ta3N14C_form__cexp_t(&v_1025);
                   if (ccode1_19) {
                      _fx_free_LN15C_form__cstmt_t(&ccode1_19);
                   }
                   if (dst_exp_18) {
                      _fx_free_N14C_form__cexp_t(&dst_exp_18);
                   }
-                  _fx_free_R16Ast__val_flags_t(&v_1003);
-                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1002);
+                  _fx_free_R16Ast__val_flags_t(&v_1024);
+                  _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1023);
                   goto _fx_endmatch_40;
                }
             }
          }
          if (for_flag_make_0.tag == 3) {
-            if (FX_REC_VARIANT_TAG(v_964) == 20) {
+            if (FX_REC_VARIANT_TAG(v_985) == 20) {
                _fx_N14C_form__ctyp_t elemtyp_3 = 0;
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1024 = {0};
-               _fx_R16Ast__val_flags_t v_1025 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1045 = {0};
+               _fx_R16Ast__val_flags_t v_1046 = {0};
                _fx_N14C_form__cexp_t dst_exp_19 = 0;
                _fx_LN15C_form__cstmt_t ccode1_20 = 0;
-               _fx_R16Ast__val_flags_t v_1026 = {0};
-               _fx_N14C_form__cexp_t v_1027 = 0;
-               _fx_Nt6option1N14C_form__cexp_t v_1028 = {0};
-               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1029 = {0};
+               _fx_R16Ast__val_flags_t v_1047 = {0};
+               _fx_N14C_form__cexp_t v_1048 = 0;
+               _fx_Nt6option1N14C_form__cexp_t v_1049 = {0};
+               _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1050 = {0};
                _fx_N14C_form__cexp_t lst_end_0 = 0;
                _fx_LN15C_form__cstmt_t ccode2_5 = 0;
-               _fx_N14C_form__cexp_t v_1030 = 0;
-               _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1031 = {0};
-               _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1032 = 0;
+               _fx_N14C_form__cexp_t v_1051 = 0;
+               _fx_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1052 = {0};
+               _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t v_1053 = 0;
                FX_CALL(
-                  _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_964->u.KTypList, &for_loc_0,
-                     &elemtyp_3, 0), _fx_catch_238);
+                  _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_985->u.KTypList, &for_loc_0,
+                     &elemtyp_3, 0), _fx_catch_242);
                if (unzip_mode_0) {
-                  _fx_R9Ast__id_t v_1033;
-                  fx_str_t slit_228 = FX_MAKE_STR("lst");
-                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_228, &v_1033, 0), _fx_catch_238);
-                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1025, 0), _fx_catch_238);
+                  _fx_R9Ast__id_t v_1054;
+                  fx_str_t slit_234 = FX_MAKE_STR("lst");
+                  FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_234, &v_1054, 0), _fx_catch_242);
+                  FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1046, 0), _fx_catch_242);
                   FX_CALL(
                      _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                        &v_1033, coll_ctyp_0, &v_1025, &_fx_g18C_gen_code__None2_, ccode_141, &for_loc_0, block_stack_ref_0,
-                        &v_1024, 0), _fx_catch_238);
+                        &v_1054, coll_ctyp_0, &v_1046, &_fx_g18C_gen_code__None2_, ccode_144, &for_loc_0, block_stack_ref_0,
+                        &v_1045, 0), _fx_catch_242);
                }
                else {
-                  fx_str_t slit_229 = FX_MAKE_STR("lst");
+                  fx_str_t slit_235 = FX_MAKE_STR("lst");
                   FX_CALL(
                      _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-                        dstexp_r_0, &slit_229, coll_ctyp_0, ccode_141, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1024, 0),
-                     _fx_catch_238);
+                        dstexp_r_0, &slit_235, coll_ctyp_0, ccode_144, &for_loc_0, block_stack_ref_0, km_idx_0, &v_1045, 0),
+                     _fx_catch_242);
                }
-               FX_COPY_PTR(v_1024.t0, &dst_exp_19);
-               FX_COPY_PTR(v_1024.t1, &ccode1_20);
-               _fx_R9Ast__id_t v_1034;
-               fx_str_t slit_230 = FX_MAKE_STR("lstend");
-               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_230, &v_1034, 0), _fx_catch_238);
-               FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1026, 0), _fx_catch_238);
-               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1027, 0), _fx_catch_238);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1027, &v_1028);
-               fx_str_t slit_231 = FX_MAKE_STR("");
+               FX_COPY_PTR(v_1045.t0, &dst_exp_19);
+               FX_COPY_PTR(v_1045.t1, &ccode1_20);
+               _fx_R9Ast__id_t v_1055;
+               fx_str_t slit_236 = FX_MAKE_STR("lstend");
+               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_236, &v_1055, 0), _fx_catch_242);
+               FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1047, 0), _fx_catch_242);
+               FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1048, 0), _fx_catch_242);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1048, &v_1049);
+               fx_str_t slit_237 = FX_MAKE_STR("");
                FX_CALL(
                   _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     &v_1034, coll_ctyp_0, &v_1026, &slit_231, &v_1028, ccode1_20, &for_loc_0, &v_1029, 0), _fx_catch_238);
-               FX_COPY_PTR(v_1029.t0, &lst_end_0);
-               FX_COPY_PTR(v_1029.t1, &ccode2_5);
-               FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1030, 0), _fx_catch_238);
+                     &v_1055, coll_ctyp_0, &v_1047, &slit_237, &v_1049, ccode1_20, &for_loc_0, &v_1050, 0), _fx_catch_242);
+               FX_COPY_PTR(v_1050.t0, &lst_end_0);
+               FX_COPY_PTR(v_1050.t1, &ccode2_5);
+               FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&for_loc_0, &v_1051, 0), _fx_catch_242);
                _fx_make_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(coll_ctyp_0,
-                  elemtyp_3, dst_exp_19, v_1030, lst_end_0, &v_1031);
+                  elemtyp_3, dst_exp_19, v_1051, lst_end_0, &v_1052);
                FX_CALL(
-                  _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1031,
-                     dst_data_0, true, &v_1032), _fx_catch_238);
+                  _fx_cons_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1052,
+                     dst_data_0, true, &v_1053), _fx_catch_242);
                _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_0);
-               FX_COPY_PTR(v_1032, &dst_data_0);
-               _fx_free_LN15C_form__cstmt_t(&ccode_141);
-               FX_COPY_PTR(ccode2_5, &ccode_141);
+               FX_COPY_PTR(v_1053, &dst_data_0);
+               _fx_free_LN15C_form__cstmt_t(&ccode_144);
+               FX_COPY_PTR(ccode2_5, &ccode_144);
 
-            _fx_catch_238: ;
-               if (v_1032) {
-                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1032);
+            _fx_catch_242: ;
+               if (v_1053) {
+                  _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1053);
                }
-               _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1031);
-               if (v_1030) {
-                  _fx_free_N14C_form__cexp_t(&v_1030);
+               _fx_free_T5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&v_1052);
+               if (v_1051) {
+                  _fx_free_N14C_form__cexp_t(&v_1051);
                }
                if (ccode2_5) {
                   _fx_free_LN15C_form__cstmt_t(&ccode2_5);
@@ -32112,20 +32352,20 @@ static int
                if (lst_end_0) {
                   _fx_free_N14C_form__cexp_t(&lst_end_0);
                }
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1029);
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1028);
-               if (v_1027) {
-                  _fx_free_N14C_form__cexp_t(&v_1027);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1050);
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1049);
+               if (v_1048) {
+                  _fx_free_N14C_form__cexp_t(&v_1048);
                }
-               _fx_free_R16Ast__val_flags_t(&v_1026);
+               _fx_free_R16Ast__val_flags_t(&v_1047);
                if (ccode1_20) {
                   _fx_free_LN15C_form__cstmt_t(&ccode1_20);
                }
                if (dst_exp_19) {
                   _fx_free_N14C_form__cexp_t(&dst_exp_19);
                }
-               _fx_free_R16Ast__val_flags_t(&v_1025);
-               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1024);
+               _fx_free_R16Ast__val_flags_t(&v_1046);
+               _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1045);
                if (elemtyp_3) {
                   _fx_free_N14C_form__ctyp_t(&elemtyp_3);
                }
@@ -32133,95 +32373,95 @@ static int
             }
          }
          fx_str_t maptype_str_0 = {0};
-         fx_str_t v_1035 = {0};
-         fx_str_t v_1036 = {0};
-         fx_str_t v_1037 = {0};
-         fx_exn_t v_1038 = {0};
+         fx_str_t v_1056 = {0};
+         fx_str_t v_1057 = {0};
+         fx_str_t v_1058 = {0};
+         fx_exn_t v_1059 = {0};
          int tag_30 = for_flag_make_0.tag;
          if (tag_30 == 2) {
-            fx_str_t slit_232 = FX_MAKE_STR("make_array"); fx_copy_str(&slit_232, &maptype_str_0);
+            fx_str_t slit_238 = FX_MAKE_STR("make_array"); fx_copy_str(&slit_238, &maptype_str_0);
          }
          else if (tag_30 == 3) {
-            fx_str_t slit_233 = FX_MAKE_STR("make_list"); fx_copy_str(&slit_233, &maptype_str_0);
+            fx_str_t slit_239 = FX_MAKE_STR("make_list"); fx_copy_str(&slit_239, &maptype_str_0);
          }
          else if (tag_30 == 4) {
-            fx_str_t slit_234 = FX_MAKE_STR("make_rrbvec"); fx_copy_str(&slit_234, &maptype_str_0);
+            fx_str_t slit_240 = FX_MAKE_STR("make_rrbvec"); fx_copy_str(&slit_240, &maptype_str_0);
          }
          else if (tag_30 == 5) {
-            fx_str_t slit_235 = FX_MAKE_STR("make_vector"); fx_copy_str(&slit_235, &maptype_str_0);
+            fx_str_t slit_241 = FX_MAKE_STR("make_vector"); fx_copy_str(&slit_241, &maptype_str_0);
          }
          else {
-            fx_str_t slit_236 = FX_MAKE_STR("???"); fx_copy_str(&slit_236, &maptype_str_0);
+            fx_str_t slit_242 = FX_MAKE_STR("???"); fx_copy_str(&slit_242, &maptype_str_0);
          }
-         FX_CHECK_EXN(_fx_catch_239);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&maptype_str_0, &v_1035, 0), _fx_catch_239);
-         FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(coll_typ_0, &v_1036, 0), _fx_catch_239);
-         fx_str_t slit_237 = FX_MAKE_STR("cgen: invalid combination of comprehension type \'");
-         fx_str_t slit_238 = FX_MAKE_STR("\' and the output collection type \'");
-         fx_str_t slit_239 = FX_MAKE_STR("\'");
+         FX_CHECK_EXN(_fx_catch_243);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&maptype_str_0, &v_1056, 0), _fx_catch_243);
+         FX_CALL(_fx_M6K_formFM6stringS1N14K_form__ktyp_t(coll_typ_0, &v_1057, 0), _fx_catch_243);
+         fx_str_t slit_243 = FX_MAKE_STR("cgen: invalid combination of comprehension type \'");
+         fx_str_t slit_244 = FX_MAKE_STR("\' and the output collection type \'");
+         fx_str_t slit_245 = FX_MAKE_STR("\'");
          {
-            const fx_str_t strs_33[] = { slit_237, v_1035, slit_238, v_1036, slit_239 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_33, 5, &v_1037), _fx_catch_239);
+            const fx_str_t strs_35[] = { slit_243, v_1056, slit_244, v_1057, slit_245 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_35, 5, &v_1058), _fx_catch_243);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1037, &v_1038, 0), _fx_catch_239);
-         FX_THROW(&v_1038, false, _fx_catch_239);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1058, &v_1059, 0), _fx_catch_243);
+         FX_THROW(&v_1059, false, _fx_catch_243);
 
-      _fx_catch_239: ;
-         fx_free_exn(&v_1038);
-         FX_FREE_STR(&v_1037);
-         FX_FREE_STR(&v_1036);
-         FX_FREE_STR(&v_1035);
+      _fx_catch_243: ;
+         fx_free_exn(&v_1059);
+         FX_FREE_STR(&v_1058);
+         FX_FREE_STR(&v_1057);
+         FX_FREE_STR(&v_1056);
          FX_FREE_STR(&maptype_str_0);
 
       _fx_endmatch_40: ;
-         FX_CHECK_EXN(_fx_catch_240);
+         FX_CHECK_EXN(_fx_catch_244);
 
-      _fx_catch_240: ;
-         if (v_964) {
-            _fx_free_N14K_form__ktyp_t(&v_964);
+      _fx_catch_244: ;
+         if (v_985) {
+            _fx_free_N14K_form__ktyp_t(&v_985);
          }
          if (coll_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&coll_ctyp_0);
          }
-         FX_CHECK_EXN(_fx_catch_242);
+         FX_CHECK_EXN(_fx_catch_246);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM3revLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t1LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(
-            dst_data_0, &dst_data_1, 0), _fx_catch_242);
+            dst_data_0, &dst_data_1, 0), _fx_catch_246);
       _fx_M10C_gen_codeFM7make_fpFPTa2LN15C_form__cstmt_t36LN15C_form__cstmt_tiLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14C_form__cexp_tLN14C_form__cexp_trLrRM11block_ctx_tLN15C_form__cstmt_trNt10Hashset__t1R9Ast__id_tLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_tN15Ast__for_make_tLSR10Ast__loc_trrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tBR10Ast__loc_tiN14C_form__cexp_tLN12Ast__scope_trLN15C_form__cstmt_triBBBN14C_form__cexp_tiN14C_form__cexp_tBrirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_tB5rLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
          block_stack_ref_1, defined_syms_ref_1, fwd_fdecls_ref_1, i2e_ref_1, *km_idx_1, &form_map_0);
-      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(vcase_24->t1, 0, 0, &v_941);
-      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_941, 0, true, &v_942), _fx_catch_242);
+      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(vcase_24->t1, 0, 0, &v_962);
+      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_962, 0, true, &v_963), _fx_catch_246);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t2LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(
-            e_idoml_l_2, v_942, &v_943, 0), _fx_catch_242);
+            e_idoml_l_2, v_963, &v_964, 0), _fx_catch_246);
       FX_CALL(
-         form_map_0.fp(0, 0, v_943, 0, 0, block_stack_ref_0, decl_nested_status_1, defined_syms_ref_0, dst_data_1,
+         form_map_0.fp(0, 0, v_964, 0, 0, block_stack_ref_0, decl_nested_status_1, defined_syms_ref_0, dst_data_1,
             &end_for_loc_0, &for_flag_make_0, for_letters_0, &for_loc_0, func_dstexp_r_ref_0, fwd_fdecls_ref_0, fx_status__0,
             glob_data_ccode_ref_0, i2e_ref_0, is_parallel_map_0, &kloc_0, km_idx_0, map_lbl_0, mod_sc_0, module_cleanup_ref_0,
             ndims_ref_0, need_make_array_0, need_make_contig_0, need_make_vec_0, nested_status_1, nfors_0, par_status_1,
-            pre_alloc_array_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, unzip_mode_0, &v_944, form_map_0.fcv),
-         _fx_catch_242);
-      FX_COPY_PTR(v_944.t0, &pre_map_ccode_0);
-      FX_COPY_PTR(v_944.t1, &map_ccode_0);
+            pre_alloc_array_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, unzip_mode_0, &v_965, form_map_0.fcv),
+         _fx_catch_246);
+      FX_COPY_PTR(v_965.t0, &pre_map_ccode_0);
+      FX_COPY_PTR(v_965.t1, &map_ccode_0);
       if (!is_parallel_map_0) {
          FX_COPY_PTR(map_ccode_0, &map_ccode_1);
       }
       else {
-         _fx_R9Ast__id_t v_1039;
-         fx_str_t slit_240 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_240, &v_1039, 0), _fx_catch_242);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(map_lbl_0, 0, true, &v_945), _fx_catch_242);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_1, v_945, false, &v_945), _fx_catch_242);
+         _fx_R9Ast__id_t v_1060;
+         fx_str_t slit_246 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_246, &v_1060, 0), _fx_catch_246);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(map_lbl_0, 0, true, &v_966), _fx_catch_246);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_1, v_966, false, &v_966), _fx_catch_246);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1039,
-               v_945, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_0, 0), _fx_catch_242);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_0, &v_946), _fx_catch_242);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_946, map_ccode_0, true, &map_ccode_1), _fx_catch_242);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1060,
+               v_966, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_0, 0), _fx_catch_246);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_0, &v_967), _fx_catch_246);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_967, map_ccode_0, true, &map_ccode_1), _fx_catch_246);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(finalize_ccode_0, map_ccode_1,
-            &map_ccode_2, 0), _fx_catch_242);
+            &map_ccode_2, 0), _fx_catch_246);
       if (!unzip_mode_0) {
          FX_COPY_PTR(map_ccode_2, &map_ccode_3);
       }
@@ -32229,7 +32469,7 @@ static int
          _fx_R9Ast__id_t tcon_1;
          FX_CALL(
             _fx_M11C_gen_typesFM15get_constructorR9Ast__id_t3N14C_form__ctyp_tBR10Ast__loc_t(ctyp_0, false, &kloc_0, &tcon_1,
-               0), _fx_catch_242);
+               0), _fx_catch_246);
          _fx_LN14C_form__cexp_t lstend_1 = 0;
          _fx_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t lst_27 = dst_data_1;
          for (; lst_27; lst_27 = lst_27->tl) {
@@ -32240,65 +32480,65 @@ static int
             FX_COPY_PTR(__pat___9->t2, &dst_exp_20);
             FX_CALL(
                _fx_M10C_gen_codeFM12make_fun_argN14C_form__cexp_t2N14C_form__cexp_tR10Ast__loc_t(dst_exp_20, &kloc_0, &res_25,
-                  0), _fx_catch_241);
+                  0), _fx_catch_245);
             _fx_LN14C_form__cexp_t node_1 = 0;
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_25, 0, false, &node_1), _fx_catch_241);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(res_25, 0, false, &node_1), _fx_catch_245);
             FX_LIST_APPEND(cargs_5, lstend_1, node_1);
 
-         _fx_catch_241: ;
+         _fx_catch_245: ;
             if (res_25) {
                _fx_free_N14C_form__cexp_t(&res_25);
             }
             if (dst_exp_20) {
                _fx_free_N14C_form__cexp_t(&dst_exp_20);
             }
-            FX_CHECK_EXN(_fx_catch_242);
+            FX_CHECK_EXN(_fx_catch_246);
          }
-         fx_str_t slit_241 = FX_MAKE_STR("tup");
+         fx_str_t slit_247 = FX_MAKE_STR("tup");
          FX_CALL(
             _fx_M10C_gen_codeFM10get_dstexpT2N14C_form__cexp_tLN15C_form__cstmt_t7rNt6option1N14C_form__cexp_tSN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_ti(
-               dstexp_r_0, &slit_241, ctyp_0, map_ccode_2, &kloc_0, block_stack_ref_0, km_idx_0, &v_947, 0), _fx_catch_242);
-         FX_COPY_PTR(v_947.t0, &t_exp_2);
-         FX_COPY_PTR(v_947.t1, &map_ccode_4);
-         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_2, &v_948, 0), _fx_catch_242);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_948, 0, true, &v_949), _fx_catch_242);
-         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(cargs_5, v_949, &v_950, 0),
-            _fx_catch_242);
+               dstexp_r_0, &slit_247, ctyp_0, map_ccode_2, &kloc_0, block_stack_ref_0, km_idx_0, &v_968, 0), _fx_catch_246);
+         FX_COPY_PTR(v_968.t0, &t_exp_2);
+         FX_COPY_PTR(v_968.t1, &map_ccode_4);
+         FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(t_exp_2, &v_969, 0), _fx_catch_246);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_969, 0, true, &v_970), _fx_catch_246);
+         FX_CALL(_fx_M10C_gen_codeFM7__add__LN14C_form__cexp_t2LN14C_form__cexp_tLN14C_form__cexp_t(cargs_5, v_970, &v_971, 0),
+            _fx_catch_246);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&tcon_1,
-               v_950, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_1, 0), _fx_catch_242);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_1, &v_951), _fx_catch_242);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_951, map_ccode_4, true, &map_ccode_3), _fx_catch_242);
+               v_971, _fx_g20C_gen_code__CTypVoid, &kloc_0, &call_mktup_1, 0), _fx_catch_246);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(call_mktup_1, &v_972), _fx_catch_246);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_972, map_ccode_4, true, &map_ccode_3), _fx_catch_246);
       }
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(pre_map_ccode_0, ccode_141,
-            &v_952, 0), _fx_catch_242);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(pre_map_ccode_0, ccode_144,
+            &v_973, 0), _fx_catch_246);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(map_ccode_3, v_952, &v_953, 0),
-         _fx_catch_242);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_953, &v_1);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(map_ccode_3, v_973, &v_974, 0),
+         _fx_catch_246);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_974, &v_1);
 
-   _fx_catch_242: ;
-      if (v_953) {
-         _fx_free_LN15C_form__cstmt_t(&v_953);
+   _fx_catch_246: ;
+      if (v_974) {
+         _fx_free_LN15C_form__cstmt_t(&v_974);
       }
-      if (v_952) {
-         _fx_free_LN15C_form__cstmt_t(&v_952);
+      if (v_973) {
+         _fx_free_LN15C_form__cstmt_t(&v_973);
       }
-      if (v_951) {
-         _fx_free_N15C_form__cstmt_t(&v_951);
+      if (v_972) {
+         _fx_free_N15C_form__cstmt_t(&v_972);
       }
       if (call_mktup_1) {
          _fx_free_N14C_form__cexp_t(&call_mktup_1);
       }
-      if (v_950) {
-         _fx_free_LN14C_form__cexp_t(&v_950);
+      if (v_971) {
+         _fx_free_LN14C_form__cexp_t(&v_971);
       }
-      if (v_949) {
-         _fx_free_LN14C_form__cexp_t(&v_949);
+      if (v_970) {
+         _fx_free_LN14C_form__cexp_t(&v_970);
       }
-      if (v_948) {
-         _fx_free_N14C_form__cexp_t(&v_948);
+      if (v_969) {
+         _fx_free_N14C_form__cexp_t(&v_969);
       }
       if (map_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_4);
@@ -32306,7 +32546,7 @@ static int
       if (t_exp_2) {
          _fx_free_N14C_form__cexp_t(&t_exp_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_947);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_968);
       if (cargs_5) {
          _fx_free_LN14C_form__cexp_t(&cargs_5);
       }
@@ -32316,14 +32556,14 @@ static int
       if (map_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_2);
       }
-      if (v_946) {
-         _fx_free_N15C_form__cstmt_t(&v_946);
+      if (v_967) {
+         _fx_free_N15C_form__cstmt_t(&v_967);
       }
       if (update_exn_parallel_0) {
          _fx_free_N14C_form__cexp_t(&update_exn_parallel_0);
       }
-      if (v_945) {
-         _fx_free_LN14C_form__cexp_t(&v_945);
+      if (v_966) {
+         _fx_free_LN14C_form__cexp_t(&v_966);
       }
       if (map_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&map_ccode_1);
@@ -32334,14 +32574,14 @@ static int
       if (pre_map_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&pre_map_ccode_0);
       }
-      _fx_free_Ta2LN15C_form__cstmt_t(&v_944);
-      if (v_943) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_943);
+      _fx_free_Ta2LN15C_form__cstmt_t(&v_965);
+      if (v_964) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_964);
       }
-      if (v_942) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_942);
+      if (v_963) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_963);
       }
-      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_941);
+      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_962);
       FX_FREE_FP(&form_map_0);
       if (dst_data_1) {
          _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_1);
@@ -32349,8 +32589,8 @@ static int
       if (finalize_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&finalize_ccode_0);
       }
-      if (ccode_141) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_141);
+      if (ccode_144) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_144);
       }
       if (dst_data_0) {
          _fx_free_LT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_t(&dst_data_0);
@@ -32358,8 +32598,8 @@ static int
       if (coll_typs_0) {
          _fx_free_LN14K_form__ktyp_t(&coll_typs_0);
       }
-      if (v_940) {
-         _fx_free_N14K_form__ktyp_t(&v_940);
+      if (v_961) {
+         _fx_free_N14K_form__ktyp_t(&v_961);
       }
       if (decl_nested_status_1) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_1);
@@ -32367,14 +32607,14 @@ static int
       if (nested_status_1) {
          _fx_free_N14C_form__cexp_t(&nested_status_1);
       }
-      if (ccode_140) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_140);
+      if (ccode_143) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_143);
       }
       if (par_status_1) {
          _fx_free_N14C_form__cexp_t(&par_status_1);
       }
-      if (v_939) {
-         _fx_free_N14C_form__cexp_t(&v_939);
+      if (v_960) {
+         _fx_free_N14C_form__cexp_t(&v_960);
       }
       if (decl_nested_status_0) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_0);
@@ -32382,25 +32622,25 @@ static int
       if (nested_status_0) {
          _fx_free_N14C_form__cexp_t(&nested_status_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_938);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_937);
-      if (v_936) {
-         _fx_free_N14C_form__cexp_t(&v_936);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_959);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_958);
+      if (v_957) {
+         _fx_free_N14C_form__cexp_t(&v_957);
       }
-      _fx_free_R16Ast__val_flags_t(&v_935);
-      if (ccode_139) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_139);
+      _fx_free_R16Ast__val_flags_t(&v_956);
+      if (ccode_142) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_142);
       }
       if (par_status_0) {
          _fx_free_N14C_form__cexp_t(&par_status_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_934);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_933);
-      if (v_932) {
-         _fx_free_N14C_form__cexp_t(&v_932);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_955);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_954);
+      if (v_953) {
+         _fx_free_N14C_form__cexp_t(&v_953);
       }
-      _fx_free_R16Ast__val_flags_t(&v_931);
-      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_930);
+      _fx_free_R16Ast__val_flags_t(&v_952);
+      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_951);
       if (glob_status_0) {
          _fx_free_N14C_form__cexp_t(&glob_status_0);
       }
@@ -32420,79 +32660,79 @@ static int
       goto _fx_endmatch_55;
    }
    if (tag_0 == 27) {
-      _fx_N14C_form__cexp_t lbl_7 = 0;
+      _fx_N14C_form__cexp_t lbl_9 = 0;
       _fx_N14C_form__cexp_t glob_status_1 = 0;
-      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_1040 = {0};
-      _fx_R16Ast__val_flags_t v_1041 = {0};
-      _fx_N14C_form__cexp_t v_1042 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1043 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1044 = {0};
+      _fx_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t v_1061 = {0};
+      _fx_R16Ast__val_flags_t v_1062 = {0};
+      _fx_N14C_form__cexp_t v_1063 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1064 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1065 = {0};
       _fx_N14C_form__cexp_t par_status_2 = 0;
-      _fx_LN15C_form__cstmt_t ccode_142 = 0;
-      _fx_R16Ast__val_flags_t v_1045 = {0};
-      _fx_N14C_form__cexp_t v_1046 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1047 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1048 = {0};
+      _fx_LN15C_form__cstmt_t ccode_145 = 0;
+      _fx_R16Ast__val_flags_t v_1066 = {0};
+      _fx_N14C_form__cexp_t v_1067 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1068 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1069 = {0};
       _fx_N14C_form__cexp_t nested_status_2 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_2 = 0;
-      _fx_N14C_form__cexp_t v_1049 = 0;
+      _fx_N14C_form__cexp_t v_1070 = 0;
       _fx_N14C_form__cexp_t par_status_3 = 0;
-      _fx_LN15C_form__cstmt_t ccode_143 = 0;
+      _fx_LN15C_form__cstmt_t ccode_146 = 0;
       _fx_N14C_form__cexp_t nested_status_3 = 0;
       _fx_LN15C_form__cstmt_t decl_nested_status_3 = 0;
-      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1050 = {0};
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1051 = 0;
+      _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1071 = {0};
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_1072 = 0;
       _fx_T8LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_tLT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_t
-         v_1052 = {0};
+         v_1073 = {0};
       _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t for_headers_0 = 0;
-      _fx_LN15C_form__cstmt_t ccode_144 = 0;
+      _fx_LN15C_form__cstmt_t ccode_147 = 0;
       _fx_LN15C_form__cstmt_t pre_body_ccode_0 = 0;
       _fx_LT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_t body_elems_0 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_0 = 0;
-      _fx_LN14C_form__cexp_t v_1053 = 0;
+      _fx_LN14C_form__cexp_t v_1074 = 0;
       _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_2 = 0;
       _fx_FPB1N14C_form__cexp_t __lambda___0 = {0};
       _fx_LN14C_form__cexp_t locked_vec_exps_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t wbctx_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1054 = 0;
-      _fx_LN15C_form__cstmt_t v_1055 = 0;
+      _fx_LN15C_form__cstmt_t v_1075 = 0;
+      _fx_LN15C_form__cstmt_t v_1076 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_1 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1056 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1057 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1077 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1078 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_2 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1058 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1079 = {0};
       _fx_N15C_form__cstmt_t body_stmt_0 = 0;
       _fx_N15C_form__cstmt_t for_stmt_0 = 0;
-      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t v_1059 = 0;
+      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t v_1080 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_1 = 0;
-      _fx_N15C_form__cstmt_t v_1060 = 0;
-      _fx_Ta2LN15C_form__cstmt_t v_1061 = {0};
-      _fx_LN14C_form__cexp_t v_1062 = 0;
+      _fx_N15C_form__cstmt_t v_1081 = 0;
+      _fx_Ta2LN15C_form__cstmt_t v_1082 = {0};
+      _fx_LN14C_form__cexp_t v_1083 = 0;
       _fx_N14C_form__cexp_t update_exn_parallel_1 = 0;
-      _fx_N15C_form__cstmt_t v_1063 = 0;
-      _fx_LN15C_form__cstmt_t v_1064 = 0;
-      _fx_N15C_form__cstmt_t v_1065 = 0;
-      _fx_LN15C_form__cstmt_t v_1066 = 0;
+      _fx_N15C_form__cstmt_t v_1084 = 0;
+      _fx_LN15C_form__cstmt_t v_1085 = 0;
+      _fx_N15C_form__cstmt_t v_1086 = 0;
+      _fx_LN15C_form__cstmt_t v_1087 = 0;
       _fx_LN15C_form__cstmt_t omp_pragma_0 = 0;
       _fx_LN15C_form__cstmt_t post_ccode_2 = 0;
-      _fx_LN15C_form__cstmt_t v_1067 = 0;
-      _fx_LN15C_form__cstmt_t v_1068 = 0;
+      _fx_LN15C_form__cstmt_t v_1088 = 0;
+      _fx_LN15C_form__cstmt_t v_1089 = 0;
       _fx_LN15C_form__cstmt_t loop_ccode_0 = 0;
       _fx_LN15C_form__cstmt_t result_ccode_0 = 0;
       _fx_rR23C_gen_code__block_ctx_t wbctx_1 = 0;
       _fx_LN15C_form__cstmt_t bctx_cleanup_2 = 0;
       _fx_LN15C_form__cstmt_t bctx_prologue_2 = 0;
       _fx_LN15C_form__cstmt_t epilogue_2 = 0;
-      _fx_N15C_form__cstmt_t v_1069 = 0;
-      _fx_LN15C_form__cstmt_t v_1070 = 0;
-      _fx_LN15C_form__cstmt_t v_1071 = 0;
+      _fx_N15C_form__cstmt_t v_1090 = 0;
+      _fx_LN15C_form__cstmt_t v_1091 = 0;
+      _fx_LN15C_form__cstmt_t v_1092 = 0;
       _fx_LN15C_form__cstmt_t wrapped_0 = 0;
       _fx_N15C_form__cstmt_t c_e_3 = 0;
-      _fx_LN14C_form__cexp_t v_1072 = 0;
-      _fx_N14C_form__cexp_t v_1073 = 0;
+      _fx_LN14C_form__cexp_t v_1093 = 0;
+      _fx_N14C_form__cexp_t v_1094 = 0;
       _fx_N15C_form__cstmt_t check_exn_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1074 = 0;
+      _fx_LN15C_form__cstmt_t v_1095 = 0;
       _fx_T5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_27 =
          &kexp_0->u.KExpFor;
       _fx_R16Ast__for_flags_t* flags_1 = &vcase_27->t3;
@@ -32500,259 +32740,259 @@ static int
       _fx_LT2R9Ast__id_tN13K_form__dom_t idoml_3 = vcase_27->t0;
       FX_CALL(
          _fx_M10C_gen_codeFM16curr_block_labelN14C_form__cexp_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &lbl_7, 0), _fx_catch_247);
+            &lbl_9, 0), _fx_catch_251);
       _fx_R10Ast__loc_t for_loc_1;
-      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_1, 0), _fx_catch_247);
+      FX_CALL(_fx_M3AstFM13get_start_locRM5loc_t1RM5loc_t(&kloc_0, &for_loc_1, 0), _fx_catch_251);
       _fx_R10Ast__loc_t end_for_loc_1;
-      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_1, 0), _fx_catch_247);
+      FX_CALL(_fx_M3AstFM11get_end_locRM5loc_t1RM5loc_t(&kloc_0, &end_for_loc_1, 0), _fx_catch_251);
       int_ ndims_4;
       FX_CALL(
          _fx_M10C_gen_codeFM17compute_for_ndimsi4iiLT2R9Ast__id_tN13K_form__dom_tR10Ast__loc_t(0, 1, idoml_3, &for_loc_1,
-            &ndims_4, 0), _fx_catch_247);
+            &ndims_4, 0), _fx_catch_251);
       FX_CALL(
          _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(fx_status__0,
-            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_1, 0), _fx_catch_247);
+            _fx_g20C_gen_code__CTypCInt, &kloc_0, &glob_status_1, 0), _fx_catch_251);
       bool is_parallel_for_0 = flags_1->for_flag_parallel;
       if (is_parallel_for_0) {
-         _fx_R9Ast__id_t v_1075;
-         fx_str_t slit_242 = FX_MAKE_STR("par_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_242, &v_1075, 0), _fx_catch_247);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1041, 0), _fx_catch_247);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1042, 0), _fx_catch_247);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1042, &v_1043);
-         fx_str_t slit_243 = FX_MAKE_STR("");
+         _fx_R9Ast__id_t v_1096;
+         fx_str_t slit_248 = FX_MAKE_STR("par_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_248, &v_1096, 0), _fx_catch_251);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1062, 0), _fx_catch_251);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1063, 0), _fx_catch_251);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1063, &v_1064);
+         fx_str_t slit_249 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1075, _fx_g20C_gen_code__CTypCInt, &v_1041, &slit_243, &v_1043, ccode_0, &kloc_0, &v_1044, 0), _fx_catch_247);
-         FX_COPY_PTR(v_1044.t0, &par_status_2);
-         FX_COPY_PTR(v_1044.t1, &ccode_142);
-         _fx_R9Ast__id_t v_1076;
-         fx_str_t slit_244 = FX_MAKE_STR("status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_244, &v_1076, 0), _fx_catch_247);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1045, 0), _fx_catch_247);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1046, 0), _fx_catch_247);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1046, &v_1047);
-         fx_str_t slit_245 = FX_MAKE_STR("fx_status");
+               &v_1096, _fx_g20C_gen_code__CTypCInt, &v_1062, &slit_249, &v_1064, ccode_0, &kloc_0, &v_1065, 0), _fx_catch_251);
+         FX_COPY_PTR(v_1065.t0, &par_status_2);
+         FX_COPY_PTR(v_1065.t1, &ccode_145);
+         _fx_R9Ast__id_t v_1097;
+         fx_str_t slit_250 = FX_MAKE_STR("status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_250, &v_1097, 0), _fx_catch_251);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1066, 0), _fx_catch_251);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kloc_0, &v_1067, 0), _fx_catch_251);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1067, &v_1068);
+         fx_str_t slit_251 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1076, _fx_g20C_gen_code__CTypCInt, &v_1045, &slit_245, &v_1047, 0, &kloc_0, &v_1048, 0), _fx_catch_247);
-         FX_COPY_PTR(v_1048.t0, &nested_status_2);
-         FX_COPY_PTR(v_1048.t1, &decl_nested_status_2);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_2, ccode_142,
-            nested_status_2, decl_nested_status_2, &v_1040);
+               &v_1097, _fx_g20C_gen_code__CTypCInt, &v_1066, &slit_251, &v_1068, 0, &kloc_0, &v_1069, 0), _fx_catch_251);
+         FX_COPY_PTR(v_1069.t0, &nested_status_2);
+         FX_COPY_PTR(v_1069.t1, &decl_nested_status_2);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(par_status_2, ccode_145,
+            nested_status_2, decl_nested_status_2, &v_1061);
       }
       else {
-         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1049, 0), _fx_catch_247);
-         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_1049, ccode_0, glob_status_1, 0,
-            &v_1040);
+         FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1070, 0), _fx_catch_251);
+         _fx_make_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(v_1070, ccode_0, glob_status_1, 0,
+            &v_1061);
       }
-      FX_COPY_PTR(v_1040.t0, &par_status_3);
-      FX_COPY_PTR(v_1040.t1, &ccode_143);
-      FX_COPY_PTR(v_1040.t2, &nested_status_3);
-      FX_COPY_PTR(v_1040.t3, &decl_nested_status_3);
-      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(body_0, 0, 0, &v_1050);
-      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1050, 0, true, &v_1051),
-         _fx_catch_247);
+      FX_COPY_PTR(v_1061.t0, &par_status_3);
+      FX_COPY_PTR(v_1061.t1, &ccode_146);
+      FX_COPY_PTR(v_1061.t2, &nested_status_3);
+      FX_COPY_PTR(v_1061.t3, &decl_nested_status_3);
+      _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(body_0, 0, 0, &v_1071);
+      FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1071, 0, true, &v_1072),
+         _fx_catch_251);
       FX_CALL(
-         process_for_0.fp(lbl_7, idoml_3, vcase_27->t1, 0, 1, ndims_4, 0, v_1051, ccode_143, &kloc_0, block_stack_ref_0,
-            defined_syms_ref_0, for_letters_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_1052, process_for_0.fcv),
-         _fx_catch_247);
-      FX_COPY_PTR(v_1052.t0, &for_headers_0);
-      FX_COPY_PTR(v_1052.t4, &ccode_144);
-      FX_COPY_PTR(v_1052.t5, &pre_body_ccode_0);
-      FX_COPY_PTR(v_1052.t6, &body_elems_0);
-      FX_COPY_PTR(v_1052.t7, &post_ccode_0);
+         process_for_0.fp(lbl_9, idoml_3, vcase_27->t1, 0, 1, ndims_4, 0, v_1072, ccode_146, &kloc_0, block_stack_ref_0,
+            defined_syms_ref_0, for_letters_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0, &v_1073, process_for_0.fcv),
+         _fx_catch_251);
+      FX_COPY_PTR(v_1073.t0, &for_headers_0);
+      FX_COPY_PTR(v_1073.t4, &ccode_147);
+      FX_COPY_PTR(v_1073.t5, &pre_body_ccode_0);
+      FX_COPY_PTR(v_1073.t6, &body_elems_0);
+      FX_COPY_PTR(v_1073.t7, &post_ccode_0);
       _fx_LN14C_form__cexp_t lstend_2 = 0;
       FX_COPY_PTR(idoml_3, &idoml_2);
       _fx_LT2R9Ast__id_tN13K_form__dom_t lst_28 = idoml_2;
       for (; lst_28; lst_28 = lst_28->tl) {
          _fx_N13K_form__dom_t dom_1 = {0};
-         _fx_N14K_form__ktyp_t v_1077 = 0;
+         _fx_N14K_form__ktyp_t v_1098 = 0;
          _fx_N14C_form__cexp_t t_14 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1078 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1099 = {0};
          _fx_T2R9Ast__id_tN13K_form__dom_t* __pat___10 = &lst_28->hd;
          _fx_copy_N13K_form__dom_t(&__pat___10->t1, &dom_1);
          int tag_31 = dom_1.tag;
          _fx_R9Ast__id_t col_1;
          if (tag_31 == 1) {
-            _fx_N14K_form__atom_t* v_1079 = &dom_1.u.DomainElem;
-            if (v_1079->tag == 1) {
-               col_1 = v_1079->u.AtomId; goto _fx_endmatch_41;
+            _fx_N14K_form__atom_t* v_1100 = &dom_1.u.DomainElem;
+            if (v_1100->tag == 1) {
+               col_1 = v_1100->u.AtomId; goto _fx_endmatch_41;
             }
          }
          if (tag_31 == 2) {
-            _fx_N14K_form__atom_t* v_1080 = &dom_1.u.DomainFast;
-            if (v_1080->tag == 1) {
-               col_1 = v_1080->u.AtomId; goto _fx_endmatch_41;
+            _fx_N14K_form__atom_t* v_1101 = &dom_1.u.DomainFast;
+            if (v_1101->tag == 1) {
+               col_1 = v_1101->u.AtomId; goto _fx_endmatch_41;
             }
          }
          col_1 = _fx_g9Ast__noid;
 
       _fx_endmatch_41: ;
-         FX_CHECK_EXN(_fx_catch_243);
-         bool v_1081;
+         FX_CHECK_EXN(_fx_catch_247);
+         bool v_1102;
          bool res_26;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&col_1, &_fx_g9Ast__noid, &res_26, 0), _fx_catch_243);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&col_1, &_fx_g9Ast__noid, &res_26, 0), _fx_catch_247);
          if (res_26) {
-            FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&col_1, &kloc_0, &v_1077, 0),
-               _fx_catch_243);
-            if (FX_REC_VARIANT_TAG(v_1077) == 19) {
-               v_1081 = true;
+            FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&col_1, &kloc_0, &v_1098, 0),
+               _fx_catch_247);
+            if (FX_REC_VARIANT_TAG(v_1098) == 19) {
+               v_1102 = true;
             }
             else {
-               v_1081 = false;
+               v_1102 = false;
             }
-            FX_CHECK_EXN(_fx_catch_243);
+            FX_CHECK_EXN(_fx_catch_247);
          }
          else {
-            v_1081 = false;
+            v_1102 = false;
          }
-         if (v_1081) {
+         if (v_1102) {
             FX_CALL(
                _fx_M10C_gen_codeFM7id2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t9R9Ast__id_tBLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_ti(
                   &col_1, false, 0, &kloc_0, block_stack_ref_0, defined_syms_ref_0, fwd_fdecls_ref_0, i2e_ref_0, km_idx_0,
-                  &v_1078, 0), _fx_catch_243);
-            FX_COPY_PTR(v_1078.t0, &t_14);
+                  &v_1099, 0), _fx_catch_247);
+            FX_COPY_PTR(v_1099.t0, &t_14);
          }
          else {
-            FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &t_14, 0), _fx_catch_243);
+            FX_CALL(_fx_M6C_formFM14make_dummy_expN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &t_14, 0), _fx_catch_247);
          }
          _fx_LN14C_form__cexp_t node_2 = 0;
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(t_14, 0, false, &node_2), _fx_catch_243);
-         FX_LIST_APPEND(v_1053, lstend_2, node_2);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(t_14, 0, false, &node_2), _fx_catch_247);
+         FX_LIST_APPEND(v_1074, lstend_2, node_2);
 
-      _fx_catch_243: ;
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1078);
+      _fx_catch_247: ;
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1099);
          if (t_14) {
             _fx_free_N14C_form__cexp_t(&t_14);
          }
-         if (v_1077) {
-            _fx_free_N14K_form__ktyp_t(&v_1077);
+         if (v_1098) {
+            _fx_free_N14K_form__ktyp_t(&v_1098);
          }
          _fx_free_N13K_form__dom_t(&dom_1);
-         FX_CHECK_EXN(_fx_catch_247);
+         FX_CHECK_EXN(_fx_catch_251);
       }
       _fx_FPB1N14C_form__cexp_t __lambda___fp_0 = { _fx_M10C_gen_codeFM10__lambda__B1N14C_form__cexp_t, 0 };
       FX_COPY_FP(&__lambda___fp_0, &__lambda___0);
       FX_CALL(
-         _fx_M10C_gen_codeFM6filterLN14C_form__cexp_t2LN14C_form__cexp_tFPB1N14C_form__cexp_t(v_1053, &__lambda___0,
-            &locked_vec_exps_0, 0), _fx_catch_247);
+         _fx_M10C_gen_codeFM6filterLN14C_form__cexp_t2LN14C_form__cexp_tFPB1N14C_form__cexp_t(v_1074, &__lambda___0,
+            &locked_vec_exps_0, 0), _fx_catch_251);
       bool have_lock_0 = locked_vec_exps_0 != 0;
       if (have_lock_0) {
          FX_CALL(
             _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-               &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_247);
+               &_fx_g27C_gen_code__BlockKind_Block, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_251);
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &wbctx_0, 0), _fx_catch_247);
+               &wbctx_0, 0), _fx_catch_251);
          _fx_LN15C_form__cstmt_t lstend_3 = 0;
          _fx_LN14C_form__cexp_t lst_29 = locked_vec_exps_0;
          for (; lst_29; lst_29 = lst_29->tl) {
-            _fx_LN14C_form__cexp_t v_1082 = 0;
-            _fx_N14C_form__cexp_t v_1083 = 0;
+            _fx_LN14C_form__cexp_t v_1103 = 0;
+            _fx_N14C_form__cexp_t v_1104 = 0;
             _fx_N15C_form__cstmt_t res_27 = 0;
             _fx_N14C_form__cexp_t e_15 = lst_29->hd;
-            _fx_R9Ast__id_t v_1084;
-            fx_str_t slit_246 = FX_MAKE_STR("FX_VEC_START_READ");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_246, &v_1084, 0), _fx_catch_244);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_15, 0, true, &v_1082), _fx_catch_244);
+            _fx_R9Ast__id_t v_1105;
+            fx_str_t slit_252 = FX_MAKE_STR("FX_VEC_START_READ");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_252, &v_1105, 0), _fx_catch_248);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_15, 0, true, &v_1103), _fx_catch_248);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1084,
-                  v_1082, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1083, 0), _fx_catch_244);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1083, &res_27), _fx_catch_244);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1105,
+                  v_1103, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1104, 0), _fx_catch_248);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1104, &res_27), _fx_catch_248);
             _fx_LN15C_form__cstmt_t node_3 = 0;
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_27, 0, false, &node_3), _fx_catch_244);
-            FX_LIST_APPEND(v_1054, lstend_3, node_3);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_27, 0, false, &node_3), _fx_catch_248);
+            FX_LIST_APPEND(v_1075, lstend_3, node_3);
 
-         _fx_catch_244: ;
+         _fx_catch_248: ;
             if (res_27) {
                _fx_free_N15C_form__cstmt_t(&res_27);
             }
-            if (v_1083) {
-               _fx_free_N14C_form__cexp_t(&v_1083);
+            if (v_1104) {
+               _fx_free_N14C_form__cexp_t(&v_1104);
             }
-            if (v_1082) {
-               _fx_free_LN14C_form__cexp_t(&v_1082);
+            if (v_1103) {
+               _fx_free_LN14C_form__cexp_t(&v_1103);
             }
-            FX_CHECK_EXN(_fx_catch_247);
+            FX_CHECK_EXN(_fx_catch_251);
          }
-         _fx_R23C_gen_code__block_ctx_t* v_1085 = &wbctx_0->data;
-         _fx_LN15C_form__cstmt_t* v_1086 = &v_1085->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1086);
-         FX_COPY_PTR(v_1054, v_1086);
+         _fx_R23C_gen_code__block_ctx_t* v_1106 = &wbctx_0->data;
+         _fx_LN15C_form__cstmt_t* v_1107 = &v_1106->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1107);
+         FX_COPY_PTR(v_1075, v_1107);
          _fx_LN15C_form__cstmt_t lstend_4 = 0;
          _fx_LN14C_form__cexp_t lst_30 = locked_vec_exps_0;
          for (; lst_30; lst_30 = lst_30->tl) {
-            _fx_LN14C_form__cexp_t v_1087 = 0;
-            _fx_N14C_form__cexp_t v_1088 = 0;
+            _fx_LN14C_form__cexp_t v_1108 = 0;
+            _fx_N14C_form__cexp_t v_1109 = 0;
             _fx_N15C_form__cstmt_t res_28 = 0;
             _fx_N14C_form__cexp_t e_16 = lst_30->hd;
-            _fx_R9Ast__id_t v_1089;
-            fx_str_t slit_247 = FX_MAKE_STR("FX_VEC_END_READ");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_247, &v_1089, 0), _fx_catch_245);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_16, 0, true, &v_1087), _fx_catch_245);
+            _fx_R9Ast__id_t v_1110;
+            fx_str_t slit_253 = FX_MAKE_STR("FX_VEC_END_READ");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_253, &v_1110, 0), _fx_catch_249);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(e_16, 0, true, &v_1108), _fx_catch_249);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1089,
-                  v_1087, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1088, 0), _fx_catch_245);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1088, &res_28), _fx_catch_245);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1110,
+                  v_1108, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1109, 0), _fx_catch_249);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1109, &res_28), _fx_catch_249);
             _fx_LN15C_form__cstmt_t node_4 = 0;
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_28, 0, false, &node_4), _fx_catch_245);
-            FX_LIST_APPEND(v_1055, lstend_4, node_4);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(res_28, 0, false, &node_4), _fx_catch_249);
+            FX_LIST_APPEND(v_1076, lstend_4, node_4);
 
-         _fx_catch_245: ;
+         _fx_catch_249: ;
             if (res_28) {
                _fx_free_N15C_form__cstmt_t(&res_28);
             }
-            if (v_1088) {
-               _fx_free_N14C_form__cexp_t(&v_1088);
+            if (v_1109) {
+               _fx_free_N14C_form__cexp_t(&v_1109);
             }
-            if (v_1087) {
-               _fx_free_LN14C_form__cexp_t(&v_1087);
+            if (v_1108) {
+               _fx_free_LN14C_form__cexp_t(&v_1108);
             }
-            FX_CHECK_EXN(_fx_catch_247);
+            FX_CHECK_EXN(_fx_catch_251);
          }
-         _fx_R23C_gen_code__block_ctx_t* v_1090 = &wbctx_0->data;
-         _fx_LN15C_form__cstmt_t* v_1091 = &v_1090->bctx_cleanup;
-         _fx_free_LN15C_form__cstmt_t(v_1091);
-         FX_COPY_PTR(v_1055, v_1091);
+         _fx_R23C_gen_code__block_ctx_t* v_1111 = &wbctx_0->data;
+         _fx_LN15C_form__cstmt_t* v_1112 = &v_1111->bctx_cleanup;
+         _fx_free_LN15C_form__cstmt_t(v_1112);
+         FX_COPY_PTR(v_1076, v_1112);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM17new_for_block_ctxv7iR16Ast__for_flags_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_trLrRM11block_ctx_ti(
-            ndims_4, flags_1, nested_status_3, par_status_3, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_247);
+            ndims_4, flags_1, nested_status_3, par_status_3, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_251);
       if (is_parallel_for_0) {
          FX_COPY_PTR(decl_nested_status_3, &body_ccode_0);
       }
       FX_CALL(
          _fx_M10C_gen_codeFM19decl_for_body_elemsLN15C_form__cstmt_t4LT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_t(
-            body_elems_0, body_ccode_0, block_stack_ref_0, i2e_ref_0, &body_ccode_1, 0), _fx_catch_247);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1056), _fx_catch_247);
+            body_elems_0, body_ccode_0, block_stack_ref_0, i2e_ref_0, &body_ccode_1, 0), _fx_catch_251);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1077), _fx_catch_251);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            body_0, v_1056, body_ccode_1, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            body_0, v_1077, body_ccode_1, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1057, fx_fv), _fx_catch_247);
-      FX_COPY_PTR(v_1057.t1, &body_ccode_2);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1078, fx_fv), _fx_catch_251);
+      FX_COPY_PTR(v_1078.t1, &body_ccode_2);
       _fx_R10Ast__loc_t body_loc_0;
-      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(body_0, &body_loc_0, 0), _fx_catch_247);
+      FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(body_0, &body_loc_0, 0), _fx_catch_251);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_2, true, &body_loc_0, block_stack_ref_0, &v_1058, 0), _fx_catch_247);
-      _fx_R9Ast__id_t br_label_0 = v_1058.t0;
-      FX_COPY_PTR(v_1058.t1, &body_stmt_0);
+            body_ccode_2, true, &body_loc_0, block_stack_ref_0, &v_1079, 0), _fx_catch_251);
+      _fx_R9Ast__id_t br_label_0 = v_1079.t0;
+      FX_COPY_PTR(v_1079.t1, &body_stmt_0);
       FX_COPY_PTR(body_stmt_0, &for_stmt_0);
       FX_CALL(
          _fx_M10C_gen_codeFM3revLT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t1LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(
-            for_headers_0, &v_1059, 0), _fx_catch_247);
+            for_headers_0, &v_1080, 0), _fx_catch_251);
       int_ k_0 = 0;
-      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t lst_31 = v_1059;
+      _fx_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t lst_31 = v_1080;
       for (; lst_31; lst_31 = lst_31->tl, k_0 += 1) {
          _fx_Nt6option1N14C_form__ctyp_t t_opt_0 = {0};
          _fx_LN14C_form__cexp_t for_inits_0 = 0;
          _fx_Nt6option1N14C_form__cexp_t for_check_opt_0 = {0};
          _fx_LN14C_form__cexp_t for_incrs_0 = 0;
          _fx_N15C_form__cstmt_t for_stmt1_0 = 0;
-         _fx_N15C_form__cstmt_t v_1092 = 0;
-         _fx_LN15C_form__cstmt_t v_1093 = 0;
+         _fx_N15C_form__cstmt_t v_1113 = 0;
+         _fx_LN15C_form__cstmt_t v_1114 = 0;
          _fx_T4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t* __pat___11 =
             &lst_31->hd;
          _fx_copy_Nt6option1N14C_form__ctyp_t(&__pat___11->t0, &t_opt_0);
@@ -32761,7 +33001,7 @@ static int
          FX_COPY_PTR(__pat___11->t3, &for_incrs_0);
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
-               &t_opt_0, for_inits_0, &for_check_opt_0, for_incrs_0, for_stmt_0, &kloc_0, &for_stmt1_0), _fx_catch_246);
+               &t_opt_0, for_inits_0, &for_check_opt_0, for_incrs_0, for_stmt_0, &kloc_0, &for_stmt1_0), _fx_catch_250);
          bool t_15;
          if (k_0 > 0) {
             t_15 = true;
@@ -32770,23 +33010,23 @@ static int
             t_15 = pre_body_ccode_0 == 0;
          }
          if (t_15) {
-            FX_COPY_PTR(for_stmt1_0, &v_1092);
+            FX_COPY_PTR(for_stmt1_0, &v_1113);
          }
          else {
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt1_0, pre_body_ccode_0, true, &v_1093), _fx_catch_246);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt1_0, pre_body_ccode_0, true, &v_1114), _fx_catch_250);
             FX_CALL(
-               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(v_1093, &for_loc_1, &v_1092, 0),
-               _fx_catch_246);
+               _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(v_1114, &for_loc_1, &v_1113, 0),
+               _fx_catch_250);
          }
          _fx_free_N15C_form__cstmt_t(&for_stmt_0);
-         FX_COPY_PTR(v_1092, &for_stmt_0);
+         FX_COPY_PTR(v_1113, &for_stmt_0);
 
-      _fx_catch_246: ;
-         if (v_1093) {
-            _fx_free_LN15C_form__cstmt_t(&v_1093);
+      _fx_catch_250: ;
+         if (v_1114) {
+            _fx_free_LN15C_form__cstmt_t(&v_1114);
          }
-         if (v_1092) {
-            _fx_free_N15C_form__cstmt_t(&v_1092);
+         if (v_1113) {
+            _fx_free_N15C_form__cstmt_t(&v_1113);
          }
          if (for_stmt1_0) {
             _fx_free_N15C_form__cstmt_t(&for_stmt1_0);
@@ -32799,105 +33039,105 @@ static int
             _fx_free_LN14C_form__cexp_t(&for_inits_0);
          }
          _fx_free_Nt6option1N14C_form__ctyp_t(&t_opt_0);
-         FX_CHECK_EXN(_fx_catch_247);
+         FX_CHECK_EXN(_fx_catch_251);
       }
       bool res_29;
-      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&br_label_0, &_fx_g9Ast__noid, &res_29, 0), _fx_catch_247);
+      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&br_label_0, &_fx_g9Ast__noid, &res_29, 0), _fx_catch_251);
       if (res_29) {
          FX_COPY_PTR(post_ccode_0, &post_ccode_1);
       }
       else {
-         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&br_label_0, &end_for_loc_1, &v_1060),
-            _fx_catch_247);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1060, post_ccode_0, true, &post_ccode_1), _fx_catch_247);
+         FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&br_label_0, &end_for_loc_1, &v_1081),
+            _fx_catch_251);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1081, post_ccode_0, true, &post_ccode_1), _fx_catch_251);
       }
       if (!is_parallel_for_0) {
-         _fx_make_Ta2LN15C_form__cstmt_t(0, post_ccode_1, &v_1061);
+         _fx_make_Ta2LN15C_form__cstmt_t(0, post_ccode_1, &v_1082);
       }
       else {
-         _fx_R9Ast__id_t v_1094;
-         fx_str_t slit_248 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_248, &v_1094, 0), _fx_catch_247);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_1062), _fx_catch_247);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_3, v_1062, false, &v_1062), _fx_catch_247);
+         _fx_R9Ast__id_t v_1115;
+         fx_str_t slit_254 = FX_MAKE_STR("FX_UPDATE_EXN_PARALLEL");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_254, &v_1115, 0), _fx_catch_251);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1083), _fx_catch_251);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(par_status_3, v_1083, false, &v_1083), _fx_catch_251);
          FX_CALL(
-            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1094,
-               v_1062, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_1, 0), _fx_catch_247);
-         fx_str_t slit_249 = FX_MAKE_STR("omp parallel for");
-         FX_CALL(_fx_M6C_formFM12CMacroPragmaN15C_form__cstmt_t2SR10Ast__loc_t(&slit_249, &kloc_0, &v_1063), _fx_catch_247);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1063, 0, true, &v_1064), _fx_catch_247);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_1, &v_1065), _fx_catch_247);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1065, post_ccode_1, true, &v_1066), _fx_catch_247);
-         _fx_make_Ta2LN15C_form__cstmt_t(v_1064, v_1066, &v_1061);
+            _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1115,
+               v_1083, _fx_g20C_gen_code__CTypVoid, &kloc_0, &update_exn_parallel_1, 0), _fx_catch_251);
+         fx_str_t slit_255 = FX_MAKE_STR("omp parallel for");
+         FX_CALL(_fx_M6C_formFM12CMacroPragmaN15C_form__cstmt_t2SR10Ast__loc_t(&slit_255, &kloc_0, &v_1084), _fx_catch_251);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1084, 0, true, &v_1085), _fx_catch_251);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(update_exn_parallel_1, &v_1086), _fx_catch_251);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1086, post_ccode_1, true, &v_1087), _fx_catch_251);
+         _fx_make_Ta2LN15C_form__cstmt_t(v_1085, v_1087, &v_1082);
       }
-      FX_COPY_PTR(v_1061.t0, &omp_pragma_0);
-      FX_COPY_PTR(v_1061.t1, &post_ccode_2);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt_0, 0, true, &v_1067), _fx_catch_247);
+      FX_COPY_PTR(v_1082.t0, &omp_pragma_0);
+      FX_COPY_PTR(v_1082.t1, &post_ccode_2);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(for_stmt_0, 0, true, &v_1088), _fx_catch_251);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1067, omp_pragma_0, &v_1068,
-            0), _fx_catch_247);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1088, omp_pragma_0, &v_1089,
+            0), _fx_catch_251);
       FX_CALL(
-         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(post_ccode_2, v_1068,
-            &loop_ccode_0, 0), _fx_catch_247);
+         _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(post_ccode_2, v_1089,
+            &loop_ccode_0, 0), _fx_catch_251);
       if (have_lock_0) {
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-               &wbctx_1, 0), _fx_catch_247);
-         _fx_R23C_gen_code__block_ctx_t* v_1095 = &wbctx_1->data;
-         int_ bctx_label_used_2 = v_1095->bctx_label_used;
-         _fx_R9Ast__id_t bctx_label_2 = v_1095->bctx_label;
-         FX_COPY_PTR(v_1095->bctx_cleanup, &bctx_cleanup_2);
-         FX_COPY_PTR(v_1095->bctx_prologue, &bctx_prologue_2);
+               &wbctx_1, 0), _fx_catch_251);
+         _fx_R23C_gen_code__block_ctx_t* v_1116 = &wbctx_1->data;
+         int_ bctx_label_used_2 = v_1116->bctx_label_used;
+         _fx_R9Ast__id_t bctx_label_2 = v_1116->bctx_label;
+         FX_COPY_PTR(v_1116->bctx_cleanup, &bctx_cleanup_2);
+         FX_COPY_PTR(v_1116->bctx_prologue, &bctx_prologue_2);
          if (bctx_label_used_2 == 0) {
             FX_COPY_PTR(bctx_cleanup_2, &epilogue_2);
          }
          else {
             FX_CALL(
-               _fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_2, &end_for_loc_1, &v_1069),
-               _fx_catch_247);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1069, 0, true, &v_1070), _fx_catch_247);
+               _fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_2, &end_for_loc_1, &v_1090),
+               _fx_catch_251);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1090, 0, true, &v_1091), _fx_catch_251);
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_2, v_1070,
-                  &epilogue_2, 0), _fx_catch_247);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_2, v_1091,
+                  &epilogue_2, 0), _fx_catch_251);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, bctx_prologue_2,
-               &v_1071, 0), _fx_catch_247);
+               &v_1092, 0), _fx_catch_251);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_2, v_1071,
-               &wrapped_0, 0), _fx_catch_247);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(epilogue_2, v_1092,
+               &wrapped_0, 0), _fx_catch_251);
          FX_CALL(
             _fx_M6C_formFM11rccode2stmtN15C_form__cstmt_t2LN15C_form__cstmt_tR10Ast__loc_t(wrapped_0, &for_loc_1, &c_e_3, 0),
-            _fx_catch_247);
+            _fx_catch_251);
          FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
-            _fx_catch_247);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_7, 0, true, &v_1072), _fx_catch_247);
+            _fx_catch_251);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(lbl_9, 0, true, &v_1093), _fx_catch_251);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g24C_form__std_FX_CHECK_EXN, v_1072, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1073, 0), _fx_catch_247);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1073, &check_exn_1), _fx_catch_247);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(c_e_3, ccode_144, true, &v_1074), _fx_catch_247);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_exn_1, v_1074, true, &result_ccode_0), _fx_catch_247);
+               &_fx_g24C_form__std_FX_CHECK_EXN, v_1093, _fx_g20C_gen_code__CTypVoid, &kloc_0, &v_1094, 0), _fx_catch_251);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1094, &check_exn_1), _fx_catch_251);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(c_e_3, ccode_147, true, &v_1095), _fx_catch_251);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_exn_1, v_1095, true, &result_ccode_0), _fx_catch_251);
       }
       else {
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, ccode_144,
-               &result_ccode_0, 0), _fx_catch_247);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(loop_ccode_0, ccode_147,
+               &result_ccode_0, 0), _fx_catch_251);
       }
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, result_ccode_0, &v_1);
 
-   _fx_catch_247: ;
-      if (v_1074) {
-         _fx_free_LN15C_form__cstmt_t(&v_1074);
+   _fx_catch_251: ;
+      if (v_1095) {
+         _fx_free_LN15C_form__cstmt_t(&v_1095);
       }
       if (check_exn_1) {
          _fx_free_N15C_form__cstmt_t(&check_exn_1);
       }
-      if (v_1073) {
-         _fx_free_N14C_form__cexp_t(&v_1073);
+      if (v_1094) {
+         _fx_free_N14C_form__cexp_t(&v_1094);
       }
-      if (v_1072) {
-         _fx_free_LN14C_form__cexp_t(&v_1072);
+      if (v_1093) {
+         _fx_free_LN14C_form__cexp_t(&v_1093);
       }
       if (c_e_3) {
          _fx_free_N15C_form__cstmt_t(&c_e_3);
@@ -32905,14 +33145,14 @@ static int
       if (wrapped_0) {
          _fx_free_LN15C_form__cstmt_t(&wrapped_0);
       }
-      if (v_1071) {
-         _fx_free_LN15C_form__cstmt_t(&v_1071);
+      if (v_1092) {
+         _fx_free_LN15C_form__cstmt_t(&v_1092);
       }
-      if (v_1070) {
-         _fx_free_LN15C_form__cstmt_t(&v_1070);
+      if (v_1091) {
+         _fx_free_LN15C_form__cstmt_t(&v_1091);
       }
-      if (v_1069) {
-         _fx_free_N15C_form__cstmt_t(&v_1069);
+      if (v_1090) {
+         _fx_free_N15C_form__cstmt_t(&v_1090);
       }
       if (epilogue_2) {
          _fx_free_LN15C_form__cstmt_t(&epilogue_2);
@@ -32932,11 +33172,11 @@ static int
       if (loop_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&loop_ccode_0);
       }
-      if (v_1068) {
-         _fx_free_LN15C_form__cstmt_t(&v_1068);
+      if (v_1089) {
+         _fx_free_LN15C_form__cstmt_t(&v_1089);
       }
-      if (v_1067) {
-         _fx_free_LN15C_form__cstmt_t(&v_1067);
+      if (v_1088) {
+         _fx_free_LN15C_form__cstmt_t(&v_1088);
       }
       if (post_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_2);
@@ -32944,33 +33184,33 @@ static int
       if (omp_pragma_0) {
          _fx_free_LN15C_form__cstmt_t(&omp_pragma_0);
       }
-      if (v_1066) {
-         _fx_free_LN15C_form__cstmt_t(&v_1066);
+      if (v_1087) {
+         _fx_free_LN15C_form__cstmt_t(&v_1087);
       }
-      if (v_1065) {
-         _fx_free_N15C_form__cstmt_t(&v_1065);
+      if (v_1086) {
+         _fx_free_N15C_form__cstmt_t(&v_1086);
       }
-      if (v_1064) {
-         _fx_free_LN15C_form__cstmt_t(&v_1064);
+      if (v_1085) {
+         _fx_free_LN15C_form__cstmt_t(&v_1085);
       }
-      if (v_1063) {
-         _fx_free_N15C_form__cstmt_t(&v_1063);
+      if (v_1084) {
+         _fx_free_N15C_form__cstmt_t(&v_1084);
       }
       if (update_exn_parallel_1) {
          _fx_free_N14C_form__cexp_t(&update_exn_parallel_1);
       }
-      if (v_1062) {
-         _fx_free_LN14C_form__cexp_t(&v_1062);
+      if (v_1083) {
+         _fx_free_LN14C_form__cexp_t(&v_1083);
       }
-      _fx_free_Ta2LN15C_form__cstmt_t(&v_1061);
-      if (v_1060) {
-         _fx_free_N15C_form__cstmt_t(&v_1060);
+      _fx_free_Ta2LN15C_form__cstmt_t(&v_1082);
+      if (v_1081) {
+         _fx_free_N15C_form__cstmt_t(&v_1081);
       }
       if (post_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_1);
       }
-      if (v_1059) {
-         _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&v_1059);
+      if (v_1080) {
+         _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&v_1080);
       }
       if (for_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&for_stmt_0);
@@ -32978,13 +33218,13 @@ static int
       if (body_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_0);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1058);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1079);
       if (body_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1057);
-      if (v_1056) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1056);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1078);
+      if (v_1077) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1077);
       }
       if (body_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_1);
@@ -32992,11 +33232,11 @@ static int
       if (body_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_0);
       }
-      if (v_1055) {
-         _fx_free_LN15C_form__cstmt_t(&v_1055);
+      if (v_1076) {
+         _fx_free_LN15C_form__cstmt_t(&v_1076);
       }
-      if (v_1054) {
-         _fx_free_LN15C_form__cstmt_t(&v_1054);
+      if (v_1075) {
+         _fx_free_LN15C_form__cstmt_t(&v_1075);
       }
       if (wbctx_0) {
          _fx_free_rR23C_gen_code__block_ctx_t(&wbctx_0);
@@ -33008,8 +33248,8 @@ static int
       if (idoml_2) {
          _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idoml_2);
       }
-      if (v_1053) {
-         _fx_free_LN14C_form__cexp_t(&v_1053);
+      if (v_1074) {
+         _fx_free_LN14C_form__cexp_t(&v_1074);
       }
       if (post_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&post_ccode_0);
@@ -33020,32 +33260,32 @@ static int
       if (pre_body_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&pre_body_ccode_0);
       }
-      if (ccode_144) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_144);
+      if (ccode_147) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_147);
       }
       if (for_headers_0) {
          _fx_free_LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_t(&for_headers_0);
       }
       _fx_free_T8LT4Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_tLT3R9Ast__id_tN14C_form__cexp_tR16Ast__val_flags_tLN15C_form__cstmt_t(
-         &v_1052);
-      if (v_1051) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1051);
+         &v_1073);
+      if (v_1072) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1072);
       }
-      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1050);
+      _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_1071);
       if (decl_nested_status_3) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_3);
       }
       if (nested_status_3) {
          _fx_free_N14C_form__cexp_t(&nested_status_3);
       }
-      if (ccode_143) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_143);
+      if (ccode_146) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_146);
       }
       if (par_status_3) {
          _fx_free_N14C_form__cexp_t(&par_status_3);
       }
-      if (v_1049) {
-         _fx_free_N14C_form__cexp_t(&v_1049);
+      if (v_1070) {
+         _fx_free_N14C_form__cexp_t(&v_1070);
       }
       if (decl_nested_status_2) {
          _fx_free_LN15C_form__cstmt_t(&decl_nested_status_2);
@@ -33053,104 +33293,104 @@ static int
       if (nested_status_2) {
          _fx_free_N14C_form__cexp_t(&nested_status_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1048);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1047);
-      if (v_1046) {
-         _fx_free_N14C_form__cexp_t(&v_1046);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1069);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1068);
+      if (v_1067) {
+         _fx_free_N14C_form__cexp_t(&v_1067);
       }
-      _fx_free_R16Ast__val_flags_t(&v_1045);
-      if (ccode_142) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_142);
+      _fx_free_R16Ast__val_flags_t(&v_1066);
+      if (ccode_145) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_145);
       }
       if (par_status_2) {
          _fx_free_N14C_form__cexp_t(&par_status_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1044);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1043);
-      if (v_1042) {
-         _fx_free_N14C_form__cexp_t(&v_1042);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1065);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1064);
+      if (v_1063) {
+         _fx_free_N14C_form__cexp_t(&v_1063);
       }
-      _fx_free_R16Ast__val_flags_t(&v_1041);
-      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_1040);
+      _fx_free_R16Ast__val_flags_t(&v_1062);
+      _fx_free_T4N14C_form__cexp_tLN15C_form__cstmt_tN14C_form__cexp_tLN15C_form__cstmt_t(&v_1061);
       if (glob_status_1) {
          _fx_free_N14C_form__cexp_t(&glob_status_1);
       }
-      if (lbl_7) {
-         _fx_free_N14C_form__cexp_t(&lbl_7);
+      if (lbl_9) {
+         _fx_free_N14C_form__cexp_t(&lbl_9);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 28) {
-      _fx_rNt6option1N14C_form__cexp_t v_1096 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1097 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1117 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1118 = {0};
       _fx_N14C_form__cexp_t cc_1 = 0;
       _fx_LN15C_form__cstmt_t cc_code_0 = 0;
-      _fx_T2BLN15C_form__cstmt_t v_1098 = {0};
+      _fx_T2BLN15C_form__cstmt_t v_1119 = {0};
       _fx_LN15C_form__cstmt_t check_code_0 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1099 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1100 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1120 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1121 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_3 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_4 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1101 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1122 = {0};
       _fx_N15C_form__cstmt_t body_stmt_1 = 0;
       _fx_N15C_form__cstmt_t loop_stmt_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1102 = 0;
+      _fx_LN15C_form__cstmt_t v_1123 = 0;
       _fx_T3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t* vcase_28 = &kexp_0->u.KExpWhile;
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_249);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1096), _fx_catch_249);
+            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_253);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1117), _fx_catch_253);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_28->t0, v_1096, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_28->t0, v_1117, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1097, fx_fv), _fx_catch_249);
-      FX_COPY_PTR(v_1097.t0, &cc_1);
-      FX_COPY_PTR(v_1097.t1, &cc_code_0);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1118, fx_fv), _fx_catch_253);
+      FX_COPY_PTR(v_1118.t0, &cc_1);
+      FX_COPY_PTR(v_1118.t1, &cc_code_0);
       if (cc_code_0 == 0) {
          if (FX_REC_VARIANT_TAG(cc_1) == 2) {
-            _fx_N14K_form__klit_t* v_1103 = &cc_1->u.CExpLit.t0;
-            if (v_1103->tag == 7) {
-               if (v_1103->u.KLitBool == true) {
-                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1098); goto _fx_endmatch_42;
+            _fx_N14K_form__klit_t* v_1124 = &cc_1->u.CExpLit.t0;
+            if (v_1124->tag == 7) {
+               if (v_1124->u.KLitBool == true) {
+                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1119); goto _fx_endmatch_42;
                }
             }
          }
       }
       if (cc_code_0 == 0) {
-         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1098); goto _fx_endmatch_42;
+         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1119); goto _fx_endmatch_42;
       }
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1104 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1125 = {0};
       _fx_N14C_form__cexp_t not_cc_0 = 0;
       _fx_N15C_form__cstmt_t break_stmt_1 = 0;
-      _fx_N15C_form__cstmt_t v_1105 = 0;
+      _fx_N15C_form__cstmt_t v_1126 = 0;
       _fx_N15C_form__cstmt_t check_cc_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1106 = 0;
+      _fx_LN15C_form__cstmt_t v_1127 = 0;
       _fx_R10Ast__loc_t cc_loc_0;
-      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_1, &cc_loc_0, 0), _fx_catch_248);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_0, &v_1104);
+      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_1, &cc_loc_0, 0), _fx_catch_252);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_0, &v_1125);
       FX_CALL(
          _fx_M6C_formFM9CExpUnaryN14C_form__cexp_t3N16C_form__cunary_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g23C_gen_code__COpLogicNot, cc_1, &v_1104, &not_cc_0), _fx_catch_248);
+            &_fx_g23C_gen_code__COpLogicNot, cc_1, &v_1125, &not_cc_0), _fx_catch_252);
       FX_CALL(
          _fx_M10C_gen_codeFM15make_break_stmtN15C_form__cstmt_t2R10Ast__loc_trLrRM11block_ctx_t(&cc_loc_0, block_stack_ref_0,
-            &break_stmt_1, 0), _fx_catch_248);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_0, &v_1105), _fx_catch_248);
+            &break_stmt_1, 0), _fx_catch_252);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_0, &v_1126), _fx_catch_252);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            not_cc_0, break_stmt_1, v_1105, &cc_loc_0, &check_cc_0, 0), _fx_catch_248);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_0, cc_code_0, true, &v_1106), _fx_catch_248);
-      _fx_make_T2BLN15C_form__cstmt_t(true, v_1106, &v_1098);
+            not_cc_0, break_stmt_1, v_1126, &cc_loc_0, &check_cc_0, 0), _fx_catch_252);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_0, cc_code_0, true, &v_1127), _fx_catch_252);
+      _fx_make_T2BLN15C_form__cstmt_t(true, v_1127, &v_1119);
 
-   _fx_catch_248: ;
-      if (v_1106) {
-         _fx_free_LN15C_form__cstmt_t(&v_1106);
+   _fx_catch_252: ;
+      if (v_1127) {
+         _fx_free_LN15C_form__cstmt_t(&v_1127);
       }
       if (check_cc_0) {
          _fx_free_N15C_form__cstmt_t(&check_cc_0);
       }
-      if (v_1105) {
-         _fx_free_N15C_form__cstmt_t(&v_1105);
+      if (v_1126) {
+         _fx_free_N15C_form__cstmt_t(&v_1126);
       }
       if (break_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&break_stmt_1);
@@ -33158,43 +33398,43 @@ static int
       if (not_cc_0) {
          _fx_free_N14C_form__cexp_t(&not_cc_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1104);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1125);
 
    _fx_endmatch_42: ;
-      FX_CHECK_EXN(_fx_catch_249);
-      bool is_for_loop_0 = v_1098.t0;
-      FX_COPY_PTR(v_1098.t1, &check_code_0);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1099), _fx_catch_249);
+      FX_CHECK_EXN(_fx_catch_253);
+      bool is_for_loop_0 = v_1119.t0;
+      FX_COPY_PTR(v_1119.t1, &check_code_0);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1120), _fx_catch_253);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_28->t1, v_1099, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_28->t1, v_1120, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1100, fx_fv), _fx_catch_249);
-      FX_COPY_PTR(v_1100.t1, &body_ccode_3);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1121, fx_fv), _fx_catch_253);
+      FX_COPY_PTR(v_1121.t1, &body_ccode_3);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(body_ccode_3, check_code_0,
-            &body_ccode_4, 0), _fx_catch_249);
+            &body_ccode_4, 0), _fx_catch_253);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_4, true, &kloc_0, block_stack_ref_0, &v_1101, 0), _fx_catch_249);
-      FX_COPY_PTR(v_1101.t1, &body_stmt_1);
+            body_ccode_4, true, &kloc_0, block_stack_ref_0, &v_1122, 0), _fx_catch_253);
+      FX_COPY_PTR(v_1122.t1, &body_stmt_1);
       if (is_for_loop_0) {
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
                &_fx_g18C_gen_code__None1_, 0, &_fx_g18C_gen_code__None2_, 0, body_stmt_1, &kloc_0, &loop_stmt_0),
-            _fx_catch_249);
+            _fx_catch_253);
       }
       else {
          FX_CALL(
             _fx_M6C_formFM10CStmtWhileN15C_form__cstmt_t3N14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(cc_1, body_stmt_1,
-               &kloc_0, &loop_stmt_0), _fx_catch_249);
+               &kloc_0, &loop_stmt_0), _fx_catch_253);
       }
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_0, ccode_0, true, &v_1102), _fx_catch_249);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1102, &v_1);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_0, ccode_0, true, &v_1123), _fx_catch_253);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1123, &v_1);
 
-   _fx_catch_249: ;
-      if (v_1102) {
-         _fx_free_LN15C_form__cstmt_t(&v_1102);
+   _fx_catch_253: ;
+      if (v_1123) {
+         _fx_free_LN15C_form__cstmt_t(&v_1123);
       }
       if (loop_stmt_0) {
          _fx_free_N15C_form__cstmt_t(&loop_stmt_0);
@@ -33202,111 +33442,111 @@ static int
       if (body_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_1);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1101);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1122);
       if (body_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_4);
       }
       if (body_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1100);
-      if (v_1099) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1099);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1121);
+      if (v_1120) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1120);
       }
       if (check_code_0) {
          _fx_free_LN15C_form__cstmt_t(&check_code_0);
       }
-      _fx_free_T2BLN15C_form__cstmt_t(&v_1098);
+      _fx_free_T2BLN15C_form__cstmt_t(&v_1119);
       if (cc_code_0) {
          _fx_free_LN15C_form__cstmt_t(&cc_code_0);
       }
       if (cc_1) {
          _fx_free_N14C_form__cexp_t(&cc_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1097);
-      if (v_1096) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1096);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1118);
+      if (v_1117) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1117);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 29) {
-      _fx_rNt6option1N14C_form__cexp_t v_1107 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1108 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1128 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1129 = {0};
       _fx_LN15C_form__cstmt_t body_ccode_5 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1109 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1110 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1130 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1131 = {0};
       _fx_N14C_form__cexp_t cc_2 = 0;
       _fx_LN15C_form__cstmt_t cc_code_1 = 0;
-      _fx_T2BLN15C_form__cstmt_t v_1111 = {0};
+      _fx_T2BLN15C_form__cstmt_t v_1132 = {0};
       _fx_LN15C_form__cstmt_t check_code_1 = 0;
       _fx_LN15C_form__cstmt_t body_ccode_6 = 0;
-      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1112 = {0};
+      _fx_T2R9Ast__id_tN15C_form__cstmt_t v_1133 = {0};
       _fx_N15C_form__cstmt_t body_stmt_2 = 0;
       _fx_N15C_form__cstmt_t loop_stmt_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1113 = 0;
+      _fx_LN15C_form__cstmt_t v_1134 = 0;
       _fx_T3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t* vcase_29 = &kexp_0->u.KExpDoWhile;
       FX_CALL(
          _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(
-            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_251);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1107), _fx_catch_251);
+            &_fx_g26C_gen_code__BlockKind_Loop, &kloc_0, block_stack_ref_0, km_idx_0, 0), _fx_catch_255);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1128), _fx_catch_255);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_29->t0, v_1107, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_29->t0, v_1128, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1108, fx_fv), _fx_catch_251);
-      FX_COPY_PTR(v_1108.t1, &body_ccode_5);
-      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1109), _fx_catch_251);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1129, fx_fv), _fx_catch_255);
+      FX_COPY_PTR(v_1129.t1, &body_ccode_5);
+      FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1130), _fx_catch_255);
       FX_CALL(
          _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-            vcase_29->t1, v_1109, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+            vcase_29->t1, v_1130, 0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
             fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1110, fx_fv), _fx_catch_251);
-      FX_COPY_PTR(v_1110.t0, &cc_2);
-      FX_COPY_PTR(v_1110.t1, &cc_code_1);
+            return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1131, fx_fv), _fx_catch_255);
+      FX_COPY_PTR(v_1131.t0, &cc_2);
+      FX_COPY_PTR(v_1131.t1, &cc_code_1);
       if (cc_code_1 == 0) {
          if (FX_REC_VARIANT_TAG(cc_2) == 2) {
-            _fx_N14K_form__klit_t* v_1114 = &cc_2->u.CExpLit.t0;
-            if (v_1114->tag == 7) {
-               if (v_1114->u.KLitBool == true) {
-                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1111); goto _fx_endmatch_43;
+            _fx_N14K_form__klit_t* v_1135 = &cc_2->u.CExpLit.t0;
+            if (v_1135->tag == 7) {
+               if (v_1135->u.KLitBool == true) {
+                  _fx_make_T2BLN15C_form__cstmt_t(true, 0, &v_1132); goto _fx_endmatch_43;
                }
             }
          }
       }
       if (cc_code_1 == 0) {
-         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1111); goto _fx_endmatch_43;
+         _fx_make_T2BLN15C_form__cstmt_t(false, 0, &v_1132); goto _fx_endmatch_43;
       }
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1115 = {0};
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1136 = {0};
       _fx_N14C_form__cexp_t not_cc_1 = 0;
       _fx_N15C_form__cstmt_t break_stmt_2 = 0;
-      _fx_N15C_form__cstmt_t v_1116 = 0;
+      _fx_N15C_form__cstmt_t v_1137 = 0;
       _fx_N15C_form__cstmt_t check_cc_1 = 0;
-      _fx_LN15C_form__cstmt_t v_1117 = 0;
+      _fx_LN15C_form__cstmt_t v_1138 = 0;
       _fx_R10Ast__loc_t cc_loc_1;
-      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_2, &cc_loc_1, 0), _fx_catch_250);
-      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_1, &v_1115);
+      FX_CALL(_fx_M6C_formFM12get_cexp_locR10Ast__loc_t1N14C_form__cexp_t(cc_2, &cc_loc_1, 0), _fx_catch_254);
+      _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(_fx_g20C_gen_code__CTypBool, &cc_loc_1, &v_1136);
       FX_CALL(
          _fx_M6C_formFM9CExpUnaryN14C_form__cexp_t3N16C_form__cunary_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(
-            &_fx_g23C_gen_code__COpLogicNot, cc_2, &v_1115, &not_cc_1), _fx_catch_250);
+            &_fx_g23C_gen_code__COpLogicNot, cc_2, &v_1136, &not_cc_1), _fx_catch_254);
       FX_CALL(
          _fx_M10C_gen_codeFM15make_break_stmtN15C_form__cstmt_t2R10Ast__loc_trLrRM11block_ctx_t(&cc_loc_1, block_stack_ref_0,
-            &break_stmt_2, 0), _fx_catch_250);
-      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_1, &v_1116), _fx_catch_250);
+            &break_stmt_2, 0), _fx_catch_254);
+      FX_CALL(_fx_M6C_formFM8CStmtNopN15C_form__cstmt_t1R10Ast__loc_t(&cc_loc_1, &v_1137), _fx_catch_254);
       FX_CALL(
          _fx_M10C_gen_codeFM7make_ifN15C_form__cstmt_t4N14C_form__cexp_tN15C_form__cstmt_tN15C_form__cstmt_tR10Ast__loc_t(
-            not_cc_1, break_stmt_2, v_1116, &cc_loc_1, &check_cc_1, 0), _fx_catch_250);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_1, cc_code_1, true, &v_1117), _fx_catch_250);
-      _fx_make_T2BLN15C_form__cstmt_t(true, v_1117, &v_1111);
+            not_cc_1, break_stmt_2, v_1137, &cc_loc_1, &check_cc_1, 0), _fx_catch_254);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(check_cc_1, cc_code_1, true, &v_1138), _fx_catch_254);
+      _fx_make_T2BLN15C_form__cstmt_t(true, v_1138, &v_1132);
 
-   _fx_catch_250: ;
-      if (v_1117) {
-         _fx_free_LN15C_form__cstmt_t(&v_1117);
+   _fx_catch_254: ;
+      if (v_1138) {
+         _fx_free_LN15C_form__cstmt_t(&v_1138);
       }
       if (check_cc_1) {
          _fx_free_N15C_form__cstmt_t(&check_cc_1);
       }
-      if (v_1116) {
-         _fx_free_N15C_form__cstmt_t(&v_1116);
+      if (v_1137) {
+         _fx_free_N15C_form__cstmt_t(&v_1137);
       }
       if (break_stmt_2) {
          _fx_free_N15C_form__cstmt_t(&break_stmt_2);
@@ -33314,36 +33554,36 @@ static int
       if (not_cc_1) {
          _fx_free_N14C_form__cexp_t(&not_cc_1);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1115);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1136);
 
    _fx_endmatch_43: ;
-      FX_CHECK_EXN(_fx_catch_251);
-      bool is_for_loop_1 = v_1111.t0;
-      FX_COPY_PTR(v_1111.t1, &check_code_1);
+      FX_CHECK_EXN(_fx_catch_255);
+      bool is_for_loop_1 = v_1132.t0;
+      FX_COPY_PTR(v_1132.t1, &check_code_1);
       FX_CALL(
          _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(check_code_1, body_ccode_5,
-            &body_ccode_6, 0), _fx_catch_251);
+            &body_ccode_6, 0), _fx_catch_255);
       FX_CALL(
          _fx_M10C_gen_codeFM18finalize_loop_bodyT2R9Ast__id_tN15C_form__cstmt_t4LN15C_form__cstmt_tBR10Ast__loc_trLrRM11block_ctx_t(
-            body_ccode_6, true, &kloc_0, block_stack_ref_0, &v_1112, 0), _fx_catch_251);
-      FX_COPY_PTR(v_1112.t1, &body_stmt_2);
+            body_ccode_6, true, &kloc_0, block_stack_ref_0, &v_1133, 0), _fx_catch_255);
+      FX_COPY_PTR(v_1133.t1, &body_stmt_2);
       if (is_for_loop_1) {
          FX_CALL(
             _fx_M6C_formFM8CStmtForN15C_form__cstmt_t6Nt6option1N14C_form__ctyp_tLN14C_form__cexp_tNt6option1N14C_form__cexp_tLN14C_form__cexp_tN15C_form__cstmt_tR10Ast__loc_t(
                &_fx_g18C_gen_code__None1_, 0, &_fx_g18C_gen_code__None2_, 0, body_stmt_2, &kloc_0, &loop_stmt_1),
-            _fx_catch_251);
+            _fx_catch_255);
       }
       else {
          FX_CALL(
             _fx_M6C_formFM12CStmtDoWhileN15C_form__cstmt_t3N15C_form__cstmt_tN14C_form__cexp_tR10Ast__loc_t(body_stmt_2, cc_2,
-               &kloc_0, &loop_stmt_1), _fx_catch_251);
+               &kloc_0, &loop_stmt_1), _fx_catch_255);
       }
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_1, ccode_0, true, &v_1113), _fx_catch_251);
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1113, &v_1);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(loop_stmt_1, ccode_0, true, &v_1134), _fx_catch_255);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, v_1134, &v_1);
 
-   _fx_catch_251: ;
-      if (v_1113) {
-         _fx_free_LN15C_form__cstmt_t(&v_1113);
+   _fx_catch_255: ;
+      if (v_1134) {
+         _fx_free_LN15C_form__cstmt_t(&v_1134);
       }
       if (loop_stmt_1) {
          _fx_free_N15C_form__cstmt_t(&loop_stmt_1);
@@ -33351,167 +33591,167 @@ static int
       if (body_stmt_2) {
          _fx_free_N15C_form__cstmt_t(&body_stmt_2);
       }
-      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1112);
+      _fx_free_T2R9Ast__id_tN15C_form__cstmt_t(&v_1133);
       if (body_ccode_6) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_6);
       }
       if (check_code_1) {
          _fx_free_LN15C_form__cstmt_t(&check_code_1);
       }
-      _fx_free_T2BLN15C_form__cstmt_t(&v_1111);
+      _fx_free_T2BLN15C_form__cstmt_t(&v_1132);
       if (cc_code_1) {
          _fx_free_LN15C_form__cstmt_t(&cc_code_1);
       }
       if (cc_2) {
          _fx_free_N14C_form__cexp_t(&cc_2);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1110);
-      if (v_1109) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1109);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1131);
+      if (v_1130) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1130);
       }
       if (body_ccode_5) {
          _fx_free_LN15C_form__cstmt_t(&body_ccode_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1108);
-      if (v_1107) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1107);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1129);
+      if (v_1128) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1128);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 30) {
-      _fx_rR23C_gen_code__block_ctx_t v_1118 = 0;
-      fx_exn_t v_1119 = {0};
-      _fx_N14C_form__cexp_t v_1120 = 0;
-      _fx_N15C_form__cstmt_t v_1121 = 0;
-      _fx_LN15C_form__cstmt_t v_1122 = 0;
+      _fx_rR23C_gen_code__block_ctx_t v_1139 = 0;
+      fx_exn_t v_1140 = {0};
+      _fx_N14C_form__cexp_t v_1141 = 0;
+      _fx_N15C_form__cstmt_t v_1142 = 0;
+      _fx_LN15C_form__cstmt_t v_1143 = 0;
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &v_1118, 0), _fx_catch_252);
-      _fx_R23C_gen_code__block_ctx_t* v_1123 = &v_1118->data;
-      _fx_N24C_gen_code__block_kind_t v_1124 = v_1123->bctx_kind;
-      if (v_1124.tag != 1) {
-         fx_str_t slit_250 = FX_MAKE_STR("cgen: unexpected ccode expression");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_250, &v_1119, 0), _fx_catch_252);
-         FX_THROW(&v_1119, false, _fx_catch_252);
+            &v_1139, 0), _fx_catch_256);
+      _fx_R23C_gen_code__block_ctx_t* v_1144 = &v_1139->data;
+      _fx_N24C_gen_code__block_kind_t v_1145 = v_1144->bctx_kind;
+      if (v_1145.tag != 1) {
+         fx_str_t slit_256 = FX_MAKE_STR("cgen: unexpected ccode expression");
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_256, &v_1140, 0), _fx_catch_256);
+         FX_THROW(&v_1140, false, _fx_catch_256);
       }
-      FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&kexp_0->u.KExpCCode.t0, &kloc_0, &v_1120),
-         _fx_catch_252);
-      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1120, &v_1121), _fx_catch_252);
-      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1121, *top_inline_ccode_0, true, &v_1122), _fx_catch_252);
+      FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&kexp_0->u.KExpCCode.t0, &kloc_0, &v_1141),
+         _fx_catch_256);
+      FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1141, &v_1142), _fx_catch_256);
+      FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1142, *top_inline_ccode_0, true, &v_1143), _fx_catch_256);
       _fx_free_LN15C_form__cstmt_t(top_inline_ccode_0);
-      FX_COPY_PTR(v_1122, top_inline_ccode_0);
+      FX_COPY_PTR(v_1143, top_inline_ccode_0);
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1);
 
-   _fx_catch_252: ;
-      if (v_1122) {
-         _fx_free_LN15C_form__cstmt_t(&v_1122);
+   _fx_catch_256: ;
+      if (v_1143) {
+         _fx_free_LN15C_form__cstmt_t(&v_1143);
       }
-      if (v_1121) {
-         _fx_free_N15C_form__cstmt_t(&v_1121);
+      if (v_1142) {
+         _fx_free_N15C_form__cstmt_t(&v_1142);
       }
-      if (v_1120) {
-         _fx_free_N14C_form__cexp_t(&v_1120);
+      if (v_1141) {
+         _fx_free_N14C_form__cexp_t(&v_1141);
       }
-      fx_free_exn(&v_1119);
-      if (v_1118) {
-         _fx_free_rR23C_gen_code__block_ctx_t(&v_1118);
+      fx_free_exn(&v_1140);
+      if (v_1139) {
+         _fx_free_rR23C_gen_code__block_ctx_t(&v_1139);
       }
       goto _fx_endmatch_55;
    }
    if (tag_0 == 31) {
-      _fx_R17K_form__kdefval_t v_1125 = {0};
+      _fx_R17K_form__kdefval_t v_1146 = {0};
       _fx_R16Ast__val_flags_t kv_flags_1 = {0};
       fx_str_t kv_cname_0 = {0};
       _fx_N14K_form__ktyp_t kv_typ_1 = 0;
       _fx_N14C_form__ctyp_t ctyp_4 = 0;
       _fx_rR23C_gen_code__block_ctx_t bctx_1 = 0;
-      _fx_T3SSR10Ast__loc_t v_1126 = {0};
+      _fx_T3SSR10Ast__loc_t v_1147 = {0};
       fx_str_t ccode_data_kind_0 = {0};
       fx_str_t ccode_data_lit_0 = {0};
-      _fx_LN15C_form__cstmt_t ccode_145 = 0;
-      _fx_N14C_form__cexp_t v_1127 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1128 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1129 = {0};
+      _fx_LN15C_form__cstmt_t ccode_148 = 0;
+      _fx_N14C_form__cexp_t v_1148 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1149 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1150 = {0};
       _fx_LN15C_form__cstmt_t delta_ccode_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1130 = 0;
-      _fx_LN15C_form__cstmt_t v_1131 = 0;
+      _fx_LN15C_form__cstmt_t v_1151 = 0;
+      _fx_LN15C_form__cstmt_t v_1152 = 0;
       _fx_N14C_form__cexp_t tag_exp_0 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1132 = {0};
-      _fx_LN14C_form__cexp_t v_1133 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1134 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1153 = {0};
+      _fx_LN14C_form__cexp_t v_1154 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1155 = {0};
       _fx_N14C_form__cexp_t init_exp_0 = 0;
-      _fx_N14C_form__cexp_t v_1135 = 0;
-      _fx_R16Ast__val_flags_t v_1136 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1137 = {0};
+      _fx_N14C_form__cexp_t v_1156 = 0;
+      _fx_R16Ast__val_flags_t v_1157 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1158 = {0};
       _fx_N14C_form__cexp_t i_exp_17 = 0;
-      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_1138 = {0};
+      _fx_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti v_1159 = {0};
       _fx_N14C_form__ctyp_t struct_ctyp_0 = 0;
-      fx_str_t v_1139 = {0};
-      fx_str_t v_1140 = {0};
+      fx_str_t v_1160 = {0};
+      fx_str_t v_1161 = {0};
       _fx_N14C_form__cexp_t rc_exp_0 = 0;
-      _fx_LN14C_form__cexp_t v_1141 = 0;
-      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1142 = {0};
+      _fx_LN14C_form__cexp_t v_1162 = 0;
+      _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1163 = {0};
       _fx_N14C_form__cexp_t data_init_0 = 0;
-      _fx_R16Ast__val_flags_t v_1143 = {0};
-      _fx_R16Ast__val_flags_t v_1144 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_1145 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1146 = {0};
+      _fx_R16Ast__val_flags_t v_1164 = {0};
+      _fx_R16Ast__val_flags_t v_1165 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_1166 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1167 = {0};
       _fx_N14C_form__cexp_t data_exp_1 = 0;
       _fx_LN15C_form__cstmt_t delta_ccode_1 = 0;
-      _fx_N14C_form__cexp_t v_1147 = 0;
+      _fx_N14C_form__cexp_t v_1168 = 0;
       _fx_N14C_form__cexp_t init_exp_1 = 0;
       _fx_LN15C_form__cstmt_t delta_ccode_2 = 0;
-      _fx_R16Ast__val_flags_t v_1148 = {0};
-      _fx_R16Ast__val_flags_t v_1149 = {0};
-      _fx_Nt6option1N14C_form__cexp_t v_1150 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1151 = {0};
+      _fx_R16Ast__val_flags_t v_1169 = {0};
+      _fx_R16Ast__val_flags_t v_1170 = {0};
+      _fx_Nt6option1N14C_form__cexp_t v_1171 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1172 = {0};
       _fx_LN15C_form__cstmt_t delta_ccode_3 = 0;
-      _fx_LN15C_form__cstmt_t v_1152 = 0;
-      _fx_LN15C_form__cstmt_t v_1153 = 0;
-      _fx_rNt6option1N14C_form__cexp_t v_1154 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1155 = {0};
+      _fx_LN15C_form__cstmt_t v_1173 = 0;
+      _fx_LN15C_form__cstmt_t v_1174 = 0;
+      _fx_rNt6option1N14C_form__cexp_t v_1175 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1176 = {0};
       _fx_N14C_form__cexp_t ce2_5 = 0;
-      _fx_LN15C_form__cstmt_t ccode_146 = 0;
+      _fx_LN15C_form__cstmt_t ccode_149 = 0;
       _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t res_30 = {0};
-      _fx_rNt6option1N14C_form__cexp_t v_1156 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1157 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1177 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1178 = {0};
       _fx_N14C_form__cexp_t ce2_6 = 0;
-      _fx_LN15C_form__cstmt_t ccode_147 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1158 = {0};
+      _fx_LN15C_form__cstmt_t ccode_150 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1179 = {0};
       _fx_LN15C_form__cstmt_t saved_cleanup_0 = 0;
-      _fx_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB v_1159 = {0};
-      _fx_T2Nt6option1N14C_form__cexp_tB v_1160 = {0};
+      _fx_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB v_1180 = {0};
+      _fx_T2Nt6option1N14C_form__cexp_tB v_1181 = {0};
       _fx_Nt6option1N14C_form__cexp_t e0_opt_0 = {0};
       _fx_R16Ast__val_flags_t flags_2 = {0};
       _fx_Nt6option1N14C_form__cexp_t e0_opt_1 = {0};
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1161 = {0};
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1182 = {0};
       _fx_N14C_form__cexp_t i_exp_18 = 0;
       _fx_LN15C_form__cstmt_t delta_ccode_4 = 0;
-      _fx_LN15C_form__cstmt_t ccode_148 = 0;
-      _fx_LN15C_form__cstmt_t v_1162 = 0;
-      _fx_LN15C_form__cstmt_t v_1163 = 0;
-      _fx_LN15C_form__cstmt_t v_1164 = 0;
-      _fx_LN15C_form__cstmt_t v_1165 = 0;
-      _fx_LN15C_form__cstmt_t v_1166 = 0;
-      _fx_LN15C_form__cstmt_t v_1167 = 0;
-      _fx_Nt6option1N14C_form__cexp_t v_1168 = {0};
-      _fx_rNt6option1N14C_form__cexp_t v_1169 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1170 = {0};
-      _fx_LN15C_form__cstmt_t ccode_149 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1171 = {0};
+      _fx_LN15C_form__cstmt_t ccode_151 = 0;
+      _fx_LN15C_form__cstmt_t v_1183 = 0;
+      _fx_LN15C_form__cstmt_t v_1184 = 0;
+      _fx_LN15C_form__cstmt_t v_1185 = 0;
+      _fx_LN15C_form__cstmt_t v_1186 = 0;
+      _fx_LN15C_form__cstmt_t v_1187 = 0;
+      _fx_LN15C_form__cstmt_t v_1188 = 0;
+      _fx_Nt6option1N14C_form__cexp_t v_1189 = {0};
+      _fx_rNt6option1N14C_form__cexp_t v_1190 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1191 = {0};
+      _fx_LN15C_form__cstmt_t ccode_152 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1192 = {0};
       _fx_N14C_form__cexp_t ce2_7 = 0;
-      _fx_LN15C_form__cstmt_t ccode_150 = 0;
-      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1172 = {0};
-      _fx_N15C_form__cinfo_t v_1173 = {0};
+      _fx_LN15C_form__cstmt_t ccode_153 = 0;
+      _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1193 = {0};
+      _fx_N15C_form__cinfo_t v_1194 = {0};
       _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_30 = &kexp_0->u.KDefVal;
       _fx_N14K_form__kexp_t e2_1 = vcase_30->t1;
       _fx_R9Ast__id_t* i_11 = &vcase_30->t0;
-      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1125, 0), _fx_catch_264);
-      _fx_copy_R16Ast__val_flags_t(&v_1125.kv_flags, &kv_flags_1);
-      fx_copy_str(&v_1125.kv_cname, &kv_cname_0);
-      FX_COPY_PTR(v_1125.kv_typ, &kv_typ_1);
+      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1146, 0), _fx_catch_268);
+      _fx_copy_R16Ast__val_flags_t(&v_1146.kv_flags, &kv_flags_1);
+      fx_copy_str(&v_1146.kv_cname, &kv_cname_0);
+      FX_COPY_PTR(v_1146.kv_typ, &kv_typ_1);
       bool res_31;
-      FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(&kv_flags_1, &res_31, 0), _fx_catch_264);
+      FX_CALL(_fx_M6K_formFM13is_val_globalB1R16Ast__val_flags_t(&kv_flags_1, &res_31, 0), _fx_catch_268);
       bool t_16;
       if (res_31) {
          t_16 = true;
@@ -33520,42 +33760,42 @@ static int
          t_16 = kv_flags_1.val_flag_ctor > 0;
       }
       if (t_16) {
-         FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, i_11, 0), _fx_catch_264);
+         FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, i_11, 0), _fx_catch_268);
       }
-      _fx_R17K_form__ktprops_t v_1174;
+      _fx_R17K_form__ktprops_t v_1195;
       FX_CALL(
-         _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &v_1174, 0),
-         _fx_catch_264);
-      bool ktp_scalar_0 = v_1174.ktp_scalar;
-      bool ktp_complex_1 = v_1174.ktp_complex;
-      bool ktp_ptr_2 = v_1174.ktp_ptr;
+         _fx_M10K_annotateFM11get_ktpropsR17K_form__ktprops_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &v_1195, 0),
+         _fx_catch_268);
+      bool ktp_scalar_0 = v_1195.ktp_scalar;
+      bool ktp_complex_3 = v_1195.ktp_complex;
+      bool ktp_ptr_2 = v_1195.ktp_ptr;
       FX_CALL(_fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(kv_typ_1, &kloc_0, &ctyp_4, 0),
-         _fx_catch_264);
+         _fx_catch_268);
       FX_CALL(
          _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0,
-            &bctx_1, 0), _fx_catch_264);
+            &bctx_1, 0), _fx_catch_268);
       if (FX_REC_VARIANT_TAG(e2_1) == 30) {
          _fx_T2ST2N14K_form__ktyp_tR10Ast__loc_t* vcase_31 = &e2_1->u.KExpCCode;
-         fx_str_t slit_251 = FX_MAKE_STR("ccode");
-         _fx_make_T3SSR10Ast__loc_t(&slit_251, &vcase_31->t0, &vcase_31->t1.t1, &v_1126);
+         fx_str_t slit_257 = FX_MAKE_STR("ccode");
+         _fx_make_T3SSR10Ast__loc_t(&slit_257, &vcase_31->t0, &vcase_31->t1.t1, &v_1147);
       }
       else {
-         fx_str_t slit_252 = FX_MAKE_STR("");
-         fx_str_t slit_253 = FX_MAKE_STR("");
-         _fx_make_T3SSR10Ast__loc_t(&slit_252, &slit_253, &kloc_0, &v_1126);
+         fx_str_t slit_258 = FX_MAKE_STR("");
+         fx_str_t slit_259 = FX_MAKE_STR("");
+         _fx_make_T3SSR10Ast__loc_t(&slit_258, &slit_259, &kloc_0, &v_1147);
       }
-      FX_CHECK_EXN(_fx_catch_264);
-      fx_copy_str(&v_1126.t0, &ccode_data_kind_0);
-      fx_copy_str(&v_1126.t1, &ccode_data_lit_0);
-      _fx_R10Ast__loc_t ccode_loc_0 = v_1126.t2;
+      FX_CHECK_EXN(_fx_catch_268);
+      fx_copy_str(&v_1147.t0, &ccode_data_kind_0);
+      fx_copy_str(&v_1147.t1, &ccode_data_lit_0);
+      _fx_R10Ast__loc_t ccode_loc_0 = v_1147.t2;
       int_ ctor_id_0 = kv_flags_1.val_flag_ctor;
       bool is_temp_0 = kv_flags_1.val_flag_temp;
       bool is_temp_ref_0 = kv_flags_1.val_flag_tempref;
-      _fx_R23C_gen_code__block_ctx_t* v_1175 = &bctx_1->data;
-      _fx_N24C_gen_code__block_kind_t v_1176 = v_1175->bctx_kind;
+      _fx_R23C_gen_code__block_ctx_t* v_1196 = &bctx_1->data;
+      _fx_N24C_gen_code__block_kind_t v_1197 = v_1196->bctx_kind;
       bool is_global_0;
       bool t_17;
-      if (v_1176.tag == 1) {
+      if (v_1197.tag == 1) {
          t_17 = !is_temp_0;
       }
       else {
@@ -33573,26 +33813,26 @@ static int
             _fx_T4N13Ast__binary_tN14K_form__atom_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_32 =
                &e2_1->u.KExpBinary;
             if (FX_REC_VARIANT_TAG(vcase_32->t0) == 26) {
-               _fx_N14K_form__atom_t* v_1177 = &vcase_32->t2;
-               if (v_1177->tag == 1) {
-                  _fx_R9Ast__id_t* l_0 = &v_1177->u.AtomId;
+               _fx_N14K_form__atom_t* v_1198 = &vcase_32->t2;
+               if (v_1198->tag == 1) {
+                  _fx_R9Ast__id_t* l_0 = &v_1198->u.AtomId;
                   bool res_32;
                   FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, l_0, &res_32, 0),
-                     _fx_catch_264);
+                     _fx_catch_268);
                   if (res_32) {
-                     _fx_N15K_form__kinfo_t v_1178 = {0};
-                     FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(l_0, &kloc_0, &v_1178, 0),
-                        _fx_catch_253);
-                     if (v_1178.tag == 2) {
-                        is_fast_cons_0 = v_1178.u.KVal.kv_flags.val_flag_temp;
+                     _fx_N15K_form__kinfo_t v_1199 = {0};
+                     FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(l_0, &kloc_0, &v_1199, 0),
+                        _fx_catch_257);
+                     if (v_1199.tag == 2) {
+                        is_fast_cons_0 = v_1199.u.KVal.kv_flags.val_flag_temp;
                      }
                      else {
                         is_fast_cons_0 = false;
                      }
-                     FX_CHECK_EXN(_fx_catch_253);
+                     FX_CHECK_EXN(_fx_catch_257);
 
-                  _fx_catch_253: ;
-                     _fx_free_N15K_form__kinfo_t(&v_1178);
+                  _fx_catch_257: ;
+                     _fx_free_N15K_form__kinfo_t(&v_1199);
                      goto _fx_endmatch_44;
                   }
                }
@@ -33601,147 +33841,147 @@ static int
          is_fast_cons_0 = false;
 
       _fx_endmatch_44: ;
-         FX_CHECK_EXN(_fx_catch_264);
+         FX_CHECK_EXN(_fx_catch_268);
       }
       else {
          is_fast_cons_0 = false;
       }
-      bool v_1179;
-      fx_str_t slit_254 = FX_MAKE_STR("ccode");
-      v_1179 = _fx_F6__eq__B2SS(&ccode_data_kind_0, &slit_254, 0);
-      if (v_1179) {
-         FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&ccode_data_lit_0, &ccode_loc_0, &v_1127),
-            _fx_catch_264);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1127, &v_1128);
-         fx_str_t slit_255 = FX_MAKE_STR("");
+      bool v_1200;
+      fx_str_t slit_260 = FX_MAKE_STR("ccode");
+      v_1200 = _fx_F6__eq__B2SS(&ccode_data_kind_0, &slit_260, 0);
+      if (v_1200) {
+         FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&ccode_data_lit_0, &ccode_loc_0, &v_1148),
+            _fx_catch_268);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1148, &v_1149);
+         fx_str_t slit_261 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               i_11, ctyp_4, &kv_flags_1, &slit_255, &v_1128, 0, &kloc_0, &v_1129, 0), _fx_catch_264);
-         FX_COPY_PTR(v_1129.t1, &delta_ccode_0);
-         _fx_R23C_gen_code__block_ctx_t* v_1180 = &bctx_1->data;
-         FX_COPY_PTR(v_1180->bctx_prologue, &v_1130);
+               i_11, ctyp_4, &kv_flags_1, &slit_261, &v_1149, 0, &kloc_0, &v_1150, 0), _fx_catch_268);
+         FX_COPY_PTR(v_1150.t1, &delta_ccode_0);
+         _fx_R23C_gen_code__block_ctx_t* v_1201 = &bctx_1->data;
+         FX_COPY_PTR(v_1201->bctx_prologue, &v_1151);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_0, v_1130,
-               &v_1131, 0), _fx_catch_264);
-         _fx_R23C_gen_code__block_ctx_t* v_1181 = &bctx_1->data;
-         _fx_LN15C_form__cstmt_t* v_1182 = &v_1181->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1182);
-         FX_COPY_PTR(v_1131, v_1182);
-         FX_COPY_PTR(ccode_0, &ccode_145);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_0, v_1151,
+               &v_1152, 0), _fx_catch_268);
+         _fx_R23C_gen_code__block_ctx_t* v_1202 = &bctx_1->data;
+         _fx_LN15C_form__cstmt_t* v_1203 = &v_1202->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1203);
+         FX_COPY_PTR(v_1152, v_1203);
+         FX_COPY_PTR(ccode_0, &ccode_148);
       }
       else if (ctor_id_0 > 0) {
          FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_id_0, &kloc_0, &tag_exp_0, 0),
-            _fx_catch_264);
+            _fx_catch_268);
          bool is_null_0;
          if (FX_REC_VARIANT_TAG(kv_typ_1) == 16) {
-            _fx_N15K_form__kinfo_t v_1183 = {0};
+            _fx_N15K_form__kinfo_t v_1204 = {0};
             FX_CALL(
-               _fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&kv_typ_1->u.KTypName, &kloc_0, &v_1183, 0),
-               _fx_catch_254);
-            if (v_1183.tag == 5) {
-               _fx_R21K_form__kdefvariant_t v_1184 = {0};
-               _fx_copy_R21K_form__kdefvariant_t(&v_1183.u.KVariant->data, &v_1184);
-               _fx_R16Ast__var_flags_t* kvar_flags_1 = &v_1184.kvar_flags;
+               _fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&kv_typ_1->u.KTypName, &kloc_0, &v_1204, 0),
+               _fx_catch_258);
+            if (v_1204.tag == 5) {
+               _fx_R21K_form__kdefvariant_t v_1205 = {0};
+               _fx_copy_R21K_form__kdefvariant_t(&v_1204.u.KVariant->data, &v_1205);
+               _fx_R16Ast__var_flags_t* kvar_flags_1 = &v_1205.kvar_flags;
                if (kvar_flags_1->var_flag_recursive) {
                   is_null_0 = kvar_flags_1->var_flag_opt;
                }
                else {
                   is_null_0 = false;
                }
-               _fx_free_R21K_form__kdefvariant_t(&v_1184);
+               _fx_free_R21K_form__kdefvariant_t(&v_1205);
             }
             else {
                is_null_0 = false;
             }
-            FX_CHECK_EXN(_fx_catch_254);
+            FX_CHECK_EXN(_fx_catch_258);
 
-         _fx_catch_254: ;
-            _fx_free_N15K_form__kinfo_t(&v_1183);
+         _fx_catch_258: ;
+            _fx_free_N15K_form__kinfo_t(&v_1204);
          }
          else {
             is_null_0 = false;
          }
-         FX_CHECK_EXN(_fx_catch_264);
+         FX_CHECK_EXN(_fx_catch_268);
          if (!ktp_ptr_2) {
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1133), _fx_catch_264);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &kloc_0, &v_1134);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1154), _fx_catch_268);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &kloc_0, &v_1155);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1133, &v_1134,
-                  &init_exp_0), _fx_catch_264);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(init_exp_0, 0, &v_1132);
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1154, &v_1155,
+                  &init_exp_0), _fx_catch_268);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(init_exp_0, 0, &v_1153);
          }
          else if (is_null_0) {
-            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1135, 0), _fx_catch_264);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1135, 0, &v_1132);
+            FX_CALL(_fx_M6C_formFM12make_nullptrN14C_form__cexp_t1R10Ast__loc_t(&kloc_0, &v_1156, 0), _fx_catch_268);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1156, 0, &v_1153);
          }
          else {
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1136, 0), _fx_catch_264);
-            fx_str_t slit_256 = FX_MAKE_STR("");
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1157, 0), _fx_catch_268);
+            fx_str_t slit_262 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_11, ctyp_4, &v_1136, &slit_256, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &v_1137, 0), _fx_catch_264);
-            FX_COPY_PTR(v_1137.t0, &i_exp_17);
+                  i_11, ctyp_4, &v_1157, &slit_262, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &v_1158, 0), _fx_catch_268);
+            FX_COPY_PTR(v_1158.t0, &i_exp_17);
             FX_CALL(
                _fx_M10C_gen_codeFM10get_structT4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti1N14C_form__cexp_t(
-                  i_exp_17, &v_1138, 0), _fx_catch_264);
-            _fx_R9Ast__id_t rn_0 = v_1138.t0;
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&rn_0, &struct_ctyp_0), _fx_catch_264);
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_11, &v_1139, 0), _fx_catch_264);
-            fx_str_t slit_257 = FX_MAKE_STR("_data");
+                  i_exp_17, &v_1159, 0), _fx_catch_268);
+            _fx_R9Ast__id_t rn_0 = v_1159.t0;
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&rn_0, &struct_ctyp_0), _fx_catch_268);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(i_11, &v_1160, 0), _fx_catch_268);
+            fx_str_t slit_263 = FX_MAKE_STR("_data");
             {
-               const fx_str_t strs_34[] = { v_1139, slit_257 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_34, 2, &v_1140), _fx_catch_264);
+               const fx_str_t strs_36[] = { v_1160, slit_263 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_36, 2, &v_1161), _fx_catch_268);
             }
             _fx_R9Ast__id_t data_id_1;
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &v_1140, &data_id_1, 0), _fx_catch_264);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &rc_exp_0, 0), _fx_catch_264);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1141), _fx_catch_264);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(rc_exp_0, v_1141, false, &v_1141), _fx_catch_264);
-            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(struct_ctyp_0, &kloc_0, &v_1142);
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &v_1161, &data_id_1, 0), _fx_catch_268);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(1, &kloc_0, &rc_exp_0, 0), _fx_catch_268);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(tag_exp_0, 0, true, &v_1162), _fx_catch_268);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(rc_exp_0, v_1162, false, &v_1162), _fx_catch_268);
+            _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(struct_ctyp_0, &kloc_0, &v_1163);
             FX_CALL(
-               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1141, &v_1142,
-                  &data_init_0), _fx_catch_264);
-            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1143, 0), _fx_catch_264);
-            _fx_make_R16Ast__val_flags_t(v_1143.val_flag_arg, v_1143.val_flag_mutable, v_1143.val_flag_temp,
-               v_1143.val_flag_tempref, true, v_1143.val_flag_subarray, v_1143.val_flag_instance, &v_1143.val_flag_method,
-               v_1143.val_flag_ctor, v_1143.val_flag_global, &v_1144);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(data_init_0, &v_1145);
-            fx_str_t slit_258 = FX_MAKE_STR("");
+               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(v_1162, &v_1163,
+                  &data_init_0), _fx_catch_268);
+            FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1164, 0), _fx_catch_268);
+            _fx_make_R16Ast__val_flags_t(v_1164.val_flag_arg, v_1164.val_flag_mutable, v_1164.val_flag_temp,
+               v_1164.val_flag_tempref, true, v_1164.val_flag_subarray, v_1164.val_flag_instance, &v_1164.val_flag_method,
+               v_1164.val_flag_ctor, v_1164.val_flag_global, &v_1165);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(data_init_0, &v_1166);
+            fx_str_t slit_264 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &data_id_1, struct_ctyp_0, &v_1144, &slit_258, &v_1145, 0, &kloc_0, &v_1146, 0), _fx_catch_264);
-            FX_COPY_PTR(v_1146.t0, &data_exp_1);
-            FX_COPY_PTR(v_1146.t1, &delta_ccode_1);
-            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(data_exp_1, &v_1147, 0), _fx_catch_264);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1147, delta_ccode_1, &v_1132);
+                  &data_id_1, struct_ctyp_0, &v_1165, &slit_264, &v_1166, 0, &kloc_0, &v_1167, 0), _fx_catch_268);
+            FX_COPY_PTR(v_1167.t0, &data_exp_1);
+            FX_COPY_PTR(v_1167.t1, &delta_ccode_1);
+            FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(data_exp_1, &v_1168, 0), _fx_catch_268);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1168, delta_ccode_1, &v_1153);
          }
-         FX_COPY_PTR(v_1132.t0, &init_exp_1);
-         FX_COPY_PTR(v_1132.t1, &delta_ccode_2);
-         FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1148, 0), _fx_catch_264);
-         _fx_make_R16Ast__val_flags_t(v_1148.val_flag_arg, v_1148.val_flag_mutable, v_1148.val_flag_temp,
-            v_1148.val_flag_tempref, v_1148.val_flag_private, v_1148.val_flag_subarray, v_1148.val_flag_instance,
-            &v_1148.val_flag_method, v_1148.val_flag_ctor, mod_sc_0, &v_1149);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(init_exp_1, &v_1150);
-         fx_str_t slit_259 = FX_MAKE_STR("");
+         FX_COPY_PTR(v_1153.t0, &init_exp_1);
+         FX_COPY_PTR(v_1153.t1, &delta_ccode_2);
+         FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_1169, 0), _fx_catch_268);
+         _fx_make_R16Ast__val_flags_t(v_1169.val_flag_arg, v_1169.val_flag_mutable, v_1169.val_flag_temp,
+            v_1169.val_flag_tempref, v_1169.val_flag_private, v_1169.val_flag_subarray, v_1169.val_flag_instance,
+            &v_1169.val_flag_method, v_1169.val_flag_ctor, mod_sc_0, &v_1170);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(init_exp_1, &v_1171);
+         fx_str_t slit_265 = FX_MAKE_STR("");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               i_11, ctyp_4, &v_1149, &slit_259, &v_1150, delta_ccode_2, &kloc_0, &v_1151, 0), _fx_catch_264);
-         FX_COPY_PTR(v_1151.t1, &delta_ccode_3);
-         _fx_R23C_gen_code__block_ctx_t* v_1185 = &bctx_1->data;
-         FX_COPY_PTR(v_1185->bctx_prologue, &v_1152);
+               i_11, ctyp_4, &v_1170, &slit_265, &v_1171, delta_ccode_2, &kloc_0, &v_1172, 0), _fx_catch_268);
+         FX_COPY_PTR(v_1172.t1, &delta_ccode_3);
+         _fx_R23C_gen_code__block_ctx_t* v_1206 = &bctx_1->data;
+         FX_COPY_PTR(v_1206->bctx_prologue, &v_1173);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_3, v_1152,
-               &v_1153, 0), _fx_catch_264);
-         _fx_R23C_gen_code__block_ctx_t* v_1186 = &bctx_1->data;
-         _fx_LN15C_form__cstmt_t* v_1187 = &v_1186->bctx_prologue;
-         _fx_free_LN15C_form__cstmt_t(v_1187);
-         FX_COPY_PTR(v_1153, v_1187);
-         FX_COPY_PTR(ccode_0, &ccode_145);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_3, v_1173,
+               &v_1174, 0), _fx_catch_268);
+         _fx_R23C_gen_code__block_ctx_t* v_1207 = &bctx_1->data;
+         _fx_LN15C_form__cstmt_t* v_1208 = &v_1207->bctx_prologue;
+         _fx_free_LN15C_form__cstmt_t(v_1208);
+         FX_COPY_PTR(v_1174, v_1208);
+         FX_COPY_PTR(ccode_0, &ccode_148);
       }
       else {
-         bool v_1188;
+         bool v_1209;
          if (is_fast_cons_0) {
-            v_1188 = true;
+            v_1209 = true;
          }
          else {
             bool t_18;
@@ -33755,48 +33995,48 @@ static int
                t_18 = false;
             }
             if (t_18) {
-               FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_11, &v_1188, 0),
-                  _fx_catch_264);
+               FX_CALL(_fx_M10C_gen_codeFM3memB2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(u1vals_0, i_11, &v_1209, 0),
+                  _fx_catch_268);
             }
             else {
-               v_1188 = false;
+               v_1209 = false;
             }
          }
-         if (v_1188) {
-            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1154), _fx_catch_264);
+         if (v_1209) {
+            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1175), _fx_catch_268);
             FX_CALL(
                _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                  e2_1, v_1154, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                  e2_1, v_1175, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                   fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1155, fx_fv), _fx_catch_264);
-            FX_COPY_PTR(v_1155.t0, &ce2_5);
-            FX_COPY_PTR(v_1155.t1, &ccode_146);
-            fx_str_t slit_260 = FX_MAKE_STR("");
+                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1176, fx_fv), _fx_catch_268);
+            FX_COPY_PTR(v_1176.t0, &ce2_5);
+            FX_COPY_PTR(v_1176.t1, &ccode_149);
+            fx_str_t slit_266 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  i_11, ctyp_4, &kv_flags_1, &slit_260, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &res_30, 0), _fx_catch_264);
+                  i_11, ctyp_4, &kv_flags_1, &slit_266, &_fx_g18C_gen_code__None2_, 0, &kloc_0, &res_30, 0), _fx_catch_268);
             FX_CALL(
                _fx_M10C_gen_codeFM3addv3Nt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tR9Ast__id_tN14C_form__cexp_t(*i2e_0, i_11,
-                  ce2_5, 0), _fx_catch_264);
-            FX_COPY_PTR(ccode_146, &ccode_145);
+                  ce2_5, 0), _fx_catch_268);
+            FX_COPY_PTR(ccode_149, &ccode_148);
          }
          else if (is_temp_ref_0) {
-            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1156), _fx_catch_264);
+            FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1177), _fx_catch_268);
             FX_CALL(
                _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                  e2_1, v_1156, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                  e2_1, v_1177, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                   fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1157, fx_fv), _fx_catch_264);
-            FX_COPY_PTR(v_1157.t0, &ce2_6);
-            FX_COPY_PTR(v_1157.t1, &ccode_147);
+                  return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1178, fx_fv), _fx_catch_268);
+            FX_COPY_PTR(v_1178.t0, &ce2_6);
+            FX_COPY_PTR(v_1178.t1, &ccode_150);
             FX_CALL(
                _fx_M10C_gen_codeFM17add_local_temprefT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tN14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_t(
-                  i_11, ctyp_4, &kv_flags_1, ce2_6, ccode_147, &kloc_0, i2e_ref_0, &v_1158, 0), _fx_catch_264);
-            FX_COPY_PTR(v_1158.t1, &ccode_145);
+                  i_11, ctyp_4, &kv_flags_1, ce2_6, ccode_150, &kloc_0, i2e_ref_0, &v_1179, 0), _fx_catch_268);
+            FX_COPY_PTR(v_1179.t1, &ccode_148);
          }
          else {
             bool t_19;
-            if (ktp_complex_1) {
+            if (ktp_complex_3) {
                t_19 = true;
             }
             else {
@@ -33842,44 +34082,44 @@ static int
                else {
                   res_33 = false;
                }
-               FX_CHECK_EXN(_fx_catch_264);
+               FX_CHECK_EXN(_fx_catch_268);
                if (res_33) {
                   t_20 = false; goto _fx_endmatch_45;
                }
                t_20 = true;
 
             _fx_endmatch_45: ;
-               FX_CHECK_EXN(_fx_catch_264);
+               FX_CHECK_EXN(_fx_catch_268);
             }
             if (t_20) {
-               _fx_R23C_gen_code__block_ctx_t* v_1189 = &bctx_1->data;
-               FX_COPY_PTR(v_1189->bctx_cleanup, &saved_cleanup_0);
-               _fx_R23C_gen_code__block_ctx_t* v_1190 = &bctx_1->data;
-               _fx_LN15C_form__cstmt_t* v_1191 = &v_1190->bctx_cleanup;
-               _fx_free_LN15C_form__cstmt_t(v_1191);
-               *v_1191 = 0;
+               _fx_R23C_gen_code__block_ctx_t* v_1210 = &bctx_1->data;
+               FX_COPY_PTR(v_1210->bctx_cleanup, &saved_cleanup_0);
+               _fx_R23C_gen_code__block_ctx_t* v_1211 = &bctx_1->data;
+               _fx_LN15C_form__cstmt_t* v_1212 = &v_1211->bctx_cleanup;
+               _fx_free_LN15C_form__cstmt_t(v_1212);
+               *v_1212 = 0;
                bool assign_e2_0;
-               if (ktp_complex_1 == true) {
+               if (ktp_complex_3 == true) {
                   if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                      _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_33 = &e2_1->u.KExpAtom;
-                     _fx_N14K_form__atom_t* v_1192 = &vcase_33->t0;
-                     if (v_1192->tag == 2) {
-                        if (v_1192->u.AtomLit.tag == 8) {
-                           _fx_N14K_form__ktyp_t v_1193 = 0;
+                     _fx_N14K_form__atom_t* v_1213 = &vcase_33->t0;
+                     if (v_1213->tag == 2) {
+                        if (v_1213->u.AtomLit.tag == 8) {
+                           _fx_N14K_form__ktyp_t v_1214 = 0;
                            FX_CALL(
                               _fx_M6K_formFM10deref_ktypN14K_form__ktyp_t2N14K_form__ktyp_tR10Ast__loc_t(vcase_33->t1.t0,
-                                 &kloc_0, &v_1193, 0), _fx_catch_255);
-                           if (FX_REC_VARIANT_TAG(v_1193) == 19) {
+                                 &kloc_0, &v_1214, 0), _fx_catch_259);
+                           if (FX_REC_VARIANT_TAG(v_1214) == 19) {
                               assign_e2_0 = true;
                            }
                            else {
                               assign_e2_0 = false;
                            }
-                           FX_CHECK_EXN(_fx_catch_255);
+                           FX_CHECK_EXN(_fx_catch_259);
 
-                        _fx_catch_255: ;
-                           if (v_1193) {
-                              _fx_free_N14K_form__ktyp_t(&v_1193);
+                        _fx_catch_259: ;
+                           if (v_1214) {
+                              _fx_free_N14K_form__ktyp_t(&v_1214);
                            }
                            goto _fx_endmatch_46;
                         }
@@ -33889,14 +34129,14 @@ static int
                assign_e2_0 = true;
 
             _fx_endmatch_46: ;
-               FX_CHECK_EXN(_fx_catch_264);
+               FX_CHECK_EXN(_fx_catch_268);
                if (!is_global_0) {
                   _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &_fx_g18C_gen_code__None2_,
-                     assign_e2_0, &v_1159);
+                     assign_e2_0, &v_1180);
                }
                else {
-                  if (ktp_complex_1) {
-                     _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1160);
+                  if (ktp_complex_3) {
+                     _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
                   }
                   else {
                      bool t_21;
@@ -33909,145 +34149,145 @@ static int
                      if (t_21) {
                         if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                            _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_34 = &e2_1->u.KExpAtom;
-                           _fx_N14K_form__atom_t* v_1194 = &vcase_34->t0;
-                           if (v_1194->tag == 2) {
+                           _fx_N14K_form__atom_t* v_1215 = &vcase_34->t0;
+                           if (v_1215->tag == 2) {
                               _fx_N14C_form__ctyp_t e2_ctyp_0 = 0;
-                              _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1195 = {0};
-                              _fx_N14C_form__cexp_t v_1196 = 0;
-                              _fx_Nt6option1N14C_form__cexp_t v_1197 = {0};
-                              _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_1198 = &vcase_34->t1;
-                              _fx_R10Ast__loc_t* e2_loc_0 = &v_1198->t1;
+                              _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1216 = {0};
+                              _fx_N14C_form__cexp_t v_1217 = 0;
+                              _fx_Nt6option1N14C_form__cexp_t v_1218 = {0};
+                              _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_1219 = &vcase_34->t1;
+                              _fx_R10Ast__loc_t* e2_loc_0 = &v_1219->t1;
                               FX_CALL(
-                                 _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_1198->t0,
-                                    e2_loc_0, &e2_ctyp_0, 0), _fx_catch_256);
-                              _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(e2_ctyp_0, e2_loc_0, &v_1195);
+                                 _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(v_1219->t0,
+                                    e2_loc_0, &e2_ctyp_0, 0), _fx_catch_260);
+                              _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(e2_ctyp_0, e2_loc_0, &v_1216);
                               FX_CALL(
                                  _fx_M6C_formFM7CExpLitN14C_form__cexp_t2N14K_form__klit_tT2N14C_form__ctyp_tR10Ast__loc_t(
-                                    &v_1194->u.AtomLit, &v_1195, &v_1196), _fx_catch_256);
-                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1196, &v_1197);
-                              _fx_make_T2Nt6option1N14C_form__cexp_tB(&v_1197, false, &v_1160);
+                                    &v_1215->u.AtomLit, &v_1216, &v_1217), _fx_catch_260);
+                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1217, &v_1218);
+                              _fx_make_T2Nt6option1N14C_form__cexp_tB(&v_1218, false, &v_1181);
 
-                           _fx_catch_256: ;
-                              _fx_free_Nt6option1N14C_form__cexp_t(&v_1197);
-                              if (v_1196) {
-                                 _fx_free_N14C_form__cexp_t(&v_1196);
+                           _fx_catch_260: ;
+                              _fx_free_Nt6option1N14C_form__cexp_t(&v_1218);
+                              if (v_1217) {
+                                 _fx_free_N14C_form__cexp_t(&v_1217);
                               }
-                              _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1195);
+                              _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1216);
                               if (e2_ctyp_0) {
                                  _fx_free_N14C_form__ctyp_t(&e2_ctyp_0);
                               }
                               goto _fx_endmatch_47;
                            }
                         }
-                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1160);
+                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
 
                      _fx_endmatch_47: ;
-                        FX_CHECK_EXN(_fx_catch_264);
+                        FX_CHECK_EXN(_fx_catch_268);
                      }
                      else {
-                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1160);
+                        _fx_make_T2Nt6option1N14C_form__cexp_tB(&_fx_g18C_gen_code__None2_, assign_e2_0, &v_1181);
                      }
                   }
-                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_1160.t0, &e0_opt_0);
-                  bool assign_e2_1 = v_1160.t1;
-                  _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &e0_opt_0, assign_e2_1, &v_1159);
+                  _fx_copy_Nt6option1N14C_form__cexp_t(&v_1181.t0, &e0_opt_0);
+                  bool assign_e2_1 = v_1181.t1;
+                  _fx_make_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&kv_flags_1, &e0_opt_0, assign_e2_1, &v_1180);
                }
-               _fx_copy_R16Ast__val_flags_t(&v_1159.t0, &flags_2);
-               _fx_copy_Nt6option1N14C_form__cexp_t(&v_1159.t1, &e0_opt_1);
-               bool assign_e2_2 = v_1159.t2;
+               _fx_copy_R16Ast__val_flags_t(&v_1180.t0, &flags_2);
+               _fx_copy_Nt6option1N14C_form__cexp_t(&v_1180.t1, &e0_opt_1);
+               bool assign_e2_2 = v_1180.t2;
                FX_CALL(
                   _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                     i_11, ctyp_4, &flags_2, &e0_opt_1, 0, &kloc_0, block_stack_ref_0, &v_1161, 0), _fx_catch_264);
-               FX_COPY_PTR(v_1161.t0, &i_exp_18);
-               FX_COPY_PTR(v_1161.t1, &delta_ccode_4);
+                     i_11, ctyp_4, &flags_2, &e0_opt_1, 0, &kloc_0, block_stack_ref_0, &v_1182, 0), _fx_catch_268);
+               FX_COPY_PTR(v_1182.t0, &i_exp_18);
+               FX_COPY_PTR(v_1182.t1, &delta_ccode_4);
                if (is_global_0) {
-                  _fx_R23C_gen_code__block_ctx_t* v_1199 = &bctx_1->data;
-                  FX_COPY_PTR(v_1199->bctx_prologue, &v_1162);
+                  _fx_R23C_gen_code__block_ctx_t* v_1220 = &bctx_1->data;
+                  FX_COPY_PTR(v_1220->bctx_prologue, &v_1183);
                   FX_CALL(
                      _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_4,
-                        v_1162, &v_1163, 0), _fx_catch_264);
-                  _fx_R23C_gen_code__block_ctx_t* v_1200 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1201 = &v_1200->bctx_prologue;
-                  _fx_free_LN15C_form__cstmt_t(v_1201);
-                  FX_COPY_PTR(v_1163, v_1201);
-                  FX_COPY_PTR(ccode_0, &ccode_148);
+                        v_1183, &v_1184, 0), _fx_catch_268);
+                  _fx_R23C_gen_code__block_ctx_t* v_1221 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1222 = &v_1221->bctx_prologue;
+                  _fx_free_LN15C_form__cstmt_t(v_1222);
+                  FX_COPY_PTR(v_1184, v_1222);
+                  FX_COPY_PTR(ccode_0, &ccode_151);
                }
                else {
                   FX_CALL(
                      _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(delta_ccode_4,
-                        ccode_0, &ccode_148, 0), _fx_catch_264);
+                        ccode_0, &ccode_151, 0), _fx_catch_268);
                }
                if (is_global_0) {
-                  _fx_R23C_gen_code__block_ctx_t* v_1202 = &bctx_1->data;
-                  FX_COPY_PTR(v_1202->bctx_cleanup, &v_1164);
+                  _fx_R23C_gen_code__block_ctx_t* v_1223 = &bctx_1->data;
+                  FX_COPY_PTR(v_1223->bctx_cleanup, &v_1185);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1164,
-                        *module_cleanup_0, &v_1165, 0), _fx_catch_264);
+                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1185,
+                        *module_cleanup_0, &v_1186, 0), _fx_catch_268);
                   _fx_free_LN15C_form__cstmt_t(module_cleanup_0);
-                  FX_COPY_PTR(v_1165, module_cleanup_0);
-                  _fx_R23C_gen_code__block_ctx_t* v_1203 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1204 = &v_1203->bctx_cleanup;
-                  _fx_free_LN15C_form__cstmt_t(v_1204);
-                  FX_COPY_PTR(saved_cleanup_0, v_1204);
+                  FX_COPY_PTR(v_1186, module_cleanup_0);
+                  _fx_R23C_gen_code__block_ctx_t* v_1224 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1225 = &v_1224->bctx_cleanup;
+                  _fx_free_LN15C_form__cstmt_t(v_1225);
+                  FX_COPY_PTR(saved_cleanup_0, v_1225);
                }
                else {
-                  _fx_R23C_gen_code__block_ctx_t* v_1205 = &bctx_1->data;
-                  FX_COPY_PTR(v_1205->bctx_cleanup, &v_1166);
+                  _fx_R23C_gen_code__block_ctx_t* v_1226 = &bctx_1->data;
+                  FX_COPY_PTR(v_1226->bctx_cleanup, &v_1187);
                   FX_CALL(
-                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1166,
-                        saved_cleanup_0, &v_1167, 0), _fx_catch_264);
-                  _fx_R23C_gen_code__block_ctx_t* v_1206 = &bctx_1->data;
-                  _fx_LN15C_form__cstmt_t* v_1207 = &v_1206->bctx_cleanup;
-                  _fx_free_LN15C_form__cstmt_t(v_1207);
-                  FX_COPY_PTR(v_1167, v_1207);
+                     _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1187,
+                        saved_cleanup_0, &v_1188, 0), _fx_catch_268);
+                  _fx_R23C_gen_code__block_ctx_t* v_1227 = &bctx_1->data;
+                  _fx_LN15C_form__cstmt_t* v_1228 = &v_1227->bctx_cleanup;
+                  _fx_free_LN15C_form__cstmt_t(v_1228);
+                  FX_COPY_PTR(v_1188, v_1228);
                }
                if (assign_e2_2) {
-                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(i_exp_18, &v_1168);
-                  FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1168, &v_1169), _fx_catch_264);
+                  _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(i_exp_18, &v_1189);
+                  FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1189, &v_1190), _fx_catch_268);
                   FX_CALL(
                      _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                        e2_1, v_1169, ccode_148, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                        e2_1, v_1190, ccode_151, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                         fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0,
-                        module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1170, fx_fv),
-                     _fx_catch_264);
-                  FX_COPY_PTR(v_1170.t1, &ccode_149);
-                  if (ccode_149 != 0) {
-                     _fx_LN15C_form__cstmt_t v_1208 = ccode_149->tl;
-                     if (v_1208 != 0) {
-                        _fx_N15C_form__cstmt_t v_1209 = v_1208->hd;
-                        if (FX_REC_VARIANT_TAG(v_1209) == 16) {
+                        module_cleanup_ref_0, return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1191, fx_fv),
+                     _fx_catch_268);
+                  FX_COPY_PTR(v_1191.t1, &ccode_152);
+                  if (ccode_152 != 0) {
+                     _fx_LN15C_form__cstmt_t v_1229 = ccode_152->tl;
+                     if (v_1229 != 0) {
+                        _fx_N15C_form__cstmt_t v_1230 = v_1229->hd;
+                        if (FX_REC_VARIANT_TAG(v_1230) == 16) {
                            _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t* vcase_35 =
-                              &v_1209->u.CDefVal;
+                              &v_1230->u.CDefVal;
                            if (vcase_35->t2.tag == 1) {
-                              _fx_N15C_form__cstmt_t v_1210 = ccode_149->hd;
-                              if (FX_REC_VARIANT_TAG(v_1210) == 3) {
-                                 _fx_N14C_form__cexp_t v_1211 = v_1210->u.CExp;
-                                 if (FX_REC_VARIANT_TAG(v_1211) == 3) {
+                              _fx_N15C_form__cstmt_t v_1231 = ccode_152->hd;
+                              if (FX_REC_VARIANT_TAG(v_1231) == 3) {
+                                 _fx_N14C_form__cexp_t v_1232 = v_1231->u.CExp;
+                                 if (FX_REC_VARIANT_TAG(v_1232) == 3) {
                                     _fx_T4N17C_form__cbinary_tN14C_form__cexp_tN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t*
-                                       vcase_36 = &v_1211->u.CExpBinary;
+                                       vcase_36 = &v_1232->u.CExpBinary;
                                     if (vcase_36->t0.tag == 15) {
-                                       _fx_N14C_form__cexp_t v_1212 = vcase_36->t1;
-                                       if (FX_REC_VARIANT_TAG(v_1212) == 1) {
+                                       _fx_N14C_form__cexp_t v_1233 = vcase_36->t1;
+                                       if (FX_REC_VARIANT_TAG(v_1233) == 1) {
                                           _fx_R9Ast__id_t* i_12 = &vcase_35->t1;
                                           bool res_34;
-                                          FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1212->u.CExpIdent.t0, i_12, &res_34, 0),
-                                             _fx_catch_264);
+                                          FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1233->u.CExpIdent.t0, i_12, &res_34, 0),
+                                             _fx_catch_268);
                                           if (res_34) {
-                                             _fx_Nt6option1N14C_form__cexp_t v_1213 = {0};
-                                             _fx_N15C_form__cstmt_t v_1214 = 0;
+                                             _fx_Nt6option1N14C_form__cexp_t v_1234 = {0};
+                                             _fx_N15C_form__cstmt_t v_1235 = 0;
                                              _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(vcase_36->t2,
-                                                &v_1213);
+                                                &v_1234);
                                              FX_CALL(
                                                 _fx_M6C_formFM7CDefValN15C_form__cstmt_t4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t(
-                                                   vcase_35->t0, i_12, &v_1213, &vcase_36->t3.t1, &v_1214), _fx_catch_257);
-                                             FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1214, v_1208->tl, true, &ccode_145),
-                                                _fx_catch_257);
+                                                   vcase_35->t0, i_12, &v_1234, &vcase_36->t3.t1, &v_1235), _fx_catch_261);
+                                             FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1235, v_1229->tl, true, &ccode_148),
+                                                _fx_catch_261);
 
-                                          _fx_catch_257: ;
-                                             if (v_1214) {
-                                                _fx_free_N15C_form__cstmt_t(&v_1214);
+                                          _fx_catch_261: ;
+                                             if (v_1235) {
+                                                _fx_free_N15C_form__cstmt_t(&v_1235);
                                              }
-                                             _fx_free_Nt6option1N14C_form__cexp_t(&v_1213);
+                                             _fx_free_Nt6option1N14C_form__cexp_t(&v_1234);
                                              goto _fx_endmatch_48;
                                           }
                                        }
@@ -34058,168 +34298,168 @@ static int
                         }
                      }
                   }
-                  FX_COPY_PTR(ccode_149, &ccode_145);
+                  FX_COPY_PTR(ccode_152, &ccode_148);
 
                _fx_endmatch_48: ;
-                  FX_CHECK_EXN(_fx_catch_264);
+                  FX_CHECK_EXN(_fx_catch_268);
                }
                else {
-                  FX_COPY_PTR(ccode_148, &ccode_145);
+                  FX_COPY_PTR(ccode_151, &ccode_148);
                }
             }
             else {
                if (ktp_ptr_2 == false) {
                   if (FX_REC_VARIANT_TAG(e2_1) == 5) {
                      _fx_T2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_37 = &e2_1->u.KExpAtom;
-                     _fx_N14K_form__atom_t* v_1215 = &vcase_37->t0;
-                     if (v_1215->tag == 2) {
-                        if (v_1215->u.AtomLit.tag == 8) {
-                           _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1216 = {0};
-                           _fx_N14C_form__cexp_t v_1217 = 0;
-                           _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &vcase_37->t1.t1, &v_1216);
+                     _fx_N14K_form__atom_t* v_1236 = &vcase_37->t0;
+                     if (v_1236->tag == 2) {
+                        if (v_1236->u.AtomLit.tag == 8) {
+                           _fx_T2N14C_form__ctyp_tR10Ast__loc_t v_1237 = {0};
+                           _fx_N14C_form__cexp_t v_1238 = 0;
+                           _fx_make_T2N14C_form__ctyp_tR10Ast__loc_t(ctyp_4, &vcase_37->t1.t1, &v_1237);
                            FX_CALL(
                               _fx_M6C_formFM8CExpInitN14C_form__cexp_t2LN14C_form__cexp_tT2N14C_form__ctyp_tR10Ast__loc_t(0,
-                                 &v_1216, &v_1217), _fx_catch_258);
-                           _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1217, ccode_0, &v_1171);
+                                 &v_1237, &v_1238), _fx_catch_262);
+                           _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(v_1238, ccode_0, &v_1192);
 
-                        _fx_catch_258: ;
-                           if (v_1217) {
-                              _fx_free_N14C_form__cexp_t(&v_1217);
+                        _fx_catch_262: ;
+                           if (v_1238) {
+                              _fx_free_N14C_form__cexp_t(&v_1238);
                            }
-                           _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1216);
+                           _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1237);
                            goto _fx_endmatch_49;
                         }
                      }
                   }
                }
-               _fx_rNt6option1N14C_form__cexp_t v_1218 = 0;
-               FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1218), _fx_catch_259);
+               _fx_rNt6option1N14C_form__cexp_t v_1239 = 0;
+               FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1239), _fx_catch_263);
                FX_CALL(
                   _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-                     e2_1, v_1218, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+                     e2_1, v_1239, ccode_0, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                      fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-                     return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1171, fx_fv), _fx_catch_259);
+                     return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1192, fx_fv), _fx_catch_263);
 
-            _fx_catch_259: ;
-               if (v_1218) {
-                  _fx_free_rNt6option1N14C_form__cexp_t(&v_1218);
+            _fx_catch_263: ;
+               if (v_1239) {
+                  _fx_free_rNt6option1N14C_form__cexp_t(&v_1239);
                }
 
             _fx_endmatch_49: ;
-               FX_CHECK_EXN(_fx_catch_264);
-               FX_COPY_PTR(v_1171.t0, &ce2_7);
-               FX_COPY_PTR(v_1171.t1, &ccode_150);
+               FX_CHECK_EXN(_fx_catch_268);
+               FX_COPY_PTR(v_1192.t0, &ce2_7);
+               FX_COPY_PTR(v_1192.t1, &ccode_153);
                if (FX_REC_VARIANT_TAG(e2_1) == 15) {
-                  if (ccode_150 != 0) {
-                     _fx_N15C_form__cstmt_t v_1219 = ccode_150->hd;
-                     if (FX_REC_VARIANT_TAG(v_1219) == 16) {
-                        _fx_Nt6option1N14C_form__cexp_t* v_1220 = &v_1219->u.CDefVal.t2;
-                        if (v_1220->tag == 2) {
-                           _fx_Nt6option1N14C_form__cexp_t v_1221 = {0};
-                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1220->u.Some, &v_1221);
+                  if (ccode_153 != 0) {
+                     _fx_N15C_form__cstmt_t v_1240 = ccode_153->hd;
+                     if (FX_REC_VARIANT_TAG(v_1240) == 16) {
+                        _fx_Nt6option1N14C_form__cexp_t* v_1241 = &v_1240->u.CDefVal.t2;
+                        if (v_1241->tag == 2) {
+                           _fx_Nt6option1N14C_form__cexp_t v_1242 = {0};
+                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1241->u.Some, &v_1242);
                            FX_CALL(
                               _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                                 i_11, ctyp_4, &kv_flags_1, &v_1221, ccode_150->tl, &kloc_0, block_stack_ref_0, &v_1172, 0),
-                              _fx_catch_260);
+                                 i_11, ctyp_4, &kv_flags_1, &v_1242, ccode_153->tl, &kloc_0, block_stack_ref_0, &v_1193, 0),
+                              _fx_catch_264);
 
-                        _fx_catch_260: ;
-                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1221);
+                        _fx_catch_264: ;
+                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1242);
                            goto _fx_endmatch_50;
                         }
                      }
                   }
                }
                if (FX_REC_VARIANT_TAG(e2_1) == 14) {
-                  if (ccode_150 != 0) {
-                     _fx_N15C_form__cstmt_t v_1222 = ccode_150->hd;
-                     if (FX_REC_VARIANT_TAG(v_1222) == 16) {
-                        _fx_Nt6option1N14C_form__cexp_t* v_1223 = &v_1222->u.CDefVal.t2;
-                        if (v_1223->tag == 2) {
-                           _fx_Nt6option1N14C_form__cexp_t v_1224 = {0};
-                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1223->u.Some, &v_1224);
+                  if (ccode_153 != 0) {
+                     _fx_N15C_form__cstmt_t v_1243 = ccode_153->hd;
+                     if (FX_REC_VARIANT_TAG(v_1243) == 16) {
+                        _fx_Nt6option1N14C_form__cexp_t* v_1244 = &v_1243->u.CDefVal.t2;
+                        if (v_1244->tag == 2) {
+                           _fx_Nt6option1N14C_form__cexp_t v_1245 = {0};
+                           _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1244->u.Some, &v_1245);
                            FX_CALL(
                               _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                                 i_11, ctyp_4, &kv_flags_1, &v_1224, ccode_150->tl, &kloc_0, block_stack_ref_0, &v_1172, 0),
-                              _fx_catch_261);
+                                 i_11, ctyp_4, &kv_flags_1, &v_1245, ccode_153->tl, &kloc_0, block_stack_ref_0, &v_1193, 0),
+                              _fx_catch_265);
 
-                        _fx_catch_261: ;
-                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1224);
+                        _fx_catch_265: ;
+                           _fx_free_Nt6option1N14C_form__cexp_t(&v_1245);
                            goto _fx_endmatch_50;
                         }
                      }
                   }
                }
-               _fx_Nt6option1N14C_form__cexp_t v_1225 = {0};
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ce2_7, &v_1225);
+               _fx_Nt6option1N14C_form__cexp_t v_1246 = {0};
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ce2_7, &v_1246);
                FX_CALL(
                   _fx_M10C_gen_codeFM9add_localT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                     i_11, ctyp_4, &kv_flags_1, &v_1225, ccode_150, &kloc_0, block_stack_ref_0, &v_1172, 0), _fx_catch_262);
+                     i_11, ctyp_4, &kv_flags_1, &v_1246, ccode_153, &kloc_0, block_stack_ref_0, &v_1193, 0), _fx_catch_266);
 
-            _fx_catch_262: ;
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1225);
+            _fx_catch_266: ;
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1246);
 
             _fx_endmatch_50: ;
-               FX_CHECK_EXN(_fx_catch_264);
-               FX_COPY_PTR(v_1172.t1, &ccode_145);
+               FX_CHECK_EXN(_fx_catch_268);
+               FX_COPY_PTR(v_1193.t1, &ccode_148);
             }
          }
       }
       if (FX_STR_LENGTH(kv_cname_0) != 0) {
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1173, 0), _fx_catch_264);
-         if (v_1173.tag == 2) {
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(i_11, &kloc_0, &v_1194, 0), _fx_catch_268);
+         if (v_1194.tag == 2) {
             _fx_R17C_form__cdefval_t cv_3 = {0};
-            _fx_N15C_form__cinfo_t v_1226 = {0};
-            _fx_R17C_form__cdefval_t* cv_4 = &v_1173.u.CVal;
+            _fx_N15C_form__cinfo_t v_1247 = {0};
+            _fx_R17C_form__cdefval_t* cv_4 = &v_1194.u.CVal;
             _fx_make_R17C_form__cdefval_t(&cv_4->cv_name, cv_4->cv_typ, &kv_cname_0, &cv_4->cv_flags, &cv_4->cv_loc, &cv_3);
-            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&cv_3, &v_1226);
-            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(i_11, &v_1226, 0), _fx_catch_263);
+            _fx_M6C_formFM4CValN15C_form__cinfo_t1RM9cdefval_t(&cv_3, &v_1247);
+            FX_CALL(_fx_M6C_formFM13set_idc_entryv2R9Ast__id_tN15C_form__cinfo_t(i_11, &v_1247, 0), _fx_catch_267);
 
-         _fx_catch_263: ;
-            _fx_free_N15C_form__cinfo_t(&v_1226);
+         _fx_catch_267: ;
+            _fx_free_N15C_form__cinfo_t(&v_1247);
             _fx_free_R17C_form__cdefval_t(&cv_3);
          }
-         FX_CHECK_EXN(_fx_catch_264);
+         FX_CHECK_EXN(_fx_catch_268);
       }
-      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_145, &v_1);
+      _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_148, &v_1);
 
-   _fx_catch_264: ;
-      _fx_free_N15C_form__cinfo_t(&v_1173);
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1172);
-      if (ccode_150) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_150);
+   _fx_catch_268: ;
+      _fx_free_N15C_form__cinfo_t(&v_1194);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1193);
+      if (ccode_153) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_153);
       }
       if (ce2_7) {
          _fx_free_N14C_form__cexp_t(&ce2_7);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1171);
-      if (ccode_149) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_149);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1192);
+      if (ccode_152) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_152);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1170);
-      if (v_1169) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1169);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1191);
+      if (v_1190) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1190);
       }
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1168);
-      if (v_1167) {
-         _fx_free_LN15C_form__cstmt_t(&v_1167);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1189);
+      if (v_1188) {
+         _fx_free_LN15C_form__cstmt_t(&v_1188);
       }
-      if (v_1166) {
-         _fx_free_LN15C_form__cstmt_t(&v_1166);
+      if (v_1187) {
+         _fx_free_LN15C_form__cstmt_t(&v_1187);
       }
-      if (v_1165) {
-         _fx_free_LN15C_form__cstmt_t(&v_1165);
+      if (v_1186) {
+         _fx_free_LN15C_form__cstmt_t(&v_1186);
       }
-      if (v_1164) {
-         _fx_free_LN15C_form__cstmt_t(&v_1164);
+      if (v_1185) {
+         _fx_free_LN15C_form__cstmt_t(&v_1185);
       }
-      if (v_1163) {
-         _fx_free_LN15C_form__cstmt_t(&v_1163);
+      if (v_1184) {
+         _fx_free_LN15C_form__cstmt_t(&v_1184);
       }
-      if (v_1162) {
-         _fx_free_LN15C_form__cstmt_t(&v_1162);
+      if (v_1183) {
+         _fx_free_LN15C_form__cstmt_t(&v_1183);
       }
-      if (ccode_148) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_148);
+      if (ccode_151) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_151);
       }
       if (delta_ccode_4) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_4);
@@ -34227,58 +34467,58 @@ static int
       if (i_exp_18) {
          _fx_free_N14C_form__cexp_t(&i_exp_18);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1161);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1182);
       _fx_free_Nt6option1N14C_form__cexp_t(&e0_opt_1);
       _fx_free_R16Ast__val_flags_t(&flags_2);
       _fx_free_Nt6option1N14C_form__cexp_t(&e0_opt_0);
-      _fx_free_T2Nt6option1N14C_form__cexp_tB(&v_1160);
-      _fx_free_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&v_1159);
+      _fx_free_T2Nt6option1N14C_form__cexp_tB(&v_1181);
+      _fx_free_T3R16Ast__val_flags_tNt6option1N14C_form__cexp_tB(&v_1180);
       if (saved_cleanup_0) {
          _fx_free_LN15C_form__cstmt_t(&saved_cleanup_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1158);
-      if (ccode_147) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_147);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1179);
+      if (ccode_150) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_150);
       }
       if (ce2_6) {
          _fx_free_N14C_form__cexp_t(&ce2_6);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1157);
-      if (v_1156) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1156);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1178);
+      if (v_1177) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1177);
       }
       _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&res_30);
-      if (ccode_146) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_146);
+      if (ccode_149) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_149);
       }
       if (ce2_5) {
          _fx_free_N14C_form__cexp_t(&ce2_5);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1155);
-      if (v_1154) {
-         _fx_free_rNt6option1N14C_form__cexp_t(&v_1154);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1176);
+      if (v_1175) {
+         _fx_free_rNt6option1N14C_form__cexp_t(&v_1175);
       }
-      if (v_1153) {
-         _fx_free_LN15C_form__cstmt_t(&v_1153);
+      if (v_1174) {
+         _fx_free_LN15C_form__cstmt_t(&v_1174);
       }
-      if (v_1152) {
-         _fx_free_LN15C_form__cstmt_t(&v_1152);
+      if (v_1173) {
+         _fx_free_LN15C_form__cstmt_t(&v_1173);
       }
       if (delta_ccode_3) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_3);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1151);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1150);
-      _fx_free_R16Ast__val_flags_t(&v_1149);
-      _fx_free_R16Ast__val_flags_t(&v_1148);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1172);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1171);
+      _fx_free_R16Ast__val_flags_t(&v_1170);
+      _fx_free_R16Ast__val_flags_t(&v_1169);
       if (delta_ccode_2) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_2);
       }
       if (init_exp_1) {
          _fx_free_N14C_form__cexp_t(&init_exp_1);
       }
-      if (v_1147) {
-         _fx_free_N14C_form__cexp_t(&v_1147);
+      if (v_1168) {
+         _fx_free_N14C_form__cexp_t(&v_1168);
       }
       if (delta_ccode_1) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_1);
@@ -34286,65 +34526,65 @@ static int
       if (data_exp_1) {
          _fx_free_N14C_form__cexp_t(&data_exp_1);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1146);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1145);
-      _fx_free_R16Ast__val_flags_t(&v_1144);
-      _fx_free_R16Ast__val_flags_t(&v_1143);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1167);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1166);
+      _fx_free_R16Ast__val_flags_t(&v_1165);
+      _fx_free_R16Ast__val_flags_t(&v_1164);
       if (data_init_0) {
          _fx_free_N14C_form__cexp_t(&data_init_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1142);
-      if (v_1141) {
-         _fx_free_LN14C_form__cexp_t(&v_1141);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1163);
+      if (v_1162) {
+         _fx_free_LN14C_form__cexp_t(&v_1162);
       }
       if (rc_exp_0) {
          _fx_free_N14C_form__cexp_t(&rc_exp_0);
       }
-      FX_FREE_STR(&v_1140);
-      FX_FREE_STR(&v_1139);
+      FX_FREE_STR(&v_1161);
+      FX_FREE_STR(&v_1160);
       if (struct_ctyp_0) {
          _fx_free_N14C_form__ctyp_t(&struct_ctyp_0);
       }
-      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_1138);
+      _fx_free_T4R9Ast__id_tN14C_form__cexp_tLT2R9Ast__id_tN14C_form__ctyp_ti(&v_1159);
       if (i_exp_17) {
          _fx_free_N14C_form__cexp_t(&i_exp_17);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1137);
-      _fx_free_R16Ast__val_flags_t(&v_1136);
-      if (v_1135) {
-         _fx_free_N14C_form__cexp_t(&v_1135);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1158);
+      _fx_free_R16Ast__val_flags_t(&v_1157);
+      if (v_1156) {
+         _fx_free_N14C_form__cexp_t(&v_1156);
       }
       if (init_exp_0) {
          _fx_free_N14C_form__cexp_t(&init_exp_0);
       }
-      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1134);
-      if (v_1133) {
-         _fx_free_LN14C_form__cexp_t(&v_1133);
+      _fx_free_T2N14C_form__ctyp_tR10Ast__loc_t(&v_1155);
+      if (v_1154) {
+         _fx_free_LN14C_form__cexp_t(&v_1154);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1132);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1153);
       if (tag_exp_0) {
          _fx_free_N14C_form__cexp_t(&tag_exp_0);
       }
-      if (v_1131) {
-         _fx_free_LN15C_form__cstmt_t(&v_1131);
+      if (v_1152) {
+         _fx_free_LN15C_form__cstmt_t(&v_1152);
       }
-      if (v_1130) {
-         _fx_free_LN15C_form__cstmt_t(&v_1130);
+      if (v_1151) {
+         _fx_free_LN15C_form__cstmt_t(&v_1151);
       }
       if (delta_ccode_0) {
          _fx_free_LN15C_form__cstmt_t(&delta_ccode_0);
       }
-      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1129);
-      _fx_free_Nt6option1N14C_form__cexp_t(&v_1128);
-      if (v_1127) {
-         _fx_free_N14C_form__cexp_t(&v_1127);
+      _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1150);
+      _fx_free_Nt6option1N14C_form__cexp_t(&v_1149);
+      if (v_1148) {
+         _fx_free_N14C_form__cexp_t(&v_1148);
       }
-      if (ccode_145) {
-         _fx_free_LN15C_form__cstmt_t(&ccode_145);
+      if (ccode_148) {
+         _fx_free_LN15C_form__cstmt_t(&ccode_148);
       }
       FX_FREE_STR(&ccode_data_lit_0);
       FX_FREE_STR(&ccode_data_kind_0);
-      _fx_free_T3SSR10Ast__loc_t(&v_1126);
+      _fx_free_T3SSR10Ast__loc_t(&v_1147);
       if (bctx_1) {
          _fx_free_rR23C_gen_code__block_ctx_t(&bctx_1);
       }
@@ -34356,192 +34596,192 @@ static int
       }
       FX_FREE_STR(&kv_cname_0);
       _fx_free_R16Ast__val_flags_t(&kv_flags_1);
-      _fx_free_R17K_form__kdefval_t(&v_1125);
+      _fx_free_R17K_form__kdefval_t(&v_1146);
       goto _fx_endmatch_55;
    }
    if (tag_0 == 32) {
       fx_str_t kf_cname_0 = {0};
       _fx_N14K_form__kexp_t kf_body_0 = 0;
       _fx_N14K_form__ktyp_t kf_rt_0 = 0;
-      _fx_N15C_form__cinfo_t v_1227 = {0};
-      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t v_1228 = {0};
+      _fx_N15C_form__cinfo_t v_1248 = {0};
+      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t v_1249 = {0};
       _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t args_13 = 0;
       _fx_N14C_form__ctyp_t rt_0 = 0;
       _fx_rR17C_form__cdeffun_t cf_0 = 0;
-      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_1229 = {0};
+      _fx_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB v_1250 = {0};
       _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t real_args_0 = 0;
       _fx_rB really_nothrow_0 = 0;
       _fx_LN15C_form__cstmt_t new_body_0 = 0;
-      _fx_LN15C_form__cstmt_t v_1230 = 0;
-      _fx_R17C_form__cdeffun_t v_1231 = {0};
-      _fx_R17K_form__kdeffun_t* v_1232 = &kexp_0->u.KDefFun->data;
-      _fx_R10Ast__loc_t kf_loc_0 = v_1232->kf_loc;
-      _fx_R16Ast__fun_flags_t kf_flags_0 = v_1232->kf_flags;
-      fx_copy_str(&v_1232->kf_cname, &kf_cname_0);
-      FX_COPY_PTR(v_1232->kf_body, &kf_body_0);
-      _fx_R25K_form__kdefclosureinfo_t kf_closure_0 = v_1232->kf_closure;
-      FX_COPY_PTR(v_1232->kf_rt, &kf_rt_0);
-      _fx_R9Ast__id_t kf_name_0 = v_1232->kf_name;
+      _fx_LN15C_form__cstmt_t v_1251 = 0;
+      _fx_R17C_form__cdeffun_t v_1252 = {0};
+      _fx_R17K_form__kdeffun_t* v_1253 = &kexp_0->u.KDefFun->data;
+      _fx_R10Ast__loc_t kf_loc_0 = v_1253->kf_loc;
+      _fx_R16Ast__fun_flags_t kf_flags_0 = v_1253->kf_flags;
+      fx_copy_str(&v_1253->kf_cname, &kf_cname_0);
+      FX_COPY_PTR(v_1253->kf_body, &kf_body_0);
+      _fx_R25K_form__kdefclosureinfo_t kf_closure_0 = v_1253->kf_closure;
+      FX_COPY_PTR(v_1253->kf_rt, &kf_rt_0);
+      _fx_R9Ast__id_t kf_name_0 = v_1253->kf_name;
       _fx_R9Ast__id_t kci_fcv_t_0 = kf_closure_0.kci_fcv_t;
       _fx_R9Ast__id_t kci_arg_0 = kf_closure_0.kci_arg;
       _fx_N17Ast__fun_constr_t ctor_0 = kf_flags_0.fun_flag_ctor;
       bool res_35;
-      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_35, 0), _fx_catch_284);
+      FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_35, 0), _fx_catch_288);
       if (res_35) {
          FX_CALL(
             _fx_M10C_gen_codeFM33ensure_sym_is_defined_or_declaredv4R9Ast__id_tR10Ast__loc_trNt10Hashset__t1R9Ast__id_trLN15C_form__cstmt_t(
-               &kf_name_0, &kf_loc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_284);
+               &kf_name_0, &kf_loc_0, defined_syms_ref_0, fwd_fdecls_ref_0, 0), _fx_catch_288);
       }
-      FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, &kf_name_0, 0), _fx_catch_284);
-      _fx_N24C_gen_code__block_kind_t v_1233;
-      _fx_M10C_gen_codeFM13BlockKind_FunN24C_gen_code__block_kind_t1R9Ast__id_t(&kf_name_0, &v_1233);
+      FX_CALL(_fx_M10C_gen_codeFM3addv2Nt10Hashset__t1R9Ast__id_tR9Ast__id_t(*defined_syms_0, &kf_name_0, 0), _fx_catch_288);
+      _fx_N24C_gen_code__block_kind_t v_1254;
+      _fx_M10C_gen_codeFM13BlockKind_FunN24C_gen_code__block_kind_t1R9Ast__id_t(&kf_name_0, &v_1254);
       FX_CALL(
-         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(&v_1233, &kloc_0,
-            block_stack_ref_0, km_idx_0, 0), _fx_catch_284);
-      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1227, 0),
-         _fx_catch_284);
-      if (v_1227.tag == 3) {
-         _fx_R17C_form__cdeffun_t v_1234 = {0};
-         _fx_rR17C_form__cdeffun_t cf_1 = v_1227.u.CFun;
-         _fx_copy_R17C_form__cdeffun_t(&cf_1->data, &v_1234);
-         bool is_nothrow_2 = v_1234.cf_flags.fun_flag_nothrow;
+         _fx_M10C_gen_codeFM13new_block_ctxv4N24C_gen_code__block_kind_tR10Ast__loc_trLrRM11block_ctx_ti(&v_1254, &kloc_0,
+            block_stack_ref_0, km_idx_0, 0), _fx_catch_288);
+      FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1248, 0),
+         _fx_catch_288);
+      if (v_1248.tag == 3) {
+         _fx_R17C_form__cdeffun_t v_1255 = {0};
+         _fx_rR17C_form__cdeffun_t cf_1 = v_1248.u.CFun;
+         _fx_copy_R17C_form__cdeffun_t(&cf_1->data, &v_1255);
+         bool is_nothrow_2 = v_1255.cf_flags.fun_flag_nothrow;
          _fx_make_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(
-            v_1234.cf_args, v_1234.cf_rt, is_nothrow_2, cf_1, &v_1228);
-         _fx_free_R17C_form__cdeffun_t(&v_1234);
+            v_1255.cf_args, v_1255.cf_rt, is_nothrow_2, cf_1, &v_1249);
+         _fx_free_R17C_form__cdeffun_t(&v_1255);
       }
       else {
-         fx_str_t v_1235 = {0};
-         fx_str_t v_1236 = {0};
-         fx_str_t v_1237 = {0};
-         fx_exn_t v_1238 = {0};
-         FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1235, 0), _fx_catch_265);
-         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1235, &v_1236, 0), _fx_catch_265);
-         fx_str_t slit_261 = FX_MAKE_STR("cgen: the function \'");
-         fx_str_t slit_262 = FX_MAKE_STR("\' declaration was not properly converted");
+         fx_str_t v_1256 = {0};
+         fx_str_t v_1257 = {0};
+         fx_str_t v_1258 = {0};
+         fx_exn_t v_1259 = {0};
+         FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1256, 0), _fx_catch_269);
+         FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1256, &v_1257, 0), _fx_catch_269);
+         fx_str_t slit_267 = FX_MAKE_STR("cgen: the function \'");
+         fx_str_t slit_268 = FX_MAKE_STR("\' declaration was not properly converted");
          {
-            const fx_str_t strs_35[] = { slit_261, v_1236, slit_262 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_35, 3, &v_1237), _fx_catch_265);
+            const fx_str_t strs_37[] = { slit_267, v_1257, slit_268 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_37, 3, &v_1258), _fx_catch_269);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1237, &v_1238, 0), _fx_catch_265);
-         FX_THROW(&v_1238, false, _fx_catch_265);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1258, &v_1259, 0), _fx_catch_269);
+         FX_THROW(&v_1259, false, _fx_catch_269);
 
-      _fx_catch_265: ;
-         fx_free_exn(&v_1238);
-         FX_FREE_STR(&v_1237);
-         FX_FREE_STR(&v_1236);
-         FX_FREE_STR(&v_1235);
+      _fx_catch_269: ;
+         fx_free_exn(&v_1259);
+         FX_FREE_STR(&v_1258);
+         FX_FREE_STR(&v_1257);
+         FX_FREE_STR(&v_1256);
       }
-      FX_CHECK_EXN(_fx_catch_284);
-      FX_COPY_PTR(v_1228.t0, &args_13);
-      FX_COPY_PTR(v_1228.t1, &rt_0);
-      bool is_nothrow_3 = v_1228.t2;
-      FX_COPY_PTR(v_1228.t3, &cf_0);
+      FX_CHECK_EXN(_fx_catch_288);
+      FX_COPY_PTR(v_1249.t0, &args_13);
+      FX_COPY_PTR(v_1249.t1, &rt_0);
+      bool is_nothrow_3 = v_1249.t2;
+      FX_COPY_PTR(v_1249.t3, &cf_0);
       FX_CALL(
          _fx_M10C_gen_codeFM15unpack_fun_argsT4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB3LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tB(
-            args_13, rt_0, is_nothrow_3, &v_1229, 0), _fx_catch_284);
-      FX_COPY_PTR(v_1229.t0, &real_args_0);
-      _fx_R9Ast__id_t retid_0 = v_1229.t1;
-      FX_CALL(_fx_make_rB(false, &really_nothrow_0), _fx_catch_284);
+            args_13, rt_0, is_nothrow_3, &v_1250, 0), _fx_catch_288);
+      FX_COPY_PTR(v_1250.t0, &real_args_0);
+      _fx_R9Ast__id_t retid_0 = v_1250.t1;
+      FX_CALL(_fx_make_rB(false, &really_nothrow_0), _fx_catch_288);
       int_ nreal_args_0;
       FX_CALL(
          _fx_M10C_gen_codeFM8length1_i1LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(real_args_0, &nreal_args_0, 0),
-         _fx_catch_284);
+         _fx_catch_288);
       if (ctor_0.tag == 1) {
          if (FX_REC_VARIANT_TAG(kf_body_0) == 30) {
-            _fx_N14C_form__cexp_t v_1239 = 0;
-            _fx_N15C_form__cstmt_t v_1240 = 0;
+            _fx_N14C_form__cexp_t v_1260 = 0;
+            _fx_N15C_form__cstmt_t v_1261 = 0;
             _fx_T2ST2N14K_form__ktyp_tR10Ast__loc_t* vcase_38 = &kf_body_0->u.KExpCCode;
-            FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&vcase_38->t0, &vcase_38->t1.t1, &v_1239),
-               _fx_catch_266);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1239, &v_1240), _fx_catch_266);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1240, 0, true, &new_body_0), _fx_catch_266);
+            FX_CALL(_fx_M6C_formFM9CExpCCodeN14C_form__cexp_t2SR10Ast__loc_t(&vcase_38->t0, &vcase_38->t1.t1, &v_1260),
+               _fx_catch_270);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1260, &v_1261), _fx_catch_270);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1261, 0, true, &new_body_0), _fx_catch_270);
 
-         _fx_catch_266: ;
-            if (v_1240) {
-               _fx_free_N15C_form__cstmt_t(&v_1240);
+         _fx_catch_270: ;
+            if (v_1261) {
+               _fx_free_N15C_form__cstmt_t(&v_1261);
             }
-            if (v_1239) {
-               _fx_free_N14C_form__cexp_t(&v_1239);
+            if (v_1260) {
+               _fx_free_N14C_form__cexp_t(&v_1260);
             }
             goto _fx_endmatch_54;
          }
       }
       if (ctor_0.tag == 1) {
-         _fx_Nt6option1N14C_form__cexp_t v_1241 = {0};
-         _fx_N14C_form__cexp_t v_1242 = 0;
-         _fx_N14C_form__cexp_t v_1243 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1262 = {0};
+         _fx_N14C_form__cexp_t v_1263 = 0;
+         _fx_N14C_form__cexp_t v_1264 = 0;
          _fx_rNt6option1N14C_form__cexp_t dstexp_r_1 = 0;
-         _fx_R16Ast__val_flags_t v_1244 = {0};
-         _fx_N14C_form__cexp_t v_1245 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1246 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1247 = {0};
+         _fx_R16Ast__val_flags_t v_1265 = {0};
+         _fx_N14C_form__cexp_t v_1266 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1267 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1268 = {0};
          _fx_N14C_form__cexp_t status_exp_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_151 = 0;
-         _fx_LN15C_form__cstmt_t ccode_152 = 0;
+         _fx_LN15C_form__cstmt_t ccode_154 = 0;
+         _fx_LN15C_form__cstmt_t ccode_155 = 0;
          _fx_N14C_form__cexp_t call_chkstk_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_153 = 0;
-         _fx_N14C_form__ctyp_t v_1248 = 0;
+         _fx_LN15C_form__cstmt_t ccode_156 = 0;
+         _fx_N14C_form__ctyp_t v_1269 = 0;
          _fx_N14C_form__ctyp_t fcv_ptr_ctyp_0 = 0;
          _fx_N14C_form__cexp_t fcv_arg_exp0_0 = 0;
          _fx_N14C_form__cexp_t cast_ptr_0 = 0;
-         _fx_R16Ast__val_flags_t v_1249 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_1250 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1251 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1252 = {0};
+         _fx_R16Ast__val_flags_t v_1270 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_1271 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1272 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1273 = {0};
          _fx_N14C_form__cexp_t ret_e_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_154 = 0;
+         _fx_LN15C_form__cstmt_t ccode_157 = 0;
          _fx_rR23C_gen_code__block_ctx_t bctx_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_155 = 0;
+         _fx_LN15C_form__cstmt_t ccode_158 = 0;
          _fx_LN15C_form__cstmt_t bctx_cleanup_3 = 0;
          _fx_LN15C_form__cstmt_t bctx_prologue_3 = 0;
-         _fx_LN15C_form__cstmt_t ccode_156 = 0;
-         _fx_N15C_form__cstmt_t v_1253 = 0;
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1254 = {0};
-         _fx_Nt6option1N14C_form__cexp_t v_1255 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1256 = {0};
-         _fx_N14C_form__cexp_t ret_e_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_157 = 0;
-         _fx_LN15C_form__cstmt_t v_1257 = 0;
-         _fx_N14C_form__cexp_t ret_e_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_158 = 0;
          _fx_LN15C_form__cstmt_t ccode_159 = 0;
+         _fx_N15C_form__cstmt_t v_1274 = 0;
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1275 = {0};
+         _fx_Nt6option1N14C_form__cexp_t v_1276 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1277 = {0};
+         _fx_N14C_form__cexp_t ret_e_1 = 0;
+         _fx_LN15C_form__cstmt_t ccode_160 = 0;
+         _fx_LN15C_form__cstmt_t v_1278 = 0;
+         _fx_N14C_form__cexp_t ret_e_2 = 0;
+         _fx_LN15C_form__cstmt_t ccode_161 = 0;
+         _fx_LN15C_form__cstmt_t ccode_162 = 0;
          _fx_N14C_form__cexp_t chk_ret_0 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1258 = {0};
-         _fx_N15C_form__cstmt_t v_1259 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1260 = {0};
-         _fx_N15C_form__cstmt_t v_1261 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1262 = {0};
-         _fx_N15C_form__cstmt_t v_1263 = 0;
-         _fx_LN15C_form__cstmt_t v_1264 = 0;
-         _fx_LN15C_form__cstmt_t v_1265 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1279 = {0};
+         _fx_N15C_form__cstmt_t v_1280 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1281 = {0};
+         _fx_N15C_form__cstmt_t v_1282 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1283 = {0};
+         _fx_N15C_form__cstmt_t v_1284 = 0;
+         _fx_LN15C_form__cstmt_t v_1285 = 0;
+         _fx_LN15C_form__cstmt_t v_1286 = 0;
          bool res_36;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&retid_0, &_fx_g9Ast__noid, &res_36, 0), _fx_catch_269);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&retid_0, &_fx_g9Ast__noid, &res_36, 0), _fx_catch_273);
          if (res_36) {
-            _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1241);
+            _fx_copy_Nt6option1N14C_form__cexp_t(&_fx_g18C_gen_code__None2_, &v_1262);
          }
          else {
-            FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &v_1242, 0),
-               _fx_catch_269);
-            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1242, &v_1243, 0), _fx_catch_269);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1243, &v_1241);
+            FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &v_1263, 0),
+               _fx_catch_273);
+            FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1263, &v_1264, 0), _fx_catch_273);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1264, &v_1262);
          }
-         FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1241, &dstexp_r_1), _fx_catch_269);
+         FX_CALL(_fx_make_rNt6option1N14C_form__cexp_t(&v_1262, &dstexp_r_1), _fx_catch_273);
          _fx_free_rNt6option1N14C_form__cexp_t(func_dstexp_r_0);
          FX_COPY_PTR(dstexp_r_1, func_dstexp_r_0);
          *return_used_0 = 0;
          _fx_R9Ast__id_t orig_status_id_0;
-         fx_str_t slit_263 = FX_MAKE_STR("fx_status");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_263, &orig_status_id_0, 0), _fx_catch_269);
-         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1244, 0), _fx_catch_269);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1245, 0), _fx_catch_269);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1245, &v_1246);
-         fx_str_t slit_264 = FX_MAKE_STR("fx_status");
+         fx_str_t slit_269 = FX_MAKE_STR("fx_status");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_269, &orig_status_id_0, 0), _fx_catch_273);
+         FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1265, 0), _fx_catch_273);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1266, 0), _fx_catch_273);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1266, &v_1267);
+         fx_str_t slit_270 = FX_MAKE_STR("fx_status");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &orig_status_id_0, _fx_g20C_gen_code__CTypCInt, &v_1244, &slit_264, &v_1246, 0, &kf_loc_0, &v_1247, 0),
-            _fx_catch_269);
-         FX_COPY_PTR(v_1247.t0, &status_exp_0);
-         FX_COPY_PTR(v_1247.t1, &ccode_151);
+               &orig_status_id_0, _fx_g20C_gen_code__CTypCInt, &v_1265, &slit_270, &v_1267, 0, &kf_loc_0, &v_1268, 0),
+            _fx_catch_273);
+         FX_COPY_PTR(v_1268.t0, &status_exp_0);
+         FX_COPY_PTR(v_1268.t1, &ccode_154);
          _fx_R9Ast__id_t status_id_0;
          if (is_nothrow_3) {
             status_id_0 = _fx_g9Ast__noid;
@@ -34550,7 +34790,7 @@ static int
             status_id_0 = orig_status_id_0;
          }
          bool res_37;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&status_id_0, &_fx_g9Ast__noid, &res_37, 0), _fx_catch_269);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&status_id_0, &_fx_g9Ast__noid, &res_37, 0), _fx_catch_273);
          bool t_22;
          if (res_37) {
             t_22 = true;
@@ -34559,118 +34799,118 @@ static int
             t_22 = !kf_flags_0.fun_flag_recursive;
          }
          if (t_22) {
-            FX_COPY_PTR(ccode_151, &ccode_152);
+            FX_COPY_PTR(ccode_154, &ccode_155);
          }
          else {
-            _fx_R9Ast__id_t v_1266;
-            fx_str_t slit_265 = FX_MAKE_STR("fx_check_stack");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_265, &v_1266, 0), _fx_catch_269);
+            _fx_R9Ast__id_t v_1287;
+            fx_str_t slit_271 = FX_MAKE_STR("fx_check_stack");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_271, &v_1287, 0), _fx_catch_273);
             FX_CALL(
-               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1266, 0,
-                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &call_chkstk_0, 0), _fx_catch_269);
+               _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1287, 0,
+                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &call_chkstk_0, 0), _fx_catch_273);
             FX_CALL(
                _fx_M10C_gen_codeFM11add_fx_callLN15C_form__cstmt_t4N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_trLrRM11block_ctx_t(
-                  call_chkstk_0, ccode_151, &kf_loc_0, block_stack_ref_0, &ccode_152, 0), _fx_catch_269);
+                  call_chkstk_0, ccode_154, &kf_loc_0, block_stack_ref_0, &ccode_155, 0), _fx_catch_273);
          }
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_32 = real_args_0;
          for (; lst_32; lst_32 = lst_32->tl) {
             _fx_LN19C_form__carg_attr_t flags_3 = 0;
-            _fx_N14C_form__cexp_t v_1267 = 0;
-            _fx_N14C_form__cexp_t v_1268 = 0;
+            _fx_N14C_form__cexp_t v_1288 = 0;
+            _fx_N14C_form__cexp_t v_1289 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___12 = &lst_32->hd;
             _fx_R9Ast__id_t a_13 = __pat___12->t0;
             FX_COPY_PTR(__pat___12->t2, &flags_3);
-            bool v_1269;
+            bool v_1290;
             FX_CALL(
                _fx_M10C_gen_codeFM3memB2LN19C_form__carg_attr_tN19C_form__carg_attr_t(flags_3,
-                  &_fx_g25C_gen_code__CArgPassByPtr, &v_1269, 0), _fx_catch_267);
-            if (v_1269) {
-               FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&a_13, &kf_loc_0, &v_1267, 0),
-                  _fx_catch_267);
-               FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1267, &v_1268, 0), _fx_catch_267);
+                  &_fx_g25C_gen_code__CArgPassByPtr, &v_1290, 0), _fx_catch_271);
+            if (v_1290) {
+               FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&a_13, &kf_loc_0, &v_1288, 0),
+                  _fx_catch_271);
+               FX_CALL(_fx_M6C_formFM10cexp_derefN14C_form__cexp_t1N14C_form__cexp_t(v_1288, &v_1289, 0), _fx_catch_271);
                FX_CALL(
                   _fx_M10C_gen_codeFM3addv3Nt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tR9Ast__id_tN14C_form__cexp_t(*i2e_0,
-                     &a_13, v_1268, 0), _fx_catch_267);
+                     &a_13, v_1289, 0), _fx_catch_271);
             }
 
-         _fx_catch_267: ;
-            if (v_1268) {
-               _fx_free_N14C_form__cexp_t(&v_1268);
+         _fx_catch_271: ;
+            if (v_1289) {
+               _fx_free_N14C_form__cexp_t(&v_1289);
             }
-            if (v_1267) {
-               _fx_free_N14C_form__cexp_t(&v_1267);
+            if (v_1288) {
+               _fx_free_N14C_form__cexp_t(&v_1288);
             }
             FX_FREE_LIST_SIMPLE(&flags_3);
-            FX_CHECK_EXN(_fx_catch_269);
+            FX_CHECK_EXN(_fx_catch_273);
          }
          bool res_38;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_38, 0), _fx_catch_269);
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&kci_arg_0, &_fx_g9Ast__noid, &res_38, 0), _fx_catch_273);
          if (res_38) {
-            FX_COPY_PTR(ccode_152, &ccode_153);
+            FX_COPY_PTR(ccode_155, &ccode_156);
          }
          else {
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&kci_fcv_t_0, &v_1248), _fx_catch_269);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(v_1248, &fcv_ptr_ctyp_0, 0), _fx_catch_269);
-            _fx_R9Ast__id_t v_1270;
-            fx_str_t slit_266 = FX_MAKE_STR("fx_fv");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_266, &v_1270, 0), _fx_catch_269);
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&kci_fcv_t_0, &v_1269), _fx_catch_273);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(v_1269, &fcv_ptr_ctyp_0, 0), _fx_catch_273);
+            _fx_R9Ast__id_t v_1291;
+            fx_str_t slit_272 = FX_MAKE_STR("fx_fv");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_272, &v_1291, 0), _fx_catch_273);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1270,
-                  _fx_g23C_form__std_CTypVoidPtr, &kf_loc_0, &fcv_arg_exp0_0, 0), _fx_catch_269);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1291,
+                  _fx_g23C_form__std_CTypVoidPtr, &kf_loc_0, &fcv_arg_exp0_0, 0), _fx_catch_273);
             FX_CALL(
                _fx_M6C_formFM8CExpCastN14C_form__cexp_t3N14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(fcv_arg_exp0_0,
-                  fcv_ptr_ctyp_0, &kf_loc_0, &cast_ptr_0), _fx_catch_269);
-            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1249, 0), _fx_catch_269);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(cast_ptr_0, &v_1250);
-            fx_str_t slit_267 = FX_MAKE_STR("");
+                  fcv_ptr_ctyp_0, &kf_loc_0, &cast_ptr_0), _fx_catch_273);
+            FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1270, 0), _fx_catch_273);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(cast_ptr_0, &v_1271);
+            fx_str_t slit_273 = FX_MAKE_STR("");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &kci_arg_0, fcv_ptr_ctyp_0, &v_1249, &slit_267, &v_1250, ccode_152, &kf_loc_0, &v_1251, 0), _fx_catch_269);
-            FX_COPY_PTR(v_1251.t1, &ccode_153);
+                  &kci_arg_0, fcv_ptr_ctyp_0, &v_1270, &slit_273, &v_1271, ccode_155, &kf_loc_0, &v_1272, 0), _fx_catch_273);
+            FX_COPY_PTR(v_1272.t1, &ccode_156);
          }
          FX_CALL(
             _fx_M10C_gen_codeFM9kexp2cexpT2N14C_form__cexp_tLN15C_form__cstmt_t17N14K_form__kexp_trNt6option1N14C_form__cexp_tLN15C_form__cstmt_trLrRM11block_ctx_trNt10Hashset__t1R9Ast__id_tLSrrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tiLN12Ast__scope_trLN15C_form__cstmt_trirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_t(
-               kf_body_0, dstexp_r_1, ccode_153, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
+               kf_body_0, dstexp_r_1, ccode_156, block_stack_ref_0, defined_syms_ref_0, for_letters_0, func_dstexp_r_ref_0,
                fwd_fdecls_ref_0, fx_status__0, glob_data_ccode_ref_0, i2e_ref_0, km_idx_0, mod_sc_0, module_cleanup_ref_0,
-               return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1252, fx_fv), _fx_catch_269);
-         FX_COPY_PTR(v_1252.t0, &ret_e_0);
-         FX_COPY_PTR(v_1252.t1, &ccode_154);
+               return_used_ref_0, top_inline_ccode_ref_0, u1vals_0, &v_1273, fx_fv), _fx_catch_273);
+         FX_COPY_PTR(v_1273.t0, &ret_e_0);
+         FX_COPY_PTR(v_1273.t1, &ccode_157);
          _fx_R10Ast__loc_t end_loc_0;
-         FX_CALL(_fx_M6K_formFM12get_kexp_endR10Ast__loc_t1N14K_form__kexp_t(kf_body_0, &end_loc_0, 0), _fx_catch_269);
+         FX_CALL(_fx_M6K_formFM12get_kexp_endR10Ast__loc_t1N14K_form__kexp_t(kf_body_0, &end_loc_0, 0), _fx_catch_273);
          FX_CALL(
             _fx_M10C_gen_codeFM14curr_block_ctxrRM11block_ctx_t2R10Ast__loc_trLrRM11block_ctx_t(&end_loc_0, block_stack_ref_0,
-               &bctx_2, 0), _fx_catch_269);
-         if (ccode_154 != 0) {
-            _fx_N15C_form__cstmt_t v_1271 = ccode_154->hd;
-            if (FX_REC_VARIANT_TAG(v_1271) == 3) {
-               _fx_N14C_form__cexp_t v_1272 = v_1271->u.CExp;
-               if (FX_REC_VARIANT_TAG(v_1272) == 9) {
-                  _fx_N14C_form__cexp_t v_1273 = v_1272->u.CExpCall.t0;
-                  if (FX_REC_VARIANT_TAG(v_1273) == 1) {
+               &bctx_2, 0), _fx_catch_273);
+         if (ccode_157 != 0) {
+            _fx_N15C_form__cstmt_t v_1292 = ccode_157->hd;
+            if (FX_REC_VARIANT_TAG(v_1292) == 3) {
+               _fx_N14C_form__cexp_t v_1293 = v_1292->u.CExp;
+               if (FX_REC_VARIANT_TAG(v_1293) == 9) {
+                  _fx_N14C_form__cexp_t v_1294 = v_1293->u.CExpCall.t0;
+                  if (FX_REC_VARIANT_TAG(v_1294) == 1) {
                      bool res_39;
                      FX_CALL(
-                        _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1273->u.CExpIdent.t0, &_fx_g24C_form__std_FX_CHECK_EXN, &res_39,
-                           0), _fx_catch_269);
+                        _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_1294->u.CExpIdent.t0, &_fx_g24C_form__std_FX_CHECK_EXN, &res_39,
+                           0), _fx_catch_273);
                      if (res_39) {
-                        _fx_R23C_gen_code__block_ctx_t* v_1274 = &bctx_2->data;
-                        _fx_R23C_gen_code__block_ctx_t* v_1275 = &bctx_2->data;
-                        v_1275->bctx_label_used = v_1274->bctx_label_used - 1;
-                        FX_COPY_PTR(ccode_154->tl, &ccode_155);
+                        _fx_R23C_gen_code__block_ctx_t* v_1295 = &bctx_2->data;
+                        _fx_R23C_gen_code__block_ctx_t* v_1296 = &bctx_2->data;
+                        v_1296->bctx_label_used = v_1295->bctx_label_used - 1;
+                        FX_COPY_PTR(ccode_157->tl, &ccode_158);
                         goto _fx_endmatch_51;
                      }
                   }
                }
             }
          }
-         FX_COPY_PTR(ccode_154, &ccode_155);
+         FX_COPY_PTR(ccode_157, &ccode_158);
 
       _fx_endmatch_51: ;
-         FX_CHECK_EXN(_fx_catch_269);
-         _fx_R23C_gen_code__block_ctx_t* v_1276 = &bctx_2->data;
-         int_ bctx_label_used_3 = v_1276->bctx_label_used;
-         FX_COPY_PTR(v_1276->bctx_cleanup, &bctx_cleanup_3);
-         FX_COPY_PTR(v_1276->bctx_prologue, &bctx_prologue_3);
-         _fx_R9Ast__id_t bctx_label_3 = v_1276->bctx_label;
+         FX_CHECK_EXN(_fx_catch_273);
+         _fx_R23C_gen_code__block_ctx_t* v_1297 = &bctx_2->data;
+         int_ bctx_label_used_3 = v_1297->bctx_label_used;
+         FX_COPY_PTR(v_1297->bctx_cleanup, &bctx_cleanup_3);
+         FX_COPY_PTR(v_1297->bctx_prologue, &bctx_prologue_3);
+         _fx_R9Ast__id_t bctx_label_3 = v_1297->bctx_label;
          bool t_23;
          if (bctx_label_used_3 > 0) {
             t_23 = true;
@@ -34679,37 +34919,37 @@ static int
             t_23 = *return_used_0 > 0;
          }
          if (t_23) {
-            FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_3, &end_loc_0, &v_1253),
-               _fx_catch_269);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1253, ccode_155, true, &ccode_156), _fx_catch_269);
+            FX_CALL(_fx_M6C_formFM10CStmtLabelN15C_form__cstmt_t2R9Ast__id_tR10Ast__loc_t(&bctx_label_3, &end_loc_0, &v_1274),
+               _fx_catch_273);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1274, ccode_158, true, &ccode_159), _fx_catch_273);
          }
          else {
-            FX_COPY_PTR(ccode_155, &ccode_156);
+            FX_COPY_PTR(ccode_158, &ccode_159);
          }
          if (bctx_cleanup_3 == 0) {
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_156, &v_1254);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1275);
          }
          else {
-            bool v_1277;
+            bool v_1298;
             bool res_40;
-            FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&retid_0, &_fx_g9Ast__noid, &res_40, 0), _fx_catch_269);
+            FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&retid_0, &_fx_g9Ast__noid, &res_40, 0), _fx_catch_273);
             bool t_24;
             if (res_40) {
                t_24 = true;
             }
             else {
                FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &t_24, 0),
-                  _fx_catch_269);
+                  _fx_catch_273);
             }
             if (t_24) {
-               v_1277 = true;
+               v_1298 = true;
             }
             else {
-               _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_1->data, &v_1255);
-               FX_CALL(_fx_M10C_gen_codeFM6issomeB1Nt6option1N14C_form__cexp_t(&v_1255, &v_1277, 0), _fx_catch_269);
+               _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_1->data, &v_1276);
+               FX_CALL(_fx_M10C_gen_codeFM6issomeB1Nt6option1N14C_form__cexp_t(&v_1276, &v_1298, 0), _fx_catch_273);
             }
-            if (v_1277) {
-               _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_156, &v_1256);
+            if (v_1298) {
+               _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1277);
             }
             else {
                int tag_33 = FX_REC_VARIANT_TAG(ret_e_0);
@@ -34728,131 +34968,131 @@ static int
                res_41 = false;
 
             _fx_endmatch_52: ;
-               FX_CHECK_EXN(_fx_catch_269);
+               FX_CHECK_EXN(_fx_catch_273);
                if (res_41) {
-                  _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_156, &v_1256); goto _fx_endmatch_53;
+                  _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_0, ccode_159, &v_1277); goto _fx_endmatch_53;
                }
-               _fx_N14C_form__ctyp_t v_1278 = 0;
-               _fx_R16Ast__val_flags_t v_1279 = {0};
-               _fx_Nt6option1N14C_form__cexp_t v_1280 = {0};
-               _fx_R9Ast__id_t v_1281;
-               fx_str_t slit_268 = FX_MAKE_STR("result");
-               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_268, &v_1281, 0), _fx_catch_268);
-               FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(ret_e_0, &v_1278, 0), _fx_catch_268);
-               FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1279, 0), _fx_catch_268);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_0, &v_1280);
-               fx_str_t slit_269 = FX_MAKE_STR("");
+               _fx_N14C_form__ctyp_t v_1299 = 0;
+               _fx_R16Ast__val_flags_t v_1300 = {0};
+               _fx_Nt6option1N14C_form__cexp_t v_1301 = {0};
+               _fx_R9Ast__id_t v_1302;
+               fx_str_t slit_274 = FX_MAKE_STR("result");
+               FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_274, &v_1302, 0), _fx_catch_272);
+               FX_CALL(_fx_M6C_formFM12get_cexp_typN14C_form__ctyp_t1N14C_form__cexp_t(ret_e_0, &v_1299, 0), _fx_catch_272);
+               FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1300, 0), _fx_catch_272);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_0, &v_1301);
+               fx_str_t slit_275 = FX_MAKE_STR("");
                FX_CALL(
                   _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     &v_1281, v_1278, &v_1279, &slit_269, &v_1280, ccode_156, &end_loc_0, &v_1256, 0), _fx_catch_268);
+                     &v_1302, v_1299, &v_1300, &slit_275, &v_1301, ccode_159, &end_loc_0, &v_1277, 0), _fx_catch_272);
 
-            _fx_catch_268: ;
-               _fx_free_Nt6option1N14C_form__cexp_t(&v_1280);
-               _fx_free_R16Ast__val_flags_t(&v_1279);
-               if (v_1278) {
-                  _fx_free_N14C_form__ctyp_t(&v_1278);
+            _fx_catch_272: ;
+               _fx_free_Nt6option1N14C_form__cexp_t(&v_1301);
+               _fx_free_R16Ast__val_flags_t(&v_1300);
+               if (v_1299) {
+                  _fx_free_N14C_form__ctyp_t(&v_1299);
                }
 
             _fx_endmatch_53: ;
-               FX_CHECK_EXN(_fx_catch_269);
+               FX_CHECK_EXN(_fx_catch_273);
             }
-            FX_COPY_PTR(v_1256.t0, &ret_e_1);
-            FX_COPY_PTR(v_1256.t1, &ccode_157);
+            FX_COPY_PTR(v_1277.t0, &ret_e_1);
+            FX_COPY_PTR(v_1277.t1, &ccode_160);
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_3, ccode_157,
-                  &v_1257, 0), _fx_catch_269);
-            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_1, v_1257, &v_1254);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(bctx_cleanup_3, ccode_160,
+                  &v_1278, 0), _fx_catch_273);
+            _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(ret_e_1, v_1278, &v_1275);
          }
-         FX_COPY_PTR(v_1254.t0, &ret_e_2);
-         FX_COPY_PTR(v_1254.t1, &ccode_158);
+         FX_COPY_PTR(v_1275.t0, &ret_e_2);
+         FX_COPY_PTR(v_1275.t1, &ccode_161);
          bool res_42;
-         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &res_42, 0), _fx_catch_269);
+         FX_CALL(_fx_M10C_gen_codeFM6__ne__B2R9Ast__id_tR9Ast__id_t(&status_id_0, &_fx_g9Ast__noid, &res_42, 0), _fx_catch_273);
          if (res_42) {
             if (*return_used_0 > 0) {
-               _fx_R9Ast__id_t v_1282;
-               fx_str_t slit_270 = FX_MAKE_STR("FX_CHECK_RETURN");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_270, &v_1282, 0), _fx_catch_269);
+               _fx_R9Ast__id_t v_1303;
+               fx_str_t slit_276 = FX_MAKE_STR("FX_CHECK_RETURN");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_276, &v_1303, 0), _fx_catch_273);
                FX_CALL(
-                  _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1282,
-                     0, _fx_g20C_gen_code__CTypCInt, &end_loc_0, &chk_ret_0, 0), _fx_catch_269);
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_ret_0, &v_1258);
+                  _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(&v_1303,
+                     0, _fx_g20C_gen_code__CTypCInt, &end_loc_0, &chk_ret_0, 0), _fx_catch_273);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(chk_ret_0, &v_1279);
                FX_CALL(
-                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1258, &end_loc_0,
-                     &v_1259), _fx_catch_269);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1259, ccode_158, true, &ccode_159), _fx_catch_269);
+                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1279, &end_loc_0,
+                     &v_1280), _fx_catch_273);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1280, ccode_161, true, &ccode_162), _fx_catch_273);
             }
             else {
-               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(status_exp_0, &v_1260);
+               _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(status_exp_0, &v_1281);
                FX_CALL(
-                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1260, &end_loc_0,
-                     &v_1261), _fx_catch_269);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1261, ccode_158, true, &ccode_159), _fx_catch_269);
+                  _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1281, &end_loc_0,
+                     &v_1282), _fx_catch_273);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1282, ccode_161, true, &ccode_162), _fx_catch_273);
             }
          }
          else if (FX_REC_VARIANT_TAG(rt_0) == 8) {
-            FX_COPY_PTR(ccode_158, &ccode_159);
+            FX_COPY_PTR(ccode_161, &ccode_162);
          }
          else {
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_2, &v_1262);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(ret_e_2, &v_1283);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1262, &end_loc_0,
-                  &v_1263), _fx_catch_269);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1263, ccode_158, true, &ccode_159), _fx_catch_269);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1283, &end_loc_0,
+                  &v_1284), _fx_catch_273);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1284, ccode_161, true, &ccode_162), _fx_catch_273);
          }
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(bctx_prologue_3, &v_1264, 0), _fx_catch_269);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(ccode_159, &v_1265, 0), _fx_catch_269);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(bctx_prologue_3, &v_1285, 0), _fx_catch_273);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(ccode_162, &v_1286, 0), _fx_catch_273);
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1264, v_1265, &new_body_0,
-               0), _fx_catch_269);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(v_1285, v_1286, &new_body_0,
+               0), _fx_catch_273);
 
-      _fx_catch_269: ;
-         if (v_1265) {
-            _fx_free_LN15C_form__cstmt_t(&v_1265);
+      _fx_catch_273: ;
+         if (v_1286) {
+            _fx_free_LN15C_form__cstmt_t(&v_1286);
          }
-         if (v_1264) {
-            _fx_free_LN15C_form__cstmt_t(&v_1264);
+         if (v_1285) {
+            _fx_free_LN15C_form__cstmt_t(&v_1285);
          }
-         if (v_1263) {
-            _fx_free_N15C_form__cstmt_t(&v_1263);
+         if (v_1284) {
+            _fx_free_N15C_form__cstmt_t(&v_1284);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1262);
-         if (v_1261) {
-            _fx_free_N15C_form__cstmt_t(&v_1261);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1283);
+         if (v_1282) {
+            _fx_free_N15C_form__cstmt_t(&v_1282);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1260);
-         if (v_1259) {
-            _fx_free_N15C_form__cstmt_t(&v_1259);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1281);
+         if (v_1280) {
+            _fx_free_N15C_form__cstmt_t(&v_1280);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1258);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1279);
          if (chk_ret_0) {
             _fx_free_N14C_form__cexp_t(&chk_ret_0);
          }
-         if (ccode_159) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_159);
+         if (ccode_162) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_162);
          }
-         if (ccode_158) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_158);
+         if (ccode_161) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_161);
          }
          if (ret_e_2) {
             _fx_free_N14C_form__cexp_t(&ret_e_2);
          }
-         if (v_1257) {
-            _fx_free_LN15C_form__cstmt_t(&v_1257);
+         if (v_1278) {
+            _fx_free_LN15C_form__cstmt_t(&v_1278);
          }
-         if (ccode_157) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_157);
+         if (ccode_160) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_160);
          }
          if (ret_e_1) {
             _fx_free_N14C_form__cexp_t(&ret_e_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1256);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1255);
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1254);
-         if (v_1253) {
-            _fx_free_N15C_form__cstmt_t(&v_1253);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1277);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1276);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1275);
+         if (v_1274) {
+            _fx_free_N15C_form__cstmt_t(&v_1274);
          }
-         if (ccode_156) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_156);
+         if (ccode_159) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_159);
          }
          if (bctx_prologue_3) {
             _fx_free_LN15C_form__cstmt_t(&bctx_prologue_3);
@@ -34860,22 +35100,22 @@ static int
          if (bctx_cleanup_3) {
             _fx_free_LN15C_form__cstmt_t(&bctx_cleanup_3);
          }
-         if (ccode_155) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_155);
+         if (ccode_158) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_158);
          }
          if (bctx_2) {
             _fx_free_rR23C_gen_code__block_ctx_t(&bctx_2);
          }
-         if (ccode_154) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_154);
+         if (ccode_157) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_157);
          }
          if (ret_e_0) {
             _fx_free_N14C_form__cexp_t(&ret_e_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1252);
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1251);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1250);
-         _fx_free_R16Ast__val_flags_t(&v_1249);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1273);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1272);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1271);
+         _fx_free_R16Ast__val_flags_t(&v_1270);
          if (cast_ptr_0) {
             _fx_free_N14C_form__cexp_t(&cast_ptr_0);
          }
@@ -34885,314 +35125,314 @@ static int
          if (fcv_ptr_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&fcv_ptr_ctyp_0);
          }
-         if (v_1248) {
-            _fx_free_N14C_form__ctyp_t(&v_1248);
+         if (v_1269) {
+            _fx_free_N14C_form__ctyp_t(&v_1269);
          }
-         if (ccode_153) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_153);
+         if (ccode_156) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_156);
          }
          if (call_chkstk_0) {
             _fx_free_N14C_form__cexp_t(&call_chkstk_0);
          }
-         if (ccode_152) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_152);
+         if (ccode_155) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_155);
          }
-         if (ccode_151) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_151);
+         if (ccode_154) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_154);
          }
          if (status_exp_0) {
             _fx_free_N14C_form__cexp_t(&status_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1247);
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1246);
-         if (v_1245) {
-            _fx_free_N14C_form__cexp_t(&v_1245);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1268);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1267);
+         if (v_1266) {
+            _fx_free_N14C_form__cexp_t(&v_1266);
          }
-         _fx_free_R16Ast__val_flags_t(&v_1244);
+         _fx_free_R16Ast__val_flags_t(&v_1265);
          if (dstexp_r_1) {
             _fx_free_rNt6option1N14C_form__cexp_t(&dstexp_r_1);
          }
-         if (v_1243) {
-            _fx_free_N14C_form__cexp_t(&v_1243);
+         if (v_1264) {
+            _fx_free_N14C_form__cexp_t(&v_1264);
          }
-         if (v_1242) {
-            _fx_free_N14C_form__cexp_t(&v_1242);
+         if (v_1263) {
+            _fx_free_N14C_form__cexp_t(&v_1263);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1241);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1262);
          goto _fx_endmatch_54;
       }
       if (ctor_0.tag == 3) {
          _fx_N14C_form__cexp_t var_exp_0 = 0;
          _fx_N14C_form__ctyp_t result_ctyp_0 = 0;
-         _fx_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t v_1283 = {0};
-         _fx_N14C_form__cexp_t v_1284 = 0;
-         _fx_LN14C_form__cexp_t v_1285 = 0;
+         _fx_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t v_1304 = {0};
+         _fx_N14C_form__cexp_t v_1305 = 0;
+         _fx_LN14C_form__cexp_t v_1306 = 0;
          _fx_N14C_form__cexp_t alloc_var_0 = 0;
-         _fx_R16Ast__val_flags_t v_1286 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1287 = {0};
+         _fx_R16Ast__val_flags_t v_1307 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1308 = {0};
          _fx_N14C_form__cexp_t var_exp_1 = 0;
-         _fx_N15C_form__cstmt_t v_1288 = 0;
-         _fx_LN15C_form__cstmt_t ccode_160 = 0;
-         _fx_LN15C_form__cstmt_t ccode_161 = 0;
+         _fx_N15C_form__cstmt_t v_1309 = 0;
+         _fx_LN15C_form__cstmt_t ccode_163 = 0;
+         _fx_LN15C_form__cstmt_t ccode_164 = 0;
          _fx_N14C_form__ctyp_t ifaces_ctyp_0 = 0;
          _fx_N14C_form__ctyp_t ifaces_ptr_ctyp_0 = 0;
-         _fx_N14C_form__cexp_t v_1289 = 0;
-         _fx_N14C_form__cexp_t v_1290 = 0;
-         _fx_N14C_form__cexp_t v_1291 = 0;
-         _fx_N14C_form__cexp_t v_1292 = 0;
-         _fx_N15C_form__cstmt_t v_1293 = 0;
-         _fx_N14C_form__cexp_t v_1294 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1295 = {0};
-         _fx_N15C_form__cstmt_t v_1296 = 0;
+         _fx_N14C_form__cexp_t v_1310 = 0;
+         _fx_N14C_form__cexp_t v_1311 = 0;
+         _fx_N14C_form__cexp_t v_1312 = 0;
+         _fx_N14C_form__cexp_t v_1313 = 0;
+         _fx_N15C_form__cstmt_t v_1314 = 0;
+         _fx_N14C_form__cexp_t v_1315 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1316 = {0};
+         _fx_N15C_form__cstmt_t v_1317 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_0 = 0;
          _fx_N14C_form__cexp_t var_exp_2 = 0;
-         _fx_LN15C_form__cstmt_t ccode_162 = 0;
+         _fx_LN15C_form__cstmt_t ccode_165 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_1 = 0;
-         _fx_N14C_form__cexp_t v_1297 = 0;
-         _fx_N14C_form__cexp_t v_1298 = 0;
+         _fx_N14C_form__cexp_t v_1318 = 0;
+         _fx_N14C_form__cexp_t v_1319 = 0;
          _fx_N14C_form__cexp_t init_tag_0 = 0;
-         _fx_LN15C_form__cstmt_t ccode_163 = 0;
-         _fx_N15C_form__cstmt_t v_1299 = 0;
+         _fx_LN15C_form__cstmt_t ccode_166 = 0;
+         _fx_N15C_form__cstmt_t v_1320 = 0;
          _fx_N14C_form__cexp_t dst_base_0 = 0;
          _fx_N14C_form__cexp_t dst_base_1 = 0;
-         _fx_LN15C_form__cstmt_t ccode_164 = 0;
-         _fx_LN15C_form__cstmt_t v_1300 = 0;
-         _fx_T3BBR9Ast__id_t v_1301;
+         _fx_LN15C_form__cstmt_t ccode_167 = 0;
+         _fx_LN15C_form__cstmt_t v_1321 = 0;
+         _fx_T3BBR9Ast__id_t v_1322;
          if (FX_REC_VARIANT_TAG(kf_rt_0) == 16) {
-            _fx_N15K_form__kinfo_t v_1302 = {0};
+            _fx_N15K_form__kinfo_t v_1323 = {0};
             _fx_R9Ast__id_t* vn_1 = &kf_rt_0->u.KTypName;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1302, 0),
-               _fx_catch_272);
-            if (v_1302.tag == 5) {
-               _fx_R21K_form__kdefvariant_t v_1303 = {0};
-               _fx_N15C_form__cinfo_t v_1304 = {0};
-               _fx_copy_R21K_form__kdefvariant_t(&v_1302.u.KVariant->data, &v_1303);
-               _fx_R16Ast__var_flags_t* kvar_flags_2 = &v_1303.kvar_flags;
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1323, 0),
+               _fx_catch_276);
+            if (v_1323.tag == 5) {
+               _fx_R21K_form__kdefvariant_t v_1324 = {0};
+               _fx_N15C_form__cinfo_t v_1325 = {0};
+               _fx_copy_R21K_form__kdefvariant_t(&v_1323.u.KVariant->data, &v_1324);
+               _fx_R16Ast__var_flags_t* kvar_flags_2 = &v_1324.kvar_flags;
                bool have_tag_1 = kvar_flags_2->var_flag_have_tag;
                bool is_recursive_1 = kvar_flags_2->var_flag_recursive;
-               FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1304, 0),
-                  _fx_catch_270);
+               FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(vn_1, &kf_loc_0, &v_1325, 0),
+                  _fx_catch_274);
                _fx_R9Ast__id_t ifaces_id_0;
-               if (v_1304.tag == 4) {
-                  _fx_R17C_form__cdeftyp_t v_1305 = {0};
-                  _fx_copy_R17C_form__cdeftyp_t(&v_1304.u.CTyp->data, &v_1305);
-                  ifaces_id_0 = v_1305.ct_ifaces_id;
-                  _fx_free_R17C_form__cdeftyp_t(&v_1305);
+               if (v_1325.tag == 4) {
+                  _fx_R17C_form__cdeftyp_t v_1326 = {0};
+                  _fx_copy_R17C_form__cdeftyp_t(&v_1325.u.CTyp->data, &v_1326);
+                  ifaces_id_0 = v_1326.ct_ifaces_id;
+                  _fx_free_R17C_form__cdeftyp_t(&v_1326);
                }
                else {
                   ifaces_id_0 = _fx_g9Ast__noid;
                }
-               FX_CHECK_EXN(_fx_catch_270);
+               FX_CHECK_EXN(_fx_catch_274);
                _fx_T3BBR9Ast__id_t tup_3 = { have_tag_1, is_recursive_1, ifaces_id_0 };
-               v_1301 = tup_3;
+               v_1322 = tup_3;
 
-            _fx_catch_270: ;
-               _fx_free_N15C_form__cinfo_t(&v_1304);
-               _fx_free_R21K_form__kdefvariant_t(&v_1303);
+            _fx_catch_274: ;
+               _fx_free_N15C_form__cinfo_t(&v_1325);
+               _fx_free_R21K_form__kdefvariant_t(&v_1324);
             }
             else {
-               fx_str_t v_1306 = {0};
-               fx_str_t v_1307 = {0};
-               fx_str_t v_1308 = {0};
-               fx_exn_t v_1309 = {0};
-               FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1306, 0), _fx_catch_271);
-               FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1306, &v_1307, 0), _fx_catch_271);
-               fx_str_t slit_271 = FX_MAKE_STR("cgen: the return type of variant constructor ");
-               fx_str_t slit_272 = FX_MAKE_STR(" is not variant");
+               fx_str_t v_1327 = {0};
+               fx_str_t v_1328 = {0};
+               fx_str_t v_1329 = {0};
+               fx_exn_t v_1330 = {0};
+               FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1327, 0), _fx_catch_275);
+               FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1327, &v_1328, 0), _fx_catch_275);
+               fx_str_t slit_277 = FX_MAKE_STR("cgen: the return type of variant constructor ");
+               fx_str_t slit_278 = FX_MAKE_STR(" is not variant");
                {
-                  const fx_str_t strs_36[] = { slit_271, v_1307, slit_272 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_36, 3, &v_1308), _fx_catch_271);
+                  const fx_str_t strs_38[] = { slit_277, v_1328, slit_278 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_38, 3, &v_1329), _fx_catch_275);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1308, &v_1309, 0), _fx_catch_271);
-               FX_THROW(&v_1309, false, _fx_catch_271);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1329, &v_1330, 0), _fx_catch_275);
+               FX_THROW(&v_1330, false, _fx_catch_275);
 
-            _fx_catch_271: ;
-               fx_free_exn(&v_1309);
-               FX_FREE_STR(&v_1308);
-               FX_FREE_STR(&v_1307);
-               FX_FREE_STR(&v_1306);
+            _fx_catch_275: ;
+               fx_free_exn(&v_1330);
+               FX_FREE_STR(&v_1329);
+               FX_FREE_STR(&v_1328);
+               FX_FREE_STR(&v_1327);
             }
-            FX_CHECK_EXN(_fx_catch_272);
+            FX_CHECK_EXN(_fx_catch_276);
 
-         _fx_catch_272: ;
-            _fx_free_N15K_form__kinfo_t(&v_1302);
+         _fx_catch_276: ;
+            _fx_free_N15K_form__kinfo_t(&v_1323);
          }
          else {
-            fx_str_t v_1310 = {0};
-            fx_str_t v_1311 = {0};
-            fx_str_t v_1312 = {0};
-            fx_exn_t v_1313 = {0};
-            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1310, 0), _fx_catch_273);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1310, &v_1311, 0), _fx_catch_273);
-            fx_str_t slit_273 = FX_MAKE_STR("cgen: the return type of variant constructor ");
-            fx_str_t slit_274 = FX_MAKE_STR(" is not variant");
+            fx_str_t v_1331 = {0};
+            fx_str_t v_1332 = {0};
+            fx_str_t v_1333 = {0};
+            fx_exn_t v_1334 = {0};
+            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(&kf_name_0, &kf_loc_0, &v_1331, 0), _fx_catch_277);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1331, &v_1332, 0), _fx_catch_277);
+            fx_str_t slit_279 = FX_MAKE_STR("cgen: the return type of variant constructor ");
+            fx_str_t slit_280 = FX_MAKE_STR(" is not variant");
             {
-               const fx_str_t strs_37[] = { slit_273, v_1311, slit_274 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_37, 3, &v_1312), _fx_catch_273);
+               const fx_str_t strs_39[] = { slit_279, v_1332, slit_280 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_39, 3, &v_1333), _fx_catch_277);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1312, &v_1313, 0), _fx_catch_273);
-            FX_THROW(&v_1313, false, _fx_catch_273);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1333, &v_1334, 0), _fx_catch_277);
+            FX_THROW(&v_1334, false, _fx_catch_277);
 
-         _fx_catch_273: ;
-            fx_free_exn(&v_1313);
-            FX_FREE_STR(&v_1312);
-            FX_FREE_STR(&v_1311);
-            FX_FREE_STR(&v_1310);
+         _fx_catch_277: ;
+            fx_free_exn(&v_1334);
+            FX_FREE_STR(&v_1333);
+            FX_FREE_STR(&v_1332);
+            FX_FREE_STR(&v_1331);
          }
-         FX_CHECK_EXN(_fx_catch_275);
-         bool have_tag_2 = v_1301.t0;
-         bool is_recursive_variant_0 = v_1301.t1;
-         _fx_R9Ast__id_t ifaces_id_1 = v_1301.t2;
+         FX_CHECK_EXN(_fx_catch_279);
+         bool have_tag_2 = v_1322.t0;
+         bool is_recursive_variant_0 = v_1322.t1;
+         _fx_R9Ast__id_t ifaces_id_1 = v_1322.t2;
          FX_CALL(_fx_M6C_formFM11make_id_expN14C_form__cexp_t2R9Ast__id_tR10Ast__loc_t(&retid_0, &kf_loc_0, &var_exp_0, 0),
-            _fx_catch_275);
+            _fx_catch_279);
          FX_CALL(
             _fx_M11C_gen_typesFM9ktyp2ctypN14C_form__ctyp_t2N14K_form__ktyp_tR10Ast__loc_t(kf_rt_0, &kf_loc_0, &result_ctyp_0,
-               0), _fx_catch_275);
+               0), _fx_catch_279);
          if (is_recursive_variant_0) {
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(result_ctyp_0, &kf_loc_0, &v_1284),
-               _fx_catch_275);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1284, 0, true, &v_1285), _fx_catch_275);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(result_ctyp_0, &kf_loc_0, &v_1305),
+               _fx_catch_279);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1305, 0, true, &v_1306), _fx_catch_279);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g48C_form__std_FX_MAKE_RECURSIVE_VARIANT_IMPL_START, v_1285, _fx_g20C_gen_code__CTypVoid, &kf_loc_0,
-                  &alloc_var_0, 0), _fx_catch_275);
-            _fx_R9Ast__id_t v_1314;
-            fx_str_t slit_275 = FX_MAKE_STR("v");
-            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_275, &v_1314, 0), _fx_catch_275);
-            FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1286, 0), _fx_catch_275);
-            fx_str_t slit_276 = FX_MAKE_STR("v");
+                  &_fx_g48C_form__std_FX_MAKE_RECURSIVE_VARIANT_IMPL_START, v_1306, _fx_g20C_gen_code__CTypVoid, &kf_loc_0,
+                  &alloc_var_0, 0), _fx_catch_279);
+            _fx_R9Ast__id_t v_1335;
+            fx_str_t slit_281 = FX_MAKE_STR("v");
+            FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_281, &v_1335, 0), _fx_catch_279);
+            FX_CALL(_fx_M3AstFM21default_tempvar_flagsRM11val_flags_t0(&v_1307, 0), _fx_catch_279);
+            fx_str_t slit_282 = FX_MAKE_STR("v");
             FX_CALL(
                _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  &v_1314, result_ctyp_0, &v_1286, &slit_276, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1287, 0),
-               _fx_catch_275);
-            FX_COPY_PTR(v_1287.t0, &var_exp_1);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_var_0, &v_1288), _fx_catch_275);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1288, 0, true, &ccode_160), _fx_catch_275);
+                  &v_1335, result_ctyp_0, &v_1307, &slit_282, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1308, 0),
+               _fx_catch_279);
+            FX_COPY_PTR(v_1308.t0, &var_exp_1);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_var_0, &v_1309), _fx_catch_279);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1309, 0, true, &ccode_163), _fx_catch_279);
             bool res_43;
-            FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ifaces_id_1, &_fx_g9Ast__noid, &res_43, 0), _fx_catch_275);
+            FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ifaces_id_1, &_fx_g9Ast__noid, &res_43, 0), _fx_catch_279);
             if (res_43) {
-               FX_COPY_PTR(ccode_160, &ccode_161);
+               FX_COPY_PTR(ccode_163, &ccode_164);
             }
             else {
-               _fx_R9Ast__id_t v_1315;
-               fx_str_t slit_277 = FX_MAKE_STR("fx_ifaces_t");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_277, &v_1315, 0), _fx_catch_275);
-               FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1315, &ifaces_ctyp_0), _fx_catch_275);
+               _fx_R9Ast__id_t v_1336;
+               fx_str_t slit_283 = FX_MAKE_STR("fx_ifaces_t");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_283, &v_1336, 0), _fx_catch_279);
+               FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&v_1336, &ifaces_ctyp_0), _fx_catch_279);
                FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(ifaces_ctyp_0, &ifaces_ptr_ctyp_0, 0),
-                  _fx_catch_275);
-               _fx_R9Ast__id_t v_1316;
-               fx_str_t slit_278 = FX_MAKE_STR("ifaces");
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_278, &v_1316, 0), _fx_catch_275);
+                  _fx_catch_279);
+               _fx_R9Ast__id_t v_1337;
+               fx_str_t slit_284 = FX_MAKE_STR("ifaces");
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_284, &v_1337, 0), _fx_catch_279);
                FX_CALL(
-                  _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_1, &v_1316,
-                     ifaces_ptr_ctyp_0, &v_1289, 0), _fx_catch_275);
+                  _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_1, &v_1337,
+                     ifaces_ptr_ctyp_0, &v_1310, 0), _fx_catch_279);
                FX_CALL(
                   _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&ifaces_id_1,
-                     ifaces_ctyp_0, &kloc_0, &v_1290, 0), _fx_catch_275);
-               FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(v_1290, &v_1291, 0), _fx_catch_275);
+                     ifaces_ctyp_0, &kloc_0, &v_1311, 0), _fx_catch_279);
+               FX_CALL(_fx_M6C_formFM13cexp_get_addrN14C_form__cexp_t1N14C_form__cexp_t(v_1311, &v_1312, 0), _fx_catch_279);
                FX_CALL(
-                  _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1289, v_1291, &v_1292, 0),
-                  _fx_catch_275);
-               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1292, &v_1293), _fx_catch_275);
-               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1293, ccode_160, true, &ccode_161), _fx_catch_275);
+                  _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1310, v_1312, &v_1313, 0),
+                  _fx_catch_279);
+               FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(v_1313, &v_1314), _fx_catch_279);
+               FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1314, ccode_163, true, &ccode_164), _fx_catch_279);
             }
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1294, 0), _fx_catch_275);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1294, &v_1295);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1315, 0), _fx_catch_279);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1315, &v_1316);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1295, &kf_loc_0,
-                  &v_1296), _fx_catch_275);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1296, 0, true, &ret_ccode_0), _fx_catch_275);
-            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_1, ccode_161, ret_ccode_0, &v_1283);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1316, &kf_loc_0,
+                  &v_1317), _fx_catch_279);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1317, 0, true, &ret_ccode_0), _fx_catch_279);
+            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_1, ccode_164, ret_ccode_0, &v_1304);
          }
          else {
-            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_0, 0, 0, &v_1283);
+            _fx_make_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(var_exp_0, 0, 0, &v_1304);
          }
-         FX_COPY_PTR(v_1283.t0, &var_exp_2);
-         FX_COPY_PTR(v_1283.t1, &ccode_162);
-         FX_COPY_PTR(v_1283.t2, &ret_ccode_1);
-         _fx_R9Ast__id_t v_1317;
-         fx_str_t slit_279 = FX_MAKE_STR("tag");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_279, &v_1317, 0), _fx_catch_275);
+         FX_COPY_PTR(v_1304.t0, &var_exp_2);
+         FX_COPY_PTR(v_1304.t1, &ccode_165);
+         FX_COPY_PTR(v_1304.t2, &ret_ccode_1);
+         _fx_R9Ast__id_t v_1338;
+         fx_str_t slit_285 = FX_MAKE_STR("tag");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_285, &v_1338, 0), _fx_catch_279);
          FX_CALL(
-            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1317,
-               _fx_g19C_gen_code__CTypInt, &v_1297, 0), _fx_catch_275);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_0.u.CtorVariant, &kloc_0, &v_1298, 0),
-            _fx_catch_275);
+            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1338,
+               _fx_g19C_gen_code__CTypInt, &v_1318, 0), _fx_catch_279);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(ctor_0.u.CtorVariant, &kloc_0, &v_1319, 0),
+            _fx_catch_279);
          FX_CALL(
-            _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1297, v_1298, &init_tag_0, 0),
-            _fx_catch_275);
+            _fx_M6C_formFM11make_assignN14C_form__cexp_t2N14C_form__cexp_tN14C_form__cexp_t(v_1318, v_1319, &init_tag_0, 0),
+            _fx_catch_279);
          if (have_tag_2) {
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(init_tag_0, &v_1299), _fx_catch_275);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1299, ccode_162, true, &ccode_163), _fx_catch_275);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(init_tag_0, &v_1320), _fx_catch_279);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1320, ccode_165, true, &ccode_166), _fx_catch_279);
          }
          else {
-            FX_COPY_PTR(ccode_162, &ccode_163);
+            FX_COPY_PTR(ccode_165, &ccode_166);
          }
-         _fx_R9Ast__id_t v_1318;
-         fx_str_t slit_280 = FX_MAKE_STR("u");
-         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_280, &v_1318, 0), _fx_catch_275);
+         _fx_R9Ast__id_t v_1339;
+         fx_str_t slit_286 = FX_MAKE_STR("u");
+         FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_286, &v_1339, 0), _fx_catch_279);
          FX_CALL(
-            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1318,
-               _fx_g19C_gen_code__CTypAny, &dst_base_0, 0), _fx_catch_275);
-         _fx_R9Ast__id_t v_1319;
-         FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(&kf_name_0, &v_1319, 0), _fx_catch_275);
+            _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(var_exp_2, &v_1339,
+               _fx_g19C_gen_code__CTypAny, &dst_base_0, 0), _fx_catch_279);
+         _fx_R9Ast__id_t v_1340;
+         FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(&kf_name_0, &v_1340, 0), _fx_catch_279);
          FX_CALL(
-            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_0, &v_1319,
-               _fx_g19C_gen_code__CTypAny, &dst_base_1, 0), _fx_catch_275);
-         FX_COPY_PTR(ccode_163, &ccode_164);
+            _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_0, &v_1340,
+               _fx_g19C_gen_code__CTypAny, &dst_base_1, 0), _fx_catch_279);
+         FX_COPY_PTR(ccode_166, &ccode_167);
          int_ idx_2 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_33 = real_args_0;
          for (; lst_33; lst_33 = lst_33->tl, idx_2 += 1) {
             _fx_N14C_form__ctyp_t t_25 = 0;
             _fx_LN19C_form__carg_attr_t flags_4 = 0;
             _fx_N14C_form__cexp_t src_exp_2 = 0;
-            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1320 = {0};
+            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1341 = {0};
             _fx_N14C_form__cexp_t src_exp_3 = 0;
             _fx_N14C_form__ctyp_t t_26 = 0;
             _fx_N14C_form__cexp_t dst_exp_21 = 0;
-            fx_str_t v_1321 = {0};
-            fx_str_t v_1322 = {0};
-            _fx_LN15C_form__cstmt_t v_1323 = 0;
+            fx_str_t v_1342 = {0};
+            fx_str_t v_1343 = {0};
+            _fx_LN15C_form__cstmt_t v_1344 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___13 = &lst_33->hd;
             _fx_R9Ast__id_t a_14 = __pat___13->t0;
             FX_COPY_PTR(__pat___13->t1, &t_25);
             FX_COPY_PTR(__pat___13->t2, &flags_4);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_14, t_25, &kf_loc_0,
-                  &src_exp_2, 0), _fx_catch_274);
+                  &src_exp_2, 0), _fx_catch_278);
             FX_CALL(
                _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                  idx_2, src_exp_2, t_25, flags_4, &kf_loc_0, &v_1320, 0), _fx_catch_274);
-            FX_COPY_PTR(v_1320.t0, &src_exp_3);
-            FX_COPY_PTR(v_1320.t1, &t_26);
+                  idx_2, src_exp_2, t_25, flags_4, &kf_loc_0, &v_1341, 0), _fx_catch_278);
+            FX_COPY_PTR(v_1341.t0, &src_exp_3);
+            FX_COPY_PTR(v_1341.t1, &t_26);
             if (nreal_args_0 == 1) {
                FX_COPY_PTR(dst_base_1, &dst_exp_21);
             }
             else {
-               FX_CALL(_fx_F6stringS1i(idx_2, &v_1321, 0), _fx_catch_274);
-               fx_str_t slit_281 = FX_MAKE_STR("t");
+               FX_CALL(_fx_F6stringS1i(idx_2, &v_1342, 0), _fx_catch_278);
+               fx_str_t slit_287 = FX_MAKE_STR("t");
                {
-                  const fx_str_t strs_38[] = { slit_281, v_1321 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_38, 2, &v_1322), _fx_catch_274);
+                  const fx_str_t strs_40[] = { slit_287, v_1342 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_40, 2, &v_1343), _fx_catch_278);
                }
                _fx_R9Ast__id_t tup_elem_0;
-               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1322, &tup_elem_0, 0), _fx_catch_274);
+               FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1343, &tup_elem_0, 0), _fx_catch_278);
                FX_CALL(
                   _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_base_1,
-                     &tup_elem_0, t_26, &dst_exp_21, 0), _fx_catch_274);
+                     &tup_elem_0, t_26, &dst_exp_21, 0), _fx_catch_278);
             }
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  src_exp_3, dst_exp_21, t_26, ccode_164, &kf_loc_0, &v_1323, 0), _fx_catch_274);
-            _fx_free_LN15C_form__cstmt_t(&ccode_164);
-            FX_COPY_PTR(v_1323, &ccode_164);
+                  src_exp_3, dst_exp_21, t_26, ccode_167, &kf_loc_0, &v_1344, 0), _fx_catch_278);
+            _fx_free_LN15C_form__cstmt_t(&ccode_167);
+            FX_COPY_PTR(v_1344, &ccode_167);
 
-         _fx_catch_274: ;
-            if (v_1323) {
-               _fx_free_LN15C_form__cstmt_t(&v_1323);
+         _fx_catch_278: ;
+            if (v_1344) {
+               _fx_free_LN15C_form__cstmt_t(&v_1344);
             }
-            FX_FREE_STR(&v_1322);
-            FX_FREE_STR(&v_1321);
+            FX_FREE_STR(&v_1343);
+            FX_FREE_STR(&v_1342);
             if (dst_exp_21) {
                _fx_free_N14C_form__cexp_t(&dst_exp_21);
             }
@@ -35202,7 +35442,7 @@ static int
             if (src_exp_3) {
                _fx_free_N14C_form__cexp_t(&src_exp_3);
             }
-            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1320);
+            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1341);
             if (src_exp_2) {
                _fx_free_N14C_form__cexp_t(&src_exp_2);
             }
@@ -35210,19 +35450,19 @@ static int
             if (t_25) {
                _fx_free_N14C_form__ctyp_t(&t_25);
             }
-            FX_CHECK_EXN(_fx_catch_275);
+            FX_CHECK_EXN(_fx_catch_279);
          }
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_1, ccode_164,
-               &v_1300, 0), _fx_catch_275);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1300, &new_body_0, 0), _fx_catch_275);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_1, ccode_167,
+               &v_1321, 0), _fx_catch_279);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1321, &new_body_0, 0), _fx_catch_279);
 
-      _fx_catch_275: ;
-         if (v_1300) {
-            _fx_free_LN15C_form__cstmt_t(&v_1300);
+      _fx_catch_279: ;
+         if (v_1321) {
+            _fx_free_LN15C_form__cstmt_t(&v_1321);
          }
-         if (ccode_164) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_164);
+         if (ccode_167) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_167);
          }
          if (dst_base_1) {
             _fx_free_N14C_form__cexp_t(&dst_base_1);
@@ -35230,26 +35470,26 @@ static int
          if (dst_base_0) {
             _fx_free_N14C_form__cexp_t(&dst_base_0);
          }
-         if (v_1299) {
-            _fx_free_N15C_form__cstmt_t(&v_1299);
+         if (v_1320) {
+            _fx_free_N15C_form__cstmt_t(&v_1320);
          }
-         if (ccode_163) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_163);
+         if (ccode_166) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_166);
          }
          if (init_tag_0) {
             _fx_free_N14C_form__cexp_t(&init_tag_0);
          }
-         if (v_1298) {
-            _fx_free_N14C_form__cexp_t(&v_1298);
+         if (v_1319) {
+            _fx_free_N14C_form__cexp_t(&v_1319);
          }
-         if (v_1297) {
-            _fx_free_N14C_form__cexp_t(&v_1297);
+         if (v_1318) {
+            _fx_free_N14C_form__cexp_t(&v_1318);
          }
          if (ret_ccode_1) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_1);
          }
-         if (ccode_162) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_162);
+         if (ccode_165) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_165);
          }
          if (var_exp_2) {
             _fx_free_N14C_form__cexp_t(&var_exp_2);
@@ -35257,27 +35497,27 @@ static int
          if (ret_ccode_0) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_0);
          }
-         if (v_1296) {
-            _fx_free_N15C_form__cstmt_t(&v_1296);
+         if (v_1317) {
+            _fx_free_N15C_form__cstmt_t(&v_1317);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1295);
-         if (v_1294) {
-            _fx_free_N14C_form__cexp_t(&v_1294);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1316);
+         if (v_1315) {
+            _fx_free_N14C_form__cexp_t(&v_1315);
          }
-         if (v_1293) {
-            _fx_free_N15C_form__cstmt_t(&v_1293);
+         if (v_1314) {
+            _fx_free_N15C_form__cstmt_t(&v_1314);
          }
-         if (v_1292) {
-            _fx_free_N14C_form__cexp_t(&v_1292);
+         if (v_1313) {
+            _fx_free_N14C_form__cexp_t(&v_1313);
          }
-         if (v_1291) {
-            _fx_free_N14C_form__cexp_t(&v_1291);
+         if (v_1312) {
+            _fx_free_N14C_form__cexp_t(&v_1312);
          }
-         if (v_1290) {
-            _fx_free_N14C_form__cexp_t(&v_1290);
+         if (v_1311) {
+            _fx_free_N14C_form__cexp_t(&v_1311);
          }
-         if (v_1289) {
-            _fx_free_N14C_form__cexp_t(&v_1289);
+         if (v_1310) {
+            _fx_free_N14C_form__cexp_t(&v_1310);
          }
          if (ifaces_ptr_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&ifaces_ptr_ctyp_0);
@@ -35285,30 +35525,30 @@ static int
          if (ifaces_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&ifaces_ctyp_0);
          }
-         if (ccode_161) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_161);
+         if (ccode_164) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_164);
          }
-         if (ccode_160) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_160);
+         if (ccode_163) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_163);
          }
-         if (v_1288) {
-            _fx_free_N15C_form__cstmt_t(&v_1288);
+         if (v_1309) {
+            _fx_free_N15C_form__cstmt_t(&v_1309);
          }
          if (var_exp_1) {
             _fx_free_N14C_form__cexp_t(&var_exp_1);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1287);
-         _fx_free_R16Ast__val_flags_t(&v_1286);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1308);
+         _fx_free_R16Ast__val_flags_t(&v_1307);
          if (alloc_var_0) {
             _fx_free_N14C_form__cexp_t(&alloc_var_0);
          }
-         if (v_1285) {
-            _fx_free_LN14C_form__cexp_t(&v_1285);
+         if (v_1306) {
+            _fx_free_LN14C_form__cexp_t(&v_1306);
          }
-         if (v_1284) {
-            _fx_free_N14C_form__cexp_t(&v_1284);
+         if (v_1305) {
+            _fx_free_N14C_form__cexp_t(&v_1305);
          }
-         _fx_free_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(&v_1283);
+         _fx_free_T3N14C_form__cexp_tLN15C_form__cstmt_tLN15C_form__cstmt_t(&v_1304);
          if (result_ctyp_0) {
             _fx_free_N14C_form__ctyp_t(&result_ctyp_0);
          }
@@ -35318,179 +35558,179 @@ static int
          goto _fx_endmatch_54;
       }
       if (ctor_0.tag == 4) {
-         _fx_N15K_form__kinfo_t v_1324 = {0};
+         _fx_N15K_form__kinfo_t v_1345 = {0};
          _fx_N14C_form__ctyp_t fcv_t_0 = 0;
-         _fx_T2BNt6option1N14C_form__cexp_t v_1325 = {0};
+         _fx_T2BNt6option1N14C_form__cexp_t v_1346 = {0};
          _fx_N14C_form__cexp_t free_f_exp_4 = 0;
-         _fx_N14C_form__cexp_t v_1326 = 0;
-         _fx_N14C_form__cexp_t v_1327 = 0;
-         _fx_LN14C_form__cexp_t v_1328 = 0;
+         _fx_N14C_form__cexp_t v_1347 = 0;
+         _fx_N14C_form__cexp_t v_1348 = 0;
+         _fx_LN14C_form__cexp_t v_1349 = 0;
          _fx_N14C_form__cexp_t alloc_fcv_0 = 0;
-         _fx_N14C_form__ctyp_t v_1329 = 0;
-         _fx_R16Ast__val_flags_t v_1330 = {0};
-         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1331 = {0};
+         _fx_N14C_form__ctyp_t v_1350 = 0;
+         _fx_R16Ast__val_flags_t v_1351 = {0};
+         _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t v_1352 = {0};
          _fx_N14C_form__cexp_t fcv_exp_0 = 0;
-         _fx_N14C_form__cexp_t v_1332 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1333 = {0};
-         _fx_N15C_form__cstmt_t v_1334 = 0;
+         _fx_N14C_form__cexp_t v_1353 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1354 = {0};
+         _fx_N15C_form__cstmt_t v_1355 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_2 = 0;
-         _fx_N15C_form__cstmt_t v_1335 = 0;
-         _fx_LN15C_form__cstmt_t ccode_165 = 0;
-         _fx_LN15C_form__cstmt_t ccode_166 = 0;
-         _fx_LN15C_form__cstmt_t v_1336 = 0;
+         _fx_N15C_form__cstmt_t v_1356 = 0;
+         _fx_LN15C_form__cstmt_t ccode_168 = 0;
+         _fx_LN15C_form__cstmt_t ccode_169 = 0;
+         _fx_LN15C_form__cstmt_t v_1357 = 0;
          _fx_R9Ast__id_t* f_id_0 = &ctor_0.u.CtorFP;
-         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1324, 0),
-            _fx_catch_279);
+         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1345, 0),
+            _fx_catch_283);
          _fx_R9Ast__id_t fcv_t_id_0;
-         if (v_1324.tag == 3) {
-            _fx_R17K_form__kdeffun_t v_1337 = {0};
-            _fx_copy_R17K_form__kdeffun_t(&v_1324.u.KFun->data, &v_1337);
-            fcv_t_id_0 = v_1337.kf_closure.kci_fcv_t;
-            _fx_free_R17K_form__kdeffun_t(&v_1337);
+         if (v_1345.tag == 3) {
+            _fx_R17K_form__kdeffun_t v_1358 = {0};
+            _fx_copy_R17K_form__kdeffun_t(&v_1345.u.KFun->data, &v_1358);
+            fcv_t_id_0 = v_1358.kf_closure.kci_fcv_t;
+            _fx_free_R17K_form__kdeffun_t(&v_1358);
          }
          else {
-            fx_str_t v_1338 = {0};
-            fx_str_t v_1339 = {0};
-            fx_str_t v_1340 = {0};
-            fx_exn_t v_1341 = {0};
-            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1338, 0), _fx_catch_276);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1338, &v_1339, 0), _fx_catch_276);
-            fx_str_t slit_282 = FX_MAKE_STR("cgen: \'");
-            fx_str_t slit_283 = FX_MAKE_STR("\' is not a function");
+            fx_str_t v_1359 = {0};
+            fx_str_t v_1360 = {0};
+            fx_str_t v_1361 = {0};
+            fx_exn_t v_1362 = {0};
+            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(f_id_0, &kf_loc_0, &v_1359, 0), _fx_catch_280);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1359, &v_1360, 0), _fx_catch_280);
+            fx_str_t slit_288 = FX_MAKE_STR("cgen: \'");
+            fx_str_t slit_289 = FX_MAKE_STR("\' is not a function");
             {
-               const fx_str_t strs_39[] = { slit_282, v_1339, slit_283 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_39, 3, &v_1340), _fx_catch_276);
+               const fx_str_t strs_41[] = { slit_288, v_1360, slit_289 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_41, 3, &v_1361), _fx_catch_280);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1340, &v_1341, 0), _fx_catch_276);
-            FX_THROW(&v_1341, false, _fx_catch_276);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1361, &v_1362, 0), _fx_catch_280);
+            FX_THROW(&v_1362, false, _fx_catch_280);
 
-         _fx_catch_276: ;
-            fx_free_exn(&v_1341);
-            FX_FREE_STR(&v_1340);
-            FX_FREE_STR(&v_1339);
-            FX_FREE_STR(&v_1338);
+         _fx_catch_280: ;
+            fx_free_exn(&v_1362);
+            FX_FREE_STR(&v_1361);
+            FX_FREE_STR(&v_1360);
+            FX_FREE_STR(&v_1359);
          }
-         FX_CHECK_EXN(_fx_catch_279);
-         FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&fcv_t_id_0, &fcv_t_0), _fx_catch_279);
+         FX_CHECK_EXN(_fx_catch_283);
+         FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&fcv_t_id_0, &fcv_t_0), _fx_catch_283);
          FX_CALL(
             _fx_M11C_gen_typesFM10get_free_fT2BNt6option1N14C_form__cexp_t4N14C_form__ctyp_tBBR10Ast__loc_t(fcv_t_0, true,
-               false, &kf_loc_0, &v_1325, 0), _fx_catch_279);
-         _fx_Nt6option1N14C_form__cexp_t* v_1342 = &v_1325.t1;
-         if (v_1342->tag == 2) {
-            FX_COPY_PTR(v_1342->u.Some, &free_f_exp_4);
+               false, &kf_loc_0, &v_1346, 0), _fx_catch_283);
+         _fx_Nt6option1N14C_form__cexp_t* v_1363 = &v_1346.t1;
+         if (v_1363->tag == 2) {
+            FX_COPY_PTR(v_1363->u.Some, &free_f_exp_4);
          }
          else {
-            fx_str_t v_1343 = {0};
-            fx_str_t v_1344 = {0};
-            fx_str_t v_1345 = {0};
-            fx_exn_t v_1346 = {0};
-            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(&fcv_t_id_0, &kf_loc_0, &v_1343, 0), _fx_catch_277);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1343, &v_1344, 0), _fx_catch_277);
-            fx_str_t slit_284 = FX_MAKE_STR("cgen: missing destructor for closure vars \'");
-            fx_str_t slit_285 = FX_MAKE_STR("\'");
+            fx_str_t v_1364 = {0};
+            fx_str_t v_1365 = {0};
+            fx_str_t v_1366 = {0};
+            fx_exn_t v_1367 = {0};
+            FX_CALL(_fx_M6K_formFM13get_idk_cnameS2R9Ast__id_tR10Ast__loc_t(&fcv_t_id_0, &kf_loc_0, &v_1364, 0), _fx_catch_281);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1364, &v_1365, 0), _fx_catch_281);
+            fx_str_t slit_290 = FX_MAKE_STR("cgen: missing destructor for closure vars \'");
+            fx_str_t slit_291 = FX_MAKE_STR("\'");
             {
-               const fx_str_t strs_40[] = { slit_284, v_1344, slit_285 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_40, 3, &v_1345), _fx_catch_277);
+               const fx_str_t strs_42[] = { slit_290, v_1365, slit_291 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_42, 3, &v_1366), _fx_catch_281);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1345, &v_1346, 0), _fx_catch_277);
-            FX_THROW(&v_1346, false, _fx_catch_277);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1366, &v_1367, 0), _fx_catch_281);
+            FX_THROW(&v_1367, false, _fx_catch_281);
 
-         _fx_catch_277: ;
-            fx_free_exn(&v_1346);
-            FX_FREE_STR(&v_1345);
-            FX_FREE_STR(&v_1344);
-            FX_FREE_STR(&v_1343);
+         _fx_catch_281: ;
+            fx_free_exn(&v_1367);
+            FX_FREE_STR(&v_1366);
+            FX_FREE_STR(&v_1365);
+            FX_FREE_STR(&v_1364);
          }
-         FX_CHECK_EXN(_fx_catch_279);
-         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(fcv_t_0, &kf_loc_0, &v_1326),
-            _fx_catch_279);
+         FX_CHECK_EXN(_fx_catch_283);
+         FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(fcv_t_0, &kf_loc_0, &v_1347),
+            _fx_catch_283);
          FX_CALL(
             _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(f_id_0,
-               _fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_1327, 0), _fx_catch_279);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1327, 0, true, &v_1328), _fx_catch_279);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_4, v_1328, false, &v_1328), _fx_catch_279);
-         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1326, v_1328, false, &v_1328), _fx_catch_279);
+               _fx_g23C_form__std_CTypVoidPtr, &kloc_0, &v_1348, 0), _fx_catch_283);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1348, 0, true, &v_1349), _fx_catch_283);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(free_f_exp_4, v_1349, false, &v_1349), _fx_catch_283);
+         FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1347, v_1349, false, &v_1349), _fx_catch_283);
          FX_CALL(
             _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-               &_fx_g33C_form__std_FX_MAKE_FP_IMPL_START, v_1328, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_fcv_0, 0),
-            _fx_catch_279);
-         _fx_R9Ast__id_t v_1347;
-         fx_str_t slit_286 = FX_MAKE_STR("fcv");
-         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_286, &v_1347, 0), _fx_catch_279);
-         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(fcv_t_0, &v_1329, 0), _fx_catch_279);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1330, 0), _fx_catch_279);
-         fx_str_t slit_287 = FX_MAKE_STR("fcv");
+               &_fx_g33C_form__std_FX_MAKE_FP_IMPL_START, v_1349, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_fcv_0, 0),
+            _fx_catch_283);
+         _fx_R9Ast__id_t v_1368;
+         fx_str_t slit_292 = FX_MAKE_STR("fcv");
+         FX_CALL(_fx_M6C_formFM7gen_idcR9Ast__id_t2iS(km_idx_0, &slit_292, &v_1368, 0), _fx_catch_283);
+         FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(fcv_t_0, &v_1350, 0), _fx_catch_283);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_1351, 0), _fx_catch_283);
+         fx_str_t slit_293 = FX_MAKE_STR("fcv");
          FX_CALL(
             _fx_M6C_formFM14create_cdefvalT2N14C_form__cexp_tLN15C_form__cstmt_t7R9Ast__id_tN14C_form__ctyp_tR16Ast__val_flags_tSNt6option1N14C_form__cexp_tLN15C_form__cstmt_tR10Ast__loc_t(
-               &v_1347, v_1329, &v_1330, &slit_287, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1331, 0), _fx_catch_279);
-         FX_COPY_PTR(v_1331.t0, &fcv_exp_0);
-         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1332, 0), _fx_catch_279);
-         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1332, &v_1333);
+               &v_1368, v_1350, &v_1351, &slit_293, &_fx_g18C_gen_code__None2_, 0, &kf_loc_0, &v_1352, 0), _fx_catch_283);
+         FX_COPY_PTR(v_1352.t0, &fcv_exp_0);
+         FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1353, 0), _fx_catch_283);
+         _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1353, &v_1354);
          FX_CALL(
-            _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1333, &kf_loc_0, &v_1334),
-            _fx_catch_279);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1334, 0, true, &ret_ccode_2), _fx_catch_279);
-         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_fcv_0, &v_1335), _fx_catch_279);
-         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1335, 0, true, &ccode_165), _fx_catch_279);
-         FX_COPY_PTR(ccode_165, &ccode_166);
+            _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1354, &kf_loc_0, &v_1355),
+            _fx_catch_283);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1355, 0, true, &ret_ccode_2), _fx_catch_283);
+         FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_fcv_0, &v_1356), _fx_catch_283);
+         FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1356, 0, true, &ccode_168), _fx_catch_283);
+         FX_COPY_PTR(ccode_168, &ccode_169);
          int_ idx_3 = 0;
          _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_34 = real_args_0;
          for (; lst_34; lst_34 = lst_34->tl, idx_3 += 1) {
             _fx_N14C_form__ctyp_t t_27 = 0;
             _fx_LN19C_form__carg_attr_t flags_5 = 0;
             _fx_N14C_form__cexp_t src_exp_4 = 0;
-            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1348 = {0};
+            _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1369 = {0};
             _fx_N14C_form__cexp_t src_exp_5 = 0;
             _fx_N14C_form__ctyp_t t_28 = 0;
-            fx_str_t v_1349 = {0};
-            fx_str_t v_1350 = {0};
+            fx_str_t v_1370 = {0};
+            fx_str_t v_1371 = {0};
             _fx_N14C_form__cexp_t dst_exp_22 = 0;
-            _fx_LN15C_form__cstmt_t v_1351 = 0;
+            _fx_LN15C_form__cstmt_t v_1372 = 0;
             _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___14 = &lst_34->hd;
             _fx_R9Ast__id_t a_15 = __pat___14->t0;
             FX_COPY_PTR(__pat___14->t1, &t_27);
             FX_COPY_PTR(__pat___14->t2, &flags_5);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_15, t_27, &kf_loc_0,
-                  &src_exp_4, 0), _fx_catch_278);
+                  &src_exp_4, 0), _fx_catch_282);
             FX_CALL(
                _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                  idx_3, src_exp_4, t_27, flags_5, &kf_loc_0, &v_1348, 0), _fx_catch_278);
-            FX_COPY_PTR(v_1348.t0, &src_exp_5);
-            FX_COPY_PTR(v_1348.t1, &t_28);
-            FX_CALL(_fx_F6stringS1i(idx_3, &v_1349, 0), _fx_catch_278);
-            fx_str_t slit_288 = FX_MAKE_STR("t");
+                  idx_3, src_exp_4, t_27, flags_5, &kf_loc_0, &v_1369, 0), _fx_catch_282);
+            FX_COPY_PTR(v_1369.t0, &src_exp_5);
+            FX_COPY_PTR(v_1369.t1, &t_28);
+            FX_CALL(_fx_F6stringS1i(idx_3, &v_1370, 0), _fx_catch_282);
+            fx_str_t slit_294 = FX_MAKE_STR("t");
             {
-               const fx_str_t strs_41[] = { slit_288, v_1349 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_41, 2, &v_1350), _fx_catch_278);
+               const fx_str_t strs_43[] = { slit_294, v_1370 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_43, 2, &v_1371), _fx_catch_282);
             }
             _fx_R9Ast__id_t fcv_elem_0;
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1350, &fcv_elem_0, 0), _fx_catch_278);
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1371, &fcv_elem_0, 0), _fx_catch_282);
             FX_CALL(
                _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(fcv_exp_0, &fcv_elem_0,
-                  t_28, &dst_exp_22, 0), _fx_catch_278);
+                  t_28, &dst_exp_22, 0), _fx_catch_282);
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  src_exp_5, dst_exp_22, t_28, ccode_166, &kf_loc_0, &v_1351, 0), _fx_catch_278);
-            _fx_free_LN15C_form__cstmt_t(&ccode_166);
-            FX_COPY_PTR(v_1351, &ccode_166);
+                  src_exp_5, dst_exp_22, t_28, ccode_169, &kf_loc_0, &v_1372, 0), _fx_catch_282);
+            _fx_free_LN15C_form__cstmt_t(&ccode_169);
+            FX_COPY_PTR(v_1372, &ccode_169);
 
-         _fx_catch_278: ;
-            if (v_1351) {
-               _fx_free_LN15C_form__cstmt_t(&v_1351);
+         _fx_catch_282: ;
+            if (v_1372) {
+               _fx_free_LN15C_form__cstmt_t(&v_1372);
             }
             if (dst_exp_22) {
                _fx_free_N14C_form__cexp_t(&dst_exp_22);
             }
-            FX_FREE_STR(&v_1350);
-            FX_FREE_STR(&v_1349);
+            FX_FREE_STR(&v_1371);
+            FX_FREE_STR(&v_1370);
             if (t_28) {
                _fx_free_N14C_form__ctyp_t(&t_28);
             }
             if (src_exp_5) {
                _fx_free_N14C_form__cexp_t(&src_exp_5);
             }
-            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1348);
+            _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1369);
             if (src_exp_4) {
                _fx_free_N14C_form__cexp_t(&src_exp_4);
             }
@@ -35498,220 +35738,220 @@ static int
             if (t_27) {
                _fx_free_N14C_form__ctyp_t(&t_27);
             }
-            FX_CHECK_EXN(_fx_catch_279);
+            FX_CHECK_EXN(_fx_catch_283);
          }
          FX_CALL(
-            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_2, ccode_166,
-               &v_1336, 0), _fx_catch_279);
-         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1336, &new_body_0, 0), _fx_catch_279);
+            _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_2, ccode_169,
+               &v_1357, 0), _fx_catch_283);
+         FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1357, &new_body_0, 0), _fx_catch_283);
 
-      _fx_catch_279: ;
-         if (v_1336) {
-            _fx_free_LN15C_form__cstmt_t(&v_1336);
+      _fx_catch_283: ;
+         if (v_1357) {
+            _fx_free_LN15C_form__cstmt_t(&v_1357);
          }
-         if (ccode_166) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_166);
+         if (ccode_169) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_169);
          }
-         if (ccode_165) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_165);
+         if (ccode_168) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_168);
          }
-         if (v_1335) {
-            _fx_free_N15C_form__cstmt_t(&v_1335);
+         if (v_1356) {
+            _fx_free_N15C_form__cstmt_t(&v_1356);
          }
          if (ret_ccode_2) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_2);
          }
-         if (v_1334) {
-            _fx_free_N15C_form__cstmt_t(&v_1334);
+         if (v_1355) {
+            _fx_free_N15C_form__cstmt_t(&v_1355);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1333);
-         if (v_1332) {
-            _fx_free_N14C_form__cexp_t(&v_1332);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1354);
+         if (v_1353) {
+            _fx_free_N14C_form__cexp_t(&v_1353);
          }
          if (fcv_exp_0) {
             _fx_free_N14C_form__cexp_t(&fcv_exp_0);
          }
-         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1331);
-         _fx_free_R16Ast__val_flags_t(&v_1330);
-         if (v_1329) {
-            _fx_free_N14C_form__ctyp_t(&v_1329);
+         _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(&v_1352);
+         _fx_free_R16Ast__val_flags_t(&v_1351);
+         if (v_1350) {
+            _fx_free_N14C_form__ctyp_t(&v_1350);
          }
          if (alloc_fcv_0) {
             _fx_free_N14C_form__cexp_t(&alloc_fcv_0);
          }
-         if (v_1328) {
-            _fx_free_LN14C_form__cexp_t(&v_1328);
+         if (v_1349) {
+            _fx_free_LN14C_form__cexp_t(&v_1349);
          }
-         if (v_1327) {
-            _fx_free_N14C_form__cexp_t(&v_1327);
+         if (v_1348) {
+            _fx_free_N14C_form__cexp_t(&v_1348);
          }
-         if (v_1326) {
-            _fx_free_N14C_form__cexp_t(&v_1326);
+         if (v_1347) {
+            _fx_free_N14C_form__cexp_t(&v_1347);
          }
          if (free_f_exp_4) {
             _fx_free_N14C_form__cexp_t(&free_f_exp_4);
          }
-         _fx_free_T2BNt6option1N14C_form__cexp_t(&v_1325);
+         _fx_free_T2BNt6option1N14C_form__cexp_t(&v_1346);
          if (fcv_t_0) {
             _fx_free_N14C_form__ctyp_t(&fcv_t_0);
          }
-         _fx_free_N15K_form__kinfo_t(&v_1324);
+         _fx_free_N15K_form__kinfo_t(&v_1345);
          goto _fx_endmatch_54;
       }
       if (ctor_0.tag == 5) {
-         _fx_N15C_form__cinfo_t v_1352 = {0};
-         _fx_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t v_1353 = {0};
+         _fx_N15C_form__cinfo_t v_1373 = {0};
+         _fx_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t v_1374 = {0};
          _fx_N14C_form__ctyp_t exn_typ_0 = 0;
          _fx_N14C_form__ctyp_t exn_data_t_0 = 0;
-         _fx_N14C_form__cexp_t v_1354 = 0;
-         _fx_N14C_form__cexp_t v_1355 = 0;
-         _fx_N14C_form__cexp_t v_1356 = 0;
-         _fx_LN14C_form__cexp_t v_1357 = 0;
+         _fx_N14C_form__cexp_t v_1375 = 0;
+         _fx_N14C_form__cexp_t v_1376 = 0;
+         _fx_N14C_form__cexp_t v_1377 = 0;
+         _fx_LN14C_form__cexp_t v_1378 = 0;
          _fx_N14C_form__cexp_t alloc_exn_data_0 = 0;
-         _fx_N14C_form__cexp_t v_1358 = 0;
-         _fx_Nt6option1N14C_form__cexp_t v_1359 = {0};
-         _fx_N15C_form__cstmt_t v_1360 = 0;
+         _fx_N14C_form__cexp_t v_1379 = 0;
+         _fx_Nt6option1N14C_form__cexp_t v_1380 = {0};
+         _fx_N15C_form__cstmt_t v_1381 = 0;
          _fx_LN15C_form__cstmt_t ret_ccode_3 = 0;
-         _fx_N14C_form__ctyp_t v_1361 = 0;
+         _fx_N14C_form__ctyp_t v_1382 = 0;
          _fx_N14C_form__cexp_t exn_data_2 = 0;
          _fx_N14C_form__cexp_t dst_exp_23 = 0;
-         _fx_N15C_form__cstmt_t v_1362 = 0;
-         _fx_LN15C_form__cstmt_t ccode_167 = 0;
-         _fx_LN15C_form__cstmt_t ccode_168 = 0;
-         _fx_LN15C_form__cstmt_t v_1363 = 0;
+         _fx_N15C_form__cstmt_t v_1383 = 0;
+         _fx_LN15C_form__cstmt_t ccode_170 = 0;
+         _fx_LN15C_form__cstmt_t ccode_171 = 0;
+         _fx_LN15C_form__cstmt_t v_1384 = 0;
          _fx_R9Ast__id_t* exn_id_0 = &ctor_0.u.CtorExn;
-         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1352, 0),
-            _fx_catch_282);
-         if (v_1352.tag == 5) {
-            _fx_R17C_form__cdefexn_t v_1364 = {0};
-            _fx_copy_R17C_form__cdefexn_t(&v_1352.u.CExn->data, &v_1364);
-            _fx_make_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(v_1364.cexn_typ, &v_1364.cexn_tag, v_1364.cexn_std,
-               &v_1364.cexn_data, &v_1364.cexn_info, &v_1353);
-            _fx_free_R17C_form__cdefexn_t(&v_1364);
+         FX_CALL(_fx_M6C_formFM6cinfo_N15C_form__cinfo_t2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1373, 0),
+            _fx_catch_286);
+         if (v_1373.tag == 5) {
+            _fx_R17C_form__cdefexn_t v_1385 = {0};
+            _fx_copy_R17C_form__cdefexn_t(&v_1373.u.CExn->data, &v_1385);
+            _fx_make_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(v_1385.cexn_typ, &v_1385.cexn_tag, v_1385.cexn_std,
+               &v_1385.cexn_data, &v_1385.cexn_info, &v_1374);
+            _fx_free_R17C_form__cdefexn_t(&v_1385);
          }
          else {
-            fx_str_t v_1365 = {0};
-            fx_str_t v_1366 = {0};
-            fx_str_t v_1367 = {0};
-            fx_exn_t v_1368 = {0};
-            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1365, 0), _fx_catch_280);
-            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1365, &v_1366, 0), _fx_catch_280);
-            fx_str_t slit_289 = FX_MAKE_STR("cgen: constructor of exception \'");
-            fx_str_t slit_290 = FX_MAKE_STR("\' is expecting converted KExn=>CExn structure");
+            fx_str_t v_1386 = {0};
+            fx_str_t v_1387 = {0};
+            fx_str_t v_1388 = {0};
+            fx_exn_t v_1389 = {0};
+            FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(exn_id_0, &kf_loc_0, &v_1386, 0), _fx_catch_284);
+            FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1386, &v_1387, 0), _fx_catch_284);
+            fx_str_t slit_295 = FX_MAKE_STR("cgen: constructor of exception \'");
+            fx_str_t slit_296 = FX_MAKE_STR("\' is expecting converted KExn=>CExn structure");
             {
-               const fx_str_t strs_42[] = { slit_289, v_1366, slit_290 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_42, 3, &v_1367), _fx_catch_280);
+               const fx_str_t strs_44[] = { slit_295, v_1387, slit_296 };
+               FX_CALL(fx_strjoin(0, 0, 0, strs_44, 3, &v_1388), _fx_catch_284);
             }
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1367, &v_1368, 0), _fx_catch_280);
-            FX_THROW(&v_1368, false, _fx_catch_280);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kf_loc_0, &v_1388, &v_1389, 0), _fx_catch_284);
+            FX_THROW(&v_1389, false, _fx_catch_284);
 
-         _fx_catch_280: ;
-            fx_free_exn(&v_1368);
-            FX_FREE_STR(&v_1367);
-            FX_FREE_STR(&v_1366);
-            FX_FREE_STR(&v_1365);
+         _fx_catch_284: ;
+            fx_free_exn(&v_1389);
+            FX_FREE_STR(&v_1388);
+            FX_FREE_STR(&v_1387);
+            FX_FREE_STR(&v_1386);
          }
-         FX_CHECK_EXN(_fx_catch_282);
-         FX_COPY_PTR(v_1353.t0, &exn_typ_0);
-         _fx_R9Ast__id_t exn_tag_0 = v_1353.t1;
-         bool exn_std_0 = v_1353.t2;
-         _fx_R9Ast__id_t exn_data_id_0 = v_1353.t3;
-         _fx_R9Ast__id_t exn_info_0 = v_1353.t4;
+         FX_CHECK_EXN(_fx_catch_286);
+         FX_COPY_PTR(v_1374.t0, &exn_typ_0);
+         _fx_R9Ast__id_t exn_tag_0 = v_1374.t1;
+         bool exn_std_0 = v_1374.t2;
+         _fx_R9Ast__id_t exn_data_id_0 = v_1374.t3;
+         _fx_R9Ast__id_t exn_info_0 = v_1374.t4;
          if (exn_std_0) {
             FX_COPY_PTR(ccode_0, &new_body_0);
          }
          else {
-            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&exn_data_id_0, &exn_data_t_0), _fx_catch_282);
+            FX_CALL(_fx_M6C_formFM8CTypNameN14C_form__ctyp_t1R9Ast__id_t(&exn_data_id_0, &exn_data_t_0), _fx_catch_286);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&exn_tag_0,
-                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &v_1354, 0), _fx_catch_282);
-            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(exn_data_t_0, &kf_loc_0, &v_1355),
-               _fx_catch_282);
+                  _fx_g20C_gen_code__CTypCInt, &kf_loc_0, &v_1375, 0), _fx_catch_286);
+            FX_CALL(_fx_M6C_formFM7CExpTypN14C_form__cexp_t2N14C_form__ctyp_tR10Ast__loc_t(exn_data_t_0, &kf_loc_0, &v_1376),
+               _fx_catch_286);
             FX_CALL(
                _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&exn_info_0,
-                  _fx_g25C_form__std_fx_exn_info_t, &kf_loc_0, &v_1356, 0), _fx_catch_282);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1356, 0, true, &v_1357), _fx_catch_282);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1355, v_1357, false, &v_1357), _fx_catch_282);
-            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1354, v_1357, false, &v_1357), _fx_catch_282);
+                  _fx_g25C_form__std_fx_exn_info_t, &kf_loc_0, &v_1377, 0), _fx_catch_286);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1377, 0, true, &v_1378), _fx_catch_286);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1376, v_1378, false, &v_1378), _fx_catch_286);
+            FX_CALL(_fx_cons_LN14C_form__cexp_t(v_1375, v_1378, false, &v_1378), _fx_catch_286);
             FX_CALL(
                _fx_M6C_formFM9make_callN14C_form__cexp_t4R9Ast__id_tLN14C_form__cexp_tN14C_form__ctyp_tR10Ast__loc_t(
-                  &_fx_g34C_form__std_FX_MAKE_EXN_IMPL_START, v_1357, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_exn_data_0,
-                  0), _fx_catch_282);
-            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1358, 0), _fx_catch_282);
-            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1358, &v_1359);
+                  &_fx_g34C_form__std_FX_MAKE_EXN_IMPL_START, v_1378, _fx_g20C_gen_code__CTypVoid, &kf_loc_0, &alloc_exn_data_0,
+                  0), _fx_catch_286);
+            FX_CALL(_fx_M6C_formFM12make_int_expN14C_form__cexp_t2iR10Ast__loc_t(0, &kf_loc_0, &v_1379, 0), _fx_catch_286);
+            _fx_M10C_gen_codeFM4SomeNt6option1N14C_form__cexp_t1N14C_form__cexp_t(v_1379, &v_1380);
             FX_CALL(
-               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1359, &kf_loc_0,
-                  &v_1360), _fx_catch_282);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1360, 0, true, &ret_ccode_3), _fx_catch_282);
-            _fx_R9Ast__id_t v_1369;
-            fx_str_t slit_291 = FX_MAKE_STR("exn_data");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_291, &v_1369, 0), _fx_catch_282);
-            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(exn_data_t_0, &v_1361, 0), _fx_catch_282);
+               _fx_M6C_formFM11CStmtReturnN15C_form__cstmt_t2Nt6option1N14C_form__cexp_tR10Ast__loc_t(&v_1380, &kf_loc_0,
+                  &v_1381), _fx_catch_286);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1381, 0, true, &ret_ccode_3), _fx_catch_286);
+            _fx_R9Ast__id_t v_1390;
+            fx_str_t slit_297 = FX_MAKE_STR("exn_data");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_297, &v_1390, 0), _fx_catch_286);
+            FX_CALL(_fx_M6C_formFM8make_ptrN14C_form__ctyp_t1N14C_form__ctyp_t(exn_data_t_0, &v_1382, 0), _fx_catch_286);
             FX_CALL(
-               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1369, v_1361,
-                  &kf_loc_0, &exn_data_2, 0), _fx_catch_282);
-            _fx_R9Ast__id_t v_1370;
-            fx_str_t slit_292 = FX_MAKE_STR("data");
-            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_292, &v_1370, 0), _fx_catch_282);
+               _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&v_1390, v_1382,
+                  &kf_loc_0, &exn_data_2, 0), _fx_catch_286);
+            _fx_R9Ast__id_t v_1391;
+            fx_str_t slit_298 = FX_MAKE_STR("data");
+            FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&slit_298, &v_1391, 0), _fx_catch_286);
             FX_CALL(
-               _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(exn_data_2, &v_1370,
-                  exn_typ_0, &dst_exp_23, 0), _fx_catch_282);
-            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_exn_data_0, &v_1362), _fx_catch_282);
-            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1362, 0, true, &ccode_167), _fx_catch_282);
-            FX_COPY_PTR(ccode_167, &ccode_168);
+               _fx_M6C_formFM10cexp_arrowN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(exn_data_2, &v_1391,
+                  exn_typ_0, &dst_exp_23, 0), _fx_catch_286);
+            FX_CALL(_fx_M6C_formFM4CExpN15C_form__cstmt_t1N14C_form__cexp_t(alloc_exn_data_0, &v_1383), _fx_catch_286);
+            FX_CALL(_fx_cons_LN15C_form__cstmt_t(v_1383, 0, true, &ccode_170), _fx_catch_286);
+            FX_COPY_PTR(ccode_170, &ccode_171);
             int_ idx_4 = 0;
             _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t lst_35 = real_args_0;
             for (; lst_35; lst_35 = lst_35->tl, idx_4 += 1) {
                _fx_N14C_form__ctyp_t t_29 = 0;
                _fx_LN19C_form__carg_attr_t flags_6 = 0;
                _fx_N14C_form__cexp_t src_exp_6 = 0;
-               _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1371 = {0};
+               _fx_T2N14C_form__cexp_tN14C_form__ctyp_t v_1392 = {0};
                _fx_N14C_form__cexp_t src_exp_7 = 0;
                _fx_N14C_form__ctyp_t t_30 = 0;
                _fx_N14C_form__cexp_t dst_exp_24 = 0;
-               fx_str_t v_1372 = {0};
-               fx_str_t v_1373 = {0};
-               _fx_LN15C_form__cstmt_t v_1374 = 0;
+               fx_str_t v_1393 = {0};
+               fx_str_t v_1394 = {0};
+               _fx_LN15C_form__cstmt_t v_1395 = 0;
                _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* __pat___15 = &lst_35->hd;
                _fx_R9Ast__id_t a_16 = __pat___15->t0;
                FX_COPY_PTR(__pat___15->t1, &t_29);
                FX_COPY_PTR(__pat___15->t2, &flags_6);
                FX_CALL(
                   _fx_M6C_formFM13make_id_t_expN14C_form__cexp_t3R9Ast__id_tN14C_form__ctyp_tR10Ast__loc_t(&a_16, t_29,
-                     &kf_loc_0, &src_exp_6, 0), _fx_catch_281);
+                     &kf_loc_0, &src_exp_6, 0), _fx_catch_285);
                FX_CALL(
                   _fx_M10C_gen_codeFM19maybe_deref_fun_argT2N14C_form__cexp_tN14C_form__ctyp_t5iN14C_form__cexp_tN14C_form__ctyp_tLN19C_form__carg_attr_tR10Ast__loc_t(
-                     idx_4, src_exp_6, t_29, flags_6, &kf_loc_0, &v_1371, 0), _fx_catch_281);
-               FX_COPY_PTR(v_1371.t0, &src_exp_7);
-               FX_COPY_PTR(v_1371.t1, &t_30);
+                     idx_4, src_exp_6, t_29, flags_6, &kf_loc_0, &v_1392, 0), _fx_catch_285);
+               FX_COPY_PTR(v_1392.t0, &src_exp_7);
+               FX_COPY_PTR(v_1392.t1, &t_30);
                if (nreal_args_0 == 1) {
                   FX_COPY_PTR(dst_exp_23, &dst_exp_24);
                }
                else {
-                  FX_CALL(_fx_F6stringS1i(idx_4, &v_1372, 0), _fx_catch_281);
-                  fx_str_t slit_293 = FX_MAKE_STR("t");
+                  FX_CALL(_fx_F6stringS1i(idx_4, &v_1393, 0), _fx_catch_285);
+                  fx_str_t slit_299 = FX_MAKE_STR("t");
                   {
-                     const fx_str_t strs_43[] = { slit_293, v_1372 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_43, 2, &v_1373), _fx_catch_281);
+                     const fx_str_t strs_45[] = { slit_299, v_1393 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_45, 2, &v_1394), _fx_catch_285);
                   }
                   _fx_R9Ast__id_t t_elem_0;
-                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1373, &t_elem_0, 0), _fx_catch_281);
+                  FX_CALL(_fx_M3AstFM6get_idRM4id_t1S(&v_1394, &t_elem_0, 0), _fx_catch_285);
                   FX_CALL(
                      _fx_M6C_formFM8cexp_memN14C_form__cexp_t3N14C_form__cexp_tR9Ast__id_tN14C_form__ctyp_t(dst_exp_23,
-                        &t_elem_0, t_30, &dst_exp_24, 0), _fx_catch_281);
+                        &t_elem_0, t_30, &dst_exp_24, 0), _fx_catch_285);
                }
                FX_CALL(
                   _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                     src_exp_7, dst_exp_24, t_30, ccode_168, &kf_loc_0, &v_1374, 0), _fx_catch_281);
-               _fx_free_LN15C_form__cstmt_t(&ccode_168);
-               FX_COPY_PTR(v_1374, &ccode_168);
+                     src_exp_7, dst_exp_24, t_30, ccode_171, &kf_loc_0, &v_1395, 0), _fx_catch_285);
+               _fx_free_LN15C_form__cstmt_t(&ccode_171);
+               FX_COPY_PTR(v_1395, &ccode_171);
 
-            _fx_catch_281: ;
-               if (v_1374) {
-                  _fx_free_LN15C_form__cstmt_t(&v_1374);
+            _fx_catch_285: ;
+               if (v_1395) {
+                  _fx_free_LN15C_form__cstmt_t(&v_1395);
                }
-               FX_FREE_STR(&v_1373);
-               FX_FREE_STR(&v_1372);
+               FX_FREE_STR(&v_1394);
+               FX_FREE_STR(&v_1393);
                if (dst_exp_24) {
                   _fx_free_N14C_form__cexp_t(&dst_exp_24);
                }
@@ -35721,7 +35961,7 @@ static int
                if (src_exp_7) {
                   _fx_free_N14C_form__cexp_t(&src_exp_7);
                }
-               _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1371);
+               _fx_free_T2N14C_form__cexp_tN14C_form__ctyp_t(&v_1392);
                if (src_exp_6) {
                   _fx_free_N14C_form__cexp_t(&src_exp_6);
                }
@@ -35729,26 +35969,26 @@ static int
                if (t_29) {
                   _fx_free_N14C_form__ctyp_t(&t_29);
                }
-               FX_CHECK_EXN(_fx_catch_282);
+               FX_CHECK_EXN(_fx_catch_286);
             }
             FX_CALL(
-               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_3, ccode_168,
-                  &v_1363, 0), _fx_catch_282);
-            FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1363, &new_body_0, 0), _fx_catch_282);
+               _fx_M10C_gen_codeFM7__add__LN15C_form__cstmt_t2LN15C_form__cstmt_tLN15C_form__cstmt_t(ret_ccode_3, ccode_171,
+                  &v_1384, 0), _fx_catch_286);
+            FX_CALL(_fx_M10C_gen_codeFM3revLN15C_form__cstmt_t1LN15C_form__cstmt_t(v_1384, &new_body_0, 0), _fx_catch_286);
          }
 
-      _fx_catch_282: ;
-         if (v_1363) {
-            _fx_free_LN15C_form__cstmt_t(&v_1363);
+      _fx_catch_286: ;
+         if (v_1384) {
+            _fx_free_LN15C_form__cstmt_t(&v_1384);
          }
-         if (ccode_168) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_168);
+         if (ccode_171) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_171);
          }
-         if (ccode_167) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_167);
+         if (ccode_170) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_170);
          }
-         if (v_1362) {
-            _fx_free_N15C_form__cstmt_t(&v_1362);
+         if (v_1383) {
+            _fx_free_N15C_form__cstmt_t(&v_1383);
          }
          if (dst_exp_23) {
             _fx_free_N14C_form__cexp_t(&dst_exp_23);
@@ -35756,33 +35996,33 @@ static int
          if (exn_data_2) {
             _fx_free_N14C_form__cexp_t(&exn_data_2);
          }
-         if (v_1361) {
-            _fx_free_N14C_form__ctyp_t(&v_1361);
+         if (v_1382) {
+            _fx_free_N14C_form__ctyp_t(&v_1382);
          }
          if (ret_ccode_3) {
             _fx_free_LN15C_form__cstmt_t(&ret_ccode_3);
          }
-         if (v_1360) {
-            _fx_free_N15C_form__cstmt_t(&v_1360);
+         if (v_1381) {
+            _fx_free_N15C_form__cstmt_t(&v_1381);
          }
-         _fx_free_Nt6option1N14C_form__cexp_t(&v_1359);
-         if (v_1358) {
-            _fx_free_N14C_form__cexp_t(&v_1358);
+         _fx_free_Nt6option1N14C_form__cexp_t(&v_1380);
+         if (v_1379) {
+            _fx_free_N14C_form__cexp_t(&v_1379);
          }
          if (alloc_exn_data_0) {
             _fx_free_N14C_form__cexp_t(&alloc_exn_data_0);
          }
-         if (v_1357) {
-            _fx_free_LN14C_form__cexp_t(&v_1357);
+         if (v_1378) {
+            _fx_free_LN14C_form__cexp_t(&v_1378);
          }
-         if (v_1356) {
-            _fx_free_N14C_form__cexp_t(&v_1356);
+         if (v_1377) {
+            _fx_free_N14C_form__cexp_t(&v_1377);
          }
-         if (v_1355) {
-            _fx_free_N14C_form__cexp_t(&v_1355);
+         if (v_1376) {
+            _fx_free_N14C_form__cexp_t(&v_1376);
          }
-         if (v_1354) {
-            _fx_free_N14C_form__cexp_t(&v_1354);
+         if (v_1375) {
+            _fx_free_N14C_form__cexp_t(&v_1375);
          }
          if (exn_data_t_0) {
             _fx_free_N14C_form__ctyp_t(&exn_data_t_0);
@@ -35790,58 +36030,58 @@ static int
          if (exn_typ_0) {
             _fx_free_N14C_form__ctyp_t(&exn_typ_0);
          }
-         _fx_free_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(&v_1353);
-         _fx_free_N15C_form__cinfo_t(&v_1352);
+         _fx_free_T5N14C_form__ctyp_tR9Ast__id_tBR9Ast__id_tR9Ast__id_t(&v_1374);
+         _fx_free_N15C_form__cinfo_t(&v_1373);
          goto _fx_endmatch_54;
       }
-      fx_str_t v_1375 = {0};
-      fx_str_t v_1376 = {0};
-      fx_str_t v_1377 = {0};
-      fx_str_t v_1378 = {0};
-      fx_exn_t v_1379 = {0};
-      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&kf_cname_0, &v_1375, 0), _fx_catch_283);
-      FX_CALL(_fx_M3AstFM8ctor2strS1N17Ast__fun_constr_t(&ctor_0, &v_1376, 0), _fx_catch_283);
-      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1376, &v_1377, 0), _fx_catch_283);
-      fx_str_t slit_294 = FX_MAKE_STR("cgen: unsupported type of constructor ");
-      fx_str_t slit_295 = FX_MAKE_STR(": ");
+      fx_str_t v_1396 = {0};
+      fx_str_t v_1397 = {0};
+      fx_str_t v_1398 = {0};
+      fx_str_t v_1399 = {0};
+      fx_exn_t v_1400 = {0};
+      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&kf_cname_0, &v_1396, 0), _fx_catch_287);
+      FX_CALL(_fx_M3AstFM8ctor2strS1N17Ast__fun_constr_t(&ctor_0, &v_1397, 0), _fx_catch_287);
+      FX_CALL(_fx_M10C_gen_codeFM6stringS1S(&v_1397, &v_1398, 0), _fx_catch_287);
+      fx_str_t slit_300 = FX_MAKE_STR("cgen: unsupported type of constructor ");
+      fx_str_t slit_301 = FX_MAKE_STR(": ");
       {
-         const fx_str_t strs_44[] = { slit_294, v_1375, slit_295, v_1377 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_44, 4, &v_1378), _fx_catch_283);
+         const fx_str_t strs_46[] = { slit_300, v_1396, slit_301, v_1398 };
+         FX_CALL(fx_strjoin(0, 0, 0, strs_46, 4, &v_1399), _fx_catch_287);
       }
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1378, &v_1379, 0), _fx_catch_283);
-      FX_THROW(&v_1379, false, _fx_catch_283);
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &v_1399, &v_1400, 0), _fx_catch_287);
+      FX_THROW(&v_1400, false, _fx_catch_287);
 
-   _fx_catch_283: ;
-      fx_free_exn(&v_1379);
-      FX_FREE_STR(&v_1378);
-      FX_FREE_STR(&v_1377);
-      FX_FREE_STR(&v_1376);
-      FX_FREE_STR(&v_1375);
+   _fx_catch_287: ;
+      fx_free_exn(&v_1400);
+      FX_FREE_STR(&v_1399);
+      FX_FREE_STR(&v_1398);
+      FX_FREE_STR(&v_1397);
+      FX_FREE_STR(&v_1396);
 
    _fx_endmatch_54: ;
-      FX_CHECK_EXN(_fx_catch_284);
+      FX_CHECK_EXN(_fx_catch_288);
       FX_CALL(_fx_M10C_gen_codeFM13pop_block_ctxv2R10Ast__loc_trLrRM11block_ctx_t(&kloc_0, block_stack_ref_0, 0),
-         _fx_catch_284);
-      _fx_R17C_form__cdeffun_t* v_1380 = &cf_0->data;
-      _fx_R16Ast__fun_flags_t* v_1381 = &v_1380->cf_flags;
-      bool v_1382 = really_nothrow_0->data;
+         _fx_catch_288);
+      _fx_R17C_form__cdeffun_t* v_1401 = &cf_0->data;
+      _fx_R16Ast__fun_flags_t* v_1402 = &v_1401->cf_flags;
+      bool v_1403 = really_nothrow_0->data;
       _fx_R16Ast__fun_flags_t new_cf_flags_0 =
-         { v_1381->fun_flag_pure, v_1381->fun_flag_ccode, v_1381->fun_flag_have_keywords, v_1381->fun_flag_inline,
-            v_1381->fun_flag_nothrow, v_1382, v_1381->fun_flag_private, v_1381->fun_flag_ctor, v_1381->fun_flag_method_of,
-            v_1381->fun_flag_uses_fv, v_1381->fun_flag_recursive, v_1381->fun_flag_instance };
-      _fx_R17C_form__cdeffun_t* v_1383 = &cf_0->data;
-      FX_CALL(_fx_M6C_formFM15filter_out_nopsLN15C_form__cstmt_t1LN15C_form__cstmt_t(new_body_0, &v_1230, 0), _fx_catch_284);
-      _fx_make_R17C_form__cdeffun_t(&v_1383->cf_name, &v_1383->cf_cname, v_1383->cf_args, v_1383->cf_rt, v_1230,
-         &new_cf_flags_0, v_1383->cf_scope, &v_1383->cf_loc, &v_1231);
-      _fx_R17C_form__cdeffun_t* v_1384 = &cf_0->data;
-      _fx_free_R17C_form__cdeffun_t(v_1384);
-      _fx_copy_R17C_form__cdeffun_t(&v_1231, v_1384);
+         { v_1402->fun_flag_pure, v_1402->fun_flag_ccode, v_1402->fun_flag_have_keywords, v_1402->fun_flag_inline,
+            v_1402->fun_flag_nothrow, v_1403, v_1402->fun_flag_private, v_1402->fun_flag_ctor, v_1402->fun_flag_method_of,
+            v_1402->fun_flag_uses_fv, v_1402->fun_flag_recursive, v_1402->fun_flag_instance };
+      _fx_R17C_form__cdeffun_t* v_1404 = &cf_0->data;
+      FX_CALL(_fx_M6C_formFM15filter_out_nopsLN15C_form__cstmt_t1LN15C_form__cstmt_t(new_body_0, &v_1251, 0), _fx_catch_288);
+      _fx_make_R17C_form__cdeffun_t(&v_1404->cf_name, &v_1404->cf_cname, v_1404->cf_args, v_1404->cf_rt, v_1251,
+         &new_cf_flags_0, v_1404->cf_scope, &v_1404->cf_loc, &v_1252);
+      _fx_R17C_form__cdeffun_t* v_1405 = &cf_0->data;
+      _fx_free_R17C_form__cdeffun_t(v_1405);
+      _fx_copy_R17C_form__cdeffun_t(&v_1252, v_1405);
       _fx_make_T3BN14C_form__cexp_tLN15C_form__cstmt_t(false, dummy_exp_0, ccode_0, &v_1);
 
-   _fx_catch_284: ;
-      _fx_free_R17C_form__cdeffun_t(&v_1231);
-      if (v_1230) {
-         _fx_free_LN15C_form__cstmt_t(&v_1230);
+   _fx_catch_288: ;
+      _fx_free_R17C_form__cdeffun_t(&v_1252);
+      if (v_1251) {
+         _fx_free_LN15C_form__cstmt_t(&v_1251);
       }
       if (new_body_0) {
          _fx_free_LN15C_form__cstmt_t(&new_body_0);
@@ -35850,7 +36090,7 @@ static int
       if (real_args_0) {
          _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&real_args_0);
       }
-      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_1229);
+      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tR9Ast__id_tN14C_form__ctyp_tB(&v_1250);
       if (cf_0) {
          _fx_free_rR17C_form__cdeffun_t(&cf_0);
       }
@@ -35860,8 +36100,8 @@ static int
       if (args_13) {
          _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&args_13);
       }
-      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(&v_1228);
-      _fx_free_N15C_form__cinfo_t(&v_1227);
+      _fx_free_T4LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_tN14C_form__ctyp_tBrR17C_form__cdeffun_t(&v_1249);
+      _fx_free_N15C_form__cinfo_t(&v_1248);
       if (kf_rt_0) {
          _fx_free_N14K_form__ktyp_t(&kf_rt_0);
       }
@@ -35906,39 +36146,39 @@ _fx_endmatch_55: ;
    else {
       _fx_copy_Nt6option1N14C_form__cexp_t(&dstexp_r_0->data, &v_3);
       if (v_3.tag == 2) {
-         _fx_LN15C_form__cstmt_t ccode_169 = 0;
+         _fx_LN15C_form__cstmt_t ccode_172 = 0;
          _fx_N14C_form__cexp_t dst_exp_25 = v_3.u.Some;
          bool skip_copy_0;
          if (FX_REC_VARIANT_TAG(result_exp_0) == 2) {
             if (result_exp_0->u.CExpLit.t0.tag == 8) {
-               _fx_R17C_form__ctprops_t v_1385 = {0};
+               _fx_R17C_form__ctprops_t v_1406 = {0};
                FX_CALL(
-                  _fx_M11C_gen_typesFM11get_ctpropsR17C_form__ctprops_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_1385,
-                     0), _fx_catch_285);
-               skip_copy_0 = v_1385.ctp_ptr;
+                  _fx_M11C_gen_typesFM11get_ctpropsR17C_form__ctprops_t2N14C_form__ctyp_tR10Ast__loc_t(ctyp_0, &kloc_0, &v_1406,
+                     0), _fx_catch_289);
+               skip_copy_0 = v_1406.ctp_ptr;
 
-            _fx_catch_285: ;
-               _fx_free_R17C_form__ctprops_t(&v_1385);
+            _fx_catch_289: ;
+               _fx_free_R17C_form__ctprops_t(&v_1406);
                goto _fx_endmatch_56;
             }
          }
          skip_copy_0 = false;
 
       _fx_endmatch_56: ;
-         FX_CHECK_EXN(_fx_catch_286);
+         FX_CHECK_EXN(_fx_catch_290);
          if (skip_copy_0) {
-            FX_COPY_PTR(ccode_1, &ccode_169);
+            FX_COPY_PTR(ccode_1, &ccode_172);
          }
          else {
             FX_CALL(
                _fx_M11C_gen_typesFM13gen_copy_codeLN15C_form__cstmt_t5N14C_form__cexp_tN14C_form__cexp_tN14C_form__ctyp_tLN15C_form__cstmt_tR10Ast__loc_t(
-                  result_exp_0, dst_exp_25, ctyp_0, ccode_1, &kloc_0, &ccode_169, 0), _fx_catch_286);
+                  result_exp_0, dst_exp_25, ctyp_0, ccode_1, &kloc_0, &ccode_172, 0), _fx_catch_290);
          }
-         _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(dst_exp_25, ccode_169, fx_result);
+         _fx_make_T2N14C_form__cexp_tLN15C_form__cstmt_t(dst_exp_25, ccode_172, fx_result);
 
-      _fx_catch_286: ;
-         if (ccode_169) {
-            _fx_free_LN15C_form__cstmt_t(&ccode_169);
+      _fx_catch_290: ;
+         if (ccode_172) {
+            _fx_free_LN15C_form__cstmt_t(&ccode_172);
          }
       }
       else {

--- a/compiler/bootstrap/C_gen_fdecls.c
+++ b/compiler/bootstrap/C_gen_fdecls.c
@@ -46,18 +46,34 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
 
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
+typedef struct _fx_N12Set__color_t {
+   int tag;
+} _fx_N12Set__color_t;
+
+typedef struct _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t {
+   struct _fx_N12Set__color_t t0;
+   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t1;
+   struct _fx_R9Ast__id_t t2;
+   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t3;
+} _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t;
+
+typedef struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t Node;
+   } u;
+} _fx_Nt11Set__tree_t1R9Ast__id_t_data_t, *_fx_Nt11Set__tree_t1R9Ast__id_t;
+
+typedef struct _fx_Rt6Set__t1R9Ast__id_t {
+   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* root;
+   int_ size;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Set__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -81,6 +97,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -100,10 +134,19 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
+
+typedef struct _fx_N13Ast__binary_t_data_t {
+   int_ rc;
+   int tag;
+   union {
+      struct _fx_N12Ast__cmpop_t OpCmp;
+      struct _fx_N12Ast__cmpop_t OpDotCmp;
+      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
+   } u;
+} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -134,49 +177,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_N12Set__color_t {
-   int tag;
-} _fx_N12Set__color_t;
-
-typedef struct _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t {
-   struct _fx_N12Set__color_t t0;
-   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t1;
-   struct _fx_R9Ast__id_t t2;
-   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t3;
-} _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t;
-
-typedef struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t Node;
-   } u;
-} _fx_Nt11Set__tree_t1R9Ast__id_t_data_t, *_fx_Nt11Set__tree_t1R9Ast__id_t;
-
-typedef struct _fx_Rt6Set__t1R9Ast__id_t {
-   struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* root;
-   int_ size;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Set__t1R9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
-
-typedef struct _fx_N13Ast__binary_t_data_t {
-   int_ rc;
-   int tag;
-   union {
-      struct _fx_N12Ast__cmpop_t OpCmp;
-      struct _fx_N12Ast__cmpop_t OpDotCmp;
-      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
-   } u;
-} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_T2R9Ast__id_tN14K_form__ktyp_t {
    struct _fx_R9Ast__id_t t0;
@@ -288,132 +288,6 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -449,6 +323,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -714,6 +604,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -759,6 +751,14 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
 
 typedef struct _fx_T2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_R9Ast__id_t t0;
@@ -814,161 +814,10 @@ typedef struct _fx_LN15C_form__cstmt_t_data_t {
    struct _fx_N15C_form__cstmt_t_data_t* hd;
 } _fx_LN15C_form__cstmt_t_data_t, *_fx_LN15C_form__cstmt_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
-
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -994,6 +843,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -1196,6 +1059,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -1247,6 +1200,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_T2Nt11Set__tree_t1R9Ast__id_ti {
    struct _fx_Nt11Set__tree_t1R9Ast__id_t_data_t* t0;
@@ -1319,68 +1319,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
 {
    fx_result->t0 = *t0;
    fx_copy_str(t1, &fx_result->t1);
-}
-
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t(
@@ -1463,6 +1401,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1475,6 +1466,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2R9Ast__id_tN14K_form__ktyp_t(struct _fx_T2R9Ast__id_tN14K_form__ktyp_t* dst)
@@ -1705,150 +1705,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1861,210 +1717,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3083,6 +2735,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3167,6 +3136,37 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
 }
 
 static void _fx_free_T2R9Ast__id_tN14C_form__ctyp_t(struct _fx_T2R9Ast__id_tN14C_form__ctyp_t* dst)
@@ -3321,165 +3321,21 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+   fx_free_str(&dst->t0);
 }
 
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
 {
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
+   fx_copy_str(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
 }
 
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
+static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
 {
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+   fx_copy_str(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
 }
 
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
@@ -3515,322 +3371,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_free_str(&dst->t0);
-}
-
-static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_copy_str(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
-{
-   fx_copy_str(t0, &fx_result->t0);
-   fx_result->t1 = *t1;
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -4582,6 +4122,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -4696,6 +4530,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2Nt11Set__tree_t1R9Ast__id_ti(struct _fx_T2Nt11Set__tree_t1R9Ast__id_ti* dst)

--- a/compiler/bootstrap/C_gen_std.c
+++ b/compiler/bootstrap/C_gen_std.c
@@ -34,14 +34,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -63,6 +55,19 @@ typedef struct _fx_N12Ast__scope_t {
       int_ ScModule;
    } u;
 } _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
 
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
@@ -99,11 +104,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
 
 typedef struct _fx_T2R9Ast__id_tN14K_form__ktyp_t {
    struct _fx_R9Ast__id_t t0;
@@ -258,165 +258,14 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
-
-typedef struct _fx_N19C_form__carg_attr_t {
+typedef struct _fx_N12Ast__cmpop_t {
    int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -442,6 +291,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -644,6 +507,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -696,6 +649,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
 
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
+
 typedef struct {
    int_ rc;
    int_ data;
@@ -738,6 +738,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -754,23 +771,6 @@ static int _fx_cons_LR9Ast__id_t(
    struct _fx_LR9Ast__id_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
 }
 
 static void _fx_free_T2R9Ast__id_tN14K_form__ktyp_t(struct _fx_T2R9Ast__id_tN14K_form__ktyp_t* dst)
@@ -1140,165 +1140,21 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+   fx_free_str(&dst->t0);
 }
 
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
 {
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
+   fx_copy_str(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
 }
 
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
+static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
 {
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+   fx_copy_str(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
 }
 
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
@@ -1334,322 +1190,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_free_str(&dst->t0);
-}
-
-static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_copy_str(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
-{
-   fx_copy_str(t0, &fx_result->t0);
-   fx_result->t1 = *t1;
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -2401,6 +1941,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -2515,6 +2349,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 _fx_N19C_form__ctyp_attr_t _fx_g20C_gen_std__CTypConst = { 1 };

--- a/compiler/bootstrap/C_gen_types.c
+++ b/compiler/bootstrap/C_gen_types.c
@@ -94,77 +94,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1S {
    uint64_t hv;
    fx_str_t key;
@@ -207,6 +136,11 @@ typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
    } u;
 } _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_N12Set__color_t {
    int tag;
 } _fx_N12Set__color_t;
@@ -231,10 +165,46 @@ typedef struct _fx_Rt6Set__t1R9Ast__id_t {
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Set__t1R9Ast__id_t;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -249,6 +219,36 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -440,145 +440,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -614,6 +475,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -879,6 +756,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -924,6 +903,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1062,161 +1062,10 @@ typedef struct _fx_LN15C_form__cstmt_t_data_t {
    struct _fx_N15C_form__cstmt_t_data_t* hd;
 } _fx_LN15C_form__cstmt_t_data_t, *_fx_LN15C_form__cstmt_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
-
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -1237,6 +1086,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -1439,6 +1302,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -1490,6 +1443,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_R29C_gen_types__ctyp_temp_info_t {
    struct _fx_rR17C_form__cdeftyp_t_data_t* ctti_struct_decl;
@@ -1661,24 +1661,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
 {
    fx_result->t0 = *t0;
    fx_copy_str(t1, &fx_result->t1);
-}
-
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_Rt24Hashset__hashset_entry_t1S(struct _fx_Rt24Hashset__hashset_entry_t1S* dst)
@@ -1873,6 +1855,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1885,6 +1876,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -2242,150 +2242,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -2398,256 +2254,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3666,6 +3272,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3750,6 +3673,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)
@@ -4061,167 +4061,6 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
-}
-
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
-{
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
-}
-
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
-{
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
-}
-
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
 {
    fx_free_list_simple(&dst->ctp_make);
@@ -4255,305 +4094,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -5305,6 +4845,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -5419,6 +5253,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R29C_gen_types__ctyp_temp_info_t(struct _fx_R29C_gen_types__ctyp_temp_info_t* dst)

--- a/compiler/bootstrap/C_post_adjust_decls.c
+++ b/compiler/bootstrap/C_post_adjust_decls.c
@@ -54,14 +54,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -84,6 +76,19 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -95,11 +100,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -310,6 +310,10 @@ typedef struct _fx_LN15C_form__cstmt_t_data_t {
    struct _fx_N15C_form__cstmt_t_data_t* hd;
 } _fx_LN15C_form__cstmt_t_data_t, *_fx_LN15C_form__cstmt_t;
 
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
+
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
    union {
@@ -334,118 +338,10 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -466,6 +362,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -668,6 +578,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -789,6 +789,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -805,23 +822,6 @@ static int _fx_cons_LR9Ast__id_t(
    struct _fx_LR9Ast__id_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1248,113 +1248,6 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
-}
-
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
 {
    fx_free_list_simple(&dst->ctp_make);
@@ -1388,193 +1281,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -2324,6 +2030,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t1 = *t1;
    _fx_copy_Nt6option1N14C_form__cexp_t(t2, &fx_result->t2);
    fx_result->t3 = *t3;
+}
+
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
 }
 
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)

--- a/compiler/bootstrap/C_post_rename_locals.c
+++ b/compiler/bootstrap/C_post_rename_locals.c
@@ -58,14 +58,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -88,6 +80,19 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -99,11 +104,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -351,19 +351,9 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -389,151 +379,10 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -554,6 +403,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -756,6 +619,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -807,6 +760,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -871,6 +871,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -887,23 +904,6 @@ static int _fx_cons_LR9Ast__id_t(
    struct _fx_LR9Ast__id_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1427,167 +1427,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
-}
-
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
-{
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
-}
-
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
-{
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
-}
-
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
 {
    fx_free_list_simple(&dst->ctp_make);
@@ -1621,305 +1460,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -2671,6 +2211,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -2785,6 +2619,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/C_pp.c
+++ b/compiler/bootstrap/C_pp.c
@@ -98,14 +98,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -128,6 +120,19 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -139,11 +144,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
 
 typedef struct _fx_N13PP__ppstyle_t {
    int tag;
@@ -365,19 +365,9 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17C_form__cdefval_t {
-   struct _fx_R9Ast__id_t cv_name;
-   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
-   fx_str_t cv_cname;
-   struct _fx_R16Ast__val_flags_t cv_flags;
-   struct _fx_R10Ast__loc_t cv_loc;
-} _fx_R17C_form__cdefval_t;
-
-typedef struct _fx_R19C_form__cdeflabel_t {
-   struct _fx_R9Ast__id_t cl_name;
-   fx_str_t cl_cname;
-   struct _fx_R10Ast__loc_t cl_loc;
-} _fx_R19C_form__cdeflabel_t;
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -403,151 +393,10 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
 typedef struct _fx_Ta2R9Ast__id_t {
    struct _fx_R9Ast__id_t t0;
    struct _fx_R9Ast__id_t t1;
 } _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
-typedef struct _fx_R17C_form__cdefexn_t {
-   struct _fx_R9Ast__id_t cexn_name;
-   fx_str_t cexn_cname;
-   fx_str_t cexn_base_cname;
-   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
-   bool cexn_std;
-   struct _fx_R9Ast__id_t cexn_tag;
-   struct _fx_R9Ast__id_t cexn_data;
-   struct _fx_R9Ast__id_t cexn_info;
-   struct _fx_R9Ast__id_t cexn_make;
-   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
-   struct _fx_R10Ast__loc_t cexn_loc;
-} _fx_R17C_form__cdefexn_t;
-
-typedef struct _fx_rR17C_form__cdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdefexn_t data;
-} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
-
-typedef struct _fx_N15C_form__cinfo_t {
-   int tag;
-   union {
-      struct _fx_R17C_form__cdefval_t CVal;
-      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
-      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
-      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
-      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
-      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
-      struct _fx_R19C_form__cdeflabel_t CLabel;
-      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
-   } u;
-} _fx_N15C_form__cinfo_t;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
 
 typedef struct _fx_T2R9Ast__id_tR10Ast__loc_t {
    struct _fx_R9Ast__id_t t0;
@@ -573,6 +422,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -775,6 +638,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
 
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
+
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
    struct _fx_LN15C_form__cstmt_t_data_t* t1;
@@ -826,6 +779,53 @@ typedef struct _fx_N15C_form__cstmt_t_data_t {
       struct _fx_T2SR10Ast__loc_t CMacroPragma;
    } u;
 } _fx_N15C_form__cstmt_t_data_t, *_fx_N15C_form__cstmt_t;
+
+typedef struct _fx_R17C_form__cdefval_t {
+   struct _fx_R9Ast__id_t cv_name;
+   struct _fx_N14C_form__ctyp_t_data_t* cv_typ;
+   fx_str_t cv_cname;
+   struct _fx_R16Ast__val_flags_t cv_flags;
+   struct _fx_R10Ast__loc_t cv_loc;
+} _fx_R17C_form__cdefval_t;
+
+typedef struct _fx_R19C_form__cdeflabel_t {
+   struct _fx_R9Ast__id_t cl_name;
+   fx_str_t cl_cname;
+   struct _fx_R10Ast__loc_t cl_loc;
+} _fx_R19C_form__cdeflabel_t;
+
+typedef struct _fx_R17C_form__cdefexn_t {
+   struct _fx_R9Ast__id_t cexn_name;
+   fx_str_t cexn_cname;
+   fx_str_t cexn_base_cname;
+   struct _fx_N14C_form__ctyp_t_data_t* cexn_typ;
+   bool cexn_std;
+   struct _fx_R9Ast__id_t cexn_tag;
+   struct _fx_R9Ast__id_t cexn_data;
+   struct _fx_R9Ast__id_t cexn_info;
+   struct _fx_R9Ast__id_t cexn_make;
+   struct _fx_LN12Ast__scope_t_data_t* cexn_scope;
+   struct _fx_R10Ast__loc_t cexn_loc;
+} _fx_R17C_form__cdefexn_t;
+
+typedef struct _fx_rR17C_form__cdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdefexn_t data;
+} _fx_rR17C_form__cdefexn_t_data_t, *_fx_rR17C_form__cdefexn_t;
+
+typedef struct _fx_N15C_form__cinfo_t {
+   int tag;
+   union {
+      struct _fx_R17C_form__cdefval_t CVal;
+      struct _fx_rR17C_form__cdeffun_t_data_t* CFun;
+      struct _fx_rR17C_form__cdeftyp_t_data_t* CTyp;
+      struct _fx_rR17C_form__cdefexn_t_data_t* CExn;
+      struct _fx_rR23C_form__cdefinterface_t_data_t* CInterface;
+      struct _fx_rR18C_form__cdefenum_t_data_t* CEnum;
+      struct _fx_R19C_form__cdeflabel_t CLabel;
+      struct _fx_rR19C_form__cdefmacro_t_data_t* CMacro;
+   } u;
+} _fx_N15C_form__cinfo_t;
 
 typedef struct _fx_N13C_pp__assoc_t {
    int tag;
@@ -1074,6 +1074,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -1090,23 +1107,6 @@ static int _fx_cons_LR9Ast__id_t(
    struct _fx_LR9Ast__id_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
 }
 
 static void _fx_free_N11PP__pptok_t(struct _fx_N11PP__pptok_t* dst)
@@ -1608,165 +1608,21 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
-   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
-   fx_free_str(&dst->cv_cname);
-   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+   fx_free_str(&dst->t0);
 }
 
-static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
 {
-   dst->cv_name = src->cv_name;
-   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
-   fx_copy_str(&src->cv_cname, &dst->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
-   dst->cv_loc = src->cv_loc;
+   fx_copy_str(&src->t0, &dst->t0);
+   dst->t1 = src->t1;
 }
 
-static void _fx_make_R17C_form__cdefval_t(
-   struct _fx_R9Ast__id_t* r_cv_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
-   fx_str_t* r_cv_cname,
-   struct _fx_R16Ast__val_flags_t* r_cv_flags,
-   struct _fx_R10Ast__loc_t* r_cv_loc,
-   struct _fx_R17C_form__cdefval_t* fx_result)
+static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
 {
-   fx_result->cv_name = *r_cv_name;
-   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
-   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
-   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
-   fx_result->cv_loc = *r_cv_loc;
-}
-
-static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   fx_free_str(&dst->cl_cname);
-}
-
-static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
-{
-   dst->cl_name = src->cl_name;
-   fx_copy_str(&src->cl_cname, &dst->cl_cname);
-   dst->cl_loc = src->cl_loc;
-}
-
-static void _fx_make_R19C_form__cdeflabel_t(
-   struct _fx_R9Ast__id_t* r_cl_name,
-   fx_str_t* r_cl_cname,
-   struct _fx_R10Ast__loc_t* r_cl_loc,
-   struct _fx_R19C_form__cdeflabel_t* fx_result)
-{
-   fx_result->cl_name = *r_cl_name;
-   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
-   fx_result->cl_loc = *r_cl_loc;
-}
-
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+   fx_copy_str(t0, &fx_result->t0);
+   fx_result->t1 = *t1;
 }
 
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
@@ -1802,322 +1658,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
-}
-
-static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
-{
-   fx_free_str(&dst->cexn_cname);
-   fx_free_str(&dst->cexn_base_cname);
-   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
-   fx_free_list_simple(&dst->cexn_scope);
-}
-
-static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
-{
-   dst->cexn_name = src->cexn_name;
-   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
-   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
-   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
-   dst->cexn_std = src->cexn_std;
-   dst->cexn_tag = src->cexn_tag;
-   dst->cexn_data = src->cexn_data;
-   dst->cexn_info = src->cexn_info;
-   dst->cexn_make = src->cexn_make;
-   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
-   dst->cexn_loc = src->cexn_loc;
-}
-
-static void _fx_make_R17C_form__cdefexn_t(
-   struct _fx_R9Ast__id_t* r_cexn_name,
-   fx_str_t* r_cexn_cname,
-   fx_str_t* r_cexn_base_cname,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
-   bool r_cexn_std,
-   struct _fx_R9Ast__id_t* r_cexn_tag,
-   struct _fx_R9Ast__id_t* r_cexn_data,
-   struct _fx_R9Ast__id_t* r_cexn_info,
-   struct _fx_R9Ast__id_t* r_cexn_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
-   struct _fx_R10Ast__loc_t* r_cexn_loc,
-   struct _fx_R17C_form__cdefexn_t* fx_result)
-{
-   fx_result->cexn_name = *r_cexn_name;
-   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
-   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
-   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
-   fx_result->cexn_std = r_cexn_std;
-   fx_result->cexn_tag = *r_cexn_tag;
-   fx_result->cexn_data = *r_cexn_data;
-   fx_result->cexn_info = *r_cexn_info;
-   fx_result->cexn_make = *r_cexn_make;
-   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
-   fx_result->cexn_loc = *r_cexn_loc;
-}
-
-static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
-}
-
-static int _fx_make_rR17C_form__cdefexn_t(
-   struct _fx_R17C_form__cdefexn_t* arg,
-   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
-}
-
-static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
-   case 3:
-      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
-   case 4:
-      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
-   case 5:
-      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
-   case 6:
-      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
-   case 7:
-      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
-   case 8:
-      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
-   case 9:
-      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
-   case 5:
-      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
-   case 6:
-      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
-   case 7:
-      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
-   case 8:
-      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
-   case 9:
-      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_free_str(&dst->t0);
-}
-
-static void _fx_copy_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* src, struct _fx_T2SR10Ast__loc_t* dst)
-{
-   fx_copy_str(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2SR10Ast__loc_t(fx_str_t* t0, struct _fx_R10Ast__loc_t* t1, struct _fx_T2SR10Ast__loc_t* fx_result)
-{
-   fx_copy_str(t0, &fx_result->t0);
-   fx_result->t1 = *t1;
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -2869,6 +2409,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
+}
+
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)
 {
    _fx_free_N14C_form__cexp_t(&dst->t0);
@@ -2983,6 +2817,172 @@ static void _fx_free_N15C_form__cstmt_t(struct _fx_N15C_form__cstmt_t_data_t** d
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->cv_typ);
+   fx_free_str(&dst->cv_cname);
+   _fx_free_R16Ast__val_flags_t(&dst->cv_flags);
+}
+
+static void _fx_copy_R17C_form__cdefval_t(struct _fx_R17C_form__cdefval_t* src, struct _fx_R17C_form__cdefval_t* dst)
+{
+   dst->cv_name = src->cv_name;
+   FX_COPY_PTR(src->cv_typ, &dst->cv_typ);
+   fx_copy_str(&src->cv_cname, &dst->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(&src->cv_flags, &dst->cv_flags);
+   dst->cv_loc = src->cv_loc;
+}
+
+static void _fx_make_R17C_form__cdefval_t(
+   struct _fx_R9Ast__id_t* r_cv_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cv_typ,
+   fx_str_t* r_cv_cname,
+   struct _fx_R16Ast__val_flags_t* r_cv_flags,
+   struct _fx_R10Ast__loc_t* r_cv_loc,
+   struct _fx_R17C_form__cdefval_t* fx_result)
+{
+   fx_result->cv_name = *r_cv_name;
+   FX_COPY_PTR(r_cv_typ, &fx_result->cv_typ);
+   fx_copy_str(r_cv_cname, &fx_result->cv_cname);
+   _fx_copy_R16Ast__val_flags_t(r_cv_flags, &fx_result->cv_flags);
+   fx_result->cv_loc = *r_cv_loc;
+}
+
+static void _fx_free_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   fx_free_str(&dst->cl_cname);
+}
+
+static void _fx_copy_R19C_form__cdeflabel_t(struct _fx_R19C_form__cdeflabel_t* src, struct _fx_R19C_form__cdeflabel_t* dst)
+{
+   dst->cl_name = src->cl_name;
+   fx_copy_str(&src->cl_cname, &dst->cl_cname);
+   dst->cl_loc = src->cl_loc;
+}
+
+static void _fx_make_R19C_form__cdeflabel_t(
+   struct _fx_R9Ast__id_t* r_cl_name,
+   fx_str_t* r_cl_cname,
+   struct _fx_R10Ast__loc_t* r_cl_loc,
+   struct _fx_R19C_form__cdeflabel_t* fx_result)
+{
+   fx_result->cl_name = *r_cl_name;
+   fx_copy_str(r_cl_cname, &fx_result->cl_cname);
+   fx_result->cl_loc = *r_cl_loc;
+}
+
+static void _fx_free_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* dst)
+{
+   fx_free_str(&dst->cexn_cname);
+   fx_free_str(&dst->cexn_base_cname);
+   _fx_free_N14C_form__ctyp_t(&dst->cexn_typ);
+   fx_free_list_simple(&dst->cexn_scope);
+}
+
+static void _fx_copy_R17C_form__cdefexn_t(struct _fx_R17C_form__cdefexn_t* src, struct _fx_R17C_form__cdefexn_t* dst)
+{
+   dst->cexn_name = src->cexn_name;
+   fx_copy_str(&src->cexn_cname, &dst->cexn_cname);
+   fx_copy_str(&src->cexn_base_cname, &dst->cexn_base_cname);
+   FX_COPY_PTR(src->cexn_typ, &dst->cexn_typ);
+   dst->cexn_std = src->cexn_std;
+   dst->cexn_tag = src->cexn_tag;
+   dst->cexn_data = src->cexn_data;
+   dst->cexn_info = src->cexn_info;
+   dst->cexn_make = src->cexn_make;
+   FX_COPY_PTR(src->cexn_scope, &dst->cexn_scope);
+   dst->cexn_loc = src->cexn_loc;
+}
+
+static void _fx_make_R17C_form__cdefexn_t(
+   struct _fx_R9Ast__id_t* r_cexn_name,
+   fx_str_t* r_cexn_cname,
+   fx_str_t* r_cexn_base_cname,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cexn_typ,
+   bool r_cexn_std,
+   struct _fx_R9Ast__id_t* r_cexn_tag,
+   struct _fx_R9Ast__id_t* r_cexn_data,
+   struct _fx_R9Ast__id_t* r_cexn_info,
+   struct _fx_R9Ast__id_t* r_cexn_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_cexn_scope,
+   struct _fx_R10Ast__loc_t* r_cexn_loc,
+   struct _fx_R17C_form__cdefexn_t* fx_result)
+{
+   fx_result->cexn_name = *r_cexn_name;
+   fx_copy_str(r_cexn_cname, &fx_result->cexn_cname);
+   fx_copy_str(r_cexn_base_cname, &fx_result->cexn_base_cname);
+   FX_COPY_PTR(r_cexn_typ, &fx_result->cexn_typ);
+   fx_result->cexn_std = r_cexn_std;
+   fx_result->cexn_tag = *r_cexn_tag;
+   fx_result->cexn_data = *r_cexn_data;
+   fx_result->cexn_info = *r_cexn_info;
+   fx_result->cexn_make = *r_cexn_make;
+   FX_COPY_PTR(r_cexn_scope, &fx_result->cexn_scope);
+   fx_result->cexn_loc = *r_cexn_loc;
+}
+
+static void _fx_free_rR17C_form__cdefexn_t(struct _fx_rR17C_form__cdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_free_R17C_form__cdefexn_t);
+}
+
+static int _fx_make_rR17C_form__cdefexn_t(
+   struct _fx_R17C_form__cdefexn_t* arg,
+   struct _fx_rR17C_form__cdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdefexn_t, _fx_copy_R17C_form__cdefexn_t);
+}
+
+static void _fx_free_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17C_form__cdefval_t(&dst->u.CVal); break;
+   case 3:
+      _fx_free_rR17C_form__cdeffun_t(&dst->u.CFun); break;
+   case 4:
+      _fx_free_rR17C_form__cdeftyp_t(&dst->u.CTyp); break;
+   case 5:
+      _fx_free_rR17C_form__cdefexn_t(&dst->u.CExn); break;
+   case 6:
+      _fx_free_rR23C_form__cdefinterface_t(&dst->u.CInterface); break;
+   case 7:
+      _fx_free_rR18C_form__cdefenum_t(&dst->u.CEnum); break;
+   case 8:
+      _fx_free_R19C_form__cdeflabel_t(&dst->u.CLabel); break;
+   case 9:
+      _fx_free_rR19C_form__cdefmacro_t(&dst->u.CMacro); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15C_form__cinfo_t(struct _fx_N15C_form__cinfo_t* src, struct _fx_N15C_form__cinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17C_form__cdefval_t(&src->u.CVal, &dst->u.CVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.CFun, &dst->u.CFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.CTyp, &dst->u.CTyp); break;
+   case 5:
+      FX_COPY_PTR(src->u.CExn, &dst->u.CExn); break;
+   case 6:
+      FX_COPY_PTR(src->u.CInterface, &dst->u.CInterface); break;
+   case 7:
+      FX_COPY_PTR(src->u.CEnum, &dst->u.CEnum); break;
+   case 8:
+      _fx_copy_R19C_form__cdeflabel_t(&src->u.CLabel, &dst->u.CLabel); break;
+   case 9:
+      FX_COPY_PTR(src->u.CMacro, &dst->u.CMacro); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T3SiN13C_pp__assoc_t(struct _fx_T3SiN13C_pp__assoc_t* dst)

--- a/compiler/bootstrap/Compiler.c
+++ b/compiler/bootstrap/Compiler.c
@@ -187,263 +187,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1S {
    uint64_t hv;
    fx_str_t key;
@@ -490,6 +233,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
          Node;
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -544,6 +327,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -625,6 +432,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -644,6 +475,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -840,6 +681,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -1012,6 +991,14 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
 
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
    struct _fx_R10Ast__loc_t t1;
@@ -1022,6 +1009,19 @@ typedef struct _fx_LT2SR10Ast__loc_t_data_t {
    struct _fx_LT2SR10Ast__loc_t_data_t* tl;
    struct _fx_T2SR10Ast__loc_t hd;
 } _fx_LT2SR10Ast__loc_t_data_t, *_fx_LT2SR10Ast__loc_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1185,113 +1185,11 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -1557,6 +1455,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1673,110 +1673,6 @@ typedef struct _fx_LN15C_form__cstmt_t_data_t {
    struct _fx_N15C_form__cstmt_t_data_t* hd;
 } _fx_LN15C_form__cstmt_t_data_t, *_fx_LN15C_form__cstmt_t;
 
-typedef struct _fx_N19C_form__carg_attr_t {
-   int tag;
-} _fx_N19C_form__carg_attr_t;
-
-typedef struct _fx_LN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_N19C_form__carg_attr_t hd;
-} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
-
-typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N14C_form__ctyp_t_data_t* t1;
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
-} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
-} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
-
-typedef struct _fx_R17C_form__cdeffun_t {
-   struct _fx_R9Ast__id_t cf_name;
-   fx_str_t cf_cname;
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
-   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
-   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
-   struct _fx_R16Ast__fun_flags_t cf_flags;
-   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
-   struct _fx_R10Ast__loc_t cf_loc;
-} _fx_R17C_form__cdeffun_t;
-
-typedef struct _fx_rR17C_form__cdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeffun_t data;
-} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
-
-typedef struct _fx_R17C_form__ctprops_t {
-   bool ctp_scalar;
-   bool ctp_complex;
-   bool ctp_ptr;
-   bool ctp_pass_by_ref;
-   struct _fx_LR9Ast__id_t_data_t* ctp_make;
-   struct _fx_Ta2R9Ast__id_t ctp_free;
-   struct _fx_Ta2R9Ast__id_t ctp_copy;
-} _fx_R17C_form__ctprops_t;
-
-typedef struct _fx_R17C_form__cdeftyp_t {
-   struct _fx_R9Ast__id_t ct_name;
-   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
-   fx_str_t ct_cname;
-   struct _fx_R17C_form__ctprops_t ct_props;
-   int_ ct_data_start;
-   struct _fx_R9Ast__id_t ct_enum;
-   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
-   struct _fx_R9Ast__id_t ct_ifaces_id;
-   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
-   struct _fx_R10Ast__loc_t ct_loc;
-} _fx_R17C_form__cdeftyp_t;
-
-typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17C_form__cdeftyp_t data;
-} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
-
-typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_Nt6option1N14C_form__cexp_t t1;
-} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
-} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
-
-typedef struct _fx_R18C_form__cdefenum_t {
-   struct _fx_R9Ast__id_t cenum_name;
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
-   fx_str_t cenum_cname;
-   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
-   struct _fx_R10Ast__loc_t cenum_loc;
-} _fx_R18C_form__cdefenum_t;
-
-typedef struct _fx_rR18C_form__cdefenum_t_data_t {
-   int_ rc;
-   struct _fx_R18C_form__cdefenum_t data;
-} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
-
-typedef struct _fx_R19C_form__cdefmacro_t {
-   struct _fx_R9Ast__id_t cm_name;
-   fx_str_t cm_cname;
-   struct _fx_LR9Ast__id_t_data_t* cm_args;
-   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
-   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
-   struct _fx_R10Ast__loc_t cm_loc;
-} _fx_R19C_form__cdefmacro_t;
-
-typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
-   int_ rc;
-   struct _fx_R19C_form__cdefmacro_t data;
-} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
-
 typedef struct _fx_N17C_form__cbinary_t {
    int tag;
    union {
@@ -1791,6 +1687,20 @@ typedef struct _fx_N16C_form__cunary_t {
 typedef struct _fx_N19C_form__ctyp_attr_t {
    int tag;
 } _fx_N19C_form__ctyp_attr_t;
+
+typedef struct _fx_N19C_form__carg_attr_t {
+   int tag;
+} _fx_N19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__ctprops_t {
+   bool ctp_scalar;
+   bool ctp_complex;
+   bool ctp_ptr;
+   bool ctp_pass_by_ref;
+   struct _fx_LR9Ast__id_t_data_t* ctp_make;
+   struct _fx_Ta2R9Ast__id_t ctp_free;
+   struct _fx_Ta2R9Ast__id_t ctp_copy;
+} _fx_R17C_form__ctprops_t;
 
 typedef struct _fx_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t {
    struct _fx_Nt6option1R9Ast__id_t t0;
@@ -1992,6 +1902,96 @@ typedef struct _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10A
    struct _fx_Nt6option1N14C_form__cexp_t t2;
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR10Ast__loc_t;
+
+typedef struct _fx_LN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_N19C_form__carg_attr_t hd;
+} _fx_LN19C_form__carg_attr_t_data_t, *_fx_LN19C_form__carg_attr_t;
+
+typedef struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N14C_form__ctyp_t_data_t* t1;
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2;
+} _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t hd;
+} _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t, *_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t;
+
+typedef struct _fx_R17C_form__cdeffun_t {
+   struct _fx_R9Ast__id_t cf_name;
+   fx_str_t cf_cname;
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* cf_args;
+   struct _fx_N14C_form__ctyp_t_data_t* cf_rt;
+   struct _fx_LN15C_form__cstmt_t_data_t* cf_body;
+   struct _fx_R16Ast__fun_flags_t cf_flags;
+   struct _fx_LN12Ast__scope_t_data_t* cf_scope;
+   struct _fx_R10Ast__loc_t cf_loc;
+} _fx_R17C_form__cdeffun_t;
+
+typedef struct _fx_rR17C_form__cdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeffun_t data;
+} _fx_rR17C_form__cdeffun_t_data_t, *_fx_rR17C_form__cdeffun_t;
+
+typedef struct _fx_R17C_form__cdeftyp_t {
+   struct _fx_R9Ast__id_t ct_name;
+   struct _fx_N14C_form__ctyp_t_data_t* ct_typ;
+   fx_str_t ct_cname;
+   struct _fx_R17C_form__ctprops_t ct_props;
+   int_ ct_data_start;
+   struct _fx_R9Ast__id_t ct_enum;
+   struct _fx_LR9Ast__id_t_data_t* ct_ifaces;
+   struct _fx_R9Ast__id_t ct_ifaces_id;
+   struct _fx_LN12Ast__scope_t_data_t* ct_scope;
+   struct _fx_R10Ast__loc_t ct_loc;
+} _fx_R17C_form__cdeftyp_t;
+
+typedef struct _fx_rR17C_form__cdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17C_form__cdeftyp_t data;
+} _fx_rR17C_form__cdeftyp_t_data_t, *_fx_rR17C_form__cdeftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_Nt6option1N14C_form__cexp_t t1;
+} _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t hd;
+} _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t, *_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t;
+
+typedef struct _fx_R18C_form__cdefenum_t {
+   struct _fx_R9Ast__id_t cenum_name;
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* cenum_members;
+   fx_str_t cenum_cname;
+   struct _fx_LN12Ast__scope_t_data_t* cenum_scope;
+   struct _fx_R10Ast__loc_t cenum_loc;
+} _fx_R18C_form__cdefenum_t;
+
+typedef struct _fx_rR18C_form__cdefenum_t_data_t {
+   int_ rc;
+   struct _fx_R18C_form__cdefenum_t data;
+} _fx_rR18C_form__cdefenum_t_data_t, *_fx_rR18C_form__cdefenum_t;
+
+typedef struct _fx_R19C_form__cdefmacro_t {
+   struct _fx_R9Ast__id_t cm_name;
+   fx_str_t cm_cname;
+   struct _fx_LR9Ast__id_t_data_t* cm_args;
+   struct _fx_LN15C_form__cstmt_t_data_t* cm_body;
+   struct _fx_LN12Ast__scope_t_data_t* cm_scope;
+   struct _fx_R10Ast__loc_t cm_loc;
+} _fx_R19C_form__cdefmacro_t;
+
+typedef struct _fx_rR19C_form__cdefmacro_t_data_t {
+   int_ rc;
+   struct _fx_R19C_form__cdefmacro_t data;
+} _fx_rR19C_form__cdefmacro_t_data_t, *_fx_rR19C_form__cdefmacro_t;
 
 typedef struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t {
    struct _fx_N14C_form__cexp_t_data_t* t0;
@@ -2440,561 +2440,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_Rt24Hashset__hashset_entry_t1S(struct _fx_Rt24Hashset__hashset_entry_t1S* dst)
 {
    fx_free_str(&dst->key);
@@ -3128,6 +2573,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
    *dst = 0;
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -3231,6 +2699,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -4188,6 +3709,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4657,6 +4584,37 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
    fx_free_str(&dst->t0);
@@ -4686,6 +4644,48 @@ static int _fx_cons_LT2SR10Ast__loc_t(
    struct _fx_LT2SR10Ast__loc_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LT2SR10Ast__loc_t, _fx_copy_T2SR10Ast__loc_t);
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -5041,119 +5041,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -5166,210 +5053,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -6388,6 +6071,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -6704,113 +6704,6 @@ static int _fx_cons_LN15C_form__cstmt_t(
    FX_MAKE_LIST_IMPL(_fx_LN15C_form__cstmt_t, FX_COPY_PTR);
 }
 
-static int _fx_cons_LN19C_form__carg_attr_t(
-   struct _fx_N19C_form__carg_attr_t* hd,
-   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->t1);
-   fx_free_list_simple(&dst->t2);
-}
-
-static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   FX_COPY_PTR(src->t2, &dst->t2);
-}
-
-static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N14C_form__ctyp_t_data_t* t1,
-   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   FX_COPY_PTR(t2, &fx_result->t2);
-}
-
-static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
-   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
-      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
-}
-
-static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
-{
-   fx_free_str(&dst->cf_cname);
-   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
-   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
-   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
-   fx_free_list_simple(&dst->cf_scope);
-}
-
-static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
-{
-   dst->cf_name = src->cf_name;
-   fx_copy_str(&src->cf_cname, &dst->cf_cname);
-   FX_COPY_PTR(src->cf_args, &dst->cf_args);
-   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
-   FX_COPY_PTR(src->cf_body, &dst->cf_body);
-   dst->cf_flags = src->cf_flags;
-   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
-   dst->cf_loc = src->cf_loc;
-}
-
-static void _fx_make_R17C_form__cdeffun_t(
-   struct _fx_R9Ast__id_t* r_cf_name,
-   fx_str_t* r_cf_cname,
-   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
-   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
-   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
-   struct _fx_R10Ast__loc_t* r_cf_loc,
-   struct _fx_R17C_form__cdeffun_t* fx_result)
-{
-   fx_result->cf_name = *r_cf_name;
-   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
-   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
-   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
-   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
-   fx_result->cf_flags = *r_cf_flags;
-   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
-   fx_result->cf_loc = *r_cf_loc;
-}
-
-static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
-}
-
-static int _fx_make_rR17C_form__cdeffun_t(
-   struct _fx_R17C_form__cdeffun_t* arg,
-   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
-}
-
 static void _fx_free_R17C_form__ctprops_t(struct _fx_R17C_form__ctprops_t* dst)
 {
    fx_free_list_simple(&dst->ctp_make);
@@ -6844,193 +6737,6 @@ static void _fx_make_R17C_form__ctprops_t(
    FX_COPY_PTR(r_ctp_make, &fx_result->ctp_make);
    fx_result->ctp_free = *r_ctp_free;
    fx_result->ctp_copy = *r_ctp_copy;
-}
-
-static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
-   fx_free_str(&dst->ct_cname);
-   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
-   fx_free_list_simple(&dst->ct_ifaces);
-   fx_free_list_simple(&dst->ct_scope);
-}
-
-static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
-{
-   dst->ct_name = src->ct_name;
-   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
-   fx_copy_str(&src->ct_cname, &dst->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
-   dst->ct_data_start = src->ct_data_start;
-   dst->ct_enum = src->ct_enum;
-   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
-   dst->ct_ifaces_id = src->ct_ifaces_id;
-   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
-   dst->ct_loc = src->ct_loc;
-}
-
-static void _fx_make_R17C_form__cdeftyp_t(
-   struct _fx_R9Ast__id_t* r_ct_name,
-   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
-   fx_str_t* r_ct_cname,
-   struct _fx_R17C_form__ctprops_t* r_ct_props,
-   int_ r_ct_data_start,
-   struct _fx_R9Ast__id_t* r_ct_enum,
-   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
-   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
-   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
-   struct _fx_R10Ast__loc_t* r_ct_loc,
-   struct _fx_R17C_form__cdeftyp_t* fx_result)
-{
-   fx_result->ct_name = *r_ct_name;
-   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
-   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
-   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
-   fx_result->ct_data_start = r_ct_data_start;
-   fx_result->ct_enum = *r_ct_enum;
-   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
-   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
-   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
-   fx_result->ct_loc = *r_ct_loc;
-}
-
-static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
-}
-
-static int _fx_make_rR17C_form__cdeftyp_t(
-   struct _fx_R17C_form__cdeftyp_t* arg,
-   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
-{
-   dst->t0 = src->t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_Nt6option1N14C_form__cexp_t* t1,
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
-   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
-}
-
-static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
-{
-   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
-   fx_free_str(&dst->cenum_cname);
-   fx_free_list_simple(&dst->cenum_scope);
-}
-
-static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
-{
-   dst->cenum_name = src->cenum_name;
-   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
-   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
-   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
-   dst->cenum_loc = src->cenum_loc;
-}
-
-static void _fx_make_R18C_form__cdefenum_t(
-   struct _fx_R9Ast__id_t* r_cenum_name,
-   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
-   fx_str_t* r_cenum_cname,
-   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
-   struct _fx_R10Ast__loc_t* r_cenum_loc,
-   struct _fx_R18C_form__cdefenum_t* fx_result)
-{
-   fx_result->cenum_name = *r_cenum_name;
-   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
-   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
-   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
-   fx_result->cenum_loc = *r_cenum_loc;
-}
-
-static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
-}
-
-static int _fx_make_rR18C_form__cdefenum_t(
-   struct _fx_R18C_form__cdefenum_t* arg,
-   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
-}
-
-static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   fx_free_str(&dst->cm_cname);
-   fx_free_list_simple(&dst->cm_args);
-   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
-   fx_free_list_simple(&dst->cm_scope);
-}
-
-static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
-{
-   dst->cm_name = src->cm_name;
-   fx_copy_str(&src->cm_cname, &dst->cm_cname);
-   FX_COPY_PTR(src->cm_args, &dst->cm_args);
-   FX_COPY_PTR(src->cm_body, &dst->cm_body);
-   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
-   dst->cm_loc = src->cm_loc;
-}
-
-static void _fx_make_R19C_form__cdefmacro_t(
-   struct _fx_R9Ast__id_t* r_cm_name,
-   fx_str_t* r_cm_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
-   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
-   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
-   struct _fx_R10Ast__loc_t* r_cm_loc,
-   struct _fx_R19C_form__cdefmacro_t* fx_result)
-{
-   fx_result->cm_name = *r_cm_name;
-   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
-   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
-   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
-   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
-   fx_result->cm_loc = *r_cm_loc;
-}
-
-static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
-}
-
-static int _fx_make_rR19C_form__cdefmacro_t(
-   struct _fx_R19C_form__cdefmacro_t* arg,
-   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
 }
 
 static void _fx_free_T2Nt6option1R9Ast__id_tLT2R9Ast__id_tN14C_form__ctyp_t(
@@ -7780,6 +7486,300 @@ static void _fx_make_T4N14C_form__ctyp_tR9Ast__id_tNt6option1N14C_form__cexp_tR1
    fx_result->t1 = *t1;
    _fx_copy_Nt6option1N14C_form__cexp_t(t2, &fx_result->t2);
    fx_result->t3 = *t3;
+}
+
+static int _fx_cons_LN19C_form__carg_attr_t(
+   struct _fx_N19C_form__carg_attr_t* hd,
+   struct _fx_LN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN19C_form__carg_attr_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->t1);
+   fx_free_list_simple(&dst->t2);
+}
+
+static void _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* src,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   FX_COPY_PTR(src->t2, &dst->t2);
+}
+
+static void _fx_make_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N14C_form__ctyp_t_data_t* t1,
+   struct _fx_LN19C_form__carg_attr_t_data_t* t2,
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   FX_COPY_PTR(t2, &fx_result->t2);
+}
+
+static void _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_free_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(
+   struct _fx_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t* hd,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t,
+      _fx_copy_T3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t);
+}
+
+static void _fx_free_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* dst)
+{
+   fx_free_str(&dst->cf_cname);
+   _fx_free_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t(&dst->cf_args);
+   _fx_free_N14C_form__ctyp_t(&dst->cf_rt);
+   _fx_free_LN15C_form__cstmt_t(&dst->cf_body);
+   fx_free_list_simple(&dst->cf_scope);
+}
+
+static void _fx_copy_R17C_form__cdeffun_t(struct _fx_R17C_form__cdeffun_t* src, struct _fx_R17C_form__cdeffun_t* dst)
+{
+   dst->cf_name = src->cf_name;
+   fx_copy_str(&src->cf_cname, &dst->cf_cname);
+   FX_COPY_PTR(src->cf_args, &dst->cf_args);
+   FX_COPY_PTR(src->cf_rt, &dst->cf_rt);
+   FX_COPY_PTR(src->cf_body, &dst->cf_body);
+   dst->cf_flags = src->cf_flags;
+   FX_COPY_PTR(src->cf_scope, &dst->cf_scope);
+   dst->cf_loc = src->cf_loc;
+}
+
+static void _fx_make_R17C_form__cdeffun_t(
+   struct _fx_R9Ast__id_t* r_cf_name,
+   fx_str_t* r_cf_cname,
+   struct _fx_LT3R9Ast__id_tN14C_form__ctyp_tLN19C_form__carg_attr_t_data_t* r_cf_args,
+   struct _fx_N14C_form__ctyp_t_data_t* r_cf_rt,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cf_body,
+   struct _fx_R16Ast__fun_flags_t* r_cf_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_cf_scope,
+   struct _fx_R10Ast__loc_t* r_cf_loc,
+   struct _fx_R17C_form__cdeffun_t* fx_result)
+{
+   fx_result->cf_name = *r_cf_name;
+   fx_copy_str(r_cf_cname, &fx_result->cf_cname);
+   FX_COPY_PTR(r_cf_args, &fx_result->cf_args);
+   FX_COPY_PTR(r_cf_rt, &fx_result->cf_rt);
+   FX_COPY_PTR(r_cf_body, &fx_result->cf_body);
+   fx_result->cf_flags = *r_cf_flags;
+   FX_COPY_PTR(r_cf_scope, &fx_result->cf_scope);
+   fx_result->cf_loc = *r_cf_loc;
+}
+
+static void _fx_free_rR17C_form__cdeffun_t(struct _fx_rR17C_form__cdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_free_R17C_form__cdeffun_t);
+}
+
+static int _fx_make_rR17C_form__cdeffun_t(
+   struct _fx_R17C_form__cdeffun_t* arg,
+   struct _fx_rR17C_form__cdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeffun_t, _fx_copy_R17C_form__cdeffun_t);
+}
+
+static void _fx_free_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   _fx_free_N14C_form__ctyp_t(&dst->ct_typ);
+   fx_free_str(&dst->ct_cname);
+   _fx_free_R17C_form__ctprops_t(&dst->ct_props);
+   fx_free_list_simple(&dst->ct_ifaces);
+   fx_free_list_simple(&dst->ct_scope);
+}
+
+static void _fx_copy_R17C_form__cdeftyp_t(struct _fx_R17C_form__cdeftyp_t* src, struct _fx_R17C_form__cdeftyp_t* dst)
+{
+   dst->ct_name = src->ct_name;
+   FX_COPY_PTR(src->ct_typ, &dst->ct_typ);
+   fx_copy_str(&src->ct_cname, &dst->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(&src->ct_props, &dst->ct_props);
+   dst->ct_data_start = src->ct_data_start;
+   dst->ct_enum = src->ct_enum;
+   FX_COPY_PTR(src->ct_ifaces, &dst->ct_ifaces);
+   dst->ct_ifaces_id = src->ct_ifaces_id;
+   FX_COPY_PTR(src->ct_scope, &dst->ct_scope);
+   dst->ct_loc = src->ct_loc;
+}
+
+static void _fx_make_R17C_form__cdeftyp_t(
+   struct _fx_R9Ast__id_t* r_ct_name,
+   struct _fx_N14C_form__ctyp_t_data_t* r_ct_typ,
+   fx_str_t* r_ct_cname,
+   struct _fx_R17C_form__ctprops_t* r_ct_props,
+   int_ r_ct_data_start,
+   struct _fx_R9Ast__id_t* r_ct_enum,
+   struct _fx_LR9Ast__id_t_data_t* r_ct_ifaces,
+   struct _fx_R9Ast__id_t* r_ct_ifaces_id,
+   struct _fx_LN12Ast__scope_t_data_t* r_ct_scope,
+   struct _fx_R10Ast__loc_t* r_ct_loc,
+   struct _fx_R17C_form__cdeftyp_t* fx_result)
+{
+   fx_result->ct_name = *r_ct_name;
+   FX_COPY_PTR(r_ct_typ, &fx_result->ct_typ);
+   fx_copy_str(r_ct_cname, &fx_result->ct_cname);
+   _fx_copy_R17C_form__ctprops_t(r_ct_props, &fx_result->ct_props);
+   fx_result->ct_data_start = r_ct_data_start;
+   fx_result->ct_enum = *r_ct_enum;
+   FX_COPY_PTR(r_ct_ifaces, &fx_result->ct_ifaces);
+   fx_result->ct_ifaces_id = *r_ct_ifaces_id;
+   FX_COPY_PTR(r_ct_scope, &fx_result->ct_scope);
+   fx_result->ct_loc = *r_ct_loc;
+}
+
+static void _fx_free_rR17C_form__cdeftyp_t(struct _fx_rR17C_form__cdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_free_R17C_form__cdeftyp_t);
+}
+
+static int _fx_make_rR17C_form__cdeftyp_t(
+   struct _fx_R17C_form__cdeftyp_t* arg,
+   struct _fx_rR17C_form__cdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17C_form__cdeftyp_t, _fx_copy_R17C_form__cdeftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t(struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   _fx_free_Nt6option1N14C_form__cexp_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* src,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* dst)
+{
+   dst->t0 = src->t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_Nt6option1N14C_form__cexp_t* t1,
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   _fx_copy_Nt6option1N14C_form__cexp_t(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_free_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(
+   struct _fx_T2R9Ast__id_tNt6option1N14C_form__cexp_t* hd,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t, _fx_copy_T2R9Ast__id_tNt6option1N14C_form__cexp_t);
+}
+
+static void _fx_free_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* dst)
+{
+   _fx_free_LT2R9Ast__id_tNt6option1N14C_form__cexp_t(&dst->cenum_members);
+   fx_free_str(&dst->cenum_cname);
+   fx_free_list_simple(&dst->cenum_scope);
+}
+
+static void _fx_copy_R18C_form__cdefenum_t(struct _fx_R18C_form__cdefenum_t* src, struct _fx_R18C_form__cdefenum_t* dst)
+{
+   dst->cenum_name = src->cenum_name;
+   FX_COPY_PTR(src->cenum_members, &dst->cenum_members);
+   fx_copy_str(&src->cenum_cname, &dst->cenum_cname);
+   FX_COPY_PTR(src->cenum_scope, &dst->cenum_scope);
+   dst->cenum_loc = src->cenum_loc;
+}
+
+static void _fx_make_R18C_form__cdefenum_t(
+   struct _fx_R9Ast__id_t* r_cenum_name,
+   struct _fx_LT2R9Ast__id_tNt6option1N14C_form__cexp_t_data_t* r_cenum_members,
+   fx_str_t* r_cenum_cname,
+   struct _fx_LN12Ast__scope_t_data_t* r_cenum_scope,
+   struct _fx_R10Ast__loc_t* r_cenum_loc,
+   struct _fx_R18C_form__cdefenum_t* fx_result)
+{
+   fx_result->cenum_name = *r_cenum_name;
+   FX_COPY_PTR(r_cenum_members, &fx_result->cenum_members);
+   fx_copy_str(r_cenum_cname, &fx_result->cenum_cname);
+   FX_COPY_PTR(r_cenum_scope, &fx_result->cenum_scope);
+   fx_result->cenum_loc = *r_cenum_loc;
+}
+
+static void _fx_free_rR18C_form__cdefenum_t(struct _fx_rR18C_form__cdefenum_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_free_R18C_form__cdefenum_t);
+}
+
+static int _fx_make_rR18C_form__cdefenum_t(
+   struct _fx_R18C_form__cdefenum_t* arg,
+   struct _fx_rR18C_form__cdefenum_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR18C_form__cdefenum_t, _fx_copy_R18C_form__cdefenum_t);
+}
+
+static void _fx_free_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   fx_free_str(&dst->cm_cname);
+   fx_free_list_simple(&dst->cm_args);
+   _fx_free_LN15C_form__cstmt_t(&dst->cm_body);
+   fx_free_list_simple(&dst->cm_scope);
+}
+
+static void _fx_copy_R19C_form__cdefmacro_t(struct _fx_R19C_form__cdefmacro_t* src, struct _fx_R19C_form__cdefmacro_t* dst)
+{
+   dst->cm_name = src->cm_name;
+   fx_copy_str(&src->cm_cname, &dst->cm_cname);
+   FX_COPY_PTR(src->cm_args, &dst->cm_args);
+   FX_COPY_PTR(src->cm_body, &dst->cm_body);
+   FX_COPY_PTR(src->cm_scope, &dst->cm_scope);
+   dst->cm_loc = src->cm_loc;
+}
+
+static void _fx_make_R19C_form__cdefmacro_t(
+   struct _fx_R9Ast__id_t* r_cm_name,
+   fx_str_t* r_cm_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_cm_args,
+   struct _fx_LN15C_form__cstmt_t_data_t* r_cm_body,
+   struct _fx_LN12Ast__scope_t_data_t* r_cm_scope,
+   struct _fx_R10Ast__loc_t* r_cm_loc,
+   struct _fx_R19C_form__cdefmacro_t* fx_result)
+{
+   fx_result->cm_name = *r_cm_name;
+   fx_copy_str(r_cm_cname, &fx_result->cm_cname);
+   FX_COPY_PTR(r_cm_args, &fx_result->cm_args);
+   FX_COPY_PTR(r_cm_body, &fx_result->cm_body);
+   FX_COPY_PTR(r_cm_scope, &fx_result->cm_scope);
+   fx_result->cm_loc = *r_cm_loc;
+}
+
+static void _fx_free_rR19C_form__cdefmacro_t(struct _fx_rR19C_form__cdefmacro_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_free_R19C_form__cdefmacro_t);
+}
+
+static int _fx_make_rR19C_form__cdefmacro_t(
+   struct _fx_R19C_form__cdefmacro_t* arg,
+   struct _fx_rR19C_form__cdefmacro_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19C_form__cdefmacro_t, _fx_copy_R19C_form__cdefmacro_t);
 }
 
 static void _fx_free_T2N14C_form__cexp_tLN15C_form__cstmt_t(struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t* dst)

--- a/compiler/bootstrap/K_annotate.c
+++ b/compiler/bootstrap/K_annotate.c
@@ -58,53 +58,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
 typedef struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -149,6 +102,11 @@ typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
    } u;
 } _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_N12Set__color_t {
    int tag;
 } _fx_N12Set__color_t;
@@ -173,10 +131,46 @@ typedef struct _fx_Rt6Set__t1R9Ast__id_t {
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Set__t1R9Ast__id_t;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -191,6 +185,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -377,13 +377,21 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -409,153 +417,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -575,6 +436,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -840,6 +717,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -885,6 +864,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -982,24 +982,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
 {
    fx_result->t0 = *t0;
    fx_copy_str(t1, &fx_result->t1);
-}
-
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t(
@@ -1208,6 +1190,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1220,6 +1211,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1572,150 +1572,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1728,256 +1584,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2996,6 +2602,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3080,6 +3003,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_cfold_dealias.c
+++ b/compiler/bootstrap/K_cfold_dealias.c
@@ -55,14 +55,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -85,22 +77,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -115,6 +109,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -301,13 +301,21 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -333,153 +341,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -499,6 +360,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -764,6 +641,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -809,6 +788,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -990,24 +990,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -1025,6 +1007,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1037,6 +1028,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1375,150 +1375,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1531,256 +1387,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2799,6 +2405,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2883,6 +2806,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_copy_n_skip.c
+++ b/compiler/bootstrap/K_copy_n_skip.c
@@ -109,263 +109,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -436,6 +179,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
@@ -489,6 +272,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -570,6 +377,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -589,6 +420,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -785,6 +626,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -957,6 +936,14 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
 
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
    struct _fx_R10Ast__loc_t t1;
@@ -967,6 +954,19 @@ typedef struct _fx_LT2SR10Ast__loc_t_data_t {
    struct _fx_LT2SR10Ast__loc_t_data_t* tl;
    struct _fx_T2SR10Ast__loc_t hd;
 } _fx_LT2SR10Ast__loc_t_data_t, *_fx_LT2SR10Ast__loc_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1082,134 +1082,11 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -1475,6 +1352,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1520,6 +1499,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1730,561 +1730,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t(
    struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t* dst)
 {
@@ -2477,6 +1922,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
    *dst = 0;
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -2580,6 +2048,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3537,6 +3058,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4006,6 +3933,37 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
    fx_free_str(&dst->t0);
@@ -4035,6 +3993,48 @@ static int _fx_cons_LT2SR10Ast__loc_t(
    struct _fx_LT2SR10Ast__loc_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LT2SR10Ast__loc_t, _fx_copy_T2SR10Ast__loc_t);
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -4307,150 +4307,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -4463,256 +4319,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -5731,6 +5337,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -5815,6 +5738,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_declosure.c
+++ b/compiler/bootstrap/K_declosure.c
@@ -77,13 +77,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
+   int_ t1;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -107,43 +120,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -158,6 +152,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -386,13 +386,21 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -418,153 +426,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -584,6 +445,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -849,6 +726,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -894,6 +873,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1079,24 +1079,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1159,6 +1141,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1171,6 +1162,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1563,150 +1563,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1719,256 +1575,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2987,6 +2593,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3071,6 +2994,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_fast_idx.c
+++ b/compiler/bootstrap/K_fast_idx.c
@@ -78,18 +78,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
 
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
    int_ t1;
-} _fx_T2R9Ast__id_ti;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -113,6 +121,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -132,38 +158,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
 } _fx_N12Ast__cmpop_t;
@@ -177,6 +171,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -399,13 +399,21 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -431,153 +439,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -597,6 +458,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -862,6 +739,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -907,6 +886,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t {
    struct _fx_N14K_form__atom_t t0;
@@ -1233,68 +1233,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1357,6 +1295,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1369,6 +1360,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1746,150 +1746,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1902,256 +1758,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3170,6 +2776,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3254,6 +3177,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t* dst)

--- a/compiler/bootstrap/K_flatten.c
+++ b/compiler/bootstrap/K_flatten.c
@@ -45,14 +45,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -75,22 +67,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -105,6 +99,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -273,6 +273,22 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
+
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
    union {
@@ -297,140 +313,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -450,6 +332,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -715,6 +613,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -836,24 +836,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -871,6 +853,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -883,6 +874,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1177,119 +1177,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1302,210 +1189,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2522,6 +2205,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t0 = *t0;
    FX_COPY_PTR(t1, &fx_result->t1);
    fx_result->t2 = *t2;
+}
+
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)

--- a/compiler/bootstrap/K_form.c
+++ b/compiler/bootstrap/K_form.c
@@ -6435,19 +6435,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M6K_formFM7resize_v3VN15K_form__kinfo_tiT2N15K_form__kinfo_tB(
-   fx_vec_t v,
-   int_ size,
-   struct _fx_T2N15K_form__kinfo_tB* val0_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_resize(v, size, val0_);
-
-}
-
 FX_EXTERN_C int _fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(
    fx_vec_t v,
    struct _fx_T2N15K_form__kinfo_tB* elem_,
@@ -7802,20 +7789,23 @@ FX_EXTERN_C int _fx_M6K_formFM13init_all_idksv0(void* fx_fv)
    for (int_ i_0 = 0; i_0 < ni_0; i_0++, dstptr_0++) {
       _fx_N16Ast__defmodule_t dm_0 = 0;
       fx_vec_t v_1 = 0;
-      fx_vec_t z_0 = 0;
-      _fx_T2N15K_form__kinfo_tB v_2 = {0};
+      fx_vec_t vec_0 = 0;
       FX_COPY_PTR(ptr_all_modules_0[i_0], &dm_0);
       FX_COPY_PTR(dm_0->u.defmodule_t.t9, &v_1);
       int_ sz_0 = FX_VEC_SIZE(v_1);
-      fx_make_vec(0, 0, sizeof(_fx_N15K_form__kinfo_t), (fx_free_t)_fx_free_N15K_form__kinfo_t,
-         (fx_copy_t)_fx_copy_N15K_form__kinfo_t, 0, &z_0);
-      _fx_make_T2N15K_form__kinfo_tB(&_fx_g13K_form__KNone, true, &v_2);
-      FX_CALL(_fx_M6K_formFM7resize_v3VN15K_form__kinfo_tiT2N15K_form__kinfo_tB(z_0, sz_0, &v_2, 0), _fx_catch_0);
-      FX_COPY_PTR(z_0, dstptr_0);
+      _fx_N15K_form__kinfo_t* dstptr_1 = 0;
+      FX_CALL(
+         fx_make_vec(sz_0, sz_0, sizeof(_fx_N15K_form__kinfo_t), (fx_free_t)_fx_free_N15K_form__kinfo_t,
+            (fx_copy_t)_fx_copy_N15K_form__kinfo_t, 0, &vec_0), _fx_catch_0);
+      dstptr_1 = (_fx_N15K_form__kinfo_t*)vec_0->data;
+      for (int_ i_1 = 0; i_1 < sz_0; i_1++) {
+         _fx_copy_N15K_form__kinfo_t(&_fx_g13K_form__KNone, dstptr_1); dstptr_1++;
+      }
+      vec_0->size = dstptr_1 - (_fx_N15K_form__kinfo_t*)vec_0->data;
+      FX_COPY_PTR(vec_0, dstptr_0);
 
    _fx_catch_0: ;
-      _fx_free_T2N15K_form__kinfo_tB(&v_2);
-      FX_FREE_VEC(&z_0);
+      FX_FREE_VEC(&vec_0);
       FX_FREE_VEC(&v_1);
       if (dm_0) {
          _fx_free_N16Ast__defmodule_t(&dm_0);

--- a/compiler/bootstrap/K_form.c
+++ b/compiler/bootstrap/K_form.c
@@ -124,263 +124,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -427,6 +170,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
          Node;
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -481,6 +264,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -562,6 +369,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -581,6 +412,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -777,6 +618,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -948,6 +927,27 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
       struct _fx_N10Ast__typ_t_data_t* EnvTyp;
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
+
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1177,144 +1177,11 @@ typedef struct _fx_FPv1N14K_form__kexp_t {
    fx_fcv_t* fcv;
 } _fx_FPv1N14K_form__kexp_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_T2N15K_form__kinfo_tB {
-   struct _fx_N15K_form__kinfo_t t0;
-   bool t1;
-} _fx_T2N15K_form__kinfo_tB;
-
-typedef struct _fx_T2N14Ast__id_info_tB {
-   struct _fx_N14Ast__id_info_t t0;
-   bool t1;
-} _fx_T2N14Ast__id_info_tB;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -1580,6 +1447,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1625,6 +1594,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t {
    struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* t0;
@@ -1712,561 +1702,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
       _fx_free_N10Ast__exp_t(&(*dst)->u.Some); fx_free(*dst);
    }
    *dst = 0;
-}
-
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
@@ -2380,6 +1815,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
    *dst = 0;
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -2483,6 +1941,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3440,6 +2951,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -3909,6 +3826,79 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
+}
+
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_Li, FX_COPY_SIMPLE);
@@ -4342,150 +4332,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -4498,293 +4344,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
-static void _fx_free_T2N15K_form__kinfo_tB(struct _fx_T2N15K_form__kinfo_tB* dst)
-{
-   _fx_free_N15K_form__kinfo_t(&dst->t0);
-}
-
-static void _fx_copy_T2N15K_form__kinfo_tB(struct _fx_T2N15K_form__kinfo_tB* src, struct _fx_T2N15K_form__kinfo_tB* dst)
-{
-   _fx_copy_N15K_form__kinfo_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N15K_form__kinfo_tB(
-   struct _fx_N15K_form__kinfo_t* t0,
-   bool t1,
-   struct _fx_T2N15K_form__kinfo_tB* fx_result)
-{
-   _fx_copy_N15K_form__kinfo_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
-}
-
-static void _fx_free_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_free_N14Ast__id_info_t(&dst->t0);
-}
-
-static void _fx_copy_T2N14Ast__id_info_tB(struct _fx_T2N14Ast__id_info_tB* src, struct _fx_T2N14Ast__id_info_tB* dst)
-{
-   _fx_copy_N14Ast__id_info_t(&src->t0, &dst->t0);
-   dst->t1 = src->t1;
-}
-
-static void _fx_make_T2N14Ast__id_info_tB(struct _fx_N14Ast__id_info_t* t0, bool t1, struct _fx_T2N14Ast__id_info_tB* fx_result)
-{
-   _fx_copy_N14Ast__id_info_t(t0, &fx_result->t0);
-   fx_result->t1 = t1;
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -5803,6 +5362,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -5887,6 +5763,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t(
@@ -6433,30 +6386,6 @@ FX_EXTERN_C int _fx_M6K_formFM3appv2LN14K_form__kexp_tFPv1N14K_form__kexp_t(
 
 _fx_cleanup: ;
    return fx_status;
-}
-
-FX_EXTERN_C int _fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(
-   fx_vec_t v,
-   struct _fx_T2N15K_form__kinfo_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
-}
-
-FX_EXTERN_C int _fx_M6K_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(
-   fx_vec_t v,
-   struct _fx_T2N14Ast__id_info_tB* elem_,
-   void* fx_fv)
-{
-
-if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-
 }
 
 FX_EXTERN_C int
@@ -7656,10 +7585,8 @@ FX_EXTERN_C int _fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(
 {
    fx_exn_t v_0 = {0};
    fx_vec_t v_1 = 0;
-   _fx_T2N14Ast__id_info_tB v_2 = {0};
-   fx_vec_t v_3 = 0;
-   _fx_T2N15K_form__kinfo_tB v_4 = {0};
-   fx_exn_t v_5 = {0};
+   fx_vec_t v_2 = 0;
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
    if (_fx_g19K_form__freeze_idks) {
       fx_str_t slit_0 = FX_MAKE_STR("internal error: new idk is requested when they are frozen");
@@ -7667,20 +7594,18 @@ FX_EXTERN_C int _fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(
       FX_THROW(&v_0, true, _fx_cleanup);
    }
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_6 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   FX_COPY_PTR(v_6->u.defmodule_t.t9, &v_1);
-   _fx_make_T2N14Ast__id_info_tB(&_fx_g14K_form__IdNone, true, &v_2);
-   FX_CALL(_fx_M6K_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_1, &v_2, 0), _fx_cleanup);
+   _fx_N16Ast__defmodule_t v_4 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_4->u.defmodule_t.t9, &v_1);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g14K_form__IdNone, _fx_cleanup);
    int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
    FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_cleanup);
-   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_3);
-   _fx_make_T2N15K_form__kinfo_tB(&_fx_g13K_form__KNone, true, &v_4);
-   FX_CALL(_fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(v_3, &v_4, 0), _fx_cleanup);
-   int_ new_kidx_0 = FX_VEC_SIZE(v_3) - 1;
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_2);
+   FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_2, _fx_g13K_form__KNone, _fx_cleanup);
+   int_ new_kidx_0 = FX_VEC_SIZE(v_2) - 1;
    if (new_idx_0 != new_kidx_0) {
       fx_str_t slit_1 = FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx() and new_idk_idx()");
-      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_5), _fx_cleanup);
-      FX_THROW(&v_5, true, _fx_cleanup);
+      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
    }
    int_ t_0;
    if (old_id_0->i != 0) {
@@ -7695,10 +7620,8 @@ FX_EXTERN_C int _fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(
 _fx_cleanup: ;
    fx_free_exn(&v_0);
    FX_FREE_VEC(&v_1);
-   _fx_free_T2N14Ast__id_info_tB(&v_2);
-   FX_FREE_VEC(&v_3);
-   _fx_free_T2N15K_form__kinfo_tB(&v_4);
-   fx_free_exn(&v_5);
+   FX_FREE_VEC(&v_2);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
@@ -7710,10 +7633,8 @@ FX_EXTERN_C int _fx_M6K_formFM7gen_idkR9Ast__id_t2iS(
 {
    fx_exn_t v_0 = {0};
    fx_vec_t v_1 = 0;
-   _fx_T2N14Ast__id_info_tB v_2 = {0};
-   fx_vec_t v_3 = 0;
-   _fx_T2N15K_form__kinfo_tB v_4 = {0};
-   fx_exn_t v_5 = {0};
+   fx_vec_t v_2 = 0;
+   fx_exn_t v_3 = {0};
    int fx_status = 0;
    int_ i_0;
    FX_CALL(_fx_M3AstFM13get_id_prefixi1S(s_0, &i_0, 0), _fx_cleanup);
@@ -7723,20 +7644,18 @@ FX_EXTERN_C int _fx_M6K_formFM7gen_idkR9Ast__id_t2iS(
       FX_THROW(&v_0, true, _fx_cleanup);
    }
    FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_cleanup);
-   _fx_N16Ast__defmodule_t v_6 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-   FX_COPY_PTR(v_6->u.defmodule_t.t9, &v_1);
-   _fx_make_T2N14Ast__id_info_tB(&_fx_g14K_form__IdNone, true, &v_2);
-   FX_CALL(_fx_M6K_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_1, &v_2, 0), _fx_cleanup);
+   _fx_N16Ast__defmodule_t v_4 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+   FX_COPY_PTR(v_4->u.defmodule_t.t9, &v_1);
+   FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g14K_form__IdNone, _fx_cleanup);
    int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
    FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_cleanup);
-   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_3);
-   _fx_make_T2N15K_form__kinfo_tB(&_fx_g13K_form__KNone, true, &v_4);
-   FX_CALL(_fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(v_3, &v_4, 0), _fx_cleanup);
-   int_ new_kidx_0 = FX_VEC_SIZE(v_3) - 1;
+   FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_2);
+   FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_2, _fx_g13K_form__KNone, _fx_cleanup);
+   int_ new_kidx_0 = FX_VEC_SIZE(v_2) - 1;
    if (new_idx_0 != new_kidx_0) {
       fx_str_t slit_1 = FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx() and new_idk_idx()");
-      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_5), _fx_cleanup);
-      FX_THROW(&v_5, true, _fx_cleanup);
+      FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_3), _fx_cleanup);
+      FX_THROW(&v_3, true, _fx_cleanup);
    }
    _fx_R9Ast__id_t rec_0 = { m_idx_0, i_0, new_kidx_0 };
    *fx_result = rec_0;
@@ -7744,10 +7663,8 @@ FX_EXTERN_C int _fx_M6K_formFM7gen_idkR9Ast__id_t2iS(
 _fx_cleanup: ;
    fx_free_exn(&v_0);
    FX_FREE_VEC(&v_1);
-   _fx_free_T2N14Ast__id_info_tB(&v_2);
-   FX_FREE_VEC(&v_3);
-   _fx_free_T2N15K_form__kinfo_tB(&v_4);
-   fx_free_exn(&v_5);
+   FX_FREE_VEC(&v_2);
+   fx_free_exn(&v_3);
    return fx_status;
 }
 
@@ -15691,19 +15608,17 @@ FX_EXTERN_C int _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iS
    else {
       fx_exn_t v_0 = {0};
       fx_vec_t v_1 = 0;
-      _fx_T2N14Ast__id_info_tB v_2 = {0};
-      fx_vec_t v_3 = 0;
-      _fx_T2N15K_form__kinfo_tB v_4 = {0};
-      fx_exn_t v_5 = {0};
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_6 = {0};
+      fx_vec_t v_2 = 0;
+      fx_exn_t v_3 = {0};
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_4 = {0};
       _fx_N14K_form__ktyp_t ktyp_0 = 0;
-      _fx_R16Ast__val_flags_t v_7 = {0};
-      _fx_R16Ast__val_flags_t v_8 = {0};
-      _fx_Nt6option1N14K_form__kexp_t v_9 = {0};
+      _fx_R16Ast__val_flags_t v_5 = {0};
+      _fx_R16Ast__val_flags_t v_6 = {0};
+      _fx_Nt6option1N14K_form__kexp_t v_7 = {0};
       _fx_R17K_form__kdefval_t dv_0 = {0};
-      _fx_N15K_form__kinfo_t v_10 = {0};
+      _fx_N15K_form__kinfo_t v_8 = {0};
       _fx_LN14K_form__kexp_t code_1 = 0;
-      _fx_N14K_form__atom_t v_11 = {0};
+      _fx_N14K_form__atom_t v_9 = {0};
       int_ i_0;
       FX_CALL(_fx_M3AstFM13get_id_prefixi1S(prefix_0, &i_0, 0), _fx_catch_3);
       if (_fx_g19K_form__freeze_idks) {
@@ -15712,33 +15627,31 @@ FX_EXTERN_C int _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iS
          FX_THROW(&v_0, true, _fx_catch_3);
       }
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, m_idx_0), _fx_catch_3);
-      _fx_N16Ast__defmodule_t v_12 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
-      FX_COPY_PTR(v_12->u.defmodule_t.t9, &v_1);
-      _fx_make_T2N14Ast__id_info_tB(&_fx_g14K_form__IdNone, true, &v_2);
-      FX_CALL(_fx_M6K_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_1, &v_2, 0), _fx_catch_3);
+      _fx_N16Ast__defmodule_t v_10 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, m_idx_0);
+      FX_COPY_PTR(v_10->u.defmodule_t.t9, &v_1);
+      FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_1, _fx_g14K_form__IdNone, _fx_catch_3);
       int_ new_idx_0 = FX_VEC_SIZE(v_1) - 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_idx_0), _fx_catch_3);
-      FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_3);
-      _fx_make_T2N15K_form__kinfo_tB(&_fx_g13K_form__KNone, true, &v_4);
-      FX_CALL(_fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(v_3, &v_4, 0), _fx_catch_3);
-      int_ new_kidx_0 = FX_VEC_SIZE(v_3) - 1;
+      FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_idx_0), &v_2);
+      FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_2, _fx_g13K_form__KNone, _fx_catch_3);
+      int_ new_kidx_0 = FX_VEC_SIZE(v_2) - 1;
       if (new_idx_0 != new_kidx_0) {
          fx_str_t slit_1 = FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx() and new_idk_idx()");
-         FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_5), _fx_catch_3);
-         FX_THROW(&v_5, true, _fx_catch_3);
+         FX_CALL(_fx_F9make_FailE1S(&slit_1, &v_3), _fx_catch_3);
+         FX_THROW(&v_3, true, _fx_catch_3);
       }
       _fx_R9Ast__id_t tmp_id_0 = { m_idx_0, i_0, new_kidx_0 };
-      FX_CALL(_fx_M6K_formFM12get_kexp_ctxT2N14K_form__ktyp_tR10Ast__loc_t1N14K_form__kexp_t(e_0, &v_6, 0), _fx_catch_3);
-      FX_COPY_PTR(v_6.t0, &ktyp_0);
-      _fx_R10Ast__loc_t kloc_0 = v_6.t1;
+      FX_CALL(_fx_M6K_formFM12get_kexp_ctxT2N14K_form__ktyp_tR10Ast__loc_t1N14K_form__kexp_t(e_0, &v_4, 0), _fx_catch_3);
+      FX_COPY_PTR(v_4.t0, &ktyp_0);
+      _fx_R10Ast__loc_t kloc_0 = v_4.t1;
       if (FX_REC_VARIANT_TAG(ktyp_0) == 7) {
-         fx_exn_t v_13 = {0};
+         fx_exn_t v_11 = {0};
          fx_str_t slit_2 = FX_MAKE_STR("\'void\' expression or declaration cannot be converted to an atom");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_2, &v_13, 0), _fx_catch_0);
-         FX_THROW(&v_13, false, _fx_catch_0);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_2, &v_11, 0), _fx_catch_0);
+         FX_THROW(&v_11, false, _fx_catch_0);
 
       _fx_catch_0: ;
-         fx_free_exn(&v_13);
+         fx_free_exn(&v_11);
       }
       FX_CHECK_EXN(_fx_catch_3);
       int tag_0 = FX_REC_VARIANT_TAG(e_0);
@@ -15777,70 +15690,68 @@ FX_EXTERN_C int _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iS
 
    _fx_endmatch_1: ;
       FX_CHECK_EXN(_fx_catch_3);
-      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_7, 0), _fx_catch_3);
-      _fx_make_R16Ast__val_flags_t(v_7.val_flag_arg, v_7.val_flag_mutable, !tref_1, tref_1, v_7.val_flag_private,
-         v_7.val_flag_subarray, v_7.val_flag_instance, &v_7.val_flag_method, v_7.val_flag_ctor, v_7.val_flag_global, &v_8);
-      _fx_M6K_formFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(e_0, &v_9);
+      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_5, 0), _fx_catch_3);
+      _fx_make_R16Ast__val_flags_t(v_5.val_flag_arg, v_5.val_flag_mutable, !tref_1, tref_1, v_5.val_flag_private,
+         v_5.val_flag_subarray, v_5.val_flag_instance, &v_5.val_flag_method, v_5.val_flag_ctor, v_5.val_flag_global, &v_6);
+      _fx_M6K_formFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(e_0, &v_7);
       fx_str_t slit_3 = FX_MAKE_STR("");
-      _fx_make_R17K_form__kdefval_t(&tmp_id_0, &slit_3, ktyp_0, &v_8, &kloc_0, &dv_0);
+      _fx_make_R17K_form__kdefval_t(&tmp_id_0, &slit_3, ktyp_0, &v_6, &kloc_0, &dv_0);
       if (FX_REC_VARIANT_TAG(ktyp_0) == 7) {
-         fx_exn_t v_14 = {0};
+         fx_exn_t v_12 = {0};
          fx_str_t slit_4 = FX_MAKE_STR("values of \'void\' type are not allowed");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_4, &v_14, 0), _fx_catch_1);
-         FX_THROW(&v_14, false, _fx_catch_1);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&kloc_0, &slit_4, &v_12, 0), _fx_catch_1);
+         FX_THROW(&v_12, false, _fx_catch_1);
 
       _fx_catch_1: ;
-         fx_free_exn(&v_14);
+         fx_free_exn(&v_12);
       }
       FX_CHECK_EXN(_fx_catch_3);
-      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_10);
-      _fx_Ta2i v_15;
-      FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(&tmp_id_0, &_fx_g10Ast__noloc, &v_15, 0), _fx_catch_3);
-      int_ m_0 = v_15.t0;
-      int_ j_0 = v_15.t1;
+      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_8);
+      _fx_Ta2i v_13;
+      FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(&tmp_id_0, &_fx_g10Ast__noloc, &v_13, 0), _fx_catch_3);
+      int_ m_0 = v_13.t0;
+      int_ j_0 = v_13.t1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_0), _fx_catch_3);
-      fx_vec_t v_16 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_0);
-      FX_VEC_CHKIDX(v_16, j_0, _fx_catch_3);
-      _fx_N15K_form__kinfo_t* v_17 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_16, j_0);
-      _fx_free_N15K_form__kinfo_t(v_17);
-      _fx_copy_N15K_form__kinfo_t(&v_10, v_17);
-      if (v_9.tag == 2) {
-         _fx_N14K_form__kexp_t v_18 = 0;
+      fx_vec_t v_14 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_0);
+      FX_VEC_CHKIDX(v_14, j_0, _fx_catch_3);
+      _fx_N15K_form__kinfo_t* v_15 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_14, j_0);
+      _fx_free_N15K_form__kinfo_t(v_15);
+      _fx_copy_N15K_form__kinfo_t(&v_8, v_15);
+      if (v_7.tag == 2) {
+         _fx_N14K_form__kexp_t v_16 = 0;
          FX_CALL(
-            _fx_M6K_formFM7KDefValN14K_form__kexp_t3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(&tmp_id_0, v_9.u.Some, &kloc_0,
-               &v_18), _fx_catch_2);
-         FX_CALL(_fx_cons_LN14K_form__kexp_t(v_18, code_0, true, &code_1), _fx_catch_2);
+            _fx_M6K_formFM7KDefValN14K_form__kexp_t3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(&tmp_id_0, v_7.u.Some, &kloc_0,
+               &v_16), _fx_catch_2);
+         FX_CALL(_fx_cons_LN14K_form__kexp_t(v_16, code_0, true, &code_1), _fx_catch_2);
 
       _fx_catch_2: ;
-         if (v_18) {
-            _fx_free_N14K_form__kexp_t(&v_18);
+         if (v_16) {
+            _fx_free_N14K_form__kexp_t(&v_16);
          }
       }
       else {
          FX_COPY_PTR(code_0, &code_1);
       }
       FX_CHECK_EXN(_fx_catch_3);
-      _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&tmp_id_0, &v_11);
-      _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_11, code_1, fx_result);
+      _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&tmp_id_0, &v_9);
+      _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_9, code_1, fx_result);
 
    _fx_catch_3: ;
-      _fx_free_N14K_form__atom_t(&v_11);
+      _fx_free_N14K_form__atom_t(&v_9);
       if (code_1) {
          _fx_free_LN14K_form__kexp_t(&code_1);
       }
-      _fx_free_N15K_form__kinfo_t(&v_10);
+      _fx_free_N15K_form__kinfo_t(&v_8);
       _fx_free_R17K_form__kdefval_t(&dv_0);
-      _fx_free_Nt6option1N14K_form__kexp_t(&v_9);
-      _fx_free_R16Ast__val_flags_t(&v_8);
-      _fx_free_R16Ast__val_flags_t(&v_7);
+      _fx_free_Nt6option1N14K_form__kexp_t(&v_7);
+      _fx_free_R16Ast__val_flags_t(&v_6);
+      _fx_free_R16Ast__val_flags_t(&v_5);
       if (ktyp_0) {
          _fx_free_N14K_form__ktyp_t(&ktyp_0);
       }
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_6);
-      fx_free_exn(&v_5);
-      _fx_free_T2N15K_form__kinfo_tB(&v_4);
-      FX_FREE_VEC(&v_3);
-      _fx_free_T2N14Ast__id_info_tB(&v_2);
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_4);
+      fx_free_exn(&v_3);
+      FX_FREE_VEC(&v_2);
       FX_FREE_VEC(&v_1);
       fx_free_exn(&v_0);
    }
@@ -16016,14 +15927,12 @@ FX_EXTERN_C int
       fx_str_t v_4 = {0};
       fx_exn_t v_5 = {0};
       fx_vec_t v_6 = 0;
-      _fx_T2N14Ast__id_info_tB v_7 = {0};
-      fx_vec_t v_8 = 0;
-      _fx_T2N15K_form__kinfo_tB v_9 = {0};
-      fx_exn_t v_10 = {0};
-      _fx_R16Ast__val_flags_t v_11 = {0};
-      _fx_R16Ast__val_flags_t v_12 = {0};
+      fx_vec_t v_7 = 0;
+      fx_exn_t v_8 = {0};
+      _fx_R16Ast__val_flags_t v_9 = {0};
+      _fx_R16Ast__val_flags_t v_10 = {0};
       _fx_R17K_form__kdefval_t dv_0 = {0};
-      _fx_N15K_form__kinfo_t v_13 = {0};
+      _fx_N15K_form__kinfo_t v_11 = {0};
       _fx_N14K_form__ktyp_t t_0 = lst_0->hd;
       FX_CALL(_fx_F6stringS1i(idx_0, &v_3, 0), _fx_catch_1);
       fx_str_t slit_0 = FX_MAKE_STR("arg");
@@ -16039,91 +15948,86 @@ FX_EXTERN_C int
          FX_THROW(&v_5, true, _fx_catch_1);
       }
       FX_CHKIDX(FX_CHKIDX1(_fx_g16Ast__all_modules, 0, km_idx_0), _fx_catch_1);
-      _fx_N16Ast__defmodule_t v_14 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, km_idx_0);
-      FX_COPY_PTR(v_14->u.defmodule_t.t9, &v_6);
-      _fx_make_T2N14Ast__id_info_tB(&_fx_g14K_form__IdNone, true, &v_7);
-      FX_CALL(_fx_M6K_formFM10push_back_v2VN14Ast__id_info_tT2N14Ast__id_info_tB(v_6, &v_7, 0), _fx_catch_1);
+      _fx_N16Ast__defmodule_t v_12 = *FX_PTR_1D(_fx_N16Ast__defmodule_t, _fx_g16Ast__all_modules, km_idx_0);
+      FX_COPY_PTR(v_12->u.defmodule_t.t9, &v_6);
+      FX_VEC_PUSH_BACK(_fx_N14Ast__id_info_t, v_6, _fx_g14K_form__IdNone, _fx_catch_1);
       int_ new_idx_0 = FX_VEC_SIZE(v_6) - 1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, km_idx_0), _fx_catch_1);
-      FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, km_idx_0), &v_8);
-      _fx_make_T2N15K_form__kinfo_tB(&_fx_g13K_form__KNone, true, &v_9);
-      FX_CALL(_fx_M6K_formFM10push_back_v2VN15K_form__kinfo_tT2N15K_form__kinfo_tB(v_8, &v_9, 0), _fx_catch_1);
-      int_ new_kidx_0 = FX_VEC_SIZE(v_8) - 1;
+      FX_COPY_PTR(*FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, km_idx_0), &v_7);
+      FX_VEC_PUSH_BACK(_fx_N15K_form__kinfo_t, v_7, _fx_g13K_form__KNone, _fx_catch_1);
+      int_ new_kidx_0 = FX_VEC_SIZE(v_7) - 1;
       if (new_idx_0 != new_kidx_0) {
          fx_str_t slit_2 = FX_MAKE_STR("internal error: unsynchronized outputs from new_id_idx() and new_idk_idx()");
-         FX_CALL(_fx_F9make_FailE1S(&slit_2, &v_10), _fx_catch_1);
-         FX_THROW(&v_10, true, _fx_catch_1);
+         FX_CALL(_fx_F9make_FailE1S(&slit_2, &v_8), _fx_catch_1);
+         FX_THROW(&v_8, true, _fx_catch_1);
       }
       _fx_R9Ast__id_t p_0 = { km_idx_0, i_0, new_kidx_0 };
-      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_11, 0), _fx_catch_1);
-      _fx_make_R16Ast__val_flags_t(true, v_11.val_flag_mutable, v_11.val_flag_temp, v_11.val_flag_tempref,
-         v_11.val_flag_private, v_11.val_flag_subarray, v_11.val_flag_instance, &v_11.val_flag_method, v_11.val_flag_ctor,
-         v_11.val_flag_global, &v_12);
+      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_9, 0), _fx_catch_1);
+      _fx_make_R16Ast__val_flags_t(true, v_9.val_flag_mutable, v_9.val_flag_temp, v_9.val_flag_tempref, v_9.val_flag_private,
+         v_9.val_flag_subarray, v_9.val_flag_instance, &v_9.val_flag_method, v_9.val_flag_ctor, v_9.val_flag_global, &v_10);
       fx_str_t slit_3 = FX_MAKE_STR("");
-      _fx_make_R17K_form__kdefval_t(&p_0, &slit_3, t_0, &v_12, loc_0, &dv_0);
+      _fx_make_R17K_form__kdefval_t(&p_0, &slit_3, t_0, &v_10, loc_0, &dv_0);
       if (FX_REC_VARIANT_TAG(t_0) == 7) {
-         fx_exn_t v_15 = {0};
+         fx_exn_t v_13 = {0};
          fx_str_t slit_4 = FX_MAKE_STR("values of \'void\' type are not allowed");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_15, 0), _fx_catch_0);
-         FX_THROW(&v_15, false, _fx_catch_0);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_4, &v_13, 0), _fx_catch_0);
+         FX_THROW(&v_13, false, _fx_catch_0);
 
       _fx_catch_0: ;
-         fx_free_exn(&v_15);
+         fx_free_exn(&v_13);
       }
       FX_CHECK_EXN(_fx_catch_1);
-      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_13);
-      _fx_Ta2i v_16;
-      FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(&p_0, &_fx_g10Ast__noloc, &v_16, 0), _fx_catch_1);
-      int_ m_0 = v_16.t0;
-      int_ j_0 = v_16.t1;
+      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_11);
+      _fx_Ta2i v_14;
+      FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(&p_0, &_fx_g10Ast__noloc, &v_14, 0), _fx_catch_1);
+      int_ m_0 = v_14.t0;
+      int_ j_0 = v_14.t1;
       FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_0), _fx_catch_1);
-      fx_vec_t v_17 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_0);
-      FX_VEC_CHKIDX(v_17, j_0, _fx_catch_1);
-      _fx_N15K_form__kinfo_t* v_18 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_17, j_0);
-      _fx_free_N15K_form__kinfo_t(v_18);
-      _fx_copy_N15K_form__kinfo_t(&v_13, v_18);
+      fx_vec_t v_15 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_0);
+      FX_VEC_CHKIDX(v_15, j_0, _fx_catch_1);
+      _fx_N15K_form__kinfo_t* v_16 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_15, j_0);
+      _fx_free_N15K_form__kinfo_t(v_16);
+      _fx_copy_N15K_form__kinfo_t(&v_11, v_16);
       _fx_LR9Ast__id_t node_0 = 0;
       FX_CALL(_fx_cons_LR9Ast__id_t(&p_0, 0, false, &node_0), _fx_catch_1);
       FX_LIST_APPEND(params_0, lstend_0, node_0);
 
    _fx_catch_1: ;
-      _fx_free_N15K_form__kinfo_t(&v_13);
+      _fx_free_N15K_form__kinfo_t(&v_11);
       _fx_free_R17K_form__kdefval_t(&dv_0);
-      _fx_free_R16Ast__val_flags_t(&v_12);
-      _fx_free_R16Ast__val_flags_t(&v_11);
-      fx_free_exn(&v_10);
-      _fx_free_T2N15K_form__kinfo_tB(&v_9);
-      FX_FREE_VEC(&v_8);
-      _fx_free_T2N14Ast__id_info_tB(&v_7);
+      _fx_free_R16Ast__val_flags_t(&v_10);
+      _fx_free_R16Ast__val_flags_t(&v_9);
+      fx_free_exn(&v_8);
+      FX_FREE_VEC(&v_7);
       FX_FREE_VEC(&v_6);
       fx_free_exn(&v_5);
       FX_FREE_STR(&v_4);
       FX_FREE_STR(&v_3);
       FX_CHECK_EXN(_fx_cleanup);
    }
-   _fx_R16Ast__fun_flags_t v_19;
-   FX_CALL(_fx_M3AstFM17default_fun_flagsRM11fun_flags_t0(&v_19, 0), _fx_cleanup);
-   _fx_R16Ast__fun_flags_t v_20 =
-      { v_19.fun_flag_pure, v_19.fun_flag_ccode, v_19.fun_flag_have_keywords, v_19.fun_flag_inline, v_19.fun_flag_nothrow,
-         v_19.fun_flag_really_nothrow, v_19.fun_flag_private, *ctor_0, v_19.fun_flag_method_of, v_19.fun_flag_uses_fv,
-         v_19.fun_flag_recursive, isinstance_0 };
+   _fx_R16Ast__fun_flags_t v_17;
+   FX_CALL(_fx_M3AstFM17default_fun_flagsRM11fun_flags_t0(&v_17, 0), _fx_cleanup);
+   _fx_R16Ast__fun_flags_t v_18 =
+      { v_17.fun_flag_pure, v_17.fun_flag_ccode, v_17.fun_flag_have_keywords, v_17.fun_flag_inline, v_17.fun_flag_nothrow,
+         v_17.fun_flag_really_nothrow, v_17.fun_flag_private, *ctor_0, v_17.fun_flag_method_of, v_17.fun_flag_uses_fv,
+         v_17.fun_flag_recursive, isinstance_0 };
    FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(loc_0, &body_0), _fx_cleanup);
-   _fx_R25K_form__kdefclosureinfo_t v_21 = { _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid
+   _fx_R25K_form__kdefclosureinfo_t v_19 = { _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid, _fx_g9Ast__noid
       };
    fx_str_t slit_5 = FX_MAKE_STR("");
-   _fx_make_R17K_form__kdeffun_t(n_0, &slit_5, params_0, rt_0, body_0, &v_20, &v_21, sc_0, loc_0, &v_0);
+   _fx_make_R17K_form__kdeffun_t(n_0, &slit_5, params_0, rt_0, body_0, &v_18, &v_19, sc_0, loc_0, &v_0);
    FX_CALL(_fx_make_rR17K_form__kdeffun_t(&v_0, &kf_0), _fx_cleanup);
    _fx_M6K_formFM4KFunN15K_form__kinfo_t1rRM9kdeffun_t(kf_0, &v_1);
-   _fx_Ta2i v_22;
-   FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(n_0, &_fx_g10Ast__noloc, &v_22, 0), _fx_cleanup);
-   int_ m_1 = v_22.t0;
-   int_ j_1 = v_22.t1;
+   _fx_Ta2i v_20;
+   FX_CALL(_fx_M3AstFM7id2idx_Ta2i2RM4id_tRM5loc_t(n_0, &_fx_g10Ast__noloc, &v_20, 0), _fx_cleanup);
+   int_ m_1 = v_20.t0;
+   int_ j_1 = v_20.t1;
    FX_CHKIDX(FX_CHKIDX1(_fx_g16K_form__all_idks, 0, m_1), _fx_cleanup);
-   fx_vec_t v_23 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_1);
-   FX_VEC_CHKIDX(v_23, j_1, _fx_cleanup);
-   _fx_N15K_form__kinfo_t* v_24 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_23, j_1);
-   _fx_free_N15K_form__kinfo_t(v_24);
-   _fx_copy_N15K_form__kinfo_t(&v_1, v_24);
+   fx_vec_t v_21 = *FX_PTR_1D(fx_vec_t, _fx_g16K_form__all_idks, m_1);
+   FX_VEC_CHKIDX(v_21, j_1, _fx_cleanup);
+   _fx_N15K_form__kinfo_t* v_22 = &FX_VEC_ELEM(_fx_N15K_form__kinfo_t, v_21, j_1);
+   _fx_free_N15K_form__kinfo_t(v_22);
+   _fx_copy_N15K_form__kinfo_t(&v_1, v_22);
    FX_CALL(_fx_M6K_formFM7KDefFunN14K_form__kexp_t1rRM9kdeffun_t(kf_0, &v_2), _fx_cleanup);
    FX_CALL(_fx_cons_LN14K_form__kexp_t(v_2, code_0, true, fx_result), _fx_cleanup);
 

--- a/compiler/bootstrap/K_freevars.c
+++ b/compiler/bootstrap/K_freevars.c
@@ -73,13 +73,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
+   int_ t1;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -103,43 +116,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -154,6 +148,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -394,13 +394,21 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -426,153 +434,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -592,6 +453,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -857,6 +734,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -902,6 +881,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t {
    struct _fx_N14K_form__atom_t t0;
@@ -1079,24 +1079,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1159,6 +1141,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1171,6 +1162,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1592,150 +1592,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1748,256 +1604,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3016,6 +2622,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3100,6 +3023,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t* dst)

--- a/compiler/bootstrap/K_fuse_loops.c
+++ b/compiler/bootstrap/K_fuse_loops.c
@@ -69,18 +69,25 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_N12Map__color_t {
+   int tag;
+} _fx_N12Map__color_t;
 
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
+typedef struct _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t {
+   struct _fx_N12Map__color_t t0;
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* t1;
+   struct _fx_R9Ast__id_t t2;
+   struct _fx_R9Ast__id_t t3;
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* t4;
+} _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t
+         Node;
+   } u;
+} _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -104,6 +111,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -123,37 +148,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_N12Map__color_t {
-   int tag;
-} _fx_N12Map__color_t;
-
-typedef struct _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t {
-   struct _fx_N12Map__color_t t0;
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* t1;
-   struct _fx_R9Ast__id_t t2;
-   struct _fx_R9Ast__id_t t3;
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* t4;
-} _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t
-         Node;
-   } u;
-} _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
 } _fx_N12Ast__cmpop_t;
@@ -167,6 +161,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -384,6 +384,22 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
+
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
    union {
@@ -408,140 +424,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -561,6 +443,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -826,6 +724,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1038,68 +1038,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void
    _fx_free_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t(
    struct _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_tR9Ast__id_tR9Ast__id_tNt11Map__tree_t2R9Ast__id_tR9Ast__id_t*
@@ -1167,6 +1105,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1179,6 +1170,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1551,119 +1551,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1676,210 +1563,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2896,6 +2579,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t0 = *t0;
    FX_COPY_PTR(t1, &fx_result->t1);
    fx_result->t2 = *t2;
+}
+
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)

--- a/compiler/bootstrap/K_inline.c
+++ b/compiler/bootstrap/K_inline.c
@@ -143,72 +143,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
 typedef struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -253,10 +187,46 @@ typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
    } u;
 } _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -271,6 +241,36 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -509,145 +509,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -683,6 +544,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -948,6 +825,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -993,6 +972,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1368,24 +1368,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t(
    struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t* dst)
 {
@@ -1529,6 +1511,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1541,6 +1532,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1943,150 +1943,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -2099,256 +1955,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3367,6 +2973,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3451,6 +3374,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_lift.c
+++ b/compiler/bootstrap/K_lift.c
@@ -74,18 +74,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
 
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
    int_ t1;
-} _fx_T2R9Ast__id_ti;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -109,6 +117,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -127,6 +153,20 @@ typedef struct _fx_R16Ast__val_flags_t {
    int_ val_flag_ctor;
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
+
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
+
+typedef struct _fx_N13Ast__binary_t_data_t {
+   int_ rc;
+   int tag;
+   union {
+      struct _fx_N12Ast__cmpop_t OpCmp;
+      struct _fx_N12Ast__cmpop_t OpDotCmp;
+      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
+   } u;
+} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -157,46 +197,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
-
-typedef struct _fx_N13Ast__binary_t_data_t {
-   int_ rc;
-   int tag;
-   union {
-      struct _fx_N12Ast__cmpop_t OpCmp;
-      struct _fx_N12Ast__cmpop_t OpDotCmp;
-      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
-   } u;
-} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -419,145 +419,6 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -593,6 +454,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -858,6 +735,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -903,6 +882,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t {
    struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* t0;
@@ -1096,68 +1096,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1220,6 +1158,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1232,6 +1223,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1609,150 +1609,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1765,256 +1621,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3033,6 +2639,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3117,6 +3040,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t(

--- a/compiler/bootstrap/K_lift_simple.c
+++ b/compiler/bootstrap/K_lift_simple.c
@@ -49,13 +49,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
+   int_ t1;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -79,11 +92,38 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
    struct _fx_N12Ast__scope_t hd;
 } _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
+
+typedef struct _fx_N13Ast__binary_t_data_t {
+   int_ rc;
+   int tag;
+   union {
+      struct _fx_N12Ast__cmpop_t OpCmp;
+      struct _fx_N12Ast__cmpop_t OpDotCmp;
+      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
+   } u;
+} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -114,46 +154,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
-
-typedef struct _fx_N13Ast__binary_t_data_t {
-   int_ rc;
-   int tag;
-   union {
-      struct _fx_N12Ast__cmpop_t OpCmp;
-      struct _fx_N12Ast__cmpop_t OpDotCmp;
-      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
-   } u;
-} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -340,145 +340,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -514,6 +375,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -779,6 +656,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -824,6 +803,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -895,24 +895,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -975,6 +957,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -987,6 +978,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1325,150 +1325,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1481,256 +1337,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2749,6 +2355,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2833,6 +2756,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_loop_inv.c
+++ b/compiler/bootstrap/K_loop_inv.c
@@ -64,13 +64,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
+   int_ t1;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -94,43 +107,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -145,6 +139,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -360,6 +360,22 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
+
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
    union {
@@ -384,140 +400,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -537,6 +419,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -802,6 +700,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -944,24 +944,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1024,6 +1006,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1036,6 +1027,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1389,119 +1389,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1514,210 +1401,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2734,6 +2417,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t0 = *t0;
    FX_COPY_PTR(t1, &fx_result->t1);
    fx_result->t2 = *t2;
+}
+
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)

--- a/compiler/bootstrap/K_mangle.c
+++ b/compiler/bootstrap/K_mangle.c
@@ -74,14 +74,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -104,22 +96,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -134,6 +128,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -367,13 +367,21 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -399,153 +407,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -565,6 +426,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -830,6 +707,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -875,6 +854,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1048,24 +1048,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -1083,6 +1065,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1095,6 +1086,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1492,150 +1492,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1648,256 +1504,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2916,6 +2522,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3000,6 +2923,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_normalize.c
+++ b/compiler/bootstrap/K_normalize.c
@@ -94,263 +94,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_N12Map__color_t {
    int tag;
 } _fx_N12Map__color_t;
@@ -377,6 +120,16 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
 typedef struct _fx_N12Set__color_t {
    int tag;
 } _fx_N12Set__color_t;
@@ -400,6 +153,36 @@ typedef struct _fx_Rt6Set__t1R9Ast__id_t {
    int_ size;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Set__t1R9Ast__id_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -454,6 +237,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -535,6 +342,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -554,6 +385,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -750,6 +591,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -922,6 +901,14 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
 
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
    struct _fx_R10Ast__loc_t t1;
@@ -937,6 +924,19 @@ typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
    struct _fx_LT2SR10Ast__loc_t_data_t* pragma_clibs;
 } _fx_R14Ast__pragmas_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1076,134 +1076,11 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_LN14K_form__ktyp_t_data_t {
    int_ rc;
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -1469,6 +1346,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1514,6 +1493,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t {
    struct _fx_N14K_form__atom_t t0;
@@ -1917,561 +1917,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_LN16Ast__env_entry_t(struct _fx_LN16Ast__env_entry_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN16Ast__env_entry_t, _fx_free_N16Ast__env_entry_t);
@@ -2536,6 +1981,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
 }
 
 static void _fx_free_T4N12Set__color_tNt11Set__tree_t1R9Ast__id_tR9Ast__id_tNt11Set__tree_t1R9Ast__id_t(
@@ -2704,6 +2172,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3661,6 +3182,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4130,6 +4057,37 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
    *dst = 0;
 }
 
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
 {
    fx_free_str(&dst->t0);
@@ -4179,6 +4137,48 @@ static void _fx_make_R14Ast__pragmas_t(
 {
    fx_result->pragma_cpp = r_pragma_cpp;
    FX_COPY_PTR(r_pragma_clibs, &fx_result->pragma_clibs);
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -4534,150 +4534,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -4690,256 +4546,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -5958,6 +5564,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -6042,6 +5965,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t* dst)

--- a/compiler/bootstrap/K_normalize.c
+++ b/compiler/bootstrap/K_normalize.c
@@ -7387,6 +7387,7 @@ _fx_N13Ast__intrin_t _fx_g27K_normalize__IntrinListHead = { 6 };
 _fx_N13Ast__intrin_t _fx_g27K_normalize__IntrinListTail = { 7 };
 _fx_N13Ast__intrin_t _fx_g28K_normalize__IntrinStrConcat = { 8 };
 _fx_N13Ast__intrin_t _fx_g26K_normalize__IntrinGetSize = { 9 };
+_fx_N13Ast__intrin_t _fx_g28K_normalize__IntrinVecSplice = { 18 };
 static _fx_N14K_form__ktyp_t_data_t KTypInt_data_1 = { 1, 1 };
 _fx_N14K_form__ktyp_t _fx_g20K_normalize__KTypInt = &KTypInt_data_1;
 static _fx_N14K_form__ktyp_t_data_t KTypCInt_data_0 = { 1, 2 };
@@ -10930,6 +10931,8 @@ FX_EXTERN_C int
    _fx_N10Ast__typ_t etyp_0 = 0;
    _fx_N14K_form__ktyp_t ktyp_0 = 0;
    _fx_T2N14K_form__ktyp_tR10Ast__loc_t kctx_0 = {0};
+   _fx_N10Ast__typ_t v_1 = 0;
+   _fx_N14K_form__ktyp_t v_2 = 0;
    int fx_status = 0;
    FX_CALL(fx_check_stack(), _fx_cleanup);
    int_ km_idx_0;
@@ -10941,225 +10944,225 @@ FX_EXTERN_C int
    _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &eloc_0, &kctx_0);
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 1) {
-      _fx_N14K_form__kexp_t v_1 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpNop, &v_1), _fx_catch_0);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_1, code_0, fx_result);
-
-   _fx_catch_0: ;
-      if (v_1) {
-         _fx_free_N14K_form__kexp_t(&v_1);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 2) {
-      _fx_N14K_form__kexp_t v_2 = 0;
-      FX_CALL(_fx_M6K_formFM9KExpBreakN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpBreak.t1, &v_2), _fx_catch_1);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_2, code_0, fx_result);
-
-   _fx_catch_1: ;
-      if (v_2) {
-         _fx_free_N14K_form__kexp_t(&v_2);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 3) {
       _fx_N14K_form__kexp_t v_3 = 0;
-      FX_CALL(_fx_M6K_formFM12KExpContinueN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpContinue, &v_3), _fx_catch_2);
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpNop, &v_3), _fx_catch_0);
       _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_3, code_0, fx_result);
 
-   _fx_catch_2: ;
+   _fx_catch_0: ;
       if (v_3) {
          _fx_free_N14K_form__kexp_t(&v_3);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 2) {
+      _fx_N14K_form__kexp_t v_4 = 0;
+      FX_CALL(_fx_M6K_formFM9KExpBreakN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpBreak.t1, &v_4), _fx_catch_1);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_4, code_0, fx_result);
+
+   _fx_catch_1: ;
+      if (v_4) {
+         _fx_free_N14K_form__kexp_t(&v_4);
+      }
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 3) {
+      _fx_N14K_form__kexp_t v_5 = 0;
+      FX_CALL(_fx_M6K_formFM12KExpContinueN14K_form__kexp_t1R10Ast__loc_t(&e_0->u.ExpContinue, &v_5), _fx_catch_2);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_5, code_0, fx_result);
+
+   _fx_catch_2: ;
+      if (v_5) {
+         _fx_free_N14K_form__kexp_t(&v_5);
+      }
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 4) {
-      _fx_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t v_4 = {0};
+      _fx_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t v_6 = {0};
       _fx_Nt6option1N14K_form__atom_t a_opt_0 = {0};
       _fx_LN14K_form__kexp_t code_1 = 0;
-      _fx_N14K_form__kexp_t v_5 = 0;
+      _fx_N14K_form__kexp_t v_7 = 0;
       _fx_T2Nt6option1N10Ast__exp_tR10Ast__loc_t* vcase_0 = &e_0->u.ExpReturn;
       _fx_Nt6option1N10Ast__exp_t e_opt_0 = vcase_0->t0;
       if ((e_opt_0 != 0) + 1 == 2) {
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_6 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_8 = {0};
          _fx_N14K_form__atom_t a_0 = {0};
          _fx_LN14K_form__kexp_t code_2 = 0;
-         _fx_Nt6option1N14K_form__atom_t v_7 = {0};
+         _fx_Nt6option1N14K_form__atom_t v_9 = {0};
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e_opt_0->u.Some, code_0, false, sc_0, &v_6, 0), _fx_catch_3);
-         _fx_copy_N14K_form__atom_t(&v_6.t0, &a_0);
-         FX_COPY_PTR(v_6.t1, &code_2);
-         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__atom_t1N14K_form__atom_t(&a_0, &v_7);
-         _fx_make_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&v_7, code_2, &v_4);
+               e_opt_0->u.Some, code_0, false, sc_0, &v_8, 0), _fx_catch_3);
+         _fx_copy_N14K_form__atom_t(&v_8.t0, &a_0);
+         FX_COPY_PTR(v_8.t1, &code_2);
+         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__atom_t1N14K_form__atom_t(&a_0, &v_9);
+         _fx_make_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&v_9, code_2, &v_6);
 
       _fx_catch_3: ;
-         _fx_free_Nt6option1N14K_form__atom_t(&v_7);
+         _fx_free_Nt6option1N14K_form__atom_t(&v_9);
          if (code_2) {
             _fx_free_LN14K_form__kexp_t(&code_2);
          }
          _fx_free_N14K_form__atom_t(&a_0);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_6);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_8);
       }
       else {
-         _fx_make_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&_fx_g19K_normalize__None5_, code_0, &v_4);
+         _fx_make_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&_fx_g19K_normalize__None5_, code_0, &v_6);
       }
       FX_CHECK_EXN(_fx_catch_4);
-      _fx_copy_Nt6option1N14K_form__atom_t(&v_4.t0, &a_opt_0);
-      FX_COPY_PTR(v_4.t1, &code_1);
+      _fx_copy_Nt6option1N14K_form__atom_t(&v_6.t0, &a_opt_0);
+      FX_COPY_PTR(v_6.t1, &code_1);
       FX_CALL(
-         _fx_M6K_formFM10KExpReturnN14K_form__kexp_t2Nt6option1N14K_form__atom_tR10Ast__loc_t(&a_opt_0, &vcase_0->t1, &v_5),
+         _fx_M6K_formFM10KExpReturnN14K_form__kexp_t2Nt6option1N14K_form__atom_tR10Ast__loc_t(&a_opt_0, &vcase_0->t1, &v_7),
          _fx_catch_4);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_5, code_1, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_7, code_1, fx_result);
 
    _fx_catch_4: ;
-      if (v_5) {
-         _fx_free_N14K_form__kexp_t(&v_5);
+      if (v_7) {
+         _fx_free_N14K_form__kexp_t(&v_7);
       }
       if (code_1) {
          _fx_free_LN14K_form__kexp_t(&code_1);
       }
       _fx_free_Nt6option1N14K_form__atom_t(&a_opt_0);
-      _fx_free_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&v_4);
-      goto _fx_endmatch_14;
+      _fx_free_T2Nt6option1N14K_form__atom_tLN14K_form__kexp_t(&v_6);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 5) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_8 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_10 = {0};
       _fx_N14K_form__atom_t a1_0 = {0};
       _fx_LN14K_form__kexp_t code_3 = 0;
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_9 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_11 = {0};
       _fx_N14K_form__atom_t a2_0 = {0};
       _fx_LN14K_form__kexp_t code_4 = 0;
-      _fx_N14K_form__klit_t v_10 = {0};
-      _fx_N14K_form__atom_t v_11 = {0};
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_12 = {0};
+      _fx_N14K_form__klit_t v_12 = {0};
+      _fx_N14K_form__atom_t v_13 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_14 = {0};
       _fx_N14K_form__atom_t a3_0 = {0};
       _fx_LN14K_form__kexp_t code_5 = 0;
-      _fx_LN14K_form__atom_t v_13 = 0;
-      _fx_N14K_form__kexp_t v_14 = 0;
+      _fx_LN14K_form__atom_t v_15 = 0;
+      _fx_N14K_form__kexp_t v_16 = 0;
       _fx_T4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_1 =
          &e_0->u.ExpRange;
       FX_CALL(
          _fx_M11K_normalizeFM13process_rpartT2N14K_form__atom_tLN14K_form__kexp_t4Nt6option1N10Ast__exp_tLN14K_form__kexp_tN14K_form__atom_tLN12Ast__scope_t(
-            vcase_1->t0, code_0, &_fx_g17K_form___ALitVoid, sc_0, &v_8, 0), _fx_catch_5);
-      _fx_copy_N14K_form__atom_t(&v_8.t0, &a1_0);
-      FX_COPY_PTR(v_8.t1, &code_3);
+            vcase_1->t0, code_0, &_fx_g17K_form___ALitVoid, sc_0, &v_10, 0), _fx_catch_5);
+      _fx_copy_N14K_form__atom_t(&v_10.t0, &a1_0);
+      FX_COPY_PTR(v_10.t1, &code_3);
       FX_CALL(
          _fx_M11K_normalizeFM13process_rpartT2N14K_form__atom_tLN14K_form__kexp_t4Nt6option1N10Ast__exp_tLN14K_form__kexp_tN14K_form__atom_tLN12Ast__scope_t(
-            vcase_1->t1, code_3, &_fx_g17K_form___ALitVoid, sc_0, &v_9, 0), _fx_catch_5);
-      _fx_copy_N14K_form__atom_t(&v_9.t0, &a2_0);
-      FX_COPY_PTR(v_9.t1, &code_4);
-      _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(1LL, &v_10);
-      _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_10, &v_11);
+            vcase_1->t1, code_3, &_fx_g17K_form___ALitVoid, sc_0, &v_11, 0), _fx_catch_5);
+      _fx_copy_N14K_form__atom_t(&v_11.t0, &a2_0);
+      FX_COPY_PTR(v_11.t1, &code_4);
+      _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(1LL, &v_12);
+      _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_12, &v_13);
       FX_CALL(
          _fx_M11K_normalizeFM13process_rpartT2N14K_form__atom_tLN14K_form__kexp_t4Nt6option1N10Ast__exp_tLN14K_form__kexp_tN14K_form__atom_tLN12Ast__scope_t(
-            vcase_1->t2, code_4, &v_11, sc_0, &v_12, 0), _fx_catch_5);
-      _fx_copy_N14K_form__atom_t(&v_12.t0, &a3_0);
-      FX_COPY_PTR(v_12.t1, &code_5);
-      FX_CALL(_fx_cons_LN14K_form__atom_t(&a3_0, 0, true, &v_13), _fx_catch_5);
-      FX_CALL(_fx_cons_LN14K_form__atom_t(&a2_0, v_13, false, &v_13), _fx_catch_5);
-      FX_CALL(_fx_cons_LN14K_form__atom_t(&a1_0, v_13, false, &v_13), _fx_catch_5);
+            vcase_1->t2, code_4, &v_13, sc_0, &v_14, 0), _fx_catch_5);
+      _fx_copy_N14K_form__atom_t(&v_14.t0, &a3_0);
+      FX_COPY_PTR(v_14.t1, &code_5);
+      FX_CALL(_fx_cons_LN14K_form__atom_t(&a3_0, 0, true, &v_15), _fx_catch_5);
+      FX_CALL(_fx_cons_LN14K_form__atom_t(&a2_0, v_15, false, &v_15), _fx_catch_5);
+      FX_CALL(_fx_cons_LN14K_form__atom_t(&a1_0, v_15, false, &v_15), _fx_catch_5);
       FX_CALL(
-         _fx_M6K_formFM11KExpMkTupleN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_13, &kctx_0, &v_14),
+         _fx_M6K_formFM11KExpMkTupleN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_15, &kctx_0, &v_16),
          _fx_catch_5);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_14, code_5, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_16, code_5, fx_result);
 
    _fx_catch_5: ;
-      if (v_14) {
-         _fx_free_N14K_form__kexp_t(&v_14);
+      if (v_16) {
+         _fx_free_N14K_form__kexp_t(&v_16);
       }
-      if (v_13) {
-         _fx_free_LN14K_form__atom_t(&v_13);
+      if (v_15) {
+         _fx_free_LN14K_form__atom_t(&v_15);
       }
       if (code_5) {
          _fx_free_LN14K_form__kexp_t(&code_5);
       }
       _fx_free_N14K_form__atom_t(&a3_0);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_12);
-      _fx_free_N14K_form__atom_t(&v_11);
-      _fx_free_N14K_form__klit_t(&v_10);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_14);
+      _fx_free_N14K_form__atom_t(&v_13);
+      _fx_free_N14K_form__klit_t(&v_12);
       if (code_4) {
          _fx_free_LN14K_form__kexp_t(&code_4);
       }
       _fx_free_N14K_form__atom_t(&a2_0);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_9);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_11);
       if (code_3) {
          _fx_free_LN14K_form__kexp_t(&code_3);
       }
       _fx_free_N14K_form__atom_t(&a1_0);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_8);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_10);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 6) {
       if (e_0->u.ExpLit.t0.tag == 8) {
-         _fx_R16Ast__val_flags_t v_15 = {0};
-         _fx_N14K_form__klit_t v_16 = {0};
-         _fx_N14K_form__atom_t v_17 = {0};
-         _fx_N14K_form__kexp_t v_18 = 0;
-         _fx_Nt6option1N14K_form__kexp_t v_19 = {0};
+         _fx_R16Ast__val_flags_t v_17 = {0};
+         _fx_N14K_form__klit_t v_18 = {0};
+         _fx_N14K_form__atom_t v_19 = {0};
+         _fx_N14K_form__kexp_t v_20 = 0;
+         _fx_Nt6option1N14K_form__kexp_t v_21 = {0};
          _fx_LN14K_form__kexp_t code_6 = 0;
-         _fx_N14K_form__atom_t v_20 = {0};
-         _fx_N14K_form__kexp_t v_21 = 0;
+         _fx_N14K_form__atom_t v_22 = {0};
+         _fx_N14K_form__kexp_t v_23 = 0;
          _fx_R9Ast__id_t z_0;
          fx_str_t slit_0 = FX_MAKE_STR("z");
          FX_CALL(_fx_M6K_formFM7gen_idkR9Ast__id_t2iS(km_idx_0, &slit_0, &z_0, 0), _fx_catch_6);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_15, 0), _fx_catch_6);
-         _fx_M6K_formFM7KLitNilN14K_form__klit_t1N14K_form__ktyp_t(ktyp_0, &v_16);
-         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_16, &v_17);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_17, 0), _fx_catch_6);
+         _fx_M6K_formFM7KLitNilN14K_form__klit_t1N14K_form__ktyp_t(ktyp_0, &v_18);
+         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_18, &v_19);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_17, &kctx_0, &v_18),
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_19, &kctx_0, &v_20),
             _fx_catch_6);
-         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(v_18, &v_19);
+         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(v_20, &v_21);
          FX_CALL(
             _fx_M6K_formFM14create_kdefvalLN14K_form__kexp_t6R9Ast__id_tN14K_form__ktyp_tR16Ast__val_flags_tNt6option1N14K_form__kexp_tLN14K_form__kexp_tR10Ast__loc_t(
-               &z_0, ktyp_0, &v_15, &v_19, code_0, &eloc_0, &code_6, 0), _fx_catch_6);
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&z_0, &v_20);
+               &z_0, ktyp_0, &v_17, &v_21, code_0, &eloc_0, &code_6, 0), _fx_catch_6);
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&z_0, &v_22);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_20, &kctx_0, &v_21),
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_22, &kctx_0, &v_23),
             _fx_catch_6);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_21, code_6, fx_result);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_23, code_6, fx_result);
 
       _fx_catch_6: ;
-         if (v_21) {
-            _fx_free_N14K_form__kexp_t(&v_21);
+         if (v_23) {
+            _fx_free_N14K_form__kexp_t(&v_23);
          }
-         _fx_free_N14K_form__atom_t(&v_20);
+         _fx_free_N14K_form__atom_t(&v_22);
          if (code_6) {
             _fx_free_LN14K_form__kexp_t(&code_6);
          }
-         _fx_free_Nt6option1N14K_form__kexp_t(&v_19);
-         if (v_18) {
-            _fx_free_N14K_form__kexp_t(&v_18);
+         _fx_free_Nt6option1N14K_form__kexp_t(&v_21);
+         if (v_20) {
+            _fx_free_N14K_form__kexp_t(&v_20);
          }
-         _fx_free_N14K_form__atom_t(&v_17);
-         _fx_free_N14K_form__klit_t(&v_16);
-         _fx_free_R16Ast__val_flags_t(&v_15);
-         goto _fx_endmatch_14;
+         _fx_free_N14K_form__atom_t(&v_19);
+         _fx_free_N14K_form__klit_t(&v_18);
+         _fx_free_R16Ast__val_flags_t(&v_17);
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 6) {
-      _fx_N14K_form__klit_t v_22 = {0};
-      _fx_N14K_form__atom_t v_23 = {0};
-      _fx_N14K_form__kexp_t v_24 = 0;
+      _fx_N14K_form__klit_t v_24 = {0};
+      _fx_N14K_form__atom_t v_25 = {0};
+      _fx_N14K_form__kexp_t v_26 = 0;
       FX_CALL(
          _fx_M11K_normalizeFM8lit2klitN14K_form__klit_t3N10Ast__lit_tN14K_form__ktyp_tR10Ast__loc_t(&e_0->u.ExpLit.t0, ktyp_0,
-            &eloc_0, &v_22, 0), _fx_catch_7);
-      _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_22, &v_23);
-      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_23, &kctx_0, &v_24),
+            &eloc_0, &v_24, 0), _fx_catch_7);
+      _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_24, &v_25);
+      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_25, &kctx_0, &v_26),
          _fx_catch_7);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_24, code_0, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_26, code_0, fx_result);
 
    _fx_catch_7: ;
-      if (v_24) {
-         _fx_free_N14K_form__kexp_t(&v_24);
+      if (v_26) {
+         _fx_free_N14K_form__kexp_t(&v_26);
       }
-      _fx_free_N14K_form__atom_t(&v_23);
-      _fx_free_N14K_form__klit_t(&v_22);
-      goto _fx_endmatch_14;
+      _fx_free_N14K_form__atom_t(&v_25);
+      _fx_free_N14K_form__klit_t(&v_24);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 7) {
-      _fx_N14K_form__kexp_t v_25 = 0;
-      _fx_N14K_form__atom_t v_26 = {0};
+      _fx_N14K_form__kexp_t v_27 = 0;
+      _fx_N14K_form__atom_t v_28 = {0};
       _fx_R9Ast__id_t* n_0 = &e_0->u.ExpIdent.t0;
       int tag_1 = FX_REC_VARIANT_TAG(ktyp_0);
       _fx_R9Ast__id_t new_n_0;
@@ -11167,30 +11170,30 @@ FX_EXTERN_C int
          new_n_0 = _fx_g9Ast__noid;
       }
       else if (tag_1 == 16) {
-         _fx_N15K_form__kinfo_t v_27 = {0};
-         _fx_R21K_form__kdefvariant_t v_28 = {0};
-         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&ktyp_0->u.KTypName, &eloc_0, &v_27, 0),
+         _fx_N15K_form__kinfo_t v_29 = {0};
+         _fx_R21K_form__kdefvariant_t v_30 = {0};
+         FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(&ktyp_0->u.KTypName, &eloc_0, &v_29, 0),
             _fx_catch_11);
-         if (v_27.tag == 5) {
-            _fx_copy_R21K_form__kdefvariant_t(&v_27.u.KVariant->data, &v_28);
-            if (v_28.kvar_name.m == n_0->m) {
+         if (v_29.tag == 5) {
+            _fx_copy_R21K_form__kdefvariant_t(&v_29.u.KVariant->data, &v_30);
+            if (v_30.kvar_name.m == n_0->m) {
                fx_exn_t exn_0 = {0};
                _fx_LR9Ast__id_t kvar_ctors_0 = 0;
                _fx_Nt6option1R9Ast__id_t __fold_result___0 = _fx_g19K_normalize__None6_;
-               FX_COPY_PTR(v_28.kvar_ctors, &kvar_ctors_0);
+               FX_COPY_PTR(v_30.kvar_ctors, &kvar_ctors_0);
                _fx_LR9Ast__id_t lst_0 = kvar_ctors_0;
                for (; lst_0; lst_0 = lst_0->tl) {
                   _fx_R9Ast__id_t* nj_0 = &lst_0->hd;
-                  _fx_R9Ast__id_t v_29;
-                  FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(nj_0, &v_29, 0), _fx_catch_8);
-                  _fx_R9Ast__id_t v_30;
-                  FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(n_0, &v_30, 0), _fx_catch_8);
+                  _fx_R9Ast__id_t v_31;
+                  FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(nj_0, &v_31, 0), _fx_catch_8);
+                  _fx_R9Ast__id_t v_32;
+                  FX_CALL(_fx_M3AstFM11get_orig_idRM4id_t1RM4id_t(n_0, &v_32, 0), _fx_catch_8);
                   bool res_0;
-                  FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_29, &v_30, &res_0, 0), _fx_catch_8);
+                  FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_31, &v_32, &res_0, 0), _fx_catch_8);
                   if (res_0) {
-                     _fx_Nt6option1R9Ast__id_t v_31;
-                     _fx_M11K_normalizeFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(nj_0, &v_31);
-                     __fold_result___0 = v_31;
+                     _fx_Nt6option1R9Ast__id_t v_33;
+                     _fx_M11K_normalizeFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(nj_0, &v_33);
+                     __fold_result___0 = v_33;
                      FX_BREAK(_fx_catch_8);
                   }
 
@@ -11232,8 +11235,8 @@ FX_EXTERN_C int
          FX_CHECK_EXN(_fx_catch_11);
 
       _fx_catch_11: ;
-         _fx_free_R21K_form__kdefvariant_t(&v_28);
-         _fx_free_N15K_form__kinfo_t(&v_27);
+         _fx_free_R21K_form__kdefvariant_t(&v_30);
+         _fx_free_N15K_form__kinfo_t(&v_29);
       }
       else {
          new_n_0 = *n_0;
@@ -11242,81 +11245,81 @@ FX_EXTERN_C int
       bool res_1;
       FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&new_n_0, &_fx_g9Ast__noid, &res_1, 0), _fx_catch_12);
       if (res_1) {
-         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_25), _fx_catch_12);
+         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_27), _fx_catch_12);
       }
       else {
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&new_n_0, &v_26);
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&new_n_0, &v_28);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_26, &kctx_0, &v_25),
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_28, &kctx_0, &v_27),
             _fx_catch_12);
       }
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_25, code_0, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_27, code_0, fx_result);
 
    _fx_catch_12: ;
-      _fx_free_N14K_form__atom_t(&v_26);
-      if (v_25) {
-         _fx_free_N14K_form__kexp_t(&v_25);
+      _fx_free_N14K_form__atom_t(&v_28);
+      if (v_27) {
+         _fx_free_N14K_form__kexp_t(&v_27);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 8) {
       _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_2 = &e_0->u.ExpBinary;
       if (FX_REC_VARIANT_TAG(vcase_2->t0) == 17) {
-         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_32 = {0};
+         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_34 = {0};
          _fx_N14K_form__kexp_t e1_0 = 0;
          _fx_LN14K_form__kexp_t code_7 = 0;
-         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_33 = {0};
+         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_35 = {0};
          _fx_N14K_form__kexp_t e2_0 = 0;
          _fx_LN14K_form__kexp_t code2_0 = 0;
-         _fx_LN14K_form__kexp_t v_34 = 0;
+         _fx_LN14K_form__kexp_t v_36 = 0;
          _fx_N14K_form__kexp_t e2_1 = 0;
-         _fx_N14K_form__klit_t v_35 = {0};
-         _fx_N14K_form__atom_t v_36 = {0};
-         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_37 = {0};
-         _fx_N14K_form__kexp_t v_38 = 0;
-         _fx_N14K_form__kexp_t v_39 = 0;
+         _fx_N14K_form__klit_t v_37 = {0};
+         _fx_N14K_form__atom_t v_38 = {0};
+         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_39 = {0};
+         _fx_N14K_form__kexp_t v_40 = 0;
+         _fx_N14K_form__kexp_t v_41 = 0;
          _fx_N10Ast__exp_t e2_2 = vcase_2->t2;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               vcase_2->t1, code_0, false, sc_0, &v_32, 0), _fx_catch_13);
-         FX_COPY_PTR(v_32.t0, &e1_0);
-         FX_COPY_PTR(v_32.t1, &code_7);
+               vcase_2->t1, code_0, false, sc_0, &v_34, 0), _fx_catch_13);
+         FX_COPY_PTR(v_34.t0, &e1_0);
+         FX_COPY_PTR(v_34.t1, &code_7);
          _fx_R10Ast__loc_t eloc2_0;
          FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e2_2, &eloc2_0, 0), _fx_catch_13);
          FX_CALL(
             _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e2_2, 0, false, sc_0, &v_33, 0), _fx_catch_13);
-         FX_COPY_PTR(v_33.t0, &e2_0);
-         FX_COPY_PTR(v_33.t1, &code2_0);
-         FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_0, code2_0, true, &v_34), _fx_catch_13);
-         FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_34, &eloc2_0, &e2_1, 0),
+               e2_2, 0, false, sc_0, &v_35, 0), _fx_catch_13);
+         FX_COPY_PTR(v_35.t0, &e2_0);
+         FX_COPY_PTR(v_35.t1, &code2_0);
+         FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_0, code2_0, true, &v_36), _fx_catch_13);
+         FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_36, &eloc2_0, &e2_1, 0),
             _fx_catch_13);
-         _fx_M6K_formFM8KLitBoolN14K_form__klit_t1B(false, &v_35);
-         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_35, &v_36);
-         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &eloc2_0, &v_37);
+         _fx_M6K_formFM8KLitBoolN14K_form__klit_t1B(false, &v_37);
+         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_37, &v_38);
+         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &eloc2_0, &v_39);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_36, &v_37, &v_38),
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_38, &v_39, &v_40),
             _fx_catch_13);
          FX_CALL(
             _fx_M6K_formFM6KExpIfN14K_form__kexp_t4N14K_form__kexp_tN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               e1_0, e2_1, v_38, &kctx_0, &v_39), _fx_catch_13);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_39, code_7, fx_result);
+               e1_0, e2_1, v_40, &kctx_0, &v_41), _fx_catch_13);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_41, code_7, fx_result);
 
       _fx_catch_13: ;
-         if (v_39) {
-            _fx_free_N14K_form__kexp_t(&v_39);
+         if (v_41) {
+            _fx_free_N14K_form__kexp_t(&v_41);
          }
-         if (v_38) {
-            _fx_free_N14K_form__kexp_t(&v_38);
+         if (v_40) {
+            _fx_free_N14K_form__kexp_t(&v_40);
          }
-         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_37);
-         _fx_free_N14K_form__atom_t(&v_36);
-         _fx_free_N14K_form__klit_t(&v_35);
+         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_39);
+         _fx_free_N14K_form__atom_t(&v_38);
+         _fx_free_N14K_form__klit_t(&v_37);
          if (e2_1) {
             _fx_free_N14K_form__kexp_t(&e2_1);
          }
-         if (v_34) {
-            _fx_free_LN14K_form__kexp_t(&v_34);
+         if (v_36) {
+            _fx_free_LN14K_form__kexp_t(&v_36);
          }
          if (code2_0) {
             _fx_free_LN14K_form__kexp_t(&code2_0);
@@ -11324,75 +11327,75 @@ FX_EXTERN_C int
          if (e2_0) {
             _fx_free_N14K_form__kexp_t(&e2_0);
          }
-         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_33);
+         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_35);
          if (code_7) {
             _fx_free_LN14K_form__kexp_t(&code_7);
          }
          if (e1_0) {
             _fx_free_N14K_form__kexp_t(&e1_0);
          }
-         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_32);
-         goto _fx_endmatch_14;
+         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_34);
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 8) {
       _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_3 = &e_0->u.ExpBinary;
       if (FX_REC_VARIANT_TAG(vcase_3->t0) == 19) {
-         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_40 = {0};
+         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_42 = {0};
          _fx_N14K_form__kexp_t e1_1 = 0;
          _fx_LN14K_form__kexp_t code_8 = 0;
-         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_41 = {0};
+         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_43 = {0};
          _fx_N14K_form__kexp_t e2_3 = 0;
          _fx_LN14K_form__kexp_t code2_1 = 0;
-         _fx_LN14K_form__kexp_t v_42 = 0;
+         _fx_LN14K_form__kexp_t v_44 = 0;
          _fx_N14K_form__kexp_t e2_4 = 0;
-         _fx_N14K_form__klit_t v_43 = {0};
-         _fx_N14K_form__atom_t v_44 = {0};
-         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_45 = {0};
-         _fx_N14K_form__kexp_t v_46 = 0;
-         _fx_N14K_form__kexp_t v_47 = 0;
+         _fx_N14K_form__klit_t v_45 = {0};
+         _fx_N14K_form__atom_t v_46 = {0};
+         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_47 = {0};
+         _fx_N14K_form__kexp_t v_48 = 0;
+         _fx_N14K_form__kexp_t v_49 = 0;
          _fx_N10Ast__exp_t e2_5 = vcase_3->t2;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               vcase_3->t1, code_0, false, sc_0, &v_40, 0), _fx_catch_14);
-         FX_COPY_PTR(v_40.t0, &e1_1);
-         FX_COPY_PTR(v_40.t1, &code_8);
+               vcase_3->t1, code_0, false, sc_0, &v_42, 0), _fx_catch_14);
+         FX_COPY_PTR(v_42.t0, &e1_1);
+         FX_COPY_PTR(v_42.t1, &code_8);
          _fx_R10Ast__loc_t eloc2_1;
          FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e2_5, &eloc2_1, 0), _fx_catch_14);
          FX_CALL(
             _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e2_5, 0, false, sc_0, &v_41, 0), _fx_catch_14);
-         FX_COPY_PTR(v_41.t0, &e2_3);
-         FX_COPY_PTR(v_41.t1, &code2_1);
-         FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_3, code2_1, true, &v_42), _fx_catch_14);
-         FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_42, &eloc2_1, &e2_4, 0),
+               e2_5, 0, false, sc_0, &v_43, 0), _fx_catch_14);
+         FX_COPY_PTR(v_43.t0, &e2_3);
+         FX_COPY_PTR(v_43.t1, &code2_1);
+         FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_3, code2_1, true, &v_44), _fx_catch_14);
+         FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_44, &eloc2_1, &e2_4, 0),
             _fx_catch_14);
-         _fx_M6K_formFM8KLitBoolN14K_form__klit_t1B(true, &v_43);
-         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_43, &v_44);
-         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &eloc2_1, &v_45);
+         _fx_M6K_formFM8KLitBoolN14K_form__klit_t1B(true, &v_45);
+         _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_45, &v_46);
+         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &eloc2_1, &v_47);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_44, &v_45, &v_46),
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&v_46, &v_47, &v_48),
             _fx_catch_14);
          FX_CALL(
             _fx_M6K_formFM6KExpIfN14K_form__kexp_t4N14K_form__kexp_tN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               e1_1, v_46, e2_4, &kctx_0, &v_47), _fx_catch_14);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_47, code_8, fx_result);
+               e1_1, v_48, e2_4, &kctx_0, &v_49), _fx_catch_14);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_49, code_8, fx_result);
 
       _fx_catch_14: ;
-         if (v_47) {
-            _fx_free_N14K_form__kexp_t(&v_47);
+         if (v_49) {
+            _fx_free_N14K_form__kexp_t(&v_49);
          }
-         if (v_46) {
-            _fx_free_N14K_form__kexp_t(&v_46);
+         if (v_48) {
+            _fx_free_N14K_form__kexp_t(&v_48);
          }
-         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_45);
-         _fx_free_N14K_form__atom_t(&v_44);
-         _fx_free_N14K_form__klit_t(&v_43);
+         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_47);
+         _fx_free_N14K_form__atom_t(&v_46);
+         _fx_free_N14K_form__klit_t(&v_45);
          if (e2_4) {
             _fx_free_N14K_form__kexp_t(&e2_4);
          }
-         if (v_42) {
-            _fx_free_LN14K_form__kexp_t(&v_42);
+         if (v_44) {
+            _fx_free_LN14K_form__kexp_t(&v_44);
          }
          if (code2_1) {
             _fx_free_LN14K_form__kexp_t(&code2_1);
@@ -11400,102 +11403,102 @@ FX_EXTERN_C int
          if (e2_3) {
             _fx_free_N14K_form__kexp_t(&e2_3);
          }
-         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_41);
+         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_43);
          if (code_8) {
             _fx_free_LN14K_form__kexp_t(&code_8);
          }
          if (e1_1) {
             _fx_free_N14K_form__kexp_t(&e1_1);
          }
-         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_40);
-         goto _fx_endmatch_14;
+         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_42);
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 8) {
       _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_4 = &e_0->u.ExpBinary;
       if (FX_REC_VARIANT_TAG(vcase_4->t0) == 26) {
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_48 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_50 = {0};
          _fx_N14K_form__atom_t a1_1 = {0};
          _fx_LN14K_form__kexp_t code_9 = 0;
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_49 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_51 = {0};
          _fx_N14K_form__atom_t a2_1 = {0};
          _fx_LN14K_form__kexp_t code_10 = 0;
-         _fx_N14K_form__kexp_t v_50 = 0;
+         _fx_N14K_form__kexp_t v_52 = 0;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               vcase_4->t1, code_0, false, sc_0, &v_48, 0), _fx_catch_15);
-         _fx_copy_N14K_form__atom_t(&v_48.t0, &a1_1);
-         FX_COPY_PTR(v_48.t1, &code_9);
+               vcase_4->t1, code_0, false, sc_0, &v_50, 0), _fx_catch_15);
+         _fx_copy_N14K_form__atom_t(&v_50.t0, &a1_1);
+         FX_COPY_PTR(v_50.t1, &code_9);
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               vcase_4->t2, code_9, false, sc_0, &v_49, 0), _fx_catch_15);
-         _fx_copy_N14K_form__atom_t(&v_49.t0, &a2_1);
-         FX_COPY_PTR(v_49.t1, &code_10);
+               vcase_4->t2, code_9, false, sc_0, &v_51, 0), _fx_catch_15);
+         _fx_copy_N14K_form__atom_t(&v_51.t0, &a2_1);
+         FX_COPY_PTR(v_51.t1, &code_10);
          FX_CALL(
             _fx_M6K_formFM10KExpBinaryN14K_form__kexp_t4N13Ast__binary_tN14K_form__atom_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               _fx_g19K_normalize__OpCons, &a1_1, &a2_1, &kctx_0, &v_50), _fx_catch_15);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_50, code_10, fx_result);
+               _fx_g19K_normalize__OpCons, &a1_1, &a2_1, &kctx_0, &v_52), _fx_catch_15);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_52, code_10, fx_result);
 
       _fx_catch_15: ;
-         if (v_50) {
-            _fx_free_N14K_form__kexp_t(&v_50);
+         if (v_52) {
+            _fx_free_N14K_form__kexp_t(&v_52);
          }
          if (code_10) {
             _fx_free_LN14K_form__kexp_t(&code_10);
          }
          _fx_free_N14K_form__atom_t(&a2_1);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_49);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_51);
          if (code_9) {
             _fx_free_LN14K_form__kexp_t(&code_9);
          }
          _fx_free_N14K_form__atom_t(&a1_1);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_48);
-         goto _fx_endmatch_14;
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_50);
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 8) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_51 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_53 = {0};
       _fx_N14K_form__atom_t a1_2 = {0};
       _fx_LN14K_form__kexp_t code_11 = 0;
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_52 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_54 = {0};
       _fx_N14K_form__atom_t a2_2 = {0};
       _fx_LN14K_form__kexp_t code_12 = 0;
-      _fx_N14K_form__ktyp_t v_53 = 0;
-      _fx_N14K_form__ktyp_t v_54 = 0;
+      _fx_N14K_form__ktyp_t v_55 = 0;
+      _fx_N14K_form__ktyp_t v_56 = 0;
       _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_5 = &e_0->u.ExpBinary;
       _fx_N13Ast__binary_t bop_0 = vcase_5->t0;
       FX_CALL(
          _fx_M11K_normalizeFM18arithm_subexp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_5->t1, code_0, false, sc_0, &v_51, 0), _fx_catch_18);
-      _fx_copy_N14K_form__atom_t(&v_51.t0, &a1_2);
-      FX_COPY_PTR(v_51.t1, &code_11);
+            vcase_5->t1, code_0, false, sc_0, &v_53, 0), _fx_catch_18);
+      _fx_copy_N14K_form__atom_t(&v_53.t0, &a1_2);
+      FX_COPY_PTR(v_53.t1, &code_11);
       FX_CALL(
          _fx_M11K_normalizeFM18arithm_subexp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_5->t2, code_11, false, sc_0, &v_52, 0), _fx_catch_18);
-      _fx_copy_N14K_form__atom_t(&v_52.t0, &a2_2);
-      FX_COPY_PTR(v_52.t1, &code_12);
-      FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a1_2, &eloc_0, &v_53, 0),
+            vcase_5->t2, code_11, false, sc_0, &v_54, 0), _fx_catch_18);
+      _fx_copy_N14K_form__atom_t(&v_54.t0, &a2_2);
+      FX_COPY_PTR(v_54.t1, &code_12);
+      FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a1_2, &eloc_0, &v_55, 0),
          _fx_catch_18);
-      FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a2_2, &eloc_0, &v_54, 0),
+      FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a2_2, &eloc_0, &v_56, 0),
          _fx_catch_18);
       bool res_2;
       if (FX_REC_VARIANT_TAG(bop_0) == 1) {
-         if (FX_REC_VARIANT_TAG(v_53) == 10) {
-            if (FX_REC_VARIANT_TAG(v_54) == 10) {
+         if (FX_REC_VARIANT_TAG(v_55) == 10) {
+            if (FX_REC_VARIANT_TAG(v_56) == 10) {
                res_2 = true; goto _fx_endmatch_1;
             }
          }
       }
       if (FX_REC_VARIANT_TAG(bop_0) == 1) {
-         if (FX_REC_VARIANT_TAG(v_53) == 9) {
-            if (FX_REC_VARIANT_TAG(v_54) == 10) {
+         if (FX_REC_VARIANT_TAG(v_55) == 9) {
+            if (FX_REC_VARIANT_TAG(v_56) == 10) {
                res_2 = true; goto _fx_endmatch_1;
             }
          }
       }
       if (FX_REC_VARIANT_TAG(bop_0) == 1) {
-         if (FX_REC_VARIANT_TAG(v_53) == 10) {
-            if (FX_REC_VARIANT_TAG(v_54) == 9) {
+         if (FX_REC_VARIANT_TAG(v_55) == 10) {
+            if (FX_REC_VARIANT_TAG(v_56) == 9) {
                res_2 = true; goto _fx_endmatch_1;
             }
          }
@@ -11505,173 +11508,173 @@ FX_EXTERN_C int
    _fx_endmatch_1: ;
       FX_CHECK_EXN(_fx_catch_18);
       if (res_2) {
-         _fx_LN14K_form__atom_t v_55 = 0;
-         _fx_N14K_form__kexp_t v_56 = 0;
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&a2_2, 0, true, &v_55), _fx_catch_16);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&a1_2, v_55, false, &v_55), _fx_catch_16);
+         _fx_LN14K_form__atom_t v_57 = 0;
+         _fx_N14K_form__kexp_t v_58 = 0;
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&a2_2, 0, true, &v_57), _fx_catch_16);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&a1_2, v_57, false, &v_57), _fx_catch_16);
          FX_CALL(
             _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               &_fx_g28K_normalize__IntrinStrConcat, v_55, &kctx_0, &v_56), _fx_catch_16);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_56, code_12, fx_result);
+               &_fx_g28K_normalize__IntrinStrConcat, v_57, &kctx_0, &v_58), _fx_catch_16);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_58, code_12, fx_result);
 
       _fx_catch_16: ;
-         if (v_56) {
-            _fx_free_N14K_form__kexp_t(&v_56);
+         if (v_58) {
+            _fx_free_N14K_form__kexp_t(&v_58);
          }
-         if (v_55) {
-            _fx_free_LN14K_form__atom_t(&v_55);
+         if (v_57) {
+            _fx_free_LN14K_form__atom_t(&v_57);
          }
          goto _fx_endmatch_2;
       }
-      _fx_N14K_form__kexp_t v_57 = 0;
+      _fx_N14K_form__kexp_t v_59 = 0;
       FX_CALL(
          _fx_M6K_formFM10KExpBinaryN14K_form__kexp_t4N13Ast__binary_tN14K_form__atom_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            bop_0, &a1_2, &a2_2, &kctx_0, &v_57), _fx_catch_17);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_57, code_12, fx_result);
+            bop_0, &a1_2, &a2_2, &kctx_0, &v_59), _fx_catch_17);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_59, code_12, fx_result);
 
    _fx_catch_17: ;
-      if (v_57) {
-         _fx_free_N14K_form__kexp_t(&v_57);
+      if (v_59) {
+         _fx_free_N14K_form__kexp_t(&v_59);
       }
 
    _fx_endmatch_2: ;
       FX_CHECK_EXN(_fx_catch_18);
 
    _fx_catch_18: ;
-      if (v_54) {
-         _fx_free_N14K_form__ktyp_t(&v_54);
+      if (v_56) {
+         _fx_free_N14K_form__ktyp_t(&v_56);
       }
-      if (v_53) {
-         _fx_free_N14K_form__ktyp_t(&v_53);
+      if (v_55) {
+         _fx_free_N14K_form__ktyp_t(&v_55);
       }
       if (code_12) {
          _fx_free_LN14K_form__kexp_t(&code_12);
       }
       _fx_free_N14K_form__atom_t(&a2_2);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_52);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_54);
       if (code_11) {
          _fx_free_LN14K_form__kexp_t(&code_11);
       }
       _fx_free_N14K_form__atom_t(&a1_2);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_51);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_53);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 9) {
       _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_6 = &e_0->u.ExpUnary;
       if (vcase_6->t0.tag == 7) {
-         _fx_T2R9Ast__id_tLN14K_form__kexp_t v_58 = {0};
+         _fx_T2R9Ast__id_tLN14K_form__kexp_t v_60 = {0};
          _fx_LN14K_form__kexp_t code_13 = 0;
-         _fx_N14K_form__atom_t v_59 = {0};
-         _fx_N14K_form__kexp_t v_60 = 0;
+         _fx_N14K_form__atom_t v_61 = {0};
+         _fx_N14K_form__kexp_t v_62 = 0;
          fx_str_t slit_1 = FX_MAKE_STR("a literal cannot be dereferenced");
          FX_CALL(
             _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(
-               vcase_6->t1, code_0, false, sc_0, &slit_1, &v_58, 0), _fx_catch_19);
-         _fx_R9Ast__id_t a_id_0 = v_58.t0;
-         FX_COPY_PTR(v_58.t1, &code_13);
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_0, &v_59);
+               vcase_6->t1, code_0, false, sc_0, &slit_1, &v_60, 0), _fx_catch_19);
+         _fx_R9Ast__id_t a_id_0 = v_60.t0;
+         FX_COPY_PTR(v_60.t1, &code_13);
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_0, &v_61);
          FX_CALL(
             _fx_M6K_formFM9KExpUnaryN14K_form__kexp_t3N12Ast__unary_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               &_fx_g20K_normalize__OpDeref, &v_59, &kctx_0, &v_60), _fx_catch_19);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_60, code_13, fx_result);
+               &_fx_g20K_normalize__OpDeref, &v_61, &kctx_0, &v_62), _fx_catch_19);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_62, code_13, fx_result);
 
       _fx_catch_19: ;
-         if (v_60) {
-            _fx_free_N14K_form__kexp_t(&v_60);
+         if (v_62) {
+            _fx_free_N14K_form__kexp_t(&v_62);
          }
-         _fx_free_N14K_form__atom_t(&v_59);
+         _fx_free_N14K_form__atom_t(&v_61);
          if (code_13) {
             _fx_free_LN14K_form__kexp_t(&code_13);
          }
-         _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_58);
-         goto _fx_endmatch_14;
+         _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_60);
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 9) {
       _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_7 = &e_0->u.ExpUnary;
       if (vcase_7->t0.tag == 3) {
          _fx_LT2N14K_form__atom_ti idx_access_stack_0 = 0;
-         _fx_T2N14K_form__atom_ti v_61 = {0};
+         _fx_T2N14K_form__atom_ti v_63 = {0};
          _fx_N14K_form__atom_t arr_0 = {0};
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_62 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_64 = {0};
          _fx_N14K_form__atom_t a_1 = {0};
          _fx_LN14K_form__kexp_t code_14 = 0;
          _fx_LN14K_form__atom_t args_0 = 0;
-         _fx_N14K_form__klit_t v_63 = {0};
-         _fx_N14K_form__atom_t v_64 = {0};
-         _fx_LN14K_form__atom_t v_65 = 0;
-         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_66 = {0};
-         _fx_N14K_form__kexp_t v_67 = 0;
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_68 = {0};
+         _fx_N14K_form__klit_t v_65 = {0};
+         _fx_N14K_form__atom_t v_66 = {0};
+         _fx_LN14K_form__atom_t v_67 = 0;
+         _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_68 = {0};
+         _fx_N14K_form__kexp_t v_69 = 0;
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_70 = {0};
          _fx_N14K_form__atom_t sz_0 = {0};
          _fx_LN14K_form__kexp_t code_15 = 0;
-         _fx_N14K_form__kexp_t v_69 = 0;
+         _fx_N14K_form__kexp_t v_71 = 0;
          FX_COPY_PTR(_fx_g29K_normalize__idx_access_stack, &idx_access_stack_0);
          if (idx_access_stack_0 != 0) {
-            _fx_T2N14K_form__atom_ti* v_70 = &idx_access_stack_0->hd; _fx_make_T2N14K_form__atom_ti(&v_70->t0, v_70->t1, &v_61);
+            _fx_T2N14K_form__atom_ti* v_72 = &idx_access_stack_0->hd; _fx_make_T2N14K_form__atom_ti(&v_72->t0, v_72->t1, &v_63);
          }
          else {
-            fx_exn_t v_71 = {0};
+            fx_exn_t v_73 = {0};
             fx_str_t slit_2 =
                FX_MAKE_STR(".- is only allowed inside array access op. .- inside of tuple indexes is not supported too.");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_2, &v_71, 0), _fx_catch_20);
-            FX_THROW(&v_71, false, _fx_catch_20);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_2, &v_73, 0), _fx_catch_20);
+            FX_THROW(&v_73, false, _fx_catch_20);
 
          _fx_catch_20: ;
-            fx_free_exn(&v_71);
+            fx_free_exn(&v_73);
          }
          FX_CHECK_EXN(_fx_catch_21);
-         _fx_copy_N14K_form__atom_t(&v_61.t0, &arr_0);
-         int_ idx_i_0 = v_61.t1;
+         _fx_copy_N14K_form__atom_t(&v_63.t0, &arr_0);
+         int_ idx_i_0 = v_63.t1;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               vcase_7->t1, code_0, false, sc_0, &v_62, 0), _fx_catch_21);
-         _fx_copy_N14K_form__atom_t(&v_62.t0, &a_1);
-         FX_COPY_PTR(v_62.t1, &code_14);
+               vcase_7->t1, code_0, false, sc_0, &v_64, 0), _fx_catch_21);
+         _fx_copy_N14K_form__atom_t(&v_64.t0, &a_1);
+         FX_COPY_PTR(v_64.t1, &code_14);
          if (idx_i_0 == 0) {
             FX_CALL(_fx_cons_LN14K_form__atom_t(&arr_0, 0, true, &args_0), _fx_catch_21);
          }
          else {
             int64_t res_3;
             FX_CALL(_fx_M11K_normalizeFM5int64l1i(idx_i_0, &res_3, 0), _fx_catch_21);
-            _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(res_3, &v_63);
-            _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_63, &v_64);
-            FX_CALL(_fx_cons_LN14K_form__atom_t(&v_64, 0, true, &v_65), _fx_catch_21);
-            FX_CALL(_fx_cons_LN14K_form__atom_t(&arr_0, v_65, true, &args_0), _fx_catch_21);
+            _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(res_3, &v_65);
+            _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_65, &v_66);
+            FX_CALL(_fx_cons_LN14K_form__atom_t(&v_66, 0, true, &v_67), _fx_catch_21);
+            FX_CALL(_fx_cons_LN14K_form__atom_t(&arr_0, v_67, true, &args_0), _fx_catch_21);
          }
-         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g20K_normalize__KTypInt, &eloc_0, &v_66);
+         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g20K_normalize__KTypInt, &eloc_0, &v_68);
          FX_CALL(
             _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               &_fx_g26K_normalize__IntrinGetSize, args_0, &v_66, &v_67), _fx_catch_21);
+               &_fx_g26K_normalize__IntrinGetSize, args_0, &v_68, &v_69), _fx_catch_21);
          fx_str_t slit_3 = FX_MAKE_STR("sz");
          FX_CALL(
             _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iSN14K_form__kexp_tBLN14K_form__kexp_t(km_idx_0,
-               &slit_3, v_67, false, code_14, &v_68, 0), _fx_catch_21);
-         _fx_copy_N14K_form__atom_t(&v_68.t0, &sz_0);
-         FX_COPY_PTR(v_68.t1, &code_15);
+               &slit_3, v_69, false, code_14, &v_70, 0), _fx_catch_21);
+         _fx_copy_N14K_form__atom_t(&v_70.t0, &sz_0);
+         FX_COPY_PTR(v_70.t1, &code_15);
          FX_CALL(
             _fx_M6K_formFM10KExpBinaryN14K_form__kexp_t4N13Ast__binary_tN14K_form__atom_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-               _fx_g18K_normalize__OpSub, &sz_0, &a_1, &kctx_0, &v_69), _fx_catch_21);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_69, code_15, fx_result);
+               _fx_g18K_normalize__OpSub, &sz_0, &a_1, &kctx_0, &v_71), _fx_catch_21);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_71, code_15, fx_result);
 
       _fx_catch_21: ;
-         if (v_69) {
-            _fx_free_N14K_form__kexp_t(&v_69);
+         if (v_71) {
+            _fx_free_N14K_form__kexp_t(&v_71);
          }
          if (code_15) {
             _fx_free_LN14K_form__kexp_t(&code_15);
          }
          _fx_free_N14K_form__atom_t(&sz_0);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_68);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_70);
+         if (v_69) {
+            _fx_free_N14K_form__kexp_t(&v_69);
+         }
+         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_68);
          if (v_67) {
-            _fx_free_N14K_form__kexp_t(&v_67);
+            _fx_free_LN14K_form__atom_t(&v_67);
          }
-         _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_66);
-         if (v_65) {
-            _fx_free_LN14K_form__atom_t(&v_65);
-         }
-         _fx_free_N14K_form__atom_t(&v_64);
-         _fx_free_N14K_form__klit_t(&v_63);
+         _fx_free_N14K_form__atom_t(&v_66);
+         _fx_free_N14K_form__klit_t(&v_65);
          if (args_0) {
             _fx_free_LN14K_form__atom_t(&args_0);
          }
@@ -11679,20 +11682,20 @@ FX_EXTERN_C int
             _fx_free_LN14K_form__kexp_t(&code_14);
          }
          _fx_free_N14K_form__atom_t(&a_1);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_62);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_64);
          _fx_free_N14K_form__atom_t(&arr_0);
-         _fx_free_T2N14K_form__atom_ti(&v_61);
+         _fx_free_T2N14K_form__atom_ti(&v_63);
          if (idx_access_stack_0) {
             _fx_free_LT2N14K_form__atom_ti(&idx_access_stack_0);
          }
-         goto _fx_endmatch_14;
+         goto _fx_endmatch_17;
       }
    }
    if (tag_0 == 9) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_72 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_74 = {0};
       _fx_N14K_form__atom_t a1_3 = {0};
       _fx_LN14K_form__kexp_t code_16 = 0;
-      _fx_N14K_form__kexp_t v_73 = 0;
+      _fx_N14K_form__kexp_t v_75 = 0;
       _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_8 = &e_0->u.ExpUnary;
       _fx_N10Ast__exp_t e1_2 = vcase_8->t1;
       _fx_N12Ast__unary_t* uop_0 = &vcase_8->t0;
@@ -11711,87 +11714,87 @@ FX_EXTERN_C int
       if (res_4) {
          FX_CALL(
             _fx_M11K_normalizeFM18arithm_subexp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e1_2, code_0, false, sc_0, &v_72, 0), _fx_catch_22);
+               e1_2, code_0, false, sc_0, &v_74, 0), _fx_catch_22);
 
       _fx_catch_22: ;
          goto _fx_endmatch_3;
       }
       FX_CALL(
          _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e1_2, code_0, false, sc_0, &v_72, 0), _fx_catch_23);
+            e1_2, code_0, false, sc_0, &v_74, 0), _fx_catch_23);
 
    _fx_catch_23: ;
 
    _fx_endmatch_3: ;
       FX_CHECK_EXN(_fx_catch_24);
-      _fx_copy_N14K_form__atom_t(&v_72.t0, &a1_3);
-      FX_COPY_PTR(v_72.t1, &code_16);
+      _fx_copy_N14K_form__atom_t(&v_74.t0, &a1_3);
+      FX_COPY_PTR(v_74.t1, &code_16);
       FX_CALL(
          _fx_M6K_formFM9KExpUnaryN14K_form__kexp_t3N12Ast__unary_tN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(uop_0,
-            &a1_3, &kctx_0, &v_73), _fx_catch_24);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_73, code_16, fx_result);
+            &a1_3, &kctx_0, &v_75), _fx_catch_24);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_75, code_16, fx_result);
 
    _fx_catch_24: ;
-      if (v_73) {
-         _fx_free_N14K_form__kexp_t(&v_73);
+      if (v_75) {
+         _fx_free_N14K_form__kexp_t(&v_75);
       }
       if (code_16) {
          _fx_free_LN14K_form__kexp_t(&code_16);
       }
       _fx_free_N14K_form__atom_t(&a1_3);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_72);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_74);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 10) {
       _fx_LN14K_form__atom_t res_5 = 0;
       _fx_LN14K_form__kexp_t code_17 = 0;
       _fx_LN10Ast__exp_t args_1 = 0;
-      _fx_LN14K_form__atom_t v_74 = 0;
-      _fx_N14K_form__kexp_t v_75 = 0;
+      _fx_LN14K_form__atom_t v_76 = 0;
+      _fx_N14K_form__kexp_t v_77 = 0;
       _fx_T3N13Ast__intrin_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_9 = &e_0->u.ExpIntrin;
       FX_COPY_PTR(code_0, &code_17);
       FX_COPY_PTR(vcase_9->t1, &args_1);
       _fx_LN10Ast__exp_t lst_1 = args_1;
       for (; lst_1; lst_1 = lst_1->tl) {
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_76 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_78 = {0};
          _fx_N14K_form__atom_t ai_0 = {0};
          _fx_LN14K_form__kexp_t code1_0 = 0;
-         _fx_LN14K_form__atom_t v_77 = 0;
+         _fx_LN14K_form__atom_t v_79 = 0;
          _fx_N10Ast__exp_t ei_0 = lst_1->hd;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               ei_0, code_17, false, sc_0, &v_76, 0), _fx_catch_25);
-         _fx_copy_N14K_form__atom_t(&v_76.t0, &ai_0);
-         FX_COPY_PTR(v_76.t1, &code1_0);
+               ei_0, code_17, false, sc_0, &v_78, 0), _fx_catch_25);
+         _fx_copy_N14K_form__atom_t(&v_78.t0, &ai_0);
+         FX_COPY_PTR(v_78.t1, &code1_0);
          _fx_free_LN14K_form__kexp_t(&code_17);
          FX_COPY_PTR(code1_0, &code_17);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_0, res_5, true, &v_77), _fx_catch_25);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_0, res_5, true, &v_79), _fx_catch_25);
          _fx_free_LN14K_form__atom_t(&res_5);
-         FX_COPY_PTR(v_77, &res_5);
+         FX_COPY_PTR(v_79, &res_5);
 
       _fx_catch_25: ;
-         if (v_77) {
-            _fx_free_LN14K_form__atom_t(&v_77);
+         if (v_79) {
+            _fx_free_LN14K_form__atom_t(&v_79);
          }
          if (code1_0) {
             _fx_free_LN14K_form__kexp_t(&code1_0);
          }
          _fx_free_N14K_form__atom_t(&ai_0);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_76);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_78);
          FX_CHECK_EXN(_fx_catch_26);
       }
-      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_5, &v_74, 0), _fx_catch_26);
+      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_5, &v_76, 0), _fx_catch_26);
       FX_CALL(
          _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            &vcase_9->t0, v_74, &kctx_0, &v_75), _fx_catch_26);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_75, code_17, fx_result);
+            &vcase_9->t0, v_76, &kctx_0, &v_77), _fx_catch_26);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_77, code_17, fx_result);
 
    _fx_catch_26: ;
-      if (v_75) {
-         _fx_free_N14K_form__kexp_t(&v_75);
+      if (v_77) {
+         _fx_free_N14K_form__kexp_t(&v_77);
       }
-      if (v_74) {
-         _fx_free_LN14K_form__atom_t(&v_74);
+      if (v_76) {
+         _fx_free_LN14K_form__atom_t(&v_76);
       }
       if (args_1) {
          _fx_free_LN10Ast__exp_t(&args_1);
@@ -11802,35 +11805,35 @@ FX_EXTERN_C int
       if (res_5) {
          _fx_free_LN14K_form__atom_t(&res_5);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 12) {
       _fx_LN12Ast__scope_t sc_1 = 0;
       _fx_LN14K_form__kexp_t code_18 = 0;
-      _fx_T2LN14K_form__kexp_tLT2SR10Ast__loc_t v_78 = {0};
+      _fx_T2LN14K_form__kexp_tLT2SR10Ast__loc_t v_80 = {0};
       _fx_LN14K_form__kexp_t code_19 = 0;
       _fx_LN10Ast__exp_t eseq_0 = e_0->u.ExpSeq.t0;
-      _fx_N12Ast__scope_t v_79;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_79, 0), _fx_catch_28);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_79, sc_0, true, &sc_1), _fx_catch_28);
+      _fx_N12Ast__scope_t v_81;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_81, 0), _fx_catch_28);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_81, sc_0, true, &sc_1), _fx_catch_28);
       FX_CALL(
          _fx_M11K_normalizeFM28transform_all_types_and_consLN14K_form__kexp_t3LN10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_t(
             eseq_0, code_0, sc_1, &code_18, 0), _fx_catch_28);
       FX_CALL(
          _fx_M11K_normalizeFM9eseq2codeT2LN14K_form__kexp_tLT2SR10Ast__loc_t3LN10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_t(
-            eseq_0, code_18, sc_1, &v_78, 0), _fx_catch_28);
-      FX_COPY_PTR(v_78.t0, &code_19);
+            eseq_0, code_18, sc_1, &v_80, 0), _fx_catch_28);
+      FX_COPY_PTR(v_80.t0, &code_19);
       if (code_19 != 0) {
          _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(code_19->hd, code_19->tl, fx_result);
       }
       else {
-         _fx_N14K_form__kexp_t v_80 = 0;
-         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_80), _fx_catch_27);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_80, code_19, fx_result);
+         _fx_N14K_form__kexp_t v_82 = 0;
+         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_82), _fx_catch_27);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_82, code_19, fx_result);
 
       _fx_catch_27: ;
-         if (v_80) {
-            _fx_free_N14K_form__kexp_t(&v_80);
+         if (v_82) {
+            _fx_free_N14K_form__kexp_t(&v_82);
          }
       }
       FX_CHECK_EXN(_fx_catch_28);
@@ -11839,43 +11842,43 @@ FX_EXTERN_C int
       if (code_19) {
          _fx_free_LN14K_form__kexp_t(&code_19);
       }
-      _fx_free_T2LN14K_form__kexp_tLT2SR10Ast__loc_t(&v_78);
+      _fx_free_T2LN14K_form__kexp_tLT2SR10Ast__loc_t(&v_80);
       if (code_18) {
          _fx_free_LN14K_form__kexp_t(&code_18);
       }
       FX_FREE_LIST_SIMPLE(&sc_1);
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 11) {
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_81 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_83 = {0};
       _fx_N14K_form__kexp_t e_1 = 0;
       _fx_LN14K_form__kexp_t code1_1 = 0;
-      _fx_LN14K_form__kexp_t v_82 = 0;
-      _fx_N14K_form__kexp_t v_83 = 0;
-      _fx_N14K_form__kexp_t v_84 = 0;
+      _fx_LN14K_form__kexp_t v_84 = 0;
+      _fx_N14K_form__kexp_t v_85 = 0;
+      _fx_N14K_form__kexp_t v_86 = 0;
       _fx_T2R9Ast__id_tN10Ast__exp_t* vcase_10 = &e_0->u.ExpSync;
       _fx_N10Ast__exp_t e0_0 = vcase_10->t1;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e0_0, 0, false, sc_0, &v_81, 0), _fx_catch_29);
-      FX_COPY_PTR(v_81.t0, &e_1);
-      FX_COPY_PTR(v_81.t1, &code1_1);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e_1, code1_1, true, &v_82), _fx_catch_29);
-      _fx_R10Ast__loc_t v_85;
-      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e0_0, &v_85, 0), _fx_catch_29);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_82, &v_85, &v_83, 0), _fx_catch_29);
-      FX_CALL(_fx_M6K_formFM8KExpSyncN14K_form__kexp_t2R9Ast__id_tN14K_form__kexp_t(&vcase_10->t0, v_83, &v_84), _fx_catch_29);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_84, code_0, fx_result);
+            e0_0, 0, false, sc_0, &v_83, 0), _fx_catch_29);
+      FX_COPY_PTR(v_83.t0, &e_1);
+      FX_COPY_PTR(v_83.t1, &code1_1);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e_1, code1_1, true, &v_84), _fx_catch_29);
+      _fx_R10Ast__loc_t v_87;
+      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e0_0, &v_87, 0), _fx_catch_29);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_84, &v_87, &v_85, 0), _fx_catch_29);
+      FX_CALL(_fx_M6K_formFM8KExpSyncN14K_form__kexp_t2R9Ast__id_tN14K_form__kexp_t(&vcase_10->t0, v_85, &v_86), _fx_catch_29);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_86, code_0, fx_result);
 
    _fx_catch_29: ;
+      if (v_86) {
+         _fx_free_N14K_form__kexp_t(&v_86);
+      }
+      if (v_85) {
+         _fx_free_N14K_form__kexp_t(&v_85);
+      }
       if (v_84) {
-         _fx_free_N14K_form__kexp_t(&v_84);
-      }
-      if (v_83) {
-         _fx_free_N14K_form__kexp_t(&v_83);
-      }
-      if (v_82) {
-         _fx_free_LN14K_form__kexp_t(&v_82);
+         _fx_free_LN14K_form__kexp_t(&v_84);
       }
       if (code1_1) {
          _fx_free_LN14K_form__kexp_t(&code1_1);
@@ -11883,58 +11886,58 @@ FX_EXTERN_C int
       if (e_1) {
          _fx_free_N14K_form__kexp_t(&e_1);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_81);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_83);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 13) {
       _fx_LN14K_form__atom_t res_6 = 0;
       _fx_LN14K_form__kexp_t code_20 = 0;
       _fx_LN10Ast__exp_t args_2 = 0;
-      _fx_LN14K_form__atom_t v_86 = 0;
-      _fx_N14K_form__kexp_t v_87 = 0;
+      _fx_LN14K_form__atom_t v_88 = 0;
+      _fx_N14K_form__kexp_t v_89 = 0;
       FX_COPY_PTR(code_0, &code_20);
       FX_COPY_PTR(e_0->u.ExpMkTuple.t0, &args_2);
       _fx_LN10Ast__exp_t lst_2 = args_2;
       for (; lst_2; lst_2 = lst_2->tl) {
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_88 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_90 = {0};
          _fx_N14K_form__atom_t ai_1 = {0};
          _fx_LN14K_form__kexp_t code1_2 = 0;
-         _fx_LN14K_form__atom_t v_89 = 0;
+         _fx_LN14K_form__atom_t v_91 = 0;
          _fx_N10Ast__exp_t ei_1 = lst_2->hd;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               ei_1, code_20, false, sc_0, &v_88, 0), _fx_catch_30);
-         _fx_copy_N14K_form__atom_t(&v_88.t0, &ai_1);
-         FX_COPY_PTR(v_88.t1, &code1_2);
+               ei_1, code_20, false, sc_0, &v_90, 0), _fx_catch_30);
+         _fx_copy_N14K_form__atom_t(&v_90.t0, &ai_1);
+         FX_COPY_PTR(v_90.t1, &code1_2);
          _fx_free_LN14K_form__kexp_t(&code_20);
          FX_COPY_PTR(code1_2, &code_20);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_1, res_6, true, &v_89), _fx_catch_30);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_1, res_6, true, &v_91), _fx_catch_30);
          _fx_free_LN14K_form__atom_t(&res_6);
-         FX_COPY_PTR(v_89, &res_6);
+         FX_COPY_PTR(v_91, &res_6);
 
       _fx_catch_30: ;
-         if (v_89) {
-            _fx_free_LN14K_form__atom_t(&v_89);
+         if (v_91) {
+            _fx_free_LN14K_form__atom_t(&v_91);
          }
          if (code1_2) {
             _fx_free_LN14K_form__kexp_t(&code1_2);
          }
          _fx_free_N14K_form__atom_t(&ai_1);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_88);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_90);
          FX_CHECK_EXN(_fx_catch_31);
       }
-      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_6, &v_86, 0), _fx_catch_31);
+      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_6, &v_88, 0), _fx_catch_31);
       FX_CALL(
-         _fx_M6K_formFM11KExpMkTupleN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_86, &kctx_0, &v_87),
+         _fx_M6K_formFM11KExpMkTupleN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_88, &kctx_0, &v_89),
          _fx_catch_31);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_87, code_20, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_89, code_20, fx_result);
 
    _fx_catch_31: ;
-      if (v_87) {
-         _fx_free_N14K_form__kexp_t(&v_87);
+      if (v_89) {
+         _fx_free_N14K_form__kexp_t(&v_89);
       }
-      if (v_86) {
-         _fx_free_LN14K_form__atom_t(&v_86);
+      if (v_88) {
+         _fx_free_LN14K_form__atom_t(&v_88);
       }
       if (args_2) {
          _fx_free_LN10Ast__exp_t(&args_2);
@@ -11945,20 +11948,20 @@ FX_EXTERN_C int
       if (res_6) {
          _fx_free_LN14K_form__atom_t(&res_6);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 14) {
-      fx_exn_t v_90 = {0};
+      fx_exn_t v_92 = {0};
       _fx_LLT2BN14K_form__atom_t krows_0 = 0;
       _fx_LN14K_form__kexp_t code_21 = 0;
       _fx_LLN10Ast__exp_t arows_0 = 0;
-      _fx_LLT2BN14K_form__atom_t v_91 = 0;
-      _fx_N14K_form__kexp_t v_92 = 0;
+      _fx_LLT2BN14K_form__atom_t v_93 = 0;
+      _fx_N14K_form__kexp_t v_94 = 0;
       _fx_LLN10Ast__exp_t arows_1 = e_0->u.ExpMkArray.t0;
       if (arows_1 == 0) {
          fx_str_t slit_4 = FX_MAKE_STR("empty arrays are not supported");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_90, 0), _fx_catch_34);
-         FX_THROW(&v_90, false, _fx_catch_34);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_92, 0), _fx_catch_34);
+         FX_THROW(&v_92, false, _fx_catch_34);
       }
       FX_COPY_PTR(code_0, &code_21);
       bool all_literals_0 = true;
@@ -11966,36 +11969,36 @@ FX_EXTERN_C int
       _fx_LLN10Ast__exp_t lst_3 = arows_0;
       for (; lst_3; lst_3 = lst_3->tl) {
          _fx_LT2BN14K_form__atom_t krow_0 = 0;
-         _fx_LT2BN14K_form__atom_t v_93 = 0;
-         _fx_LLT2BN14K_form__atom_t v_94 = 0;
+         _fx_LT2BN14K_form__atom_t v_95 = 0;
+         _fx_LLT2BN14K_form__atom_t v_96 = 0;
          _fx_LN10Ast__exp_t arow_0 = lst_3->hd;
          _fx_LN10Ast__exp_t lst_4 = arow_0;
          for (; lst_4; lst_4 = lst_4->tl) {
-            _fx_T3BN10Ast__exp_tB v_95 = {0};
+            _fx_T3BN10Ast__exp_tB v_97 = {0};
             _fx_N10Ast__exp_t e_2 = 0;
-            _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_96 = {0};
+            _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_98 = {0};
             _fx_N14K_form__atom_t a_2 = {0};
             _fx_LN14K_form__kexp_t code1_3 = 0;
-            _fx_T2BN14K_form__atom_t v_97 = {0};
-            _fx_LT2BN14K_form__atom_t v_98 = 0;
+            _fx_T2BN14K_form__atom_t v_99 = {0};
+            _fx_LT2BN14K_form__atom_t v_100 = 0;
             _fx_N10Ast__exp_t e_3 = lst_4->hd;
             int tag_3 = FX_REC_VARIANT_TAG(e_3);
             if (tag_3 == 9) {
                _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_11 = &e_3->u.ExpUnary;
                if (vcase_11->t0.tag == 8) {
-                  _fx_make_T3BN10Ast__exp_tB(true, vcase_11->t1, false, &v_95); goto _fx_endmatch_4;
+                  _fx_make_T3BN10Ast__exp_tB(true, vcase_11->t1, false, &v_97); goto _fx_endmatch_4;
                }
             }
             if (tag_3 == 6) {
-               _fx_N10Ast__lit_t* v_99 = &e_3->u.ExpLit.t0;
+               _fx_N10Ast__lit_t* v_101 = &e_3->u.ExpLit.t0;
                bool res_7;
-               if (v_99->tag == 5) {
+               if (v_101->tag == 5) {
                   res_7 = true;
                }
-               else if (v_99->tag == 9) {
+               else if (v_101->tag == 9) {
                   res_7 = true;
                }
-               else if (v_99->tag == 8) {
+               else if (v_101->tag == 8) {
                   res_7 = true;
                }
                else {
@@ -12003,77 +12006,77 @@ FX_EXTERN_C int
                }
                FX_CHECK_EXN(_fx_catch_32);
                if (res_7) {
-                  _fx_make_T3BN10Ast__exp_tB(false, e_3, false, &v_95); goto _fx_endmatch_4;
+                  _fx_make_T3BN10Ast__exp_tB(false, e_3, false, &v_97); goto _fx_endmatch_4;
                }
             }
             if (tag_3 == 6) {
-               _fx_make_T3BN10Ast__exp_tB(false, e_3, true, &v_95); goto _fx_endmatch_4;
+               _fx_make_T3BN10Ast__exp_tB(false, e_3, true, &v_97); goto _fx_endmatch_4;
             }
-            _fx_make_T3BN10Ast__exp_tB(false, e_3, false, &v_95);
+            _fx_make_T3BN10Ast__exp_tB(false, e_3, false, &v_97);
 
          _fx_endmatch_4: ;
             FX_CHECK_EXN(_fx_catch_32);
-            bool f_0 = v_95.t0;
-            FX_COPY_PTR(v_95.t1, &e_2);
-            bool islit_0 = v_95.t2;
+            bool f_0 = v_97.t0;
+            FX_COPY_PTR(v_97.t1, &e_2);
+            bool islit_0 = v_97.t2;
             FX_CALL(
                _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-                  e_2, code_21, false, sc_0, &v_96, 0), _fx_catch_32);
-            _fx_copy_N14K_form__atom_t(&v_96.t0, &a_2);
-            FX_COPY_PTR(v_96.t1, &code1_3);
+                  e_2, code_21, false, sc_0, &v_98, 0), _fx_catch_32);
+            _fx_copy_N14K_form__atom_t(&v_98.t0, &a_2);
+            FX_COPY_PTR(v_98.t1, &code1_3);
             _fx_free_LN14K_form__kexp_t(&code_21);
             FX_COPY_PTR(code1_3, &code_21);
-            _fx_make_T2BN14K_form__atom_t(f_0, &a_2, &v_97);
-            FX_CALL(_fx_cons_LT2BN14K_form__atom_t(&v_97, krow_0, true, &v_98), _fx_catch_32);
+            _fx_make_T2BN14K_form__atom_t(f_0, &a_2, &v_99);
+            FX_CALL(_fx_cons_LT2BN14K_form__atom_t(&v_99, krow_0, true, &v_100), _fx_catch_32);
             _fx_free_LT2BN14K_form__atom_t(&krow_0);
-            FX_COPY_PTR(v_98, &krow_0);
+            FX_COPY_PTR(v_100, &krow_0);
             all_literals_0 = (bool)(all_literals_0 & islit_0);
 
          _fx_catch_32: ;
-            if (v_98) {
-               _fx_free_LT2BN14K_form__atom_t(&v_98);
+            if (v_100) {
+               _fx_free_LT2BN14K_form__atom_t(&v_100);
             }
-            _fx_free_T2BN14K_form__atom_t(&v_97);
+            _fx_free_T2BN14K_form__atom_t(&v_99);
             if (code1_3) {
                _fx_free_LN14K_form__kexp_t(&code1_3);
             }
             _fx_free_N14K_form__atom_t(&a_2);
-            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_96);
+            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_98);
             if (e_2) {
                _fx_free_N10Ast__exp_t(&e_2);
             }
-            _fx_free_T3BN10Ast__exp_tB(&v_95);
+            _fx_free_T3BN10Ast__exp_tB(&v_97);
             FX_CHECK_EXN(_fx_catch_33);
          }
-         FX_CALL(_fx_M11K_normalizeFM3revLT2BN14K_form__atom_t1LT2BN14K_form__atom_t(krow_0, &v_93, 0), _fx_catch_33);
-         FX_CALL(_fx_cons_LLT2BN14K_form__atom_t(v_93, krows_0, true, &v_94), _fx_catch_33);
+         FX_CALL(_fx_M11K_normalizeFM3revLT2BN14K_form__atom_t1LT2BN14K_form__atom_t(krow_0, &v_95, 0), _fx_catch_33);
+         FX_CALL(_fx_cons_LLT2BN14K_form__atom_t(v_95, krows_0, true, &v_96), _fx_catch_33);
          _fx_free_LLT2BN14K_form__atom_t(&krows_0);
-         FX_COPY_PTR(v_94, &krows_0);
+         FX_COPY_PTR(v_96, &krows_0);
 
       _fx_catch_33: ;
-         if (v_94) {
-            _fx_free_LLT2BN14K_form__atom_t(&v_94);
+         if (v_96) {
+            _fx_free_LLT2BN14K_form__atom_t(&v_96);
          }
-         if (v_93) {
-            _fx_free_LT2BN14K_form__atom_t(&v_93);
+         if (v_95) {
+            _fx_free_LT2BN14K_form__atom_t(&v_95);
          }
          if (krow_0) {
             _fx_free_LT2BN14K_form__atom_t(&krow_0);
          }
          FX_CHECK_EXN(_fx_catch_34);
       }
-      FX_CALL(_fx_M11K_normalizeFM3revLLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(krows_0, &v_91, 0), _fx_catch_34);
+      FX_CALL(_fx_M11K_normalizeFM3revLLT2BN14K_form__atom_t1LLT2BN14K_form__atom_t(krows_0, &v_93, 0), _fx_catch_34);
       FX_CALL(
          _fx_M6K_formFM11KExpMkArrayN14K_form__kexp_t3BLLT2BN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(all_literals_0,
-            v_91, &kctx_0, &v_92), _fx_catch_34);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_92, code_21, fx_result);
+            v_93, &kctx_0, &v_94), _fx_catch_34);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_94, code_21, fx_result);
 
    _fx_catch_34: ;
-      if (v_92) {
-         _fx_free_N14K_form__kexp_t(&v_92);
+      if (v_94) {
+         _fx_free_N14K_form__kexp_t(&v_94);
       }
-      if (v_91) {
-         _fx_free_LLT2BN14K_form__atom_t(&v_91);
+      if (v_93) {
+         _fx_free_LLT2BN14K_form__atom_t(&v_93);
       }
       if (arows_0) {
          _fx_free_LLN10Ast__exp_t(&arows_0);
@@ -12084,86 +12087,86 @@ FX_EXTERN_C int
       if (krows_0) {
          _fx_free_LLT2BN14K_form__atom_t(&krows_0);
       }
-      fx_free_exn(&v_90);
-      goto _fx_endmatch_14;
+      fx_free_exn(&v_92);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 15) {
-      fx_exn_t v_100 = {0};
+      fx_exn_t v_102 = {0};
       _fx_LT2BN14K_form__atom_t res_8 = 0;
       _fx_LN14K_form__kexp_t code_22 = 0;
       _fx_LN10Ast__exp_t elems_0 = 0;
-      _fx_LT2BN14K_form__atom_t v_101 = 0;
-      _fx_N14K_form__kexp_t v_102 = 0;
+      _fx_LT2BN14K_form__atom_t v_103 = 0;
+      _fx_N14K_form__kexp_t v_104 = 0;
       _fx_LN10Ast__exp_t elems_1 = e_0->u.ExpMkVector.t0;
       if (elems_1 == 0) {
          fx_str_t slit_5 = FX_MAKE_STR("empty rrbvec literals are not supported");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_100, 0), _fx_catch_36);
-         FX_THROW(&v_100, false, _fx_catch_36);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_102, 0), _fx_catch_36);
+         FX_THROW(&v_102, false, _fx_catch_36);
       }
       FX_COPY_PTR(code_0, &code_22);
       FX_COPY_PTR(elems_1, &elems_0);
       _fx_LN10Ast__exp_t lst_5 = elems_0;
       for (; lst_5; lst_5 = lst_5->tl) {
-         _fx_T2BN10Ast__exp_t v_103 = {0};
+         _fx_T2BN10Ast__exp_t v_105 = {0};
          _fx_N10Ast__exp_t e_4 = 0;
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_104 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_106 = {0};
          _fx_N14K_form__atom_t a_3 = {0};
          _fx_LN14K_form__kexp_t code1_4 = 0;
-         _fx_T2BN14K_form__atom_t v_105 = {0};
-         _fx_LT2BN14K_form__atom_t v_106 = 0;
+         _fx_T2BN14K_form__atom_t v_107 = {0};
+         _fx_LT2BN14K_form__atom_t v_108 = 0;
          _fx_N10Ast__exp_t e_5 = lst_5->hd;
          if (FX_REC_VARIANT_TAG(e_5) == 9) {
             _fx_T3N12Ast__unary_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_12 = &e_5->u.ExpUnary;
             if (vcase_12->t0.tag == 8) {
-               _fx_make_T2BN10Ast__exp_t(true, vcase_12->t1, &v_103); goto _fx_endmatch_5;
+               _fx_make_T2BN10Ast__exp_t(true, vcase_12->t1, &v_105); goto _fx_endmatch_5;
             }
          }
-         _fx_make_T2BN10Ast__exp_t(false, e_5, &v_103);
+         _fx_make_T2BN10Ast__exp_t(false, e_5, &v_105);
 
       _fx_endmatch_5: ;
          FX_CHECK_EXN(_fx_catch_35);
-         bool f_1 = v_103.t0;
-         FX_COPY_PTR(v_103.t1, &e_4);
+         bool f_1 = v_105.t0;
+         FX_COPY_PTR(v_105.t1, &e_4);
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e_4, code_22, false, sc_0, &v_104, 0), _fx_catch_35);
-         _fx_copy_N14K_form__atom_t(&v_104.t0, &a_3);
-         FX_COPY_PTR(v_104.t1, &code1_4);
+               e_4, code_22, false, sc_0, &v_106, 0), _fx_catch_35);
+         _fx_copy_N14K_form__atom_t(&v_106.t0, &a_3);
+         FX_COPY_PTR(v_106.t1, &code1_4);
          _fx_free_LN14K_form__kexp_t(&code_22);
          FX_COPY_PTR(code1_4, &code_22);
-         _fx_make_T2BN14K_form__atom_t(f_1, &a_3, &v_105);
-         FX_CALL(_fx_cons_LT2BN14K_form__atom_t(&v_105, res_8, true, &v_106), _fx_catch_35);
+         _fx_make_T2BN14K_form__atom_t(f_1, &a_3, &v_107);
+         FX_CALL(_fx_cons_LT2BN14K_form__atom_t(&v_107, res_8, true, &v_108), _fx_catch_35);
          _fx_free_LT2BN14K_form__atom_t(&res_8);
-         FX_COPY_PTR(v_106, &res_8);
+         FX_COPY_PTR(v_108, &res_8);
 
       _fx_catch_35: ;
-         if (v_106) {
-            _fx_free_LT2BN14K_form__atom_t(&v_106);
+         if (v_108) {
+            _fx_free_LT2BN14K_form__atom_t(&v_108);
          }
-         _fx_free_T2BN14K_form__atom_t(&v_105);
+         _fx_free_T2BN14K_form__atom_t(&v_107);
          if (code1_4) {
             _fx_free_LN14K_form__kexp_t(&code1_4);
          }
          _fx_free_N14K_form__atom_t(&a_3);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_104);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_106);
          if (e_4) {
             _fx_free_N10Ast__exp_t(&e_4);
          }
-         _fx_free_T2BN10Ast__exp_t(&v_103);
+         _fx_free_T2BN10Ast__exp_t(&v_105);
          FX_CHECK_EXN(_fx_catch_36);
       }
-      FX_CALL(_fx_M11K_normalizeFM3revLT2BN14K_form__atom_t1LT2BN14K_form__atom_t(res_8, &v_101, 0), _fx_catch_36);
+      FX_CALL(_fx_M11K_normalizeFM3revLT2BN14K_form__atom_t1LT2BN14K_form__atom_t(res_8, &v_103, 0), _fx_catch_36);
       FX_CALL(
-         _fx_M6K_formFM12KExpMkVectorN14K_form__kexp_t2LT2BN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_101, &kctx_0,
-            &v_102), _fx_catch_36);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_102, code_22, fx_result);
+         _fx_M6K_formFM12KExpMkVectorN14K_form__kexp_t2LT2BN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_103, &kctx_0,
+            &v_104), _fx_catch_36);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_104, code_22, fx_result);
 
    _fx_catch_36: ;
-      if (v_102) {
-         _fx_free_N14K_form__kexp_t(&v_102);
+      if (v_104) {
+         _fx_free_N14K_form__kexp_t(&v_104);
       }
-      if (v_101) {
-         _fx_free_LT2BN14K_form__atom_t(&v_101);
+      if (v_103) {
+         _fx_free_LT2BN14K_form__atom_t(&v_103);
       }
       if (elems_0) {
          _fx_free_LN10Ast__exp_t(&elems_0);
@@ -12174,69 +12177,69 @@ FX_EXTERN_C int
       if (res_8) {
          _fx_free_LT2BN14K_form__atom_t(&res_8);
       }
-      fx_free_exn(&v_100);
-      goto _fx_endmatch_14;
+      fx_free_exn(&v_102);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 16) {
-      _fx_N10Ast__typ_t v_107 = 0;
-      _fx_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_108 = {0};
-      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_109 = {0};
+      _fx_N10Ast__typ_t v_109 = 0;
+      _fx_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_110 = {0};
+      _fx_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB v_111 = {0};
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_0 = 0;
       _fx_LN14K_form__atom_t ratoms_0 = 0;
       _fx_LN14K_form__kexp_t code_23 = 0;
-      _fx_LN14K_form__atom_t v_110 = 0;
-      _fx_N14K_form__kexp_t v_111 = 0;
       _fx_LN14K_form__atom_t v_112 = 0;
       _fx_N14K_form__kexp_t v_113 = 0;
+      _fx_LN14K_form__atom_t v_114 = 0;
+      _fx_N14K_form__kexp_t v_115 = 0;
       _fx_T3N10Ast__exp_tLT2R9Ast__id_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_13 = &e_0->u.ExpMkRecord;
       _fx_N10Ast__exp_t rn_0 = vcase_13->t0;
-      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_107, 0), _fx_catch_45);
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_109, 0), _fx_catch_45);
       if (FX_REC_VARIANT_TAG(rn_0) == 7) {
-         _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_114 = {0};
+         _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_116 = {0};
          _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_1 = 0;
          _fx_R9Ast__id_t* rn_id_0 = &rn_0->u.ExpIdent.t0;
-         _fx_Nt6option1R9Ast__id_t v_115;
-         _fx_M11K_normalizeFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(rn_id_0, &v_115);
+         _fx_Nt6option1R9Ast__id_t v_117;
+         _fx_M11K_normalizeFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(rn_id_0, &v_117);
          FX_CALL(
             _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-               &v_115, etyp_0, false, &eloc_0, &v_114, 0), _fx_catch_37);
-         _fx_R9Ast__id_t ctor_0 = v_114.t0;
-         FX_COPY_PTR(v_114.t1, &relems_1);
+               &v_117, etyp_0, false, &eloc_0, &v_116, 0), _fx_catch_37);
+         _fx_R9Ast__id_t ctor_0 = v_116.t0;
+         FX_COPY_PTR(v_116.t1, &relems_1);
          _fx_make_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(rn_id_0, &ctor_0,
-            relems_1, &v_108);
+            relems_1, &v_110);
 
       _fx_catch_37: ;
          if (relems_1) {
             _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_1);
          }
-         _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_114);
+         _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_116);
          goto _fx_endmatch_6;
       }
       if (FX_REC_VARIANT_TAG(rn_0) == 1) {
-         if (FX_REC_VARIANT_TAG(v_107) == 22) {
-            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_107->u.TypRecord->data, &v_109);
-            if (v_109.t1 == true) {
+         if (FX_REC_VARIANT_TAG(v_109) == 22) {
+            _fx_copy_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_109->u.TypRecord->data, &v_111);
+            if (v_111.t1 == true) {
                _fx_make_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&_fx_g9Ast__noid,
-                  &_fx_g9Ast__noid, v_109.t0, &v_108);
+                  &_fx_g9Ast__noid, v_111.t0, &v_110);
                goto _fx_endmatch_6;
             }
          }
       }
-      fx_exn_t v_116 = {0};
-      _fx_R10Ast__loc_t v_117;
-      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(rn_0, &v_117, 0), _fx_catch_38);
+      fx_exn_t v_118 = {0};
+      _fx_R10Ast__loc_t v_119;
+      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(rn_0, &v_119, 0), _fx_catch_38);
       fx_str_t slit_6 = FX_MAKE_STR("k-normalization: in the record construction identifier is expected after type check");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_117, &slit_6, &v_116, 0), _fx_catch_38);
-      FX_THROW(&v_116, false, _fx_catch_38);
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_119, &slit_6, &v_118, 0), _fx_catch_38);
+      FX_THROW(&v_118, false, _fx_catch_38);
 
    _fx_catch_38: ;
-      fx_free_exn(&v_116);
+      fx_free_exn(&v_118);
 
    _fx_endmatch_6: ;
       FX_CHECK_EXN(_fx_catch_45);
-      _fx_R9Ast__id_t rn_id_1 = v_108.t0;
-      _fx_R9Ast__id_t ctor_1 = v_108.t1;
-      FX_COPY_PTR(v_108.t2, &relems_0);
+      _fx_R9Ast__id_t rn_id_1 = v_110.t0;
+      _fx_R9Ast__id_t ctor_1 = v_110.t1;
+      FX_COPY_PTR(v_110.t2, &relems_0);
       FX_COPY_PTR(code_0, &code_23);
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_6 = relems_0;
       for (; lst_6; lst_6 = lst_6->tl) {
@@ -12244,10 +12247,10 @@ FX_EXTERN_C int
          _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t __fold_result___2 = {0};
          _fx_LT2R9Ast__id_tN10Ast__exp_t rinitelems_0 = 0;
          _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t __fold_result___3 = {0};
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_118 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_120 = {0};
          _fx_N14K_form__atom_t a_4 = {0};
          _fx_LN14K_form__kexp_t code1_5 = 0;
-         _fx_LN14K_form__atom_t v_119 = 0;
+         _fx_LN14K_form__atom_t v_121 = 0;
          _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___0 = &lst_6->hd;
          _fx_R9Ast__id_t ni_0 = __pat___0->t1;
          FX_COPY_PTR(__pat___0->t3, &vi_0);
@@ -12255,20 +12258,20 @@ FX_EXTERN_C int
          FX_COPY_PTR(vcase_13->t1, &rinitelems_0);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lst_7 = rinitelems_0;
          for (; lst_7; lst_7 = lst_7->tl) {
-            _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t v_120 = {0};
+            _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t v_122 = {0};
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___1 = &lst_7->hd;
             _fx_R9Ast__id_t nj_1 = __pat___1->t0;
             bool res_9;
             FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ni_0, &nj_1, &res_9, 0), _fx_catch_39);
             if (res_9) {
-               _fx_M11K_normalizeFM4SomeNt6option1T2R9Ast__id_tN10Ast__exp_t1T2R9Ast__id_tN10Ast__exp_t(__pat___1, &v_120);
+               _fx_M11K_normalizeFM4SomeNt6option1T2R9Ast__id_tN10Ast__exp_t1T2R9Ast__id_tN10Ast__exp_t(__pat___1, &v_122);
                _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___2);
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_120, &__fold_result___2);
+               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_122, &__fold_result___2);
                FX_BREAK(_fx_catch_39);
             }
 
          _fx_catch_39: ;
-            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_120);
+            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_122);
             FX_CHECK_BREAK();
             FX_CHECK_EXN(_fx_catch_44);
          }
@@ -12276,44 +12279,44 @@ FX_EXTERN_C int
          if (__fold_result___3.tag == 2) {
             FX_CALL(
                _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-                  __fold_result___3.u.Some.t1, code_23, false, sc_0, &v_118, 0), _fx_catch_40);
+                  __fold_result___3.u.Some.t1, code_23, false, sc_0, &v_120, 0), _fx_catch_40);
 
          _fx_catch_40: ;
          }
          else {
             if (FX_REC_VARIANT_TAG(vi_0) == 1) {
-               fx_str_t v_121 = {0};
-               fx_str_t v_122 = {0};
                fx_str_t v_123 = {0};
                fx_str_t v_124 = {0};
                fx_str_t v_125 = {0};
-               fx_exn_t v_126 = {0};
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&rn_id_1, &v_121, 0), _fx_catch_41);
-               FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_121, &v_122, 0), _fx_catch_41);
-               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_123, 0), _fx_catch_41);
+               fx_str_t v_126 = {0};
+               fx_str_t v_127 = {0};
+               fx_exn_t v_128 = {0};
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&rn_id_1, &v_123, 0), _fx_catch_41);
                FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_123, &v_124, 0), _fx_catch_41);
+               FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&ni_0, &v_125, 0), _fx_catch_41);
+               FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_125, &v_126, 0), _fx_catch_41);
                fx_str_t slit_7 = FX_MAKE_STR("there is no explicit initializer for the field \'");
                fx_str_t slit_8 = FX_MAKE_STR(".");
                fx_str_t slit_9 = FX_MAKE_STR("\' nor there is default initializer for it");
                {
-                  const fx_str_t strs_0[] = { slit_7, v_122, slit_8, v_124, slit_9 };
-                  FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_125), _fx_catch_41);
+                  const fx_str_t strs_0[] = { slit_7, v_124, slit_8, v_126, slit_9 };
+                  FX_CALL(fx_strjoin(0, 0, 0, strs_0, 5, &v_127), _fx_catch_41);
                }
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_125, &v_126, 0), _fx_catch_41);
-               FX_THROW(&v_126, false, _fx_catch_41);
+               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_127, &v_128, 0), _fx_catch_41);
+               FX_THROW(&v_128, false, _fx_catch_41);
 
             _fx_catch_41: ;
-               fx_free_exn(&v_126);
+               fx_free_exn(&v_128);
+               FX_FREE_STR(&v_127);
+               FX_FREE_STR(&v_126);
                FX_FREE_STR(&v_125);
                FX_FREE_STR(&v_124);
                FX_FREE_STR(&v_123);
-               FX_FREE_STR(&v_122);
-               FX_FREE_STR(&v_121);
             }
             else {
                FX_CALL(
                   _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-                     vi_0, code_23, false, sc_0, &v_118, 0), _fx_catch_42);
+                     vi_0, code_23, false, sc_0, &v_120, 0), _fx_catch_42);
 
             _fx_catch_42: ;
             }
@@ -12322,23 +12325,23 @@ FX_EXTERN_C int
          _fx_catch_43: ;
          }
          FX_CHECK_EXN(_fx_catch_44);
-         _fx_copy_N14K_form__atom_t(&v_118.t0, &a_4);
-         FX_COPY_PTR(v_118.t1, &code1_5);
+         _fx_copy_N14K_form__atom_t(&v_120.t0, &a_4);
+         FX_COPY_PTR(v_120.t1, &code1_5);
          _fx_free_LN14K_form__kexp_t(&code_23);
          FX_COPY_PTR(code1_5, &code_23);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&a_4, ratoms_0, true, &v_119), _fx_catch_44);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&a_4, ratoms_0, true, &v_121), _fx_catch_44);
          _fx_free_LN14K_form__atom_t(&ratoms_0);
-         FX_COPY_PTR(v_119, &ratoms_0);
+         FX_COPY_PTR(v_121, &ratoms_0);
 
       _fx_catch_44: ;
-         if (v_119) {
-            _fx_free_LN14K_form__atom_t(&v_119);
+         if (v_121) {
+            _fx_free_LN14K_form__atom_t(&v_121);
          }
          if (code1_5) {
             _fx_free_LN14K_form__kexp_t(&code1_5);
          }
          _fx_free_N14K_form__atom_t(&a_4);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_118);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_120);
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___3);
          if (rinitelems_0) {
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&rinitelems_0);
@@ -12352,32 +12355,32 @@ FX_EXTERN_C int
       bool res_10;
       FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ctor_1, &_fx_g9Ast__noid, &res_10, 0), _fx_catch_45);
       if (res_10) {
-         FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(ratoms_0, &v_110, 0), _fx_catch_45);
-         FX_CALL(
-            _fx_M6K_formFM12KExpMkRecordN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_110, &kctx_0,
-               &v_111), _fx_catch_45);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_111, code_23, fx_result);
-      }
-      else {
          FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(ratoms_0, &v_112, 0), _fx_catch_45);
          FX_CALL(
-            _fx_M6K_formFM8KExpCallN14K_form__kexp_t3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&ctor_1,
-               v_112, &kctx_0, &v_113), _fx_catch_45);
+            _fx_M6K_formFM12KExpMkRecordN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_112, &kctx_0,
+               &v_113), _fx_catch_45);
          _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_113, code_23, fx_result);
+      }
+      else {
+         FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(ratoms_0, &v_114, 0), _fx_catch_45);
+         FX_CALL(
+            _fx_M6K_formFM8KExpCallN14K_form__kexp_t3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&ctor_1,
+               v_114, &kctx_0, &v_115), _fx_catch_45);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_115, code_23, fx_result);
       }
 
    _fx_catch_45: ;
+      if (v_115) {
+         _fx_free_N14K_form__kexp_t(&v_115);
+      }
+      if (v_114) {
+         _fx_free_LN14K_form__atom_t(&v_114);
+      }
       if (v_113) {
          _fx_free_N14K_form__kexp_t(&v_113);
       }
       if (v_112) {
          _fx_free_LN14K_form__atom_t(&v_112);
-      }
-      if (v_111) {
-         _fx_free_N14K_form__kexp_t(&v_111);
-      }
-      if (v_110) {
-         _fx_free_LN14K_form__atom_t(&v_110);
       }
       if (code_23) {
          _fx_free_LN14K_form__kexp_t(&code_23);
@@ -12388,84 +12391,84 @@ FX_EXTERN_C int
       if (relems_0) {
          _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_0);
       }
-      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_109);
-      _fx_free_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_108);
-      if (v_107) {
-         _fx_free_N10Ast__typ_t(&v_107);
+      _fx_free_T2LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_tB(&v_111);
+      _fx_free_T3R9Ast__id_tR9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_110);
+      if (v_109) {
+         _fx_free_N10Ast__typ_t(&v_109);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 17) {
-      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_127 = {0};
+      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_129 = {0};
       _fx_LN14K_form__kexp_t code_24 = 0;
-      _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_128 = {0};
+      _fx_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t v_130 = {0};
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t relems_2 = 0;
       _fx_LN14K_form__atom_t ratoms_1 = 0;
       _fx_LN14K_form__kexp_t code_25 = 0;
-      _fx_LN14K_form__atom_t v_129 = 0;
-      _fx_N14K_form__kexp_t v_130 = 0;
+      _fx_LN14K_form__atom_t v_131 = 0;
+      _fx_N14K_form__kexp_t v_132 = 0;
       _fx_T3N10Ast__exp_tLT2R9Ast__id_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_14 = &e_0->u.ExpUpdateRecord;
       fx_str_t slit_10 = FX_MAKE_STR("the updated record cannot be a literal");
       FX_CALL(
          _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(
-            vcase_14->t0, code_0, true, sc_0, &slit_10, &v_127, 0), _fx_catch_50);
-      _fx_R9Ast__id_t rec_n_0 = v_127.t0;
-      FX_COPY_PTR(v_127.t1, &code_24);
+            vcase_14->t0, code_0, true, sc_0, &slit_10, &v_129, 0), _fx_catch_50);
+      _fx_R9Ast__id_t rec_n_0 = v_129.t0;
+      FX_COPY_PTR(v_129.t1, &code_24);
       FX_CALL(
          _fx_M13Ast_typecheckFM16get_record_elemsT2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t4Nt6option1R9Ast__id_tN10Ast__typ_tBR10Ast__loc_t(
-            &_fx_g19K_normalize__None6_, etyp_0, false, &eloc_0, &v_128, 0), _fx_catch_50);
-      FX_COPY_PTR(v_128.t1, &relems_2);
+            &_fx_g19K_normalize__None6_, etyp_0, false, &eloc_0, &v_130, 0), _fx_catch_50);
+      FX_COPY_PTR(v_130.t1, &relems_2);
       FX_COPY_PTR(code_24, &code_25);
       int_ idx_0 = 0;
       _fx_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t lst_8 = relems_2;
       for (; lst_8; lst_8 = lst_8->tl, idx_0 += 1) {
          _fx_N10Ast__typ_t ti_0 = 0;
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_131 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_133 = {0};
          fx_exn_t exn_1 = {0};
          _fx_N14K_form__atom_t a_5 = {0};
          _fx_LN14K_form__kexp_t code1_6 = 0;
-         _fx_LN14K_form__atom_t v_132 = 0;
+         _fx_LN14K_form__atom_t v_134 = 0;
          _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t* __pat___2 = &lst_8->hd;
          _fx_R9Ast__id_t ni_1 = __pat___2->t1;
          FX_COPY_PTR(__pat___2->t2, &ti_0);
          _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t __fold_result___4 = {0};
          _fx_LT2R9Ast__id_tN10Ast__exp_t new_elems_0 = 0;
          _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t __fold_result___5 = {0};
-         _fx_T2R9Ast__id_tN10Ast__exp_t v_133 = {0};
+         _fx_T2R9Ast__id_tN10Ast__exp_t v_135 = {0};
          _fx_N10Ast__exp_t ej_0 = 0;
          _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&_fx_g19K_normalize__None2_, &__fold_result___4);
          FX_COPY_PTR(vcase_14->t1, &new_elems_0);
          _fx_LT2R9Ast__id_tN10Ast__exp_t lst_9 = new_elems_0;
          for (; lst_9; lst_9 = lst_9->tl) {
-            _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t v_134 = {0};
+            _fx_Nt6option1T2R9Ast__id_tN10Ast__exp_t v_136 = {0};
             _fx_T2R9Ast__id_tN10Ast__exp_t* __pat___3 = &lst_9->hd;
             _fx_R9Ast__id_t nj_2 = __pat___3->t0;
             bool res_11;
             FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&ni_1, &nj_2, &res_11, 0), _fx_catch_46);
             if (res_11) {
-               _fx_M11K_normalizeFM4SomeNt6option1T2R9Ast__id_tN10Ast__exp_t1T2R9Ast__id_tN10Ast__exp_t(__pat___3, &v_134);
+               _fx_M11K_normalizeFM4SomeNt6option1T2R9Ast__id_tN10Ast__exp_t1T2R9Ast__id_tN10Ast__exp_t(__pat___3, &v_136);
                _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___4);
-               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_134, &__fold_result___4);
+               _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_136, &__fold_result___4);
                FX_BREAK(_fx_catch_46);
             }
 
          _fx_catch_46: ;
-            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_134);
+            _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&v_136);
             FX_CHECK_BREAK();
             FX_CHECK_EXN(_fx_catch_47);
          }
          _fx_copy_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___4, &__fold_result___5);
          if (__fold_result___5.tag == 2) {
-            _fx_copy_T2R9Ast__id_tN10Ast__exp_t(&__fold_result___5.u.Some, &v_133);
+            _fx_copy_T2R9Ast__id_tN10Ast__exp_t(&__fold_result___5.u.Some, &v_135);
          }
          else {
             FX_FAST_THROW(FX_EXN_NotFoundError, _fx_catch_47);
          }
          FX_CHECK_EXN(_fx_catch_47);
-         FX_COPY_PTR(v_133.t1, &ej_0);
+         FX_COPY_PTR(v_135.t1, &ej_0);
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               ej_0, code_25, false, sc_0, &v_131, 0), _fx_catch_47);
+               ej_0, code_25, false, sc_0, &v_133, 0), _fx_catch_47);
 
       _fx_catch_47: ;
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___4);
@@ -12473,49 +12476,49 @@ FX_EXTERN_C int
             _fx_free_LT2R9Ast__id_tN10Ast__exp_t(&new_elems_0);
          }
          _fx_free_Nt6option1T2R9Ast__id_tN10Ast__exp_t(&__fold_result___5);
-         _fx_free_T2R9Ast__id_tN10Ast__exp_t(&v_133);
+         _fx_free_T2R9Ast__id_tN10Ast__exp_t(&v_135);
          if (ej_0) {
             _fx_free_N10Ast__exp_t(&ej_0);
          }
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_1);
             fx_status = 0;
-            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_131);
+            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_133);
             if (exn_1.tag == FX_EXN_NotFoundError) {
                _fx_N14K_form__ktyp_t ti__0 = 0;
-               _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_135 = {0};
+               _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_137 = {0};
                _fx_N14K_form__kexp_t get_ni_0 = 0;
-               _fx_R16Ast__val_flags_t v_136 = {0};
-               _fx_Nt6option1N14K_form__kexp_t v_137 = {0};
+               _fx_R16Ast__val_flags_t v_138 = {0};
+               _fx_Nt6option1N14K_form__kexp_t v_139 = {0};
                _fx_LN14K_form__kexp_t code_26 = 0;
-               _fx_N14K_form__atom_t v_138 = {0};
+               _fx_N14K_form__atom_t v_140 = {0};
                _fx_R9Ast__id_t ni__0;
                FX_CALL(_fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(km_idx_0, &ni_1, &ni__0, 0), _fx_catch_48);
                FX_CALL(_fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(ti_0, &eloc_0, &ti__0, 0),
                   _fx_catch_48);
-               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(ti__0, &eloc_0, &v_135);
+               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(ti__0, &eloc_0, &v_137);
                FX_CALL(
-                  _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&rec_n_0, idx_0, &v_135,
+                  _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&rec_n_0, idx_0, &v_137,
                      &get_ni_0), _fx_catch_48);
-               FX_CALL(_fx_M3AstFM21default_tempref_flagsRM11val_flags_t0(&v_136, 0), _fx_catch_48);
-               _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(get_ni_0, &v_137);
+               FX_CALL(_fx_M3AstFM21default_tempref_flagsRM11val_flags_t0(&v_138, 0), _fx_catch_48);
+               _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(get_ni_0, &v_139);
                FX_CALL(
                   _fx_M6K_formFM14create_kdefvalLN14K_form__kexp_t6R9Ast__id_tN14K_form__ktyp_tR16Ast__val_flags_tNt6option1N14K_form__kexp_tLN14K_form__kexp_tR10Ast__loc_t(
-                     &ni__0, ti__0, &v_136, &v_137, code_25, &eloc_0, &code_26, 0), _fx_catch_48);
-               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&ni__0, &v_138);
-               _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_138, code_26, &v_131);
+                     &ni__0, ti__0, &v_138, &v_139, code_25, &eloc_0, &code_26, 0), _fx_catch_48);
+               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&ni__0, &v_140);
+               _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_140, code_26, &v_133);
 
             _fx_catch_48: ;
-               _fx_free_N14K_form__atom_t(&v_138);
+               _fx_free_N14K_form__atom_t(&v_140);
                if (code_26) {
                   _fx_free_LN14K_form__kexp_t(&code_26);
                }
-               _fx_free_Nt6option1N14K_form__kexp_t(&v_137);
-               _fx_free_R16Ast__val_flags_t(&v_136);
+               _fx_free_Nt6option1N14K_form__kexp_t(&v_139);
+               _fx_free_R16Ast__val_flags_t(&v_138);
                if (get_ni_0) {
                   _fx_free_N14K_form__kexp_t(&get_ni_0);
                }
-               _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_135);
+               _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_137);
                if (ti__0) {
                   _fx_free_N14K_form__ktyp_t(&ti__0);
                }
@@ -12525,41 +12528,41 @@ FX_EXTERN_C int
             }
             FX_CHECK_EXN(_fx_catch_49);
          }
-         _fx_copy_N14K_form__atom_t(&v_131.t0, &a_5);
-         FX_COPY_PTR(v_131.t1, &code1_6);
+         _fx_copy_N14K_form__atom_t(&v_133.t0, &a_5);
+         FX_COPY_PTR(v_133.t1, &code1_6);
          _fx_free_LN14K_form__kexp_t(&code_25);
          FX_COPY_PTR(code1_6, &code_25);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&a_5, ratoms_1, true, &v_132), _fx_catch_49);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&a_5, ratoms_1, true, &v_134), _fx_catch_49);
          _fx_free_LN14K_form__atom_t(&ratoms_1);
-         FX_COPY_PTR(v_132, &ratoms_1);
+         FX_COPY_PTR(v_134, &ratoms_1);
 
       _fx_catch_49: ;
-         if (v_132) {
-            _fx_free_LN14K_form__atom_t(&v_132);
+         if (v_134) {
+            _fx_free_LN14K_form__atom_t(&v_134);
          }
          if (code1_6) {
             _fx_free_LN14K_form__kexp_t(&code1_6);
          }
          _fx_free_N14K_form__atom_t(&a_5);
          fx_free_exn(&exn_1);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_131);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_133);
          if (ti_0) {
             _fx_free_N10Ast__typ_t(&ti_0);
          }
          FX_CHECK_EXN(_fx_catch_50);
       }
-      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(ratoms_1, &v_129, 0), _fx_catch_50);
+      FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(ratoms_1, &v_131, 0), _fx_catch_50);
       FX_CALL(
-         _fx_M6K_formFM12KExpMkRecordN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_129, &kctx_0,
-            &v_130), _fx_catch_50);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_130, code_25, fx_result);
+         _fx_M6K_formFM12KExpMkRecordN14K_form__kexp_t2LN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(v_131, &kctx_0,
+            &v_132), _fx_catch_50);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_132, code_25, fx_result);
 
    _fx_catch_50: ;
-      if (v_130) {
-         _fx_free_N14K_form__kexp_t(&v_130);
+      if (v_132) {
+         _fx_free_N14K_form__kexp_t(&v_132);
       }
-      if (v_129) {
-         _fx_free_LN14K_form__atom_t(&v_129);
+      if (v_131) {
+         _fx_free_LN14K_form__atom_t(&v_131);
       }
       if (code_25) {
          _fx_free_LN14K_form__kexp_t(&code_25);
@@ -12570,123 +12573,123 @@ FX_EXTERN_C int
       if (relems_2) {
          _fx_free_LT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&relems_2);
       }
-      _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_128);
+      _fx_free_T2R9Ast__id_tLT4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(&v_130);
       if (code_24) {
          _fx_free_LN14K_form__kexp_t(&code_24);
       }
-      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_127);
-      goto _fx_endmatch_14;
+      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_129);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 18) {
-      _fx_LN10Ast__exp_t v_139 = 0;
-      _fx_T2LN10Ast__exp_tNt6option1N10Ast__exp_t v_140 = {0};
+      _fx_LN10Ast__exp_t v_141 = 0;
+      _fx_T2LN10Ast__exp_tNt6option1N10Ast__exp_t v_142 = {0};
       _fx_LN10Ast__exp_t args_3 = 0;
       _fx_Nt6option1N10Ast__exp_t kwarg_opt_0 = 0;
       _fx_LN14K_form__atom_t res_12 = 0;
       _fx_LN14K_form__kexp_t code_27 = 0;
-      _fx_T2LN14K_form__atom_tLN14K_form__kexp_t v_141 = {0};
+      _fx_T2LN14K_form__atom_tLN14K_form__kexp_t v_143 = {0};
       _fx_LN14K_form__atom_t args_4 = 0;
       _fx_LN14K_form__kexp_t code_28 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_142 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_144 = {0};
       _fx_N14K_form__kexp_t f_exp_0 = 0;
       _fx_LN14K_form__kexp_t code_29 = 0;
       _fx_T3N10Ast__exp_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_15 = &e_0->u.ExpCall;
       _fx_LN10Ast__exp_t args_5 = vcase_15->t1;
-      FX_CALL(_fx_M11K_normalizeFM3revLN10Ast__exp_t1LN10Ast__exp_t(args_5, &v_139, 0), _fx_catch_61);
-      if (v_139 != 0) {
-         _fx_N10Ast__exp_t mkrec_0 = v_139->hd;
+      FX_CALL(_fx_M11K_normalizeFM3revLN10Ast__exp_t1LN10Ast__exp_t(args_5, &v_141, 0), _fx_catch_61);
+      if (v_141 != 0) {
+         _fx_N10Ast__exp_t mkrec_0 = v_141->hd;
          if (FX_REC_VARIANT_TAG(mkrec_0) == 16) {
             if (FX_REC_VARIANT_TAG(mkrec_0->u.ExpMkRecord.t0) == 1) {
-               _fx_LN10Ast__exp_t v_143 = 0;
-               _fx_Nt6option1N10Ast__exp_t v_144 = 0;
-               FX_CALL(_fx_M11K_normalizeFM3revLN10Ast__exp_t1LN10Ast__exp_t(v_139->tl, &v_143, 0), _fx_catch_51);
-               FX_CALL(_fx_M11K_normalizeFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(mkrec_0, &v_144), _fx_catch_51);
-               _fx_make_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(v_143, v_144, &v_140);
+               _fx_LN10Ast__exp_t v_145 = 0;
+               _fx_Nt6option1N10Ast__exp_t v_146 = 0;
+               FX_CALL(_fx_M11K_normalizeFM3revLN10Ast__exp_t1LN10Ast__exp_t(v_141->tl, &v_145, 0), _fx_catch_51);
+               FX_CALL(_fx_M11K_normalizeFM4SomeNt6option1N10Ast__exp_t1N10Ast__exp_t(mkrec_0, &v_146), _fx_catch_51);
+               _fx_make_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(v_145, v_146, &v_142);
 
             _fx_catch_51: ;
-               if (v_144) {
-                  _fx_free_Nt6option1N10Ast__exp_t(&v_144);
+               if (v_146) {
+                  _fx_free_Nt6option1N10Ast__exp_t(&v_146);
                }
-               if (v_143) {
-                  _fx_free_LN10Ast__exp_t(&v_143);
+               if (v_145) {
+                  _fx_free_LN10Ast__exp_t(&v_145);
                }
                goto _fx_endmatch_7;
             }
          }
       }
-      _fx_make_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(args_5, _fx_g19K_normalize__None7_, &v_140);
+      _fx_make_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(args_5, _fx_g19K_normalize__None7_, &v_142);
 
    _fx_endmatch_7: ;
       FX_CHECK_EXN(_fx_catch_61);
-      FX_COPY_PTR(v_140.t0, &args_3);
-      FX_COPY_PTR(v_140.t1, &kwarg_opt_0);
+      FX_COPY_PTR(v_142.t0, &args_3);
+      FX_COPY_PTR(v_142.t1, &kwarg_opt_0);
       FX_COPY_PTR(code_0, &code_27);
       _fx_LN10Ast__exp_t lst_10 = args_3;
       for (; lst_10; lst_10 = lst_10->tl) {
-         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_145 = {0};
+         _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_147 = {0};
          _fx_N14K_form__atom_t ai_2 = {0};
          _fx_LN14K_form__kexp_t code1_7 = 0;
-         _fx_LN14K_form__atom_t v_146 = 0;
+         _fx_LN14K_form__atom_t v_148 = 0;
          _fx_N10Ast__exp_t ei_2 = lst_10->hd;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               ei_2, code_27, false, sc_0, &v_145, 0), _fx_catch_52);
-         _fx_copy_N14K_form__atom_t(&v_145.t0, &ai_2);
-         FX_COPY_PTR(v_145.t1, &code1_7);
+               ei_2, code_27, false, sc_0, &v_147, 0), _fx_catch_52);
+         _fx_copy_N14K_form__atom_t(&v_147.t0, &ai_2);
+         FX_COPY_PTR(v_147.t1, &code1_7);
          _fx_free_LN14K_form__kexp_t(&code_27);
          FX_COPY_PTR(code1_7, &code_27);
-         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_2, res_12, true, &v_146), _fx_catch_52);
+         FX_CALL(_fx_cons_LN14K_form__atom_t(&ai_2, res_12, true, &v_148), _fx_catch_52);
          _fx_free_LN14K_form__atom_t(&res_12);
-         FX_COPY_PTR(v_146, &res_12);
+         FX_COPY_PTR(v_148, &res_12);
 
       _fx_catch_52: ;
-         if (v_146) {
-            _fx_free_LN14K_form__atom_t(&v_146);
+         if (v_148) {
+            _fx_free_LN14K_form__atom_t(&v_148);
          }
          if (code1_7) {
             _fx_free_LN14K_form__kexp_t(&code1_7);
          }
          _fx_free_N14K_form__atom_t(&ai_2);
-         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_145);
+         _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_147);
          FX_CHECK_EXN(_fx_catch_61);
       }
       if ((kwarg_opt_0 != 0) + 1 == 2) {
-         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_147 = {0};
+         _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_149 = {0};
          _fx_N14K_form__kexp_t ke_0 = 0;
          _fx_LN14K_form__kexp_t code_30 = 0;
          _fx_N10Ast__exp_t e_6 = kwarg_opt_0->u.Some;
          FX_CALL(
             _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-               e_6, code_27, false, sc_0, &v_147, 0), _fx_catch_55);
-         FX_COPY_PTR(v_147.t0, &ke_0);
-         FX_COPY_PTR(v_147.t1, &code_30);
+               e_6, code_27, false, sc_0, &v_149, 0), _fx_catch_55);
+         FX_COPY_PTR(v_149.t0, &ke_0);
+         FX_COPY_PTR(v_149.t1, &code_30);
          if (FX_REC_VARIANT_TAG(ke_0) == 15) {
-            _fx_LN14K_form__atom_t v_148 = 0;
-            _fx_LN14K_form__atom_t v_149 = 0;
-            FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_12, &v_148, 0), _fx_catch_53);
+            _fx_LN14K_form__atom_t v_150 = 0;
+            _fx_LN14K_form__atom_t v_151 = 0;
+            FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_12, &v_150, 0), _fx_catch_53);
             FX_CALL(
-               _fx_M11K_normalizeFM7__add__LN14K_form__atom_t2LN14K_form__atom_tLN14K_form__atom_t(v_148,
-                  ke_0->u.KExpMkRecord.t0, &v_149, 0), _fx_catch_53);
-            _fx_make_T2LN14K_form__atom_tLN14K_form__kexp_t(v_149, code_30, &v_141);
+               _fx_M11K_normalizeFM7__add__LN14K_form__atom_t2LN14K_form__atom_tLN14K_form__atom_t(v_150,
+                  ke_0->u.KExpMkRecord.t0, &v_151, 0), _fx_catch_53);
+            _fx_make_T2LN14K_form__atom_tLN14K_form__kexp_t(v_151, code_30, &v_143);
 
          _fx_catch_53: ;
-            if (v_149) {
-               _fx_free_LN14K_form__atom_t(&v_149);
+            if (v_151) {
+               _fx_free_LN14K_form__atom_t(&v_151);
             }
-            if (v_148) {
-               _fx_free_LN14K_form__atom_t(&v_148);
+            if (v_150) {
+               _fx_free_LN14K_form__atom_t(&v_150);
             }
          }
          else {
-            fx_exn_t v_150 = {0};
-            _fx_R10Ast__loc_t v_151;
-            FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_6, &v_151, 0), _fx_catch_54);
+            fx_exn_t v_152 = {0};
+            _fx_R10Ast__loc_t v_153;
+            FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e_6, &v_153, 0), _fx_catch_54);
             fx_str_t slit_11 = FX_MAKE_STR("the expression should convert to KExpMkRecord()");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_151, &slit_11, &v_150, 0), _fx_catch_54);
-            FX_THROW(&v_150, false, _fx_catch_54);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_153, &slit_11, &v_152, 0), _fx_catch_54);
+            FX_THROW(&v_152, false, _fx_catch_54);
 
          _fx_catch_54: ;
-            fx_free_exn(&v_150);
+            fx_free_exn(&v_152);
          }
          FX_CHECK_EXN(_fx_catch_55);
 
@@ -12697,105 +12700,105 @@ FX_EXTERN_C int
          if (ke_0) {
             _fx_free_N14K_form__kexp_t(&ke_0);
          }
-         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_147);
+         _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_149);
       }
       else {
-         _fx_LN14K_form__atom_t v_152 = 0;
-         FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_12, &v_152, 0), _fx_catch_56);
-         _fx_make_T2LN14K_form__atom_tLN14K_form__kexp_t(v_152, code_27, &v_141);
+         _fx_LN14K_form__atom_t v_154 = 0;
+         FX_CALL(_fx_M11K_normalizeFM3revLN14K_form__atom_t1LN14K_form__atom_t(res_12, &v_154, 0), _fx_catch_56);
+         _fx_make_T2LN14K_form__atom_tLN14K_form__kexp_t(v_154, code_27, &v_143);
 
       _fx_catch_56: ;
-         if (v_152) {
-            _fx_free_LN14K_form__atom_t(&v_152);
+         if (v_154) {
+            _fx_free_LN14K_form__atom_t(&v_154);
          }
       }
       FX_CHECK_EXN(_fx_catch_61);
-      FX_COPY_PTR(v_141.t0, &args_4);
-      FX_COPY_PTR(v_141.t1, &code_28);
+      FX_COPY_PTR(v_143.t0, &args_4);
+      FX_COPY_PTR(v_143.t1, &code_28);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_15->t0, code_28, false, sc_0, &v_142, 0), _fx_catch_61);
-      FX_COPY_PTR(v_142.t0, &f_exp_0);
-      FX_COPY_PTR(v_142.t1, &code_29);
+            vcase_15->t0, code_28, false, sc_0, &v_144, 0), _fx_catch_61);
+      FX_COPY_PTR(v_144.t0, &f_exp_0);
+      FX_COPY_PTR(v_144.t1, &code_29);
       if (FX_REC_VARIANT_TAG(f_exp_0) == 20) {
          _fx_N14K_form__ktyp_t t_0 = 0;
-         _fx_Nt6option1rR23K_form__kdefinterface_t v_153 = {0};
+         _fx_Nt6option1rR23K_form__kdefinterface_t v_155 = {0};
          _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_16 = &f_exp_0->u.KExpMem;
          _fx_R10Ast__loc_t* f_loc_0 = &vcase_16->t2.t1;
          _fx_R9Ast__id_t* obj_0 = &vcase_16->t0;
          FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(obj_0, f_loc_0, &t_0, 0), _fx_catch_59);
          FX_CALL(
             _fx_M6K_formFM18get_kinterface_optNt6option1rRM15kdefinterface_t2N14K_form__ktyp_tR10Ast__loc_t(t_0, f_loc_0,
-               &v_153, 0), _fx_catch_59);
-         if (v_153.tag == 2) {
-            _fx_N14K_form__kexp_t v_154 = 0;
+               &v_155, 0), _fx_catch_59);
+         if (v_155.tag == 2) {
+            _fx_N14K_form__kexp_t v_156 = 0;
             FX_CALL(
                _fx_M6K_formFM9KExpICallN14K_form__kexp_t4R9Ast__id_tiLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(obj_0,
-                  vcase_16->t1, args_4, &kctx_0, &v_154), _fx_catch_57);
-            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_154, code_29, fx_result);
+                  vcase_16->t1, args_4, &kctx_0, &v_156), _fx_catch_57);
+            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_156, code_29, fx_result);
 
          _fx_catch_57: ;
-            if (v_154) {
-               _fx_free_N14K_form__kexp_t(&v_154);
+            if (v_156) {
+               _fx_free_N14K_form__kexp_t(&v_156);
             }
          }
          else {
-            _fx_T2R9Ast__id_tLN14K_form__kexp_t v_155 = {0};
+            _fx_T2R9Ast__id_tLN14K_form__kexp_t v_157 = {0};
             _fx_LN14K_form__kexp_t code_31 = 0;
-            _fx_N14K_form__kexp_t v_156 = 0;
+            _fx_N14K_form__kexp_t v_158 = 0;
             fx_str_t slit_12 = FX_MAKE_STR("f");
             fx_str_t slit_13 = FX_MAKE_STR("cannot reduce obj.idx to an id (?!)");
             FX_CALL(
                _fx_M6K_formFM7kexp2idT2R9Ast__id_tLN14K_form__kexp_t6iSN14K_form__kexp_tBLN14K_form__kexp_tS(km_idx_0, &slit_12,
-                  f_exp_0, true, code_29, &slit_13, &v_155, 0), _fx_catch_58);
-            _fx_R9Ast__id_t f_id_0 = v_155.t0;
-            FX_COPY_PTR(v_155.t1, &code_31);
+                  f_exp_0, true, code_29, &slit_13, &v_157, 0), _fx_catch_58);
+            _fx_R9Ast__id_t f_id_0 = v_157.t0;
+            FX_COPY_PTR(v_157.t1, &code_31);
             FX_CALL(
                _fx_M6K_formFM8KExpCallN14K_form__kexp_t3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&f_id_0,
-                  args_4, &kctx_0, &v_156), _fx_catch_58);
-            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_156, code_31, fx_result);
+                  args_4, &kctx_0, &v_158), _fx_catch_58);
+            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_158, code_31, fx_result);
 
          _fx_catch_58: ;
-            if (v_156) {
-               _fx_free_N14K_form__kexp_t(&v_156);
+            if (v_158) {
+               _fx_free_N14K_form__kexp_t(&v_158);
             }
             if (code_31) {
                _fx_free_LN14K_form__kexp_t(&code_31);
             }
-            _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_155);
+            _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_157);
          }
          FX_CHECK_EXN(_fx_catch_59);
 
       _fx_catch_59: ;
-         _fx_free_Nt6option1rR23K_form__kdefinterface_t(&v_153);
+         _fx_free_Nt6option1rR23K_form__kdefinterface_t(&v_155);
          if (t_0) {
             _fx_free_N14K_form__ktyp_t(&t_0);
          }
       }
       else {
-         _fx_T2R9Ast__id_tLN14K_form__kexp_t v_157 = {0};
+         _fx_T2R9Ast__id_tLN14K_form__kexp_t v_159 = {0};
          _fx_LN14K_form__kexp_t code_32 = 0;
-         _fx_N14K_form__kexp_t v_158 = 0;
+         _fx_N14K_form__kexp_t v_160 = 0;
          fx_str_t slit_14 = FX_MAKE_STR("f");
          fx_str_t slit_15 = FX_MAKE_STR("cannot reduce function expression to an id");
          FX_CALL(
             _fx_M6K_formFM7kexp2idT2R9Ast__id_tLN14K_form__kexp_t6iSN14K_form__kexp_tBLN14K_form__kexp_tS(km_idx_0, &slit_14,
-               f_exp_0, true, code_29, &slit_15, &v_157, 0), _fx_catch_60);
-         _fx_R9Ast__id_t f_id_1 = v_157.t0;
-         FX_COPY_PTR(v_157.t1, &code_32);
+               f_exp_0, true, code_29, &slit_15, &v_159, 0), _fx_catch_60);
+         _fx_R9Ast__id_t f_id_1 = v_159.t0;
+         FX_COPY_PTR(v_159.t1, &code_32);
          FX_CALL(
             _fx_M6K_formFM8KExpCallN14K_form__kexp_t3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&f_id_1,
-               args_4, &kctx_0, &v_158), _fx_catch_60);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_158, code_32, fx_result);
+               args_4, &kctx_0, &v_160), _fx_catch_60);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_160, code_32, fx_result);
 
       _fx_catch_60: ;
-         if (v_158) {
-            _fx_free_N14K_form__kexp_t(&v_158);
+         if (v_160) {
+            _fx_free_N14K_form__kexp_t(&v_160);
          }
          if (code_32) {
             _fx_free_LN14K_form__kexp_t(&code_32);
          }
-         _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_157);
+         _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_159);
       }
       FX_CHECK_EXN(_fx_catch_61);
 
@@ -12806,14 +12809,14 @@ FX_EXTERN_C int
       if (f_exp_0) {
          _fx_free_N14K_form__kexp_t(&f_exp_0);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_142);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_144);
       if (code_28) {
          _fx_free_LN14K_form__kexp_t(&code_28);
       }
       if (args_4) {
          _fx_free_LN14K_form__atom_t(&args_4);
       }
-      _fx_free_T2LN14K_form__atom_tLN14K_form__kexp_t(&v_141);
+      _fx_free_T2LN14K_form__atom_tLN14K_form__kexp_t(&v_143);
       if (code_27) {
          _fx_free_LN14K_form__kexp_t(&code_27);
       }
@@ -12826,62 +12829,62 @@ FX_EXTERN_C int
       if (args_3) {
          _fx_free_LN10Ast__exp_t(&args_3);
       }
-      _fx_free_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(&v_140);
-      if (v_139) {
-         _fx_free_LN10Ast__exp_t(&v_139);
+      _fx_free_T2LN10Ast__exp_tNt6option1N10Ast__exp_t(&v_142);
+      if (v_141) {
+         _fx_free_LN10Ast__exp_t(&v_141);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 22) {
-      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_159 = {0};
+      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_161 = {0};
       _fx_LN14K_form__kexp_t code_33 = 0;
-      _fx_N14K_form__kexp_t v_160 = 0;
+      _fx_N14K_form__kexp_t v_162 = 0;
       fx_str_t slit_16 = FX_MAKE_STR("a literal cannot be thrown as exception");
       FX_CALL(
          _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(
-            e_0->u.ExpThrow.t0, code_0, false, sc_0, &slit_16, &v_159, 0), _fx_catch_62);
-      _fx_R9Ast__id_t a_id_1 = v_159.t0;
-      FX_COPY_PTR(v_159.t1, &code_33);
-      FX_CALL(_fx_M6K_formFM9KExpThrowN14K_form__kexp_t3R9Ast__id_tBR10Ast__loc_t(&a_id_1, false, &eloc_0, &v_160),
+            e_0->u.ExpThrow.t0, code_0, false, sc_0, &slit_16, &v_161, 0), _fx_catch_62);
+      _fx_R9Ast__id_t a_id_1 = v_161.t0;
+      FX_COPY_PTR(v_161.t1, &code_33);
+      FX_CALL(_fx_M6K_formFM9KExpThrowN14K_form__kexp_t3R9Ast__id_tBR10Ast__loc_t(&a_id_1, false, &eloc_0, &v_162),
          _fx_catch_62);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_160, code_33, fx_result);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_162, code_33, fx_result);
 
    _fx_catch_62: ;
-      if (v_160) {
-         _fx_free_N14K_form__kexp_t(&v_160);
+      if (v_162) {
+         _fx_free_N14K_form__kexp_t(&v_162);
       }
       if (code_33) {
          _fx_free_LN14K_form__kexp_t(&code_33);
       }
-      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_159);
-      goto _fx_endmatch_14;
+      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_161);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 23) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_161 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_163 = {0};
       _fx_N14K_form__atom_t c_0 = {0};
       _fx_LN14K_form__kexp_t code_34 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_162 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_164 = {0};
       _fx_N14K_form__kexp_t e2_6 = 0;
       _fx_LN14K_form__kexp_t code2_2 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_163 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_165 = {0};
       _fx_N14K_form__kexp_t e3_0 = 0;
       _fx_LN14K_form__kexp_t code3_0 = 0;
-      _fx_LN14K_form__kexp_t v_164 = 0;
+      _fx_LN14K_form__kexp_t v_166 = 0;
       _fx_N14K_form__kexp_t if_then_0 = 0;
-      _fx_LN14K_form__kexp_t v_165 = 0;
+      _fx_LN14K_form__kexp_t v_167 = 0;
       _fx_N14K_form__kexp_t if_else_0 = 0;
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_166 = {0};
-      _fx_N14K_form__kexp_t v_167 = 0;
-      _fx_N14K_form__kexp_t v_168 = 0;
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_168 = {0};
+      _fx_N14K_form__kexp_t v_169 = 0;
+      _fx_N14K_form__kexp_t v_170 = 0;
       _fx_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_17 = &e_0->u.ExpIf;
       _fx_N10Ast__exp_t e3_1 = vcase_17->t2;
       _fx_N10Ast__exp_t e2_7 = vcase_17->t1;
       _fx_N10Ast__exp_t e1_3 = vcase_17->t0;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e1_3, code_0, false, sc_0, &v_161, 0), _fx_catch_63);
-      _fx_copy_N14K_form__atom_t(&v_161.t0, &c_0);
-      FX_COPY_PTR(v_161.t1, &code_34);
+            e1_3, code_0, false, sc_0, &v_163, 0), _fx_catch_63);
+      _fx_copy_N14K_form__atom_t(&v_163.t0, &c_0);
+      FX_COPY_PTR(v_163.t1, &code_34);
       _fx_R10Ast__loc_t loc1_0;
       FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e1_3, &loc1_0, 0), _fx_catch_63);
       _fx_R10Ast__loc_t loc2_0;
@@ -12890,47 +12893,47 @@ FX_EXTERN_C int
       FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e3_1, &loc3_0, 0), _fx_catch_63);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e2_7, 0, false, sc_0, &v_162, 0), _fx_catch_63);
-      FX_COPY_PTR(v_162.t0, &e2_6);
-      FX_COPY_PTR(v_162.t1, &code2_2);
+            e2_7, 0, false, sc_0, &v_164, 0), _fx_catch_63);
+      FX_COPY_PTR(v_164.t0, &e2_6);
+      FX_COPY_PTR(v_164.t1, &code2_2);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e3_1, 0, false, sc_0, &v_163, 0), _fx_catch_63);
-      FX_COPY_PTR(v_163.t0, &e3_0);
-      FX_COPY_PTR(v_163.t1, &code3_0);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_6, code2_2, true, &v_164), _fx_catch_63);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_164, &loc2_0, &if_then_0, 0),
+            e3_1, 0, false, sc_0, &v_165, 0), _fx_catch_63);
+      FX_COPY_PTR(v_165.t0, &e3_0);
+      FX_COPY_PTR(v_165.t1, &code3_0);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_6, code2_2, true, &v_166), _fx_catch_63);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_166, &loc2_0, &if_then_0, 0),
          _fx_catch_63);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e3_0, code3_0, true, &v_165), _fx_catch_63);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_165, &loc3_0, &if_else_0, 0),
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e3_0, code3_0, true, &v_167), _fx_catch_63);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_167, &loc3_0, &if_else_0, 0),
          _fx_catch_63);
-      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &loc1_0, &v_166);
-      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&c_0, &v_166, &v_167),
+      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypBool, &loc1_0, &v_168);
+      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&c_0, &v_168, &v_169),
          _fx_catch_63);
       FX_CALL(
          _fx_M6K_formFM6KExpIfN14K_form__kexp_t4N14K_form__kexp_tN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            v_167, if_then_0, if_else_0, &kctx_0, &v_168), _fx_catch_63);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_168, code_34, fx_result);
+            v_169, if_then_0, if_else_0, &kctx_0, &v_170), _fx_catch_63);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_170, code_34, fx_result);
 
    _fx_catch_63: ;
-      if (v_168) {
-         _fx_free_N14K_form__kexp_t(&v_168);
+      if (v_170) {
+         _fx_free_N14K_form__kexp_t(&v_170);
       }
-      if (v_167) {
-         _fx_free_N14K_form__kexp_t(&v_167);
+      if (v_169) {
+         _fx_free_N14K_form__kexp_t(&v_169);
       }
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_166);
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_168);
       if (if_else_0) {
          _fx_free_N14K_form__kexp_t(&if_else_0);
       }
-      if (v_165) {
-         _fx_free_LN14K_form__kexp_t(&v_165);
+      if (v_167) {
+         _fx_free_LN14K_form__kexp_t(&v_167);
       }
       if (if_then_0) {
          _fx_free_N14K_form__kexp_t(&if_then_0);
       }
-      if (v_164) {
-         _fx_free_LN14K_form__kexp_t(&v_164);
+      if (v_166) {
+         _fx_free_LN14K_form__kexp_t(&v_166);
       }
       if (code3_0) {
          _fx_free_LN14K_form__kexp_t(&code3_0);
@@ -12938,33 +12941,33 @@ FX_EXTERN_C int
       if (e3_0) {
          _fx_free_N14K_form__kexp_t(&e3_0);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_163);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_165);
       if (code2_2) {
          _fx_free_LN14K_form__kexp_t(&code2_2);
       }
       if (e2_6) {
          _fx_free_N14K_form__kexp_t(&e2_6);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_162);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_164);
       if (code_34) {
          _fx_free_LN14K_form__kexp_t(&code_34);
       }
       _fx_free_N14K_form__atom_t(&c_0);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_161);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_163);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 24) {
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_169 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_171 = {0};
       _fx_N14K_form__kexp_t e1_4 = 0;
       _fx_LN14K_form__kexp_t code1_8 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_170 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_172 = {0};
       _fx_N14K_form__kexp_t e2_8 = 0;
       _fx_LN14K_form__kexp_t code2_3 = 0;
-      _fx_LN14K_form__kexp_t v_171 = 0;
+      _fx_LN14K_form__kexp_t v_173 = 0;
       _fx_N14K_form__kexp_t c_1 = 0;
-      _fx_LN14K_form__kexp_t v_172 = 0;
+      _fx_LN14K_form__kexp_t v_174 = 0;
       _fx_N14K_form__kexp_t body_0 = 0;
-      _fx_N14K_form__kexp_t v_173 = 0;
+      _fx_N14K_form__kexp_t v_175 = 0;
       _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_18 = &e_0->u.ExpWhile;
       _fx_N10Ast__exp_t e2_9 = vcase_18->t1;
       _fx_N10Ast__exp_t e1_5 = vcase_18->t0;
@@ -12974,40 +12977,40 @@ FX_EXTERN_C int
       FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e2_9, &loc2_1, 0), _fx_catch_64);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e1_5, 0, false, sc_0, &v_169, 0), _fx_catch_64);
-      FX_COPY_PTR(v_169.t0, &e1_4);
-      FX_COPY_PTR(v_169.t1, &code1_8);
+            e1_5, 0, false, sc_0, &v_171, 0), _fx_catch_64);
+      FX_COPY_PTR(v_171.t0, &e1_4);
+      FX_COPY_PTR(v_171.t1, &code1_8);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e2_9, 0, false, sc_0, &v_170, 0), _fx_catch_64);
-      FX_COPY_PTR(v_170.t0, &e2_8);
-      FX_COPY_PTR(v_170.t1, &code2_3);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_4, code1_8, true, &v_171), _fx_catch_64);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_171, &loc1_1, &c_1, 0),
+            e2_9, 0, false, sc_0, &v_172, 0), _fx_catch_64);
+      FX_COPY_PTR(v_172.t0, &e2_8);
+      FX_COPY_PTR(v_172.t1, &code2_3);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_4, code1_8, true, &v_173), _fx_catch_64);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_173, &loc1_1, &c_1, 0),
          _fx_catch_64);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_8, code2_3, true, &v_172), _fx_catch_64);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_172, &loc2_1, &body_0, 0),
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e2_8, code2_3, true, &v_174), _fx_catch_64);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_174, &loc2_1, &body_0, 0),
          _fx_catch_64);
       FX_CALL(
          _fx_M6K_formFM9KExpWhileN14K_form__kexp_t3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t(c_1, body_0, &eloc_0,
-            &v_173), _fx_catch_64);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_173, code_0, fx_result);
+            &v_175), _fx_catch_64);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_175, code_0, fx_result);
 
    _fx_catch_64: ;
-      if (v_173) {
-         _fx_free_N14K_form__kexp_t(&v_173);
+      if (v_175) {
+         _fx_free_N14K_form__kexp_t(&v_175);
       }
       if (body_0) {
          _fx_free_N14K_form__kexp_t(&body_0);
       }
-      if (v_172) {
-         _fx_free_LN14K_form__kexp_t(&v_172);
+      if (v_174) {
+         _fx_free_LN14K_form__kexp_t(&v_174);
       }
       if (c_1) {
          _fx_free_N14K_form__kexp_t(&c_1);
       }
-      if (v_171) {
-         _fx_free_LN14K_form__kexp_t(&v_171);
+      if (v_173) {
+         _fx_free_LN14K_form__kexp_t(&v_173);
       }
       if (code2_3) {
          _fx_free_LN14K_form__kexp_t(&code2_3);
@@ -13015,48 +13018,48 @@ FX_EXTERN_C int
       if (e2_8) {
          _fx_free_N14K_form__kexp_t(&e2_8);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_170);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_172);
       if (code1_8) {
          _fx_free_LN14K_form__kexp_t(&code1_8);
       }
       if (e1_4) {
          _fx_free_N14K_form__kexp_t(&e1_4);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_169);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_171);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 25) {
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_174 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_176 = {0};
       _fx_N14K_form__kexp_t e1_6 = 0;
       _fx_LN14K_form__kexp_t code1_9 = 0;
-      _fx_LN14K_form__kexp_t v_175 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_176 = {0};
+      _fx_LN14K_form__kexp_t v_177 = 0;
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_178 = {0};
       _fx_N14K_form__kexp_t e2_10 = 0;
       _fx_LN14K_form__kexp_t code2_4 = 0;
       _fx_N14K_form__kexp_t body_1 = 0;
-      _fx_N14K_form__kexp_t v_177 = 0;
+      _fx_N14K_form__kexp_t v_179 = 0;
       _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_19 = &e_0->u.ExpDoWhile;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_19->t0, 0, false, sc_0, &v_174, 0), _fx_catch_65);
-      FX_COPY_PTR(v_174.t0, &e1_6);
-      FX_COPY_PTR(v_174.t1, &code1_9);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_6, code1_9, true, &v_175), _fx_catch_65);
+            vcase_19->t0, 0, false, sc_0, &v_176, 0), _fx_catch_65);
+      FX_COPY_PTR(v_176.t0, &e1_6);
+      FX_COPY_PTR(v_176.t1, &code1_9);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_6, code1_9, true, &v_177), _fx_catch_65);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_19->t1, v_175, false, sc_0, &v_176, 0), _fx_catch_65);
-      FX_COPY_PTR(v_176.t0, &e2_10);
-      FX_COPY_PTR(v_176.t1, &code2_4);
+            vcase_19->t1, v_177, false, sc_0, &v_178, 0), _fx_catch_65);
+      FX_COPY_PTR(v_178.t0, &e2_10);
+      FX_COPY_PTR(v_178.t1, &code2_4);
       FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(code2_4, &eloc_0, &body_1, 0),
          _fx_catch_65);
       FX_CALL(
          _fx_M6K_formFM11KExpDoWhileN14K_form__kexp_t3N14K_form__kexp_tN14K_form__kexp_tR10Ast__loc_t(body_1, e2_10, &eloc_0,
-            &v_177), _fx_catch_65);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_177, code_0, fx_result);
+            &v_179), _fx_catch_65);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_179, code_0, fx_result);
 
    _fx_catch_65: ;
-      if (v_177) {
-         _fx_free_N14K_form__kexp_t(&v_177);
+      if (v_179) {
+         _fx_free_N14K_form__kexp_t(&v_179);
       }
       if (body_1) {
          _fx_free_N14K_form__kexp_t(&body_1);
@@ -13067,9 +13070,9 @@ FX_EXTERN_C int
       if (e2_10) {
          _fx_free_N14K_form__kexp_t(&e2_10);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_176);
-      if (v_175) {
-         _fx_free_LN14K_form__kexp_t(&v_175);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_178);
+      if (v_177) {
+         _fx_free_LN14K_form__kexp_t(&v_177);
       }
       if (code1_9) {
          _fx_free_LN14K_form__kexp_t(&code1_9);
@@ -13077,58 +13080,58 @@ FX_EXTERN_C int
       if (e1_6) {
          _fx_free_N14K_form__kexp_t(&e1_6);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_174);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_176);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 26) {
       _fx_LN12Ast__scope_t body_sc_0 = 0;
-      _fx_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t v_178 = {0};
+      _fx_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t v_180 = {0};
       _fx_LT2R9Ast__id_tN13K_form__dom_t idom_list_0 = 0;
       _fx_LR9Ast__id_t at_ids_0 = 0;
       _fx_LN14K_form__kexp_t code_35 = 0;
       _fx_LN14K_form__kexp_t body_code_0 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_179 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_181 = {0};
       _fx_N14K_form__kexp_t last_e_0 = 0;
       _fx_LN14K_form__kexp_t body_code_1 = 0;
-      _fx_LN14K_form__kexp_t v_180 = 0;
+      _fx_LN14K_form__kexp_t v_182 = 0;
       _fx_N14K_form__kexp_t body_kexp_0 = 0;
-      _fx_N14K_form__kexp_t v_181 = 0;
+      _fx_N14K_form__kexp_t v_183 = 0;
       _fx_T5LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_20 = &e_0->u.ExpFor;
       _fx_N10Ast__exp_t body_2 = vcase_20->t2;
-      _fx_N12Ast__scope_t v_182;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_182, 0), _fx_catch_66);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_182, sc_0, true, &body_sc_0), _fx_catch_66);
+      _fx_N12Ast__scope_t v_184;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_184, 0), _fx_catch_66);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_184, sc_0, true, &body_sc_0), _fx_catch_66);
       FX_CALL(
          _fx_M11K_normalizeFM13transform_forT4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tLN14K_form__kexp_tLN12Ast__scope_tLN12Ast__scope_tR10Ast__loc_ti(
-            vcase_20->t0, vcase_20->t1, code_0, sc_0, body_sc_0, &eloc_0, km_idx_0, &v_178, 0), _fx_catch_66);
-      FX_COPY_PTR(v_178.t0, &idom_list_0);
-      FX_COPY_PTR(v_178.t1, &at_ids_0);
-      FX_COPY_PTR(v_178.t2, &code_35);
-      FX_COPY_PTR(v_178.t3, &body_code_0);
+            vcase_20->t0, vcase_20->t1, code_0, sc_0, body_sc_0, &eloc_0, km_idx_0, &v_180, 0), _fx_catch_66);
+      FX_COPY_PTR(v_180.t0, &idom_list_0);
+      FX_COPY_PTR(v_180.t1, &at_ids_0);
+      FX_COPY_PTR(v_180.t2, &code_35);
+      FX_COPY_PTR(v_180.t3, &body_code_0);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            body_2, body_code_0, false, body_sc_0, &v_179, 0), _fx_catch_66);
-      FX_COPY_PTR(v_179.t0, &last_e_0);
-      FX_COPY_PTR(v_179.t1, &body_code_1);
+            body_2, body_code_0, false, body_sc_0, &v_181, 0), _fx_catch_66);
+      FX_COPY_PTR(v_181.t0, &last_e_0);
+      FX_COPY_PTR(v_181.t1, &body_code_1);
       _fx_R10Ast__loc_t bloc_0;
       FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(body_2, &bloc_0, 0), _fx_catch_66);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(last_e_0, body_code_1, true, &v_180), _fx_catch_66);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_180, &bloc_0, &body_kexp_0, 0),
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(last_e_0, body_code_1, true, &v_182), _fx_catch_66);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_182, &bloc_0, &body_kexp_0, 0),
          _fx_catch_66);
       FX_CALL(
          _fx_M6K_formFM7KExpForN14K_form__kexp_t5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t(
-            idom_list_0, at_ids_0, body_kexp_0, &vcase_20->t3, &eloc_0, &v_181), _fx_catch_66);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_181, code_35, fx_result);
+            idom_list_0, at_ids_0, body_kexp_0, &vcase_20->t3, &eloc_0, &v_183), _fx_catch_66);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_183, code_35, fx_result);
 
    _fx_catch_66: ;
-      if (v_181) {
-         _fx_free_N14K_form__kexp_t(&v_181);
+      if (v_183) {
+         _fx_free_N14K_form__kexp_t(&v_183);
       }
       if (body_kexp_0) {
          _fx_free_N14K_form__kexp_t(&body_kexp_0);
       }
-      if (v_180) {
-         _fx_free_LN14K_form__kexp_t(&v_180);
+      if (v_182) {
+         _fx_free_LN14K_form__kexp_t(&v_182);
       }
       if (body_code_1) {
          _fx_free_LN14K_form__kexp_t(&body_code_1);
@@ -13136,7 +13139,7 @@ FX_EXTERN_C int
       if (last_e_0) {
          _fx_free_N14K_form__kexp_t(&last_e_0);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_179);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_181);
       if (body_code_0) {
          _fx_free_LN14K_form__kexp_t(&body_code_0);
       }
@@ -13147,9 +13150,9 @@ FX_EXTERN_C int
       if (idom_list_0) {
          _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idom_list_0);
       }
-      _fx_free_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t(&v_178);
+      _fx_free_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t(&v_180);
       FX_FREE_LIST_SIMPLE(&body_sc_0);
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 27) {
       _fx_LN12Ast__scope_t body_sc_1 = 0;
@@ -13158,58 +13161,58 @@ FX_EXTERN_C int
       _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t pew_ll_0 = 0;
       _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t pre_idom_ll_1 = 0;
       _fx_LN14K_form__kexp_t body_code_2 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_183 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_185 = {0};
       _fx_N14K_form__kexp_t last_e_1 = 0;
       _fx_LN14K_form__kexp_t body_code_3 = 0;
-      _fx_LN14K_form__kexp_t v_184 = 0;
+      _fx_LN14K_form__kexp_t v_186 = 0;
       _fx_N14K_form__kexp_t body_kexp_1 = 0;
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_185 = 0;
-      _fx_N14K_form__kexp_t v_186 = 0;
+      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_187 = 0;
+      _fx_N14K_form__kexp_t v_188 = 0;
       _fx_T4LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tN10Ast__exp_tR16Ast__for_flags_tT2N10Ast__typ_tR10Ast__loc_t*
          vcase_21 = &e_0->u.ExpMap;
       _fx_N10Ast__exp_t body_3 = vcase_21->t1;
-      _fx_N12Ast__scope_t v_187;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_187, 0), _fx_catch_68);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_187, sc_0, true, &body_sc_1), _fx_catch_68);
+      _fx_N12Ast__scope_t v_189;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_189, 0), _fx_catch_68);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_189, sc_0, true, &body_sc_1), _fx_catch_68);
       FX_COPY_PTR(vcase_21->t0, &pew_ll_0);
       _fx_LT2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t lst_11 = pew_ll_0;
       for (; lst_11; lst_11 = lst_11->tl) {
          _fx_LT2N10Ast__pat_tN10Ast__exp_t pe_l_0 = 0;
          _fx_N10Ast__pat_t idx_pat_0 = 0;
-         _fx_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t v_188 = {0};
+         _fx_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t v_190 = {0};
          _fx_LT2R9Ast__id_tN13K_form__dom_t idom_list_1 = 0;
          _fx_LR9Ast__id_t at_ids_1 = 0;
          _fx_LN14K_form__kexp_t pre_code_0 = 0;
          _fx_LN14K_form__kexp_t body_code_4 = 0;
          _fx_N14K_form__kexp_t pre_exp_0 = 0;
-         _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_189 = {0};
-         _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_190 = 0;
+         _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_191 = {0};
+         _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_192 = 0;
          _fx_T2LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_t* __pat___4 = &lst_11->hd;
          FX_COPY_PTR(__pat___4->t0, &pe_l_0);
          FX_COPY_PTR(__pat___4->t1, &idx_pat_0);
          FX_CALL(
             _fx_M11K_normalizeFM13transform_forT4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t7LT2N10Ast__pat_tN10Ast__exp_tN10Ast__pat_tLN14K_form__kexp_tLN12Ast__scope_tLN12Ast__scope_tR10Ast__loc_ti(
-               pe_l_0, idx_pat_0, prev_body_code_0, sc_0, body_sc_1, &eloc_0, km_idx_0, &v_188, 0), _fx_catch_67);
-         FX_COPY_PTR(v_188.t0, &idom_list_1);
-         FX_COPY_PTR(v_188.t1, &at_ids_1);
-         FX_COPY_PTR(v_188.t2, &pre_code_0);
-         FX_COPY_PTR(v_188.t3, &body_code_4);
+               pe_l_0, idx_pat_0, prev_body_code_0, sc_0, body_sc_1, &eloc_0, km_idx_0, &v_190, 0), _fx_catch_67);
+         FX_COPY_PTR(v_190.t0, &idom_list_1);
+         FX_COPY_PTR(v_190.t1, &at_ids_1);
+         FX_COPY_PTR(v_190.t2, &pre_code_0);
+         FX_COPY_PTR(v_190.t3, &body_code_4);
          FX_CALL(
             _fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(pre_code_0, &eloc_0, &pre_exp_0, 0),
             _fx_catch_67);
          _fx_free_LN14K_form__kexp_t(&prev_body_code_0);
          FX_COPY_PTR(body_code_4, &prev_body_code_0);
-         _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(pre_exp_0, idom_list_1, at_ids_1, &v_189);
-         FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_189, pre_idom_ll_0, true, &v_190),
+         _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(pre_exp_0, idom_list_1, at_ids_1, &v_191);
+         FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_191, pre_idom_ll_0, true, &v_192),
             _fx_catch_67);
          _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&pre_idom_ll_0);
-         FX_COPY_PTR(v_190, &pre_idom_ll_0);
+         FX_COPY_PTR(v_192, &pre_idom_ll_0);
 
       _fx_catch_67: ;
-         if (v_190) {
-            _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_190);
+         if (v_192) {
+            _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_192);
          }
-         _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_189);
+         _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_191);
          if (pre_exp_0) {
             _fx_free_N14K_form__kexp_t(&pre_exp_0);
          }
@@ -13223,7 +13226,7 @@ FX_EXTERN_C int
          if (idom_list_1) {
             _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&idom_list_1);
          }
-         _fx_free_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t(&v_188);
+         _fx_free_T4LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14K_form__kexp_tLN14K_form__kexp_t(&v_190);
          if (idx_pat_0) {
             _fx_free_N10Ast__pat_t(&idx_pat_0);
          }
@@ -13236,34 +13239,34 @@ FX_EXTERN_C int
       FX_COPY_PTR(prev_body_code_0, &body_code_2);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            body_3, body_code_2, false, body_sc_1, &v_183, 0), _fx_catch_68);
-      FX_COPY_PTR(v_183.t0, &last_e_1);
-      FX_COPY_PTR(v_183.t1, &body_code_3);
+            body_3, body_code_2, false, body_sc_1, &v_185, 0), _fx_catch_68);
+      FX_COPY_PTR(v_185.t0, &last_e_1);
+      FX_COPY_PTR(v_185.t1, &body_code_3);
       _fx_R10Ast__loc_t bloc_1;
       FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(body_3, &bloc_1, 0), _fx_catch_68);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(last_e_1, body_code_3, true, &v_184), _fx_catch_68);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_184, &bloc_1, &body_kexp_1, 0),
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(last_e_1, body_code_3, true, &v_186), _fx_catch_68);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_186, &bloc_1, &body_kexp_1, 0),
          _fx_catch_68);
       FX_CALL(
          _fx_M11K_normalizeFM3revLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t1LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(
-            pre_idom_ll_1, &v_185, 0), _fx_catch_68);
+            pre_idom_ll_1, &v_187, 0), _fx_catch_68);
       FX_CALL(
          _fx_M6K_formFM7KExpMapN14K_form__kexp_t4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            v_185, body_kexp_1, &vcase_21->t2, &kctx_0, &v_186), _fx_catch_68);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_186, code_0, fx_result);
+            v_187, body_kexp_1, &vcase_21->t2, &kctx_0, &v_188), _fx_catch_68);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_188, code_0, fx_result);
 
    _fx_catch_68: ;
-      if (v_186) {
-         _fx_free_N14K_form__kexp_t(&v_186);
+      if (v_188) {
+         _fx_free_N14K_form__kexp_t(&v_188);
       }
-      if (v_185) {
-         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_185);
+      if (v_187) {
+         _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_187);
       }
       if (body_kexp_1) {
          _fx_free_N14K_form__kexp_t(&body_kexp_1);
       }
-      if (v_184) {
-         _fx_free_LN14K_form__kexp_t(&v_184);
+      if (v_186) {
+         _fx_free_LN14K_form__kexp_t(&v_186);
       }
       if (body_code_3) {
          _fx_free_LN14K_form__kexp_t(&body_code_3);
@@ -13271,7 +13274,7 @@ FX_EXTERN_C int
       if (last_e_1) {
          _fx_free_N14K_form__kexp_t(&last_e_1);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_183);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_185);
       if (body_code_2) {
          _fx_free_LN14K_form__kexp_t(&body_code_2);
       }
@@ -13288,35 +13291,35 @@ FX_EXTERN_C int
          _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&pre_idom_ll_0);
       }
       FX_FREE_LIST_SIMPLE(&body_sc_1);
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 19) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_191 = {0};
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_193 = {0};
       _fx_N14K_form__atom_t arr_1 = {0};
       _fx_LN14K_form__kexp_t code_36 = 0;
       _fx_N10Ast__typ_t probably_tuple_type_0 = 0;
-      _fx_T2LN13K_form__dom_tLN14K_form__kexp_t v_192 = {0};
+      _fx_T2LN13K_form__dom_tLN14K_form__kexp_t v_194 = {0};
       _fx_LN13K_form__dom_t dlist_0 = 0;
       _fx_LN14K_form__kexp_t code_37 = 0;
-      _fx_LN13K_form__dom_t v_193 = 0;
-      _fx_N14K_form__kexp_t v_194 = 0;
+      _fx_LN13K_form__dom_t v_195 = 0;
+      _fx_N14K_form__kexp_t v_196 = 0;
       _fx_T5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_22 =
          &e_0->u.ExpAt;
       _fx_LN10Ast__exp_t idxlist_0 = vcase_22->t3;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_22->t0, code_0, true, sc_0, &v_191, 0), _fx_catch_76);
-      _fx_copy_N14K_form__atom_t(&v_191.t0, &arr_1);
-      FX_COPY_PTR(v_191.t1, &code_36);
+            vcase_22->t0, code_0, true, sc_0, &v_193, 0), _fx_catch_76);
+      _fx_copy_N14K_form__atom_t(&v_193.t0, &arr_1);
+      FX_COPY_PTR(v_193.t1, &code_36);
       if (idxlist_0 != 0) {
          if (idxlist_0->tl == 0) {
-            _fx_N10Ast__typ_t v_195 = 0;
-            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(idxlist_0->hd, &v_195, 0), _fx_catch_69);
-            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_195, &probably_tuple_type_0, 0), _fx_catch_69);
+            _fx_N10Ast__typ_t v_197 = 0;
+            FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(idxlist_0->hd, &v_197, 0), _fx_catch_69);
+            FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(v_197, &probably_tuple_type_0, 0), _fx_catch_69);
 
          _fx_catch_69: ;
-            if (v_195) {
-               _fx_free_N10Ast__typ_t(&v_195);
+            if (v_197) {
+               _fx_free_N10Ast__typ_t(&v_197);
             }
             goto _fx_endmatch_8;
          }
@@ -13331,97 +13334,97 @@ FX_EXTERN_C int
             bool res_13;
             FX_CALL(_fx_M11K_normalizeFM8is_rangeB1N10Ast__exp_t(tupidx_0, &res_13, 0), _fx_catch_76);
             if (!res_13) {
-               _fx_T2N10Ast__typ_tR10Ast__loc_t v_196 = {0};
-               fx_exn_t v_197 = {0};
-               _fx_T2R9Ast__id_tLN14K_form__kexp_t v_198 = {0};
+               _fx_T2N10Ast__typ_tR10Ast__loc_t v_198 = {0};
+               fx_exn_t v_199 = {0};
+               _fx_T2R9Ast__id_tLN14K_form__kexp_t v_200 = {0};
                _fx_LN14K_form__kexp_t code_38 = 0;
                _fx_LN13K_form__dom_t dlist_1 = 0;
                _fx_LN14K_form__kexp_t code_39 = 0;
                _fx_LN10Ast__typ_t idxtype_0 = 0;
-               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(tupidx_0, &v_196, 0), _fx_catch_71);
-               _fx_R10Ast__loc_t iloc_0 = v_196.t1;
-               int_ v_199;
-               FX_CALL(_fx_M11K_normalizeFM8length1_i1LN10Ast__exp_t(idxlist_0->tl, &v_199, 0), _fx_catch_71);
-               if (v_199 != 0) {
+               FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(tupidx_0, &v_198, 0), _fx_catch_71);
+               _fx_R10Ast__loc_t iloc_0 = v_198.t1;
+               int_ v_201;
+               FX_CALL(_fx_M11K_normalizeFM8length1_i1LN10Ast__exp_t(idxlist_0->tl, &v_201, 0), _fx_catch_71);
+               if (v_201 != 0) {
                   fx_str_t slit_17 = FX_MAKE_STR("internal error: tuple index is not only");
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_17, &v_197, 0), _fx_catch_71);
-                  FX_THROW(&v_197, false, _fx_catch_71);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_17, &v_199, 0), _fx_catch_71);
+                  FX_THROW(&v_199, false, _fx_catch_71);
                }
                fx_str_t slit_18 = FX_MAKE_STR("internal error: a literal instead of tuple");
                FX_CALL(
                   _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(
-                     tupidx_0, code_36, false, sc_0, &slit_18, &v_198, 0), _fx_catch_71);
-               _fx_R9Ast__id_t tup_id_0 = v_198.t0;
-               FX_COPY_PTR(v_198.t1, &code_38);
+                     tupidx_0, code_36, false, sc_0, &slit_18, &v_200, 0), _fx_catch_71);
+               _fx_R9Ast__id_t tup_id_0 = v_200.t0;
+               FX_COPY_PTR(v_200.t1, &code_38);
                FX_COPY_PTR(code_38, &code_39);
                int_ elnum_0 = 0;
                FX_COPY_PTR(probably_tuple_type_0->u.TypTuple, &idxtype_0);
                _fx_LN10Ast__typ_t lst_12 = idxtype_0;
                for (; lst_12; lst_12 = lst_12->tl, elnum_0 += 1) {
-                  _fx_N14K_form__ktyp_t v_200 = 0;
-                  _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_201 = {0};
-                  _fx_N14K_form__kexp_t v_202 = 0;
-                  _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_203 = {0};
+                  _fx_N14K_form__ktyp_t v_202 = 0;
+                  _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_203 = {0};
+                  _fx_N14K_form__kexp_t v_204 = 0;
+                  _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_205 = {0};
                   _fx_N14K_form__atom_t d_0 = {0};
                   _fx_LN14K_form__kexp_t code1_10 = 0;
-                  _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_204 = {0};
+                  _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_206 = {0};
                   _fx_N14K_form__atom_t d_1 = {0};
                   _fx_LN14K_form__kexp_t code2_5 = 0;
-                  _fx_N13K_form__dom_t v_205 = {0};
-                  _fx_LN13K_form__dom_t v_206 = 0;
+                  _fx_N13K_form__dom_t v_207 = {0};
+                  _fx_LN13K_form__dom_t v_208 = 0;
                   _fx_N10Ast__typ_t eltyp_0 = lst_12->hd;
-                  int_ v_207;
-                  FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_0, &v_207, 0), _fx_catch_70);
+                  int_ v_209;
+                  FX_CALL(_fx_M3AstFM11curr_modulei1LN12Ast__scope_t(sc_0, &v_209, 0), _fx_catch_70);
                   FX_CALL(
-                     _fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(eltyp_0, &iloc_0, &v_200, 0),
+                     _fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(eltyp_0, &iloc_0, &v_202, 0),
                      _fx_catch_70);
-                  _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(v_200, &iloc_0, &v_201);
+                  _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(v_202, &iloc_0, &v_203);
                   FX_CALL(
                      _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&tup_id_0, elnum_0,
-                        &v_201, &v_202), _fx_catch_70);
+                        &v_203, &v_204), _fx_catch_70);
                   fx_str_t slit_19 = FX_MAKE_STR("idx");
                   FX_CALL(
-                     _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iSN14K_form__kexp_tBLN14K_form__kexp_t(v_207,
-                        &slit_19, v_202, false, code_39, &v_203, 0), _fx_catch_70);
-                  _fx_copy_N14K_form__atom_t(&v_203.t0, &d_0);
-                  FX_COPY_PTR(v_203.t1, &code1_10);
+                     _fx_M6K_formFM9kexp2atomT2N14K_form__atom_tLN14K_form__kexp_t5iSN14K_form__kexp_tBLN14K_form__kexp_t(v_209,
+                        &slit_19, v_204, false, code_39, &v_205, 0), _fx_catch_70);
+                  _fx_copy_N14K_form__atom_t(&v_205.t0, &d_0);
+                  FX_COPY_PTR(v_205.t1, &code1_10);
                   FX_CALL(
                      _fx_M11K_normalizeFM14cast_if_neededT2N14K_form__atom_tLN14K_form__kexp_t4N14K_form__atom_tLN14K_form__kexp_tR10Ast__loc_tLN12Ast__scope_t(
-                        &d_0, code1_10, &iloc_0, sc_0, &v_204, 0), _fx_catch_70);
-                  _fx_copy_N14K_form__atom_t(&v_204.t0, &d_1);
-                  FX_COPY_PTR(v_204.t1, &code2_5);
+                        &d_0, code1_10, &iloc_0, sc_0, &v_206, 0), _fx_catch_70);
+                  _fx_copy_N14K_form__atom_t(&v_206.t0, &d_1);
+                  FX_COPY_PTR(v_206.t1, &code2_5);
                   _fx_free_LN14K_form__kexp_t(&code_39);
                   FX_COPY_PTR(code2_5, &code_39);
-                  _fx_M6K_formFM10DomainElemN13K_form__dom_t1N14K_form__atom_t(&d_1, &v_205);
-                  FX_CALL(_fx_cons_LN13K_form__dom_t(&v_205, dlist_1, true, &v_206), _fx_catch_70);
+                  _fx_M6K_formFM10DomainElemN13K_form__dom_t1N14K_form__atom_t(&d_1, &v_207);
+                  FX_CALL(_fx_cons_LN13K_form__dom_t(&v_207, dlist_1, true, &v_208), _fx_catch_70);
                   _fx_free_LN13K_form__dom_t(&dlist_1);
-                  FX_COPY_PTR(v_206, &dlist_1);
+                  FX_COPY_PTR(v_208, &dlist_1);
 
                _fx_catch_70: ;
-                  if (v_206) {
-                     _fx_free_LN13K_form__dom_t(&v_206);
+                  if (v_208) {
+                     _fx_free_LN13K_form__dom_t(&v_208);
                   }
-                  _fx_free_N13K_form__dom_t(&v_205);
+                  _fx_free_N13K_form__dom_t(&v_207);
                   if (code2_5) {
                      _fx_free_LN14K_form__kexp_t(&code2_5);
                   }
                   _fx_free_N14K_form__atom_t(&d_1);
-                  _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_204);
+                  _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_206);
                   if (code1_10) {
                      _fx_free_LN14K_form__kexp_t(&code1_10);
                   }
                   _fx_free_N14K_form__atom_t(&d_0);
-                  _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_203);
-                  if (v_202) {
-                     _fx_free_N14K_form__kexp_t(&v_202);
+                  _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_205);
+                  if (v_204) {
+                     _fx_free_N14K_form__kexp_t(&v_204);
                   }
-                  _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_201);
-                  if (v_200) {
-                     _fx_free_N14K_form__ktyp_t(&v_200);
+                  _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_203);
+                  if (v_202) {
+                     _fx_free_N14K_form__ktyp_t(&v_202);
                   }
                   FX_CHECK_EXN(_fx_catch_71);
                }
-               _fx_make_T2LN13K_form__dom_tLN14K_form__kexp_t(dlist_1, code_39, &v_192);
+               _fx_make_T2LN13K_form__dom_tLN14K_form__kexp_t(dlist_1, code_39, &v_194);
 
             _fx_catch_71: ;
                if (idxtype_0) {
@@ -13436,9 +13439,9 @@ FX_EXTERN_C int
                if (code_38) {
                   _fx_free_LN14K_form__kexp_t(&code_38);
                }
-               _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_198);
-               fx_free_exn(&v_197);
-               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_196);
+               _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_200);
+               fx_free_exn(&v_199);
+               _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_198);
                goto _fx_endmatch_9;
             }
          }
@@ -13451,114 +13454,114 @@ FX_EXTERN_C int
       FX_COPY_PTR(idxlist_0, &idxlist_1);
       _fx_LN10Ast__exp_t lst_13 = idxlist_1;
       for (; lst_13; lst_13 = lst_13->tl, idx_1 += 1) {
-         _fx_T2N14K_form__atom_ti v_208 = {0};
-         _fx_LT2N14K_form__atom_ti v_209 = 0;
-         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_210 = {0};
-         fx_exn_t exn_2 = {0};
+         _fx_T2N14K_form__atom_ti v_210 = {0};
          _fx_LT2N14K_form__atom_ti v_211 = 0;
+         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_212 = {0};
+         fx_exn_t exn_2 = {0};
+         _fx_LT2N14K_form__atom_ti v_213 = 0;
          _fx_N13K_form__dom_t d_2 = {0};
          _fx_LN14K_form__kexp_t code1_11 = 0;
-         _fx_T2N10Ast__typ_tR10Ast__loc_t v_212 = {0};
-         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_213 = {0};
+         _fx_T2N10Ast__typ_tR10Ast__loc_t v_214 = {0};
+         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_215 = {0};
          _fx_N13K_form__dom_t d_3 = {0};
          _fx_LN14K_form__kexp_t code2_6 = 0;
-         _fx_LN13K_form__dom_t v_214 = 0;
+         _fx_LN13K_form__dom_t v_216 = 0;
          _fx_N10Ast__exp_t i_0 = lst_13->hd;
-         _fx_make_T2N14K_form__atom_ti(&arr_1, idx_1, &v_208);
-         FX_CALL(_fx_cons_LT2N14K_form__atom_ti(&v_208, _fx_g29K_normalize__idx_access_stack, true, &v_209), _fx_catch_74);
+         _fx_make_T2N14K_form__atom_ti(&arr_1, idx_1, &v_210);
+         FX_CALL(_fx_cons_LT2N14K_form__atom_ti(&v_210, _fx_g29K_normalize__idx_access_stack, true, &v_211), _fx_catch_74);
          _fx_free_LT2N14K_form__atom_ti(&_fx_g29K_normalize__idx_access_stack);
-         FX_COPY_PTR(v_209, &_fx_g29K_normalize__idx_access_stack);
-         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_215 = {0};
-         _fx_LT2N14K_form__atom_ti v_216 = 0;
+         FX_COPY_PTR(v_211, &_fx_g29K_normalize__idx_access_stack);
+         _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_217 = {0};
+         _fx_LT2N14K_form__atom_ti v_218 = 0;
          FX_CALL(
             _fx_M11K_normalizeFM7exp2domT2N13K_form__dom_tLN14K_form__kexp_t3N10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_t(
-               i_0, code_40, sc_0, &v_215, 0), _fx_catch_72);
+               i_0, code_40, sc_0, &v_217, 0), _fx_catch_72);
          FX_CALL(
-            _fx_M11K_normalizeFM2tlLT2N14K_form__atom_ti1LT2N14K_form__atom_ti(_fx_g29K_normalize__idx_access_stack, &v_216, 0),
+            _fx_M11K_normalizeFM2tlLT2N14K_form__atom_ti1LT2N14K_form__atom_ti(_fx_g29K_normalize__idx_access_stack, &v_218, 0),
             _fx_catch_72);
          _fx_free_LT2N14K_form__atom_ti(&_fx_g29K_normalize__idx_access_stack);
-         FX_COPY_PTR(v_216, &_fx_g29K_normalize__idx_access_stack);
-         _fx_copy_T2N13K_form__dom_tLN14K_form__kexp_t(&v_215, &v_210);
+         FX_COPY_PTR(v_218, &_fx_g29K_normalize__idx_access_stack);
+         _fx_copy_T2N13K_form__dom_tLN14K_form__kexp_t(&v_217, &v_212);
 
       _fx_catch_72: ;
-         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_215);
-         if (v_216) {
-            _fx_free_LT2N14K_form__atom_ti(&v_216);
+         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_217);
+         if (v_218) {
+            _fx_free_LT2N14K_form__atom_ti(&v_218);
          }
          if (fx_status < 0) {
             fx_exn_get_and_reset(fx_status, &exn_2);
             fx_status = 0;
-            _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_210);
+            _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_212);
             FX_CALL(
-               _fx_M11K_normalizeFM2tlLT2N14K_form__atom_ti1LT2N14K_form__atom_ti(_fx_g29K_normalize__idx_access_stack, &v_211,
+               _fx_M11K_normalizeFM2tlLT2N14K_form__atom_ti1LT2N14K_form__atom_ti(_fx_g29K_normalize__idx_access_stack, &v_213,
                   0), _fx_catch_74);
             _fx_free_LT2N14K_form__atom_ti(&_fx_g29K_normalize__idx_access_stack);
-            FX_COPY_PTR(v_211, &_fx_g29K_normalize__idx_access_stack);
+            FX_COPY_PTR(v_213, &_fx_g29K_normalize__idx_access_stack);
             FX_THROW(&exn_2, false, _fx_catch_74);
          }
-         _fx_copy_N13K_form__dom_t(&v_210.t0, &d_2);
-         FX_COPY_PTR(v_210.t1, &code1_11);
-         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(i_0, &v_212, 0), _fx_catch_74);
-         _fx_R10Ast__loc_t iloc_1 = v_212.t1;
+         _fx_copy_N13K_form__dom_t(&v_212.t0, &d_2);
+         FX_COPY_PTR(v_212.t1, &code1_11);
+         FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(i_0, &v_214, 0), _fx_catch_74);
+         _fx_R10Ast__loc_t iloc_1 = v_214.t1;
          if (d_2.tag == 1) {
-            _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_217 = {0};
+            _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_219 = {0};
             _fx_N14K_form__atom_t scalar_idx_0 = {0};
             _fx_LN14K_form__kexp_t code_41 = 0;
-            _fx_N13K_form__dom_t v_218 = {0};
+            _fx_N13K_form__dom_t v_220 = {0};
             FX_CALL(
                _fx_M11K_normalizeFM14cast_if_neededT2N14K_form__atom_tLN14K_form__kexp_t4N14K_form__atom_tLN14K_form__kexp_tR10Ast__loc_tLN12Ast__scope_t(
-                  &d_2.u.DomainElem, code1_11, &iloc_1, sc_0, &v_217, 0), _fx_catch_73);
-            _fx_copy_N14K_form__atom_t(&v_217.t0, &scalar_idx_0);
-            FX_COPY_PTR(v_217.t1, &code_41);
-            _fx_M6K_formFM10DomainElemN13K_form__dom_t1N14K_form__atom_t(&scalar_idx_0, &v_218);
-            _fx_make_T2N13K_form__dom_tLN14K_form__kexp_t(&v_218, code_41, &v_213);
+                  &d_2.u.DomainElem, code1_11, &iloc_1, sc_0, &v_219, 0), _fx_catch_73);
+            _fx_copy_N14K_form__atom_t(&v_219.t0, &scalar_idx_0);
+            FX_COPY_PTR(v_219.t1, &code_41);
+            _fx_M6K_formFM10DomainElemN13K_form__dom_t1N14K_form__atom_t(&scalar_idx_0, &v_220);
+            _fx_make_T2N13K_form__dom_tLN14K_form__kexp_t(&v_220, code_41, &v_215);
 
          _fx_catch_73: ;
-            _fx_free_N13K_form__dom_t(&v_218);
+            _fx_free_N13K_form__dom_t(&v_220);
             if (code_41) {
                _fx_free_LN14K_form__kexp_t(&code_41);
             }
             _fx_free_N14K_form__atom_t(&scalar_idx_0);
-            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_217);
+            _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_219);
          }
          else {
-            _fx_make_T2N13K_form__dom_tLN14K_form__kexp_t(&d_2, code1_11, &v_213);
+            _fx_make_T2N13K_form__dom_tLN14K_form__kexp_t(&d_2, code1_11, &v_215);
          }
          FX_CHECK_EXN(_fx_catch_74);
-         _fx_copy_N13K_form__dom_t(&v_213.t0, &d_3);
-         FX_COPY_PTR(v_213.t1, &code2_6);
+         _fx_copy_N13K_form__dom_t(&v_215.t0, &d_3);
+         FX_COPY_PTR(v_215.t1, &code2_6);
          _fx_free_LN14K_form__kexp_t(&code_40);
          FX_COPY_PTR(code2_6, &code_40);
-         FX_CALL(_fx_cons_LN13K_form__dom_t(&d_3, dlist_2, true, &v_214), _fx_catch_74);
+         FX_CALL(_fx_cons_LN13K_form__dom_t(&d_3, dlist_2, true, &v_216), _fx_catch_74);
          _fx_free_LN13K_form__dom_t(&dlist_2);
-         FX_COPY_PTR(v_214, &dlist_2);
+         FX_COPY_PTR(v_216, &dlist_2);
 
       _fx_catch_74: ;
-         if (v_214) {
-            _fx_free_LN13K_form__dom_t(&v_214);
+         if (v_216) {
+            _fx_free_LN13K_form__dom_t(&v_216);
          }
          if (code2_6) {
             _fx_free_LN14K_form__kexp_t(&code2_6);
          }
          _fx_free_N13K_form__dom_t(&d_3);
-         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_213);
-         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_212);
+         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_215);
+         _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_214);
          if (code1_11) {
             _fx_free_LN14K_form__kexp_t(&code1_11);
          }
          _fx_free_N13K_form__dom_t(&d_2);
+         if (v_213) {
+            _fx_free_LT2N14K_form__atom_ti(&v_213);
+         }
+         fx_free_exn(&exn_2);
+         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_212);
          if (v_211) {
             _fx_free_LT2N14K_form__atom_ti(&v_211);
          }
-         fx_free_exn(&exn_2);
-         _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_210);
-         if (v_209) {
-            _fx_free_LT2N14K_form__atom_ti(&v_209);
-         }
-         _fx_free_T2N14K_form__atom_ti(&v_208);
+         _fx_free_T2N14K_form__atom_ti(&v_210);
          FX_CHECK_EXN(_fx_catch_75);
       }
-      _fx_make_T2LN13K_form__dom_tLN14K_form__kexp_t(dlist_2, code_40, &v_192);
+      _fx_make_T2LN13K_form__dom_tLN14K_form__kexp_t(dlist_2, code_40, &v_194);
 
    _fx_catch_75: ;
       if (idxlist_1) {
@@ -13573,20 +13576,20 @@ FX_EXTERN_C int
 
    _fx_endmatch_9: ;
       FX_CHECK_EXN(_fx_catch_76);
-      FX_COPY_PTR(v_192.t0, &dlist_0);
-      FX_COPY_PTR(v_192.t1, &code_37);
-      FX_CALL(_fx_M11K_normalizeFM3revLN13K_form__dom_t1LN13K_form__dom_t(dlist_0, &v_193, 0), _fx_catch_76);
+      FX_COPY_PTR(v_194.t0, &dlist_0);
+      FX_COPY_PTR(v_194.t1, &code_37);
+      FX_CALL(_fx_M11K_normalizeFM3revLN13K_form__dom_t1LN13K_form__dom_t(dlist_0, &v_195, 0), _fx_catch_76);
       FX_CALL(
          _fx_M6K_formFM6KExpAtN14K_form__kexp_t5N14K_form__atom_tN13Ast__border_tN18Ast__interpolate_tLN13K_form__dom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            &arr_1, &vcase_22->t1, &vcase_22->t2, v_193, &kctx_0, &v_194), _fx_catch_76);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_194, code_37, fx_result);
+            &arr_1, &vcase_22->t1, &vcase_22->t2, v_195, &kctx_0, &v_196), _fx_catch_76);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_196, code_37, fx_result);
 
    _fx_catch_76: ;
-      if (v_194) {
-         _fx_free_N14K_form__kexp_t(&v_194);
+      if (v_196) {
+         _fx_free_N14K_form__kexp_t(&v_196);
       }
-      if (v_193) {
-         _fx_free_LN13K_form__dom_t(&v_193);
+      if (v_195) {
+         _fx_free_LN13K_form__dom_t(&v_195);
       }
       if (code_37) {
          _fx_free_LN14K_form__kexp_t(&code_37);
@@ -13594,7 +13597,7 @@ FX_EXTERN_C int
       if (dlist_0) {
          _fx_free_LN13K_form__dom_t(&dlist_0);
       }
-      _fx_free_T2LN13K_form__dom_tLN14K_form__kexp_t(&v_192);
+      _fx_free_T2LN13K_form__dom_tLN14K_form__kexp_t(&v_194);
       if (probably_tuple_type_0) {
          _fx_free_N10Ast__typ_t(&probably_tuple_type_0);
       }
@@ -13602,14 +13605,14 @@ FX_EXTERN_C int
          _fx_free_LN14K_form__kexp_t(&code_36);
       }
       _fx_free_N14K_form__atom_t(&arr_1);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_191);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_193);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 21) {
-      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_219 = {0};
+      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_221 = {0};
       _fx_LN14K_form__kexp_t code_42 = 0;
       _fx_N14K_form__ktyp_t ktyp_1 = 0;
-      _fx_N15K_form__kinfo_t v_220 = {0};
+      _fx_N15K_form__kinfo_t v_222 = {0};
       _fx_T3N10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_23 = &e_0->u.ExpMem;
       _fx_N10Ast__exp_t elem_0 = vcase_23->t1;
       _fx_N10Ast__exp_t e1_7 = vcase_23->t0;
@@ -13618,54 +13621,54 @@ FX_EXTERN_C int
       fx_str_t slit_20 = FX_MAKE_STR("the literal does not have members to access");
       FX_CALL(
          _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(e1_7,
-            code_0, true, sc_0, &slit_20, &v_219, 0), _fx_catch_85);
-      _fx_R9Ast__id_t a_id_2 = v_219.t0;
-      FX_COPY_PTR(v_219.t1, &code_42);
+            code_0, true, sc_0, &slit_20, &v_221, 0), _fx_catch_85);
+      _fx_R9Ast__id_t a_id_2 = v_221.t0;
+      FX_COPY_PTR(v_221.t1, &code_42);
       FX_CALL(_fx_M6K_formFM12get_idk_ktypN14K_form__ktyp_t2R9Ast__id_tR10Ast__loc_t(&a_id_2, &e1loc_0, &ktyp_1, 0),
          _fx_catch_85);
       if (FX_REC_VARIANT_TAG(elem_0) == 6) {
          _fx_T2N10Ast__lit_tT2N10Ast__typ_tR10Ast__loc_t* vcase_24 = &elem_0->u.ExpLit;
-         _fx_N10Ast__lit_t* v_221 = &vcase_24->t0;
-         if (v_221->tag == 1) {
+         _fx_N10Ast__lit_t* v_223 = &vcase_24->t0;
+         if (v_223->tag == 1) {
             if (FX_REC_VARIANT_TAG(ktyp_1) == 14) {
-               fx_str_t v_222 = {0};
-               fx_str_t v_223 = {0};
-               fx_exn_t v_224 = {0};
-               _fx_N14K_form__kexp_t v_225 = 0;
+               fx_str_t v_224 = {0};
+               fx_str_t v_225 = {0};
+               fx_exn_t v_226 = {0};
+               _fx_N14K_form__kexp_t v_227 = 0;
                int_ idx_2;
-               FX_CALL(_fx_M11K_normalizeFM3inti1l(v_221->u.LitInt, &idx_2, 0), _fx_catch_77);
+               FX_CALL(_fx_M11K_normalizeFM3inti1l(v_223->u.LitInt, &idx_2, 0), _fx_catch_77);
                int_ n_1;
                FX_CALL(_fx_M11K_normalizeFM8length1_i1LN14K_form__ktyp_t(ktyp_1->u.KTypTuple, &n_1, 0), _fx_catch_77);
                if (!(bool)((0 <= idx_2) & (idx_2 < n_1))) {
-                  FX_CALL(_fx_F6stringS1i(n_1, &v_222, 0), _fx_catch_77);
+                  FX_CALL(_fx_F6stringS1i(n_1, &v_224, 0), _fx_catch_77);
                   fx_str_t slit_21 = FX_MAKE_STR("the tuple index is outside of the range [0, ");
                   fx_str_t slit_22 = FX_MAKE_STR(")");
                   {
-                     const fx_str_t strs_1[] = { slit_21, v_222, slit_22 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_223), _fx_catch_77);
+                     const fx_str_t strs_1[] = { slit_21, v_224, slit_22 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_225), _fx_catch_77);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&vcase_24->t1.t1, &v_223, &v_224, 0), _fx_catch_77);
-                  FX_THROW(&v_224, false, _fx_catch_77);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&vcase_24->t1.t1, &v_225, &v_226, 0), _fx_catch_77);
+                  FX_THROW(&v_226, false, _fx_catch_77);
                }
                FX_CALL(
                   _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&a_id_2, idx_2, &kctx_0,
-                     &v_225), _fx_catch_77);
-               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_225, code_42, fx_result);
+                     &v_227), _fx_catch_77);
+               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_227, code_42, fx_result);
 
             _fx_catch_77: ;
-               if (v_225) {
-                  _fx_free_N14K_form__kexp_t(&v_225);
+               if (v_227) {
+                  _fx_free_N14K_form__kexp_t(&v_227);
                }
-               fx_free_exn(&v_224);
-               FX_FREE_STR(&v_223);
-               FX_FREE_STR(&v_222);
+               fx_free_exn(&v_226);
+               FX_FREE_STR(&v_225);
+               FX_FREE_STR(&v_224);
                goto _fx_endmatch_10;
             }
          }
       }
       if (FX_REC_VARIANT_TAG(elem_0) == 7) {
          if (FX_REC_VARIANT_TAG(ktyp_1) == 15) {
-            _fx_N14K_form__kexp_t v_226 = 0;
+            _fx_N14K_form__kexp_t v_228 = 0;
             _fx_T2R9Ast__id_tLT2R9Ast__id_tN14K_form__ktyp_t* vcase_25 = &ktyp_1->u.KTypRecord;
             int_ i_1;
             FX_CALL(
@@ -13673,12 +13676,12 @@ FX_EXTERN_C int
                   &vcase_25->t0, vcase_25->t1, &elem_0->u.ExpIdent.t0, &eloc_0, &i_1, 0), _fx_catch_78);
             FX_CALL(
                _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&a_id_2, i_1, &kctx_0,
-                  &v_226), _fx_catch_78);
-            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_226, code_42, fx_result);
+                  &v_228), _fx_catch_78);
+            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_228, code_42, fx_result);
 
          _fx_catch_78: ;
-            if (v_226) {
-               _fx_free_N14K_form__kexp_t(&v_226);
+            if (v_228) {
+               _fx_free_N14K_form__kexp_t(&v_228);
             }
             goto _fx_endmatch_10;
          }
@@ -13687,9 +13690,9 @@ FX_EXTERN_C int
          if (FX_REC_VARIANT_TAG(ktyp_1) == 16) {
             _fx_R9Ast__id_t* tn_0 = &ktyp_1->u.KTypName;
             _fx_R9Ast__id_t* n_2 = &elem_0->u.ExpIdent.t0;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(tn_0, &eloc_0, &v_220, 0), _fx_catch_85);
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(tn_0, &eloc_0, &v_222, 0), _fx_catch_85);
             bool res_14;
-            if (v_220.tag == 7) {
+            if (v_222.tag == 7) {
                res_14 = true;
             }
             else {
@@ -13698,20 +13701,20 @@ FX_EXTERN_C int
             FX_CHECK_EXN(_fx_catch_85);
             if (res_14) {
                _fx_rR19Ast__definterface_t iface_0 = 0;
-               _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t v_227 = 0;
-               fx_str_t v_228 = {0};
-               fx_str_t v_229 = {0};
+               _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t v_229 = 0;
                fx_str_t v_230 = {0};
                fx_str_t v_231 = {0};
                fx_str_t v_232 = {0};
-               fx_exn_t v_233 = {0};
-               _fx_N14K_form__kexp_t v_234 = 0;
+               fx_str_t v_233 = {0};
+               fx_str_t v_234 = {0};
+               fx_exn_t v_235 = {0};
+               _fx_N14K_form__kexp_t v_236 = 0;
                FX_CALL(_fx_M3AstFM9get_ifacerRM14definterface_t2RM4id_tRM5loc_t(tn_0, &eloc_0, &iface_0, 0), _fx_catch_80);
                int_ idx_3 = -1;
-               _fx_R19Ast__definterface_t* v_235 = &iface_0->data;
-               FX_COPY_PTR(v_235->di_all_methods, &v_227);
+               _fx_R19Ast__definterface_t* v_237 = &iface_0->data;
+               FX_COPY_PTR(v_237->di_all_methods, &v_229);
                int_ i_2 = 0;
-               _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t lst_14 = v_227;
+               _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t lst_14 = v_229;
                for (; lst_14; lst_14 = lst_14->tl, i_2 += 1) {
                   _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* __pat___5 = &lst_14->hd;
                   _fx_R9Ast__id_t f_2 = __pat___5->t0;
@@ -13726,37 +13729,37 @@ FX_EXTERN_C int
                   FX_CHECK_EXN(_fx_catch_80);
                }
                if (idx_3 < 0) {
-                  FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_2, &v_228, 0), _fx_catch_80);
-                  FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_228, &v_229, 0), _fx_catch_80);
-                  FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(tn_0, &eloc_0, &v_230, 0), _fx_catch_80);
+                  FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_2, &v_230, 0), _fx_catch_80);
                   FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_230, &v_231, 0), _fx_catch_80);
+                  FX_CALL(_fx_M6K_formFM7idk2strS2R9Ast__id_tR10Ast__loc_t(tn_0, &eloc_0, &v_232, 0), _fx_catch_80);
+                  FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_232, &v_233, 0), _fx_catch_80);
                   fx_str_t slit_23 = FX_MAKE_STR("k-norm: method \'");
                   fx_str_t slit_24 = FX_MAKE_STR("\' is not found in interface \'");
                   fx_str_t slit_25 = FX_MAKE_STR("\'");
                   {
-                     const fx_str_t strs_2[] = { slit_23, v_229, slit_24, v_231, slit_25 };
-                     FX_CALL(fx_strjoin(0, 0, 0, strs_2, 5, &v_232), _fx_catch_80);
+                     const fx_str_t strs_2[] = { slit_23, v_231, slit_24, v_233, slit_25 };
+                     FX_CALL(fx_strjoin(0, 0, 0, strs_2, 5, &v_234), _fx_catch_80);
                   }
-                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_232, &v_233, 0), _fx_catch_80);
-                  FX_THROW(&v_233, false, _fx_catch_80);
+                  FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &v_234, &v_235, 0), _fx_catch_80);
+                  FX_THROW(&v_235, false, _fx_catch_80);
                }
                FX_CALL(
                   _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&a_id_2, idx_3, &kctx_0,
-                     &v_234), _fx_catch_80);
-               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_234, code_42, fx_result);
+                     &v_236), _fx_catch_80);
+               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_236, code_42, fx_result);
 
             _fx_catch_80: ;
-               if (v_234) {
-                  _fx_free_N14K_form__kexp_t(&v_234);
+               if (v_236) {
+                  _fx_free_N14K_form__kexp_t(&v_236);
                }
-               fx_free_exn(&v_233);
+               fx_free_exn(&v_235);
+               FX_FREE_STR(&v_234);
+               FX_FREE_STR(&v_233);
                FX_FREE_STR(&v_232);
                FX_FREE_STR(&v_231);
                FX_FREE_STR(&v_230);
-               FX_FREE_STR(&v_229);
-               FX_FREE_STR(&v_228);
-               if (v_227) {
-                  _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&v_227);
+               if (v_229) {
+                  _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&v_229);
                }
                if (iface_0) {
                   _fx_free_rR19Ast__definterface_t(&iface_0);
@@ -13767,81 +13770,81 @@ FX_EXTERN_C int
       }
       if (FX_REC_VARIANT_TAG(elem_0) == 7) {
          if (FX_REC_VARIANT_TAG(ktyp_1) == 16) {
-            _fx_N14K_form__atom_t v_236 = {0};
-            _fx_LN14K_form__atom_t v_237 = 0;
-            _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_238 = {0};
-            _fx_N14K_form__kexp_t v_239 = 0;
-            _fx_T2T4R9Ast__id_tiN14K_form__ktyp_tBLT2R9Ast__id_tN14K_form__ktyp_t v_240 = {0};
+            _fx_N14K_form__atom_t v_238 = {0};
+            _fx_LN14K_form__atom_t v_239 = 0;
+            _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_240 = {0};
+            _fx_N14K_form__kexp_t v_241 = 0;
+            _fx_T2T4R9Ast__id_tiN14K_form__ktyp_tBLT2R9Ast__id_tN14K_form__ktyp_t v_242 = {0};
             _fx_N14K_form__ktyp_t vt_0 = 0;
             _fx_LT2R9Ast__id_tN14K_form__ktyp_t relems_3 = 0;
-            _fx_N14K_form__atom_t v_241 = {0};
-            _fx_N14K_form__klit_t v_242 = {0};
             _fx_N14K_form__atom_t v_243 = {0};
-            _fx_LN14K_form__atom_t v_244 = 0;
-            _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_245 = {0};
+            _fx_N14K_form__klit_t v_244 = {0};
+            _fx_N14K_form__atom_t v_245 = {0};
+            _fx_LN14K_form__atom_t v_246 = 0;
+            _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_247 = {0};
             _fx_N14K_form__kexp_t get_vcase_0 = 0;
-            _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_246 = {0};
-            _fx_T2R9Ast__id_tLN14K_form__kexp_t v_247 = {0};
+            _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_248 = {0};
+            _fx_T2R9Ast__id_tLN14K_form__kexp_t v_249 = {0};
             _fx_LN14K_form__kexp_t code_43 = 0;
-            _fx_N14K_form__kexp_t v_248 = 0;
+            _fx_N14K_form__kexp_t v_250 = 0;
             _fx_N14K_form__kexp_t get_elem_0 = 0;
             _fx_LN14K_form__kexp_t code_44 = 0;
             _fx_R9Ast__id_t* n_3 = &elem_0->u.ExpIdent.t0;
             bool res_16;
             FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(n_3, &_fx_g15Ast__std__tag__, &res_16, 0), _fx_catch_81);
             if (res_16) {
-               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_236);
-               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_236, 0, true, &v_237), _fx_catch_81);
-               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypCInt, &eloc_0, &v_238);
+               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_238);
+               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_238, 0, true, &v_239), _fx_catch_81);
+               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypCInt, &eloc_0, &v_240);
                FX_CALL(
                   _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-                     &_fx_g29K_normalize__IntrinVariantTag, v_237, &v_238, &v_239), _fx_catch_81);
-               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_239, code_42, fx_result);
+                     &_fx_g29K_normalize__IntrinVariantTag, v_239, &v_240, &v_241), _fx_catch_81);
+               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_241, code_42, fx_result);
             }
             else {
                FX_CALL(
                   _fx_M11K_normalizeFM18get_record_elems_kT2T4R9Ast__id_tiN14K_form__ktyp_tBLT2R9Ast__id_tN14K_form__ktyp_t3Nt6option1R9Ast__id_tN14K_form__ktyp_tR10Ast__loc_t(
-                     &_fx_g19K_normalize__None6_, ktyp_1, &eloc_0, &v_240, 0), _fx_catch_81);
-               _fx_T4R9Ast__id_tiN14K_form__ktyp_tB* v_249 = &v_240.t0;
-               _fx_R9Ast__id_t ctor_2 = v_249->t0;
-               int_ case_i_0 = v_249->t1;
-               FX_COPY_PTR(v_249->t2, &vt_0);
-               FX_COPY_PTR(v_240.t1, &relems_3);
-               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_241);
+                     &_fx_g19K_normalize__None6_, ktyp_1, &eloc_0, &v_242, 0), _fx_catch_81);
+               _fx_T4R9Ast__id_tiN14K_form__ktyp_tB* v_251 = &v_242.t0;
+               _fx_R9Ast__id_t ctor_2 = v_251->t0;
+               int_ case_i_0 = v_251->t1;
+               FX_COPY_PTR(v_251->t2, &vt_0);
+               FX_COPY_PTR(v_242.t1, &relems_3);
+               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_243);
                int64_t res_17;
                FX_CALL(_fx_M11K_normalizeFM5int64l1i(case_i_0, &res_17, 0), _fx_catch_81);
-               _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(res_17, &v_242);
-               _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_242, &v_243);
-               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_243, 0, true, &v_244), _fx_catch_81);
-               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_241, v_244, false, &v_244), _fx_catch_81);
-               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(vt_0, &eloc_0, &v_245);
+               _fx_M6K_formFM7KLitIntN14K_form__klit_t1l(res_17, &v_244);
+               _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_244, &v_245);
+               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_245, 0, true, &v_246), _fx_catch_81);
+               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_243, v_246, false, &v_246), _fx_catch_81);
+               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(vt_0, &eloc_0, &v_247);
                FX_CALL(
                   _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-                     &_fx_g30K_normalize__IntrinVariantCase, v_244, &v_245, &get_vcase_0), _fx_catch_81);
+                     &_fx_g30K_normalize__IntrinVariantCase, v_246, &v_247, &get_vcase_0), _fx_catch_81);
                int_ i_3;
                FX_CALL(
                   _fx_M11K_normalizeFM10find_relemi4R9Ast__id_tLT2R9Ast__id_tN14K_form__ktyp_tR9Ast__id_tR10Ast__loc_t(&ctor_2,
                      relems_3, n_3, &eloc_0, &i_3, 0), _fx_catch_81);
-               int_ v_250;
-               FX_CALL(_fx_M11K_normalizeFM8length1_i1LT2R9Ast__id_tN14K_form__ktyp_t(relems_3, &v_250, 0), _fx_catch_81);
-               if (v_250 == 1) {
-                  _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(get_vcase_0, code_42, &v_246);
+               int_ v_252;
+               FX_CALL(_fx_M11K_normalizeFM8length1_i1LT2R9Ast__id_tN14K_form__ktyp_t(relems_3, &v_252, 0), _fx_catch_81);
+               if (v_252 == 1) {
+                  _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(get_vcase_0, code_42, &v_248);
                }
                else {
                   fx_str_t slit_26 = FX_MAKE_STR("vcase");
                   fx_str_t slit_27 = FX_MAKE_STR("variant case extraction should produce id, not literal");
                   FX_CALL(
                      _fx_M6K_formFM7kexp2idT2R9Ast__id_tLN14K_form__kexp_t6iSN14K_form__kexp_tBLN14K_form__kexp_tS(km_idx_0,
-                        &slit_26, get_vcase_0, true, code_42, &slit_27, &v_247, 0), _fx_catch_81);
-                  _fx_R9Ast__id_t v_id_0 = v_247.t0;
-                  FX_COPY_PTR(v_247.t1, &code_43);
+                        &slit_26, get_vcase_0, true, code_42, &slit_27, &v_249, 0), _fx_catch_81);
+                  _fx_R9Ast__id_t v_id_0 = v_249.t0;
+                  FX_COPY_PTR(v_249.t1, &code_43);
                   FX_CALL(
                      _fx_M6K_formFM7KExpMemN14K_form__kexp_t3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t(&v_id_0, i_3, &kctx_0,
-                        &v_248), _fx_catch_81);
-                  _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_248, code_43, &v_246);
+                        &v_250), _fx_catch_81);
+                  _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_250, code_43, &v_248);
                }
-               FX_COPY_PTR(v_246.t0, &get_elem_0);
-               FX_COPY_PTR(v_246.t1, &code_44);
+               FX_COPY_PTR(v_248.t0, &get_elem_0);
+               FX_COPY_PTR(v_248.t1, &code_44);
                _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(get_elem_0, code_44, fx_result);
             }
 
@@ -13852,39 +13855,39 @@ FX_EXTERN_C int
             if (get_elem_0) {
                _fx_free_N14K_form__kexp_t(&get_elem_0);
             }
-            if (v_248) {
-               _fx_free_N14K_form__kexp_t(&v_248);
+            if (v_250) {
+               _fx_free_N14K_form__kexp_t(&v_250);
             }
             if (code_43) {
                _fx_free_LN14K_form__kexp_t(&code_43);
             }
-            _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_247);
-            _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_246);
+            _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_249);
+            _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_248);
             if (get_vcase_0) {
                _fx_free_N14K_form__kexp_t(&get_vcase_0);
             }
-            _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_245);
-            if (v_244) {
-               _fx_free_LN14K_form__atom_t(&v_244);
+            _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_247);
+            if (v_246) {
+               _fx_free_LN14K_form__atom_t(&v_246);
             }
+            _fx_free_N14K_form__atom_t(&v_245);
+            _fx_free_N14K_form__klit_t(&v_244);
             _fx_free_N14K_form__atom_t(&v_243);
-            _fx_free_N14K_form__klit_t(&v_242);
-            _fx_free_N14K_form__atom_t(&v_241);
             if (relems_3) {
                _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&relems_3);
             }
             if (vt_0) {
                _fx_free_N14K_form__ktyp_t(&vt_0);
             }
-            _fx_free_T2T4R9Ast__id_tiN14K_form__ktyp_tBLT2R9Ast__id_tN14K_form__ktyp_t(&v_240);
+            _fx_free_T2T4R9Ast__id_tiN14K_form__ktyp_tBLT2R9Ast__id_tN14K_form__ktyp_t(&v_242);
+            if (v_241) {
+               _fx_free_N14K_form__kexp_t(&v_241);
+            }
+            _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_240);
             if (v_239) {
-               _fx_free_N14K_form__kexp_t(&v_239);
+               _fx_free_LN14K_form__atom_t(&v_239);
             }
-            _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_238);
-            if (v_237) {
-               _fx_free_LN14K_form__atom_t(&v_237);
-            }
-            _fx_free_N14K_form__atom_t(&v_236);
+            _fx_free_N14K_form__atom_t(&v_238);
             goto _fx_endmatch_10;
          }
       }
@@ -13894,117 +13897,351 @@ FX_EXTERN_C int
             FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&elem_0->u.ExpIdent.t0, &_fx_g15Ast__std__tag__, &res_18, 0),
                _fx_catch_85);
             if (res_18) {
-               _fx_N14K_form__atom_t v_251 = {0};
-               _fx_LN14K_form__atom_t v_252 = 0;
-               _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_253 = {0};
-               _fx_N14K_form__kexp_t v_254 = 0;
-               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_251);
-               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_251, 0, true, &v_252), _fx_catch_82);
-               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypCInt, &eloc_0, &v_253);
+               _fx_N14K_form__atom_t v_253 = {0};
+               _fx_LN14K_form__atom_t v_254 = 0;
+               _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_255 = {0};
+               _fx_N14K_form__kexp_t v_256 = 0;
+               _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&a_id_2, &v_253);
+               FX_CALL(_fx_cons_LN14K_form__atom_t(&v_253, 0, true, &v_254), _fx_catch_82);
+               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypCInt, &eloc_0, &v_255);
                FX_CALL(
                   _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-                     &_fx_g29K_normalize__IntrinVariantTag, v_252, &v_253, &v_254), _fx_catch_82);
-               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_254, code_42, fx_result);
+                     &_fx_g29K_normalize__IntrinVariantTag, v_254, &v_255, &v_256), _fx_catch_82);
+               _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_256, code_42, fx_result);
 
             _fx_catch_82: ;
+               if (v_256) {
+                  _fx_free_N14K_form__kexp_t(&v_256);
+               }
+               _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_255);
                if (v_254) {
-                  _fx_free_N14K_form__kexp_t(&v_254);
+                  _fx_free_LN14K_form__atom_t(&v_254);
                }
-               _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_253);
-               if (v_252) {
-                  _fx_free_LN14K_form__atom_t(&v_252);
-               }
-               _fx_free_N14K_form__atom_t(&v_251);
+               _fx_free_N14K_form__atom_t(&v_253);
                goto _fx_endmatch_10;
             }
          }
       }
       if (FX_REC_VARIANT_TAG(elem_0) == 7) {
-         _fx_N10Ast__typ_t v_255 = 0;
-         fx_str_t v_256 = {0};
-         fx_str_t v_257 = {0};
+         _fx_N10Ast__typ_t v_257 = 0;
          fx_str_t v_258 = {0};
          fx_str_t v_259 = {0};
          fx_str_t v_260 = {0};
-         fx_exn_t v_261 = {0};
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_7, &v_255, 0), _fx_catch_83);
-         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(v_255, &v_256, 0), _fx_catch_83);
-         FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_256, &v_257, 0), _fx_catch_83);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&elem_0->u.ExpIdent.t0, &v_258, 0), _fx_catch_83);
+         fx_str_t v_261 = {0};
+         fx_str_t v_262 = {0};
+         fx_exn_t v_263 = {0};
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e1_7, &v_257, 0), _fx_catch_83);
+         FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(v_257, &v_258, 0), _fx_catch_83);
          FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_258, &v_259, 0), _fx_catch_83);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(&elem_0->u.ExpIdent.t0, &v_260, 0), _fx_catch_83);
+         FX_CALL(_fx_M11K_normalizeFM6stringS1S(&v_260, &v_261, 0), _fx_catch_83);
          fx_str_t slit_28 = FX_MAKE_STR("unsupported \'(some_struct : ");
          fx_str_t slit_29 = FX_MAKE_STR(").");
          fx_str_t slit_30 = FX_MAKE_STR("\' access operation");
          {
-            const fx_str_t strs_3[] = { slit_28, v_257, slit_29, v_259, slit_30 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_260), _fx_catch_83);
+            const fx_str_t strs_3[] = { slit_28, v_259, slit_29, v_261, slit_30 };
+            FX_CALL(fx_strjoin(0, 0, 0, strs_3, 5, &v_262), _fx_catch_83);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1loc_0, &v_260, &v_261, 0), _fx_catch_83);
-         FX_THROW(&v_261, false, _fx_catch_83);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1loc_0, &v_262, &v_263, 0), _fx_catch_83);
+         FX_THROW(&v_263, false, _fx_catch_83);
 
       _fx_catch_83: ;
-         fx_free_exn(&v_261);
+         fx_free_exn(&v_263);
+         FX_FREE_STR(&v_262);
+         FX_FREE_STR(&v_261);
          FX_FREE_STR(&v_260);
          FX_FREE_STR(&v_259);
          FX_FREE_STR(&v_258);
-         FX_FREE_STR(&v_257);
-         FX_FREE_STR(&v_256);
-         if (v_255) {
-            _fx_free_N10Ast__typ_t(&v_255);
+         if (v_257) {
+            _fx_free_N10Ast__typ_t(&v_257);
          }
          goto _fx_endmatch_10;
       }
-      fx_exn_t v_262 = {0};
+      fx_exn_t v_264 = {0};
       fx_str_t slit_31 = FX_MAKE_STR("unsupported access operation");
-      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1loc_0, &slit_31, &v_262, 0), _fx_catch_84);
-      FX_THROW(&v_262, false, _fx_catch_84);
+      FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&e1loc_0, &slit_31, &v_264, 0), _fx_catch_84);
+      FX_THROW(&v_264, false, _fx_catch_84);
 
    _fx_catch_84: ;
-      fx_free_exn(&v_262);
+      fx_free_exn(&v_264);
 
    _fx_endmatch_10: ;
       FX_CHECK_EXN(_fx_catch_85);
 
    _fx_catch_85: ;
-      _fx_free_N15K_form__kinfo_t(&v_220);
+      _fx_free_N15K_form__kinfo_t(&v_222);
       if (ktyp_1) {
          _fx_free_N14K_form__ktyp_t(&ktyp_1);
       }
       if (code_42) {
          _fx_free_LN14K_form__kexp_t(&code_42);
       }
-      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_219);
-      goto _fx_endmatch_14;
+      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_221);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 20) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_263 = {0};
+      _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_26 = &e_0->u.ExpAssign;
+      _fx_N10Ast__exp_t v_265 = vcase_26->t0;
+      if (FX_REC_VARIANT_TAG(v_265) == 19) {
+         _fx_T5N10Ast__exp_tN13Ast__border_tN18Ast__interpolate_tLN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_27 =
+            &v_265->u.ExpAt;
+         if (vcase_27->t1.tag == 1) {
+            if (vcase_27->t2.tag == 1) {
+               _fx_LN10Ast__exp_t v_266 = vcase_27->t3;
+               if (v_266 != 0) {
+                  if (v_266->tl == 0) {
+                     _fx_N10Ast__exp_t idx_4 = v_266->hd;
+                     _fx_N10Ast__exp_t arr_2 = vcase_27->t0;
+                     _fx_N10Ast__exp_t e2_11 = vcase_26->t1;
+                     bool res_19;
+                     FX_CALL(_fx_M11K_normalizeFM8is_rangeB1N10Ast__exp_t(idx_4, &res_19, 0), _fx_cleanup);
+                     bool t_1;
+                     if (res_19) {
+                        FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(arr_2, &v_1, 0), _fx_cleanup);
+                        _fx_R10Ast__loc_t v_267;
+                        FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arr_2, &v_267, 0), _fx_cleanup);
+                        FX_CALL(_fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(v_1, &v_267, &v_2, 0),
+                           _fx_cleanup);
+                        if (FX_REC_VARIANT_TAG(v_2) == 19) {
+                           t_1 = true;
+                        }
+                        else {
+                           t_1 = false;
+                        }
+                        FX_CHECK_EXN(_fx_cleanup);
+                     }
+                     else {
+                        t_1 = false;
+                     }
+                     if (t_1) {
+                        _fx_N10Ast__typ_t v_268 = 0;
+                        _fx_N14K_form__ktyp_t vec_ktyp_0 = 0;
+                        fx_exn_t v_269 = {0};
+                        _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_270 = {0};
+                        _fx_N14K_form__atom_t arr_a_0 = {0};
+                        _fx_LN14K_form__kexp_t code_45 = 0;
+                        _fx_T2N13K_form__dom_tLN14K_form__kexp_t v_271 = {0};
+                        _fx_N13K_form__dom_t dom_0 = {0};
+                        _fx_LN14K_form__kexp_t code_46 = 0;
+                        _fx_Ta3N14K_form__atom_t v_272 = {0};
+                        _fx_N14K_form__atom_t a_at_0 = {0};
+                        _fx_N14K_form__atom_t b_at_0 = {0};
+                        _fx_N14K_form__atom_t d_at_0 = {0};
+                        _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_273 = {0};
+                        _fx_N14K_form__klit_t v_274 = {0};
+                        _fx_N14K_form__atom_t v_275 = {0};
+                        _fx_N14K_form__atom_t rhs_a_0 = {0};
+                        _fx_LN14K_form__kexp_t code_47 = 0;
+                        _fx_LN14K_form__atom_t v_276 = 0;
+                        _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_277 = {0};
+                        _fx_N14K_form__kexp_t v_278 = 0;
+                        FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(arr_2, &v_268, 0), _fx_catch_87);
+                        _fx_R10Ast__loc_t v_279;
+                        FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(arr_2, &v_279, 0), _fx_catch_87);
+                        FX_CALL(
+                           _fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(v_268, &v_279, &vec_ktyp_0,
+                              0), _fx_catch_87);
+                        int tag_4 = FX_REC_VARIANT_TAG(idx_4);
+                        bool delta_is_one_0;
+                        if (tag_4 == 5) {
+                           if ((idx_4->u.ExpRange.t2 != 0) + 1 == 1) {
+                              delta_is_one_0 = true; goto _fx_endmatch_11;
+                           }
+                        }
+                        if (tag_4 == 5) {
+                           _fx_Nt6option1N10Ast__exp_t v_280 = idx_4->u.ExpRange.t2;
+                           if ((v_280 != 0) + 1 == 2) {
+                              _fx_N10Ast__exp_t v_281 = v_280->u.Some;
+                              if (FX_REC_VARIANT_TAG(v_281) == 6) {
+                                 _fx_N10Ast__lit_t* v_282 = &v_281->u.ExpLit.t0;
+                                 if (v_282->tag == 1) {
+                                    if (v_282->u.LitInt == 1LL) {
+                                       delta_is_one_0 = true; goto _fx_endmatch_11;
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                        delta_is_one_0 = false;
+
+                     _fx_endmatch_11: ;
+                        FX_CHECK_EXN(_fx_catch_87);
+                        int tag_5 = FX_REC_VARIANT_TAG(e2_11);
+                        bool rhs_is_empty_0;
+                        if (tag_5 == 6) {
+                           if (e2_11->u.ExpLit.t0.tag == 8) {
+                              rhs_is_empty_0 = true; goto _fx_endmatch_13;
+                           }
+                        }
+                        bool res_20;
+                        if (tag_5 == 14) {
+                           if (e2_11->u.ExpMkArray.t0 == 0) {
+                              res_20 = true; goto _fx_endmatch_12;
+                           }
+                        }
+                        if (tag_5 == 14) {
+                           _fx_LLN10Ast__exp_t v_283 = e2_11->u.ExpMkArray.t0;
+                           if (v_283 != 0) {
+                              if (v_283->tl == 0) {
+                                 if (v_283->hd == 0) {
+                                    res_20 = true; goto _fx_endmatch_12;
+                                 }
+                              }
+                           }
+                        }
+                        if (tag_5 == 15) {
+                           if (e2_11->u.ExpMkVector.t0 == 0) {
+                              res_20 = true; goto _fx_endmatch_12;
+                           }
+                        }
+                        res_20 = false;
+
+                     _fx_endmatch_12: ;
+                        FX_CHECK_EXN(_fx_catch_87);
+                        if (res_20) {
+                           rhs_is_empty_0 = true; goto _fx_endmatch_13;
+                        }
+                        rhs_is_empty_0 = false;
+
+                     _fx_endmatch_13: ;
+                        FX_CHECK_EXN(_fx_catch_87);
+                        bool t_2;
+                        if (!delta_is_one_0) {
+                           t_2 = !rhs_is_empty_0;
+                        }
+                        else {
+                           t_2 = false;
+                        }
+                        if (t_2) {
+                           fx_str_t slit_32 =
+                              FX_MAKE_STR(
+                                 "a strided vector slice (step != 1) can only be deleted by assigning \'[]\'; replacing strided elements with a non-empty vector is not supported");
+                           FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_32, &v_269, 0), _fx_catch_87);
+                           FX_THROW(&v_269, false, _fx_catch_87);
+                        }
+                        FX_CALL(
+                           _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
+                              arr_2, code_0, false, sc_0, &v_270, 0), _fx_catch_87);
+                        _fx_copy_N14K_form__atom_t(&v_270.t0, &arr_a_0);
+                        FX_COPY_PTR(v_270.t1, &code_45);
+                        FX_CALL(
+                           _fx_M11K_normalizeFM7exp2domT2N13K_form__dom_tLN14K_form__kexp_t3N10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_t(
+                              idx_4, code_45, sc_0, &v_271, 0), _fx_catch_87);
+                        _fx_copy_N13K_form__dom_t(&v_271.t0, &dom_0);
+                        FX_COPY_PTR(v_271.t1, &code_46);
+                        if (dom_0.tag == 3) {
+                           _fx_Ta3N14K_form__atom_t* vcase_28 = &dom_0.u.DomainRange;
+                           _fx_make_Ta3N14K_form__atom_t(&vcase_28->t0, &vcase_28->t1, &vcase_28->t2, &v_272);
+                        }
+                        else {
+                           fx_exn_t v_284 = {0};
+                           fx_str_t slit_33 = FX_MAKE_STR("k-norm: vector slice-assign index is not a range");
+                           FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_33, &v_284, 0), _fx_catch_86);
+                           FX_THROW(&v_284, false, _fx_catch_86);
+
+                        _fx_catch_86: ;
+                           fx_free_exn(&v_284);
+                        }
+                        FX_CHECK_EXN(_fx_catch_87);
+                        _fx_copy_N14K_form__atom_t(&v_272.t0, &a_at_0);
+                        _fx_copy_N14K_form__atom_t(&v_272.t1, &b_at_0);
+                        _fx_copy_N14K_form__atom_t(&v_272.t2, &d_at_0);
+                        if (rhs_is_empty_0) {
+                           _fx_M6K_formFM7KLitNilN14K_form__klit_t1N14K_form__ktyp_t(vec_ktyp_0, &v_274);
+                           _fx_M6K_formFM7AtomLitN14K_form__atom_t1N14K_form__klit_t(&v_274, &v_275);
+                           _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_275, code_46, &v_273);
+                        }
+                        else {
+                           FX_CALL(
+                              _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
+                                 e2_11, code_46, false, sc_0, &v_273, 0), _fx_catch_87);
+                        }
+                        _fx_copy_N14K_form__atom_t(&v_273.t0, &rhs_a_0);
+                        FX_COPY_PTR(v_273.t1, &code_47);
+                        FX_CALL(_fx_cons_LN14K_form__atom_t(&rhs_a_0, 0, true, &v_276), _fx_catch_87);
+                        FX_CALL(_fx_cons_LN14K_form__atom_t(&d_at_0, v_276, false, &v_276), _fx_catch_87);
+                        FX_CALL(_fx_cons_LN14K_form__atom_t(&b_at_0, v_276, false, &v_276), _fx_catch_87);
+                        FX_CALL(_fx_cons_LN14K_form__atom_t(&a_at_0, v_276, false, &v_276), _fx_catch_87);
+                        FX_CALL(_fx_cons_LN14K_form__atom_t(&arr_a_0, v_276, false, &v_276), _fx_catch_87);
+                        _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g21K_normalize__KTypVoid, &eloc_0, &v_277);
+                        FX_CALL(
+                           _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
+                              &_fx_g28K_normalize__IntrinVecSplice, v_276, &v_277, &v_278), _fx_catch_87);
+                        _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_278, code_47, fx_result);
+
+                     _fx_catch_87: ;
+                        if (v_278) {
+                           _fx_free_N14K_form__kexp_t(&v_278);
+                        }
+                        _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_277);
+                        if (v_276) {
+                           _fx_free_LN14K_form__atom_t(&v_276);
+                        }
+                        if (code_47) {
+                           _fx_free_LN14K_form__kexp_t(&code_47);
+                        }
+                        _fx_free_N14K_form__atom_t(&rhs_a_0);
+                        _fx_free_N14K_form__atom_t(&v_275);
+                        _fx_free_N14K_form__klit_t(&v_274);
+                        _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_273);
+                        _fx_free_N14K_form__atom_t(&d_at_0);
+                        _fx_free_N14K_form__atom_t(&b_at_0);
+                        _fx_free_N14K_form__atom_t(&a_at_0);
+                        _fx_free_Ta3N14K_form__atom_t(&v_272);
+                        if (code_46) {
+                           _fx_free_LN14K_form__kexp_t(&code_46);
+                        }
+                        _fx_free_N13K_form__dom_t(&dom_0);
+                        _fx_free_T2N13K_form__dom_tLN14K_form__kexp_t(&v_271);
+                        if (code_45) {
+                           _fx_free_LN14K_form__kexp_t(&code_45);
+                        }
+                        _fx_free_N14K_form__atom_t(&arr_a_0);
+                        _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_270);
+                        fx_free_exn(&v_269);
+                        if (vec_ktyp_0) {
+                           _fx_free_N14K_form__ktyp_t(&vec_ktyp_0);
+                        }
+                        if (v_268) {
+                           _fx_free_N10Ast__typ_t(&v_268);
+                        }
+                        goto _fx_endmatch_17;
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   if (tag_0 == 20) {
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_285 = {0};
       _fx_N14K_form__atom_t a2_3 = {0};
-      _fx_LN14K_form__kexp_t code_45 = 0;
-      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_264 = {0};
-      _fx_LN14K_form__kexp_t code_46 = 0;
+      _fx_LN14K_form__kexp_t code_48 = 0;
+      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_286 = {0};
+      _fx_LN14K_form__kexp_t code_49 = 0;
       _fx_R17K_form__kdefval_t kv_0 = {0};
       _fx_N14K_form__ktyp_t kv_typ_0 = 0;
       _fx_R16Ast__val_flags_t kv_flags_0 = {0};
       _fx_R16Ast__val_flags_t kv_flags_1 = {0};
       _fx_LN10Ast__exp_t idxs_0 = 0;
-      _fx_R16Ast__val_flags_t v_265 = {0};
+      _fx_R16Ast__val_flags_t v_287 = {0};
       _fx_R17K_form__kdefval_t kv_1 = {0};
-      _fx_N15K_form__kinfo_t v_266 = {0};
-      _fx_N14K_form__kexp_t v_267 = 0;
-      _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_26 = &e_0->u.ExpAssign;
-      _fx_N10Ast__exp_t e1_8 = vcase_26->t0;
+      _fx_N15K_form__kinfo_t v_288 = {0};
+      _fx_N14K_form__kexp_t v_289 = 0;
+      _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_29 = &e_0->u.ExpAssign;
+      _fx_N10Ast__exp_t e1_8 = vcase_29->t0;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_26->t1, code_0, false, sc_0, &v_263, 0), _fx_catch_87);
-      _fx_copy_N14K_form__atom_t(&v_263.t0, &a2_3);
-      FX_COPY_PTR(v_263.t1, &code_45);
-      fx_str_t slit_32 = FX_MAKE_STR("a literal cannot be assigned");
+            vcase_29->t1, code_0, false, sc_0, &v_285, 0), _fx_catch_89);
+      _fx_copy_N14K_form__atom_t(&v_285.t0, &a2_3);
+      FX_COPY_PTR(v_285.t1, &code_48);
+      fx_str_t slit_34 = FX_MAKE_STR("a literal cannot be assigned");
       FX_CALL(
          _fx_M11K_normalizeFM6exp2idT2R9Ast__id_tLN14K_form__kexp_t5N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_tS(e1_8,
-            code_45, true, sc_0, &slit_32, &v_264, 0), _fx_catch_87);
-      _fx_R9Ast__id_t a_id_3 = v_264.t0;
-      FX_COPY_PTR(v_264.t1, &code_46);
-      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(&a_id_3, &eloc_0, &kv_0, 0), _fx_catch_87);
+            code_48, true, sc_0, &slit_34, &v_286, 0), _fx_catch_89);
+      _fx_R9Ast__id_t a_id_3 = v_286.t0;
+      FX_COPY_PTR(v_286.t1, &code_49);
+      FX_CALL(_fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(&a_id_3, &eloc_0, &kv_0, 0), _fx_catch_89);
       FX_COPY_PTR(kv_0.kv_typ, &kv_typ_0);
       _fx_copy_R16Ast__val_flags_t(&kv_0.kv_flags, &kv_flags_0);
       if (FX_REC_VARIANT_TAG(kv_typ_0) == 17) {
@@ -14013,47 +14250,47 @@ FX_EXTERN_C int
             FX_COPY_PTR(e1_8->u.ExpAt.t3, &idxs_0);
             _fx_LN10Ast__exp_t lst_15 = idxs_0;
             for (; lst_15; lst_15 = lst_15->tl) {
-               _fx_N10Ast__exp_t idx_4 = lst_15->hd;
-               bool res_19;
-               FX_CALL(_fx_M11K_normalizeFM8is_rangeB1N10Ast__exp_t(idx_4, &res_19, 0), _fx_catch_86);
-               if (res_19) {
-                  __fold_result___6 = true; FX_BREAK(_fx_catch_86);
+               _fx_N10Ast__exp_t idx_5 = lst_15->hd;
+               bool res_21;
+               FX_CALL(_fx_M11K_normalizeFM8is_rangeB1N10Ast__exp_t(idx_5, &res_21, 0), _fx_catch_88);
+               if (res_21) {
+                  __fold_result___6 = true; FX_BREAK(_fx_catch_88);
                }
 
-            _fx_catch_86: ;
+            _fx_catch_88: ;
                FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_87);
+               FX_CHECK_EXN(_fx_catch_89);
             }
             if (__fold_result___6) {
                _fx_make_R16Ast__val_flags_t(kv_flags_0.val_flag_arg, kv_flags_0.val_flag_mutable, kv_flags_0.val_flag_temp,
                   kv_flags_0.val_flag_tempref, kv_flags_0.val_flag_private, true, kv_flags_0.val_flag_instance,
                   &kv_flags_0.val_flag_method, kv_flags_0.val_flag_ctor, kv_flags_0.val_flag_global, &kv_flags_1);
-               goto _fx_endmatch_11;
+               goto _fx_endmatch_14;
             }
          }
       }
       _fx_copy_R16Ast__val_flags_t(&kv_flags_0, &kv_flags_1);
 
-   _fx_endmatch_11: ;
-      FX_CHECK_EXN(_fx_catch_87);
+   _fx_endmatch_14: ;
+      FX_CHECK_EXN(_fx_catch_89);
       _fx_make_R16Ast__val_flags_t(kv_flags_1.val_flag_arg, true, kv_flags_1.val_flag_temp, kv_flags_1.val_flag_tempref,
          kv_flags_1.val_flag_private, kv_flags_1.val_flag_subarray, kv_flags_1.val_flag_instance, &kv_flags_1.val_flag_method,
-         kv_flags_1.val_flag_ctor, kv_flags_1.val_flag_global, &v_265);
-      _fx_make_R17K_form__kdefval_t(&kv_0.kv_name, &kv_0.kv_cname, kv_0.kv_typ, &v_265, &kv_0.kv_loc, &kv_1);
-      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&kv_1, &v_266);
-      FX_CALL(_fx_M6K_formFM13set_idk_entryv2R9Ast__id_tN15K_form__kinfo_t(&a_id_3, &v_266, 0), _fx_catch_87);
+         kv_flags_1.val_flag_ctor, kv_flags_1.val_flag_global, &v_287);
+      _fx_make_R17K_form__kdefval_t(&kv_0.kv_name, &kv_0.kv_cname, kv_0.kv_typ, &v_287, &kv_0.kv_loc, &kv_1);
+      _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&kv_1, &v_288);
+      FX_CALL(_fx_M6K_formFM13set_idk_entryv2R9Ast__id_tN15K_form__kinfo_t(&a_id_3, &v_288, 0), _fx_catch_89);
       FX_CALL(
-         _fx_M6K_formFM10KExpAssignN14K_form__kexp_t3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t(&a_id_3, &a2_3, &eloc_0, &v_267),
-         _fx_catch_87);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_267, code_46, fx_result);
+         _fx_M6K_formFM10KExpAssignN14K_form__kexp_t3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t(&a_id_3, &a2_3, &eloc_0, &v_289),
+         _fx_catch_89);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_289, code_49, fx_result);
 
-   _fx_catch_87: ;
-      if (v_267) {
-         _fx_free_N14K_form__kexp_t(&v_267);
+   _fx_catch_89: ;
+      if (v_289) {
+         _fx_free_N14K_form__kexp_t(&v_289);
       }
-      _fx_free_N15K_form__kinfo_t(&v_266);
+      _fx_free_N15K_form__kinfo_t(&v_288);
       _fx_free_R17K_form__kdefval_t(&kv_1);
-      _fx_free_R16Ast__val_flags_t(&v_265);
+      _fx_free_R16Ast__val_flags_t(&v_287);
       if (idxs_0) {
          _fx_free_LN10Ast__exp_t(&idxs_0);
       }
@@ -14063,135 +14300,135 @@ FX_EXTERN_C int
          _fx_free_N14K_form__ktyp_t(&kv_typ_0);
       }
       _fx_free_R17K_form__kdefval_t(&kv_0);
-      if (code_46) {
-         _fx_free_LN14K_form__kexp_t(&code_46);
+      if (code_49) {
+         _fx_free_LN14K_form__kexp_t(&code_49);
       }
-      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_264);
-      if (code_45) {
-         _fx_free_LN14K_form__kexp_t(&code_45);
-      }
-      _fx_free_N14K_form__atom_t(&a2_3);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_263);
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 30) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_268 = {0};
-      _fx_N14K_form__atom_t a_6 = {0};
-      _fx_LN14K_form__kexp_t code_47 = 0;
-      _fx_N14K_form__kexp_t v_269 = 0;
-      FX_CALL(
-         _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e_0->u.ExpCast.t0, code_0, false, sc_0, &v_268, 0), _fx_catch_88);
-      _fx_copy_N14K_form__atom_t(&v_268.t0, &a_6);
-      FX_COPY_PTR(v_268.t1, &code_47);
-      FX_CALL(
-         _fx_M6K_formFM8KExpCastN14K_form__kexp_t3N14K_form__atom_tN14K_form__ktyp_tR10Ast__loc_t(&a_6, ktyp_0, &eloc_0,
-            &v_269), _fx_catch_88);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_269, code_47, fx_result);
-
-   _fx_catch_88: ;
-      if (v_269) {
-         _fx_free_N14K_form__kexp_t(&v_269);
-      }
-      if (code_47) {
-         _fx_free_LN14K_form__kexp_t(&code_47);
-      }
-      _fx_free_N14K_form__atom_t(&a_6);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_268);
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 31) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_270 = {0};
-      _fx_N14K_form__atom_t a_7 = {0};
-      _fx_LN14K_form__kexp_t code_48 = 0;
-      _fx_N14K_form__ktyp_t t_1 = 0;
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_271 = {0};
-      _fx_N14K_form__kexp_t v_272 = 0;
-      _fx_T3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tR10Ast__loc_t* vcase_27 = &e_0->u.ExpTyped;
-      FX_CALL(
-         _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_27->t0, code_0, false, sc_0, &v_270, 0), _fx_catch_89);
-      _fx_copy_N14K_form__atom_t(&v_270.t0, &a_7);
-      FX_COPY_PTR(v_270.t1, &code_48);
-      FX_CALL(_fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(vcase_27->t1, &eloc_0, &t_1, 0),
-         _fx_catch_89);
-      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(t_1, &eloc_0, &v_271);
-      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&a_7, &v_271, &v_272),
-         _fx_catch_89);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_272, code_48, fx_result);
-
-   _fx_catch_89: ;
-      if (v_272) {
-         _fx_free_N14K_form__kexp_t(&v_272);
-      }
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_271);
-      if (t_1) {
-         _fx_free_N14K_form__ktyp_t(&t_1);
-      }
+      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_286);
       if (code_48) {
          _fx_free_LN14K_form__kexp_t(&code_48);
       }
-      _fx_free_N14K_form__atom_t(&a_7);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_270);
-      goto _fx_endmatch_14;
+      _fx_free_N14K_form__atom_t(&a2_3);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_285);
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 32) {
-      _fx_N14K_form__kexp_t v_273 = 0;
-      FX_CALL(_fx_M6K_formFM9KExpCCodeN14K_form__kexp_t2ST2N14K_form__ktyp_tR10Ast__loc_t(&e_0->u.ExpCCode.t0, &kctx_0, &v_273),
-         _fx_catch_90);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_273, code_0, fx_result);
-
-   _fx_catch_90: ;
-      if (v_273) {
-         _fx_free_N14K_form__kexp_t(&v_273);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 33) {
-      _fx_N14K_form__kexp_t v_274 = 0;
-      _fx_T3SST2N10Ast__typ_tR10Ast__loc_t* vcase_28 = &e_0->u.ExpData;
-      FX_CALL(
-         _fx_M11K_normalizeFM10embed_dataN14K_form__kexp_t3SST2N14K_form__ktyp_tR10Ast__loc_t(&vcase_28->t0, &vcase_28->t1,
-            &kctx_0, &v_274, 0), _fx_catch_91);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_274, code_0, fx_result);
-
-   _fx_catch_91: ;
-      if (v_274) {
-         _fx_free_N14K_form__kexp_t(&v_274);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 29) {
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_275 = {0};
-      _fx_N14K_form__atom_t a_8 = {0};
-      _fx_LN14K_form__kexp_t code_49 = 0;
-      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_276 = {0};
-      _fx_N14K_form__ktyp_t t_2 = 0;
-      _fx_R16Ast__val_flags_t v_277 = {0};
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_278 = {0};
-      _fx_N14K_form__kexp_t v_279 = 0;
-      _fx_Nt6option1N14K_form__kexp_t v_280 = {0};
+   if (tag_0 == 30) {
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_290 = {0};
+      _fx_N14K_form__atom_t a_6 = {0};
       _fx_LN14K_form__kexp_t code_50 = 0;
-      _fx_N14K_form__atom_t v_281 = {0};
-      _fx_N14K_form__atom_t b_0 = {0};
-      _fx_LN14K_form__kexp_t code_51 = 0;
-      _fx_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t v_282 = {0};
-      _fx_LT2LN14K_form__kexp_tN14K_form__kexp_t k_cases_0 = 0;
-      _fx_LN14K_form__kexp_t code_52 = 0;
-      _fx_N14K_form__kexp_t v_283 = 0;
-      _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_29 = &e_0->u.ExpMatch;
-      _fx_N10Ast__exp_t e1_9 = vcase_29->t0;
-      _fx_R10Ast__loc_t loc1_2;
-      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e1_9, &loc1_2, 0), _fx_catch_93);
+      _fx_N14K_form__kexp_t v_291 = 0;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e1_9, code_0, false, sc_0, &v_275, 0), _fx_catch_93);
-      _fx_copy_N14K_form__atom_t(&v_275.t0, &a_8);
-      FX_COPY_PTR(v_275.t1, &code_49);
-      bool v_284;
-      FX_CALL(_fx_M6K_formFM15is_mutable_atomB2N14K_form__atom_tR10Ast__loc_t(&a_8, &loc1_2, &v_284, 0), _fx_catch_93);
-      if (!v_284) {
-         _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&a_8, code_49, &v_276);
+            e_0->u.ExpCast.t0, code_0, false, sc_0, &v_290, 0), _fx_catch_90);
+      _fx_copy_N14K_form__atom_t(&v_290.t0, &a_6);
+      FX_COPY_PTR(v_290.t1, &code_50);
+      FX_CALL(
+         _fx_M6K_formFM8KExpCastN14K_form__kexp_t3N14K_form__atom_tN14K_form__ktyp_tR10Ast__loc_t(&a_6, ktyp_0, &eloc_0,
+            &v_291), _fx_catch_90);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_291, code_50, fx_result);
+
+   _fx_catch_90: ;
+      if (v_291) {
+         _fx_free_N14K_form__kexp_t(&v_291);
+      }
+      if (code_50) {
+         _fx_free_LN14K_form__kexp_t(&code_50);
+      }
+      _fx_free_N14K_form__atom_t(&a_6);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_290);
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 31) {
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_292 = {0};
+      _fx_N14K_form__atom_t a_7 = {0};
+      _fx_LN14K_form__kexp_t code_51 = 0;
+      _fx_N14K_form__ktyp_t t_3 = 0;
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_293 = {0};
+      _fx_N14K_form__kexp_t v_294 = 0;
+      _fx_T3N10Ast__exp_tN10Ast__typ_tT2N10Ast__typ_tR10Ast__loc_t* vcase_30 = &e_0->u.ExpTyped;
+      FX_CALL(
+         _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
+            vcase_30->t0, code_0, false, sc_0, &v_292, 0), _fx_catch_91);
+      _fx_copy_N14K_form__atom_t(&v_292.t0, &a_7);
+      FX_COPY_PTR(v_292.t1, &code_51);
+      FX_CALL(_fx_M11K_normalizeFM8typ2ktypN14K_form__ktyp_t2N10Ast__typ_tR10Ast__loc_t(vcase_30->t1, &eloc_0, &t_3, 0),
+         _fx_catch_91);
+      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(t_3, &eloc_0, &v_293);
+      FX_CALL(_fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&a_7, &v_293, &v_294),
+         _fx_catch_91);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_294, code_51, fx_result);
+
+   _fx_catch_91: ;
+      if (v_294) {
+         _fx_free_N14K_form__kexp_t(&v_294);
+      }
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_293);
+      if (t_3) {
+         _fx_free_N14K_form__ktyp_t(&t_3);
+      }
+      if (code_51) {
+         _fx_free_LN14K_form__kexp_t(&code_51);
+      }
+      _fx_free_N14K_form__atom_t(&a_7);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_292);
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 32) {
+      _fx_N14K_form__kexp_t v_295 = 0;
+      FX_CALL(_fx_M6K_formFM9KExpCCodeN14K_form__kexp_t2ST2N14K_form__ktyp_tR10Ast__loc_t(&e_0->u.ExpCCode.t0, &kctx_0, &v_295),
+         _fx_catch_92);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_295, code_0, fx_result);
+
+   _fx_catch_92: ;
+      if (v_295) {
+         _fx_free_N14K_form__kexp_t(&v_295);
+      }
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 33) {
+      _fx_N14K_form__kexp_t v_296 = 0;
+      _fx_T3SST2N10Ast__typ_tR10Ast__loc_t* vcase_31 = &e_0->u.ExpData;
+      FX_CALL(
+         _fx_M11K_normalizeFM10embed_dataN14K_form__kexp_t3SST2N14K_form__ktyp_tR10Ast__loc_t(&vcase_31->t0, &vcase_31->t1,
+            &kctx_0, &v_296, 0), _fx_catch_93);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_296, code_0, fx_result);
+
+   _fx_catch_93: ;
+      if (v_296) {
+         _fx_free_N14K_form__kexp_t(&v_296);
+      }
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 29) {
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_297 = {0};
+      _fx_N14K_form__atom_t a_8 = {0};
+      _fx_LN14K_form__kexp_t code_52 = 0;
+      _fx_T2N14K_form__atom_tLN14K_form__kexp_t v_298 = {0};
+      _fx_N14K_form__ktyp_t t_4 = 0;
+      _fx_R16Ast__val_flags_t v_299 = {0};
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_300 = {0};
+      _fx_N14K_form__kexp_t v_301 = 0;
+      _fx_Nt6option1N14K_form__kexp_t v_302 = {0};
+      _fx_LN14K_form__kexp_t code_53 = 0;
+      _fx_N14K_form__atom_t v_303 = {0};
+      _fx_N14K_form__atom_t b_0 = {0};
+      _fx_LN14K_form__kexp_t code_54 = 0;
+      _fx_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t v_304 = {0};
+      _fx_LT2LN14K_form__kexp_tN14K_form__kexp_t k_cases_0 = 0;
+      _fx_LN14K_form__kexp_t code_55 = 0;
+      _fx_N14K_form__kexp_t v_305 = 0;
+      _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_32 = &e_0->u.ExpMatch;
+      _fx_N10Ast__exp_t e1_9 = vcase_32->t0;
+      _fx_R10Ast__loc_t loc1_2;
+      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e1_9, &loc1_2, 0), _fx_catch_95);
+      FX_CALL(
+         _fx_M11K_normalizeFM8exp2atomT2N14K_form__atom_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
+            e1_9, code_0, false, sc_0, &v_297, 0), _fx_catch_95);
+      _fx_copy_N14K_form__atom_t(&v_297.t0, &a_8);
+      FX_COPY_PTR(v_297.t1, &code_52);
+      bool v_306;
+      FX_CALL(_fx_M6K_formFM15is_mutable_atomB2N14K_form__atom_tR10Ast__loc_t(&a_8, &loc1_2, &v_306, 0), _fx_catch_95);
+      if (!v_306) {
+         _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&a_8, code_52, &v_298);
       }
       else {
          _fx_R9Ast__id_t a_id_4;
@@ -14199,181 +14436,181 @@ FX_EXTERN_C int
             a_id_4 = a_8.u.AtomId;
          }
          else {
-            fx_exn_t v_285 = {0};
-            fx_str_t slit_33 = FX_MAKE_STR("k-norm: invalid mutable atom (id is expected)");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&loc1_2, &slit_33, &v_285, 0), _fx_catch_92);
-            FX_THROW(&v_285, false, _fx_catch_92);
+            fx_exn_t v_307 = {0};
+            fx_str_t slit_35 = FX_MAKE_STR("k-norm: invalid mutable atom (id is expected)");
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&loc1_2, &slit_35, &v_307, 0), _fx_catch_94);
+            FX_THROW(&v_307, false, _fx_catch_94);
 
-         _fx_catch_92: ;
-            fx_free_exn(&v_285);
+         _fx_catch_94: ;
+            fx_free_exn(&v_307);
          }
-         FX_CHECK_EXN(_fx_catch_93);
-         FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_8, &loc1_2, &t_2, 0),
-            _fx_catch_93);
+         FX_CHECK_EXN(_fx_catch_95);
+         FX_CALL(_fx_M6K_formFM13get_atom_ktypN14K_form__ktyp_t2N14K_form__atom_tR10Ast__loc_t(&a_8, &loc1_2, &t_4, 0),
+            _fx_catch_95);
          _fx_R9Ast__id_t b_1;
-         FX_CALL(_fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(km_idx_0, &a_id_4, &b_1, 0), _fx_catch_93);
-         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_277, 0), _fx_catch_93);
-         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(t_2, &loc1_2, &v_278);
+         FX_CALL(_fx_M6K_formFM7dup_idkR9Ast__id_t2iR9Ast__id_t(km_idx_0, &a_id_4, &b_1, 0), _fx_catch_95);
+         FX_CALL(_fx_M3AstFM21default_tempval_flagsRM11val_flags_t0(&v_299, 0), _fx_catch_95);
+         _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(t_4, &loc1_2, &v_300);
          FX_CALL(
-            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&a_8, &v_278, &v_279),
-            _fx_catch_93);
-         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(v_279, &v_280);
+            _fx_M6K_formFM8KExpAtomN14K_form__kexp_t2N14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(&a_8, &v_300, &v_301),
+            _fx_catch_95);
+         _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(v_301, &v_302);
          FX_CALL(
             _fx_M6K_formFM14create_kdefvalLN14K_form__kexp_t6R9Ast__id_tN14K_form__ktyp_tR16Ast__val_flags_tNt6option1N14K_form__kexp_tLN14K_form__kexp_tR10Ast__loc_t(
-               &b_1, t_2, &v_277, &v_280, code_49, &loc1_2, &code_50, 0), _fx_catch_93);
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&b_1, &v_281);
-         _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_281, code_50, &v_276);
+               &b_1, t_4, &v_299, &v_302, code_52, &loc1_2, &code_53, 0), _fx_catch_95);
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&b_1, &v_303);
+         _fx_make_T2N14K_form__atom_tLN14K_form__kexp_t(&v_303, code_53, &v_298);
       }
-      _fx_copy_N14K_form__atom_t(&v_276.t0, &b_0);
-      FX_COPY_PTR(v_276.t1, &code_51);
+      _fx_copy_N14K_form__atom_t(&v_298.t0, &b_0);
+      FX_COPY_PTR(v_298.t1, &code_54);
       FX_CALL(
          _fx_M11K_normalizeFM22transform_pat_matchingT2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t6N14K_form__atom_tLT2N10Ast__pat_tN10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_tR10Ast__loc_tB(
-            &b_0, vcase_29->t1, code_51, sc_0, &eloc_0, false, &v_282, 0), _fx_catch_93);
-      FX_COPY_PTR(v_282.t0, &k_cases_0);
-      FX_COPY_PTR(v_282.t1, &code_52);
+            &b_0, vcase_32->t1, code_54, sc_0, &eloc_0, false, &v_304, 0), _fx_catch_95);
+      FX_COPY_PTR(v_304.t0, &k_cases_0);
+      FX_COPY_PTR(v_304.t1, &code_55);
       FX_CALL(
          _fx_M6K_formFM9KExpMatchN14K_form__kexp_t2LT2LN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            k_cases_0, &kctx_0, &v_283), _fx_catch_93);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_283, code_52, fx_result);
+            k_cases_0, &kctx_0, &v_305), _fx_catch_95);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_305, code_55, fx_result);
 
-   _fx_catch_93: ;
-      if (v_283) {
-         _fx_free_N14K_form__kexp_t(&v_283);
+   _fx_catch_95: ;
+      if (v_305) {
+         _fx_free_N14K_form__kexp_t(&v_305);
       }
-      if (code_52) {
-         _fx_free_LN14K_form__kexp_t(&code_52);
+      if (code_55) {
+         _fx_free_LN14K_form__kexp_t(&code_55);
       }
       if (k_cases_0) {
          _fx_free_LT2LN14K_form__kexp_tN14K_form__kexp_t(&k_cases_0);
       }
-      _fx_free_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t(&v_282);
-      if (code_51) {
-         _fx_free_LN14K_form__kexp_t(&code_51);
+      _fx_free_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t(&v_304);
+      if (code_54) {
+         _fx_free_LN14K_form__kexp_t(&code_54);
       }
       _fx_free_N14K_form__atom_t(&b_0);
-      _fx_free_N14K_form__atom_t(&v_281);
-      if (code_50) {
-         _fx_free_LN14K_form__kexp_t(&code_50);
+      _fx_free_N14K_form__atom_t(&v_303);
+      if (code_53) {
+         _fx_free_LN14K_form__kexp_t(&code_53);
       }
-      _fx_free_Nt6option1N14K_form__kexp_t(&v_280);
-      if (v_279) {
-         _fx_free_N14K_form__kexp_t(&v_279);
+      _fx_free_Nt6option1N14K_form__kexp_t(&v_302);
+      if (v_301) {
+         _fx_free_N14K_form__kexp_t(&v_301);
       }
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_278);
-      _fx_free_R16Ast__val_flags_t(&v_277);
-      if (t_2) {
-         _fx_free_N14K_form__ktyp_t(&t_2);
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_300);
+      _fx_free_R16Ast__val_flags_t(&v_299);
+      if (t_4) {
+         _fx_free_N14K_form__ktyp_t(&t_4);
       }
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_276);
-      if (code_49) {
-         _fx_free_LN14K_form__kexp_t(&code_49);
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_298);
+      if (code_52) {
+         _fx_free_LN14K_form__kexp_t(&code_52);
       }
       _fx_free_N14K_form__atom_t(&a_8);
-      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_275);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(&v_297);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 28) {
       _fx_LN12Ast__scope_t try_sc_0 = 0;
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_286 = {0};
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_308 = {0};
       _fx_N14K_form__kexp_t e1_10 = 0;
       _fx_LN14K_form__kexp_t body_code_5 = 0;
-      _fx_LN14K_form__kexp_t v_287 = 0;
+      _fx_LN14K_form__kexp_t v_309 = 0;
       _fx_N14K_form__kexp_t try_body_0 = 0;
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_288 = {0};
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_310 = {0};
       _fx_N14K_form__kexp_t pop_e_0 = 0;
       _fx_LN12Ast__scope_t catch_sc_0 = 0;
-      _fx_R16Ast__val_flags_t v_289 = {0};
-      _fx_Nt6option1N14K_form__kexp_t v_290 = {0};
+      _fx_R16Ast__val_flags_t v_311 = {0};
+      _fx_Nt6option1N14K_form__kexp_t v_312 = {0};
       _fx_LN14K_form__kexp_t catch_code_0 = 0;
-      _fx_N14K_form__atom_t v_291 = {0};
-      _fx_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t v_292 = {0};
+      _fx_N14K_form__atom_t v_313 = {0};
+      _fx_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t v_314 = {0};
       _fx_LT2LN14K_form__kexp_tN14K_form__kexp_t k_cases_1 = 0;
       _fx_LN14K_form__kexp_t catch_code_1 = 0;
       _fx_N14K_form__kexp_t handle_exn_0 = 0;
-      _fx_LN14K_form__kexp_t v_293 = 0;
+      _fx_LN14K_form__kexp_t v_315 = 0;
       _fx_N14K_form__kexp_t handle_exn_1 = 0;
-      _fx_N14K_form__kexp_t v_294 = 0;
-      _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_30 = &e_0->u.ExpTryCatch;
-      _fx_LT2N10Ast__pat_tN10Ast__exp_t cases_0 = vcase_30->t1;
-      _fx_N10Ast__exp_t e1_11 = vcase_30->t0;
+      _fx_N14K_form__kexp_t v_316 = 0;
+      _fx_T3N10Ast__exp_tLT2N10Ast__pat_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_33 = &e_0->u.ExpTryCatch;
+      _fx_LT2N10Ast__pat_tN10Ast__exp_t cases_0 = vcase_33->t1;
+      _fx_N10Ast__exp_t e1_11 = vcase_33->t0;
       _fx_R10Ast__loc_t e1loc_1;
-      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e1_11, &e1loc_1, 0), _fx_catch_96);
-      _fx_N12Ast__scope_t v_295;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_295, 0), _fx_catch_96);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_295, sc_0, true, &try_sc_0), _fx_catch_96);
+      FX_CALL(_fx_M3AstFM11get_exp_locRM5loc_t1N10Ast__exp_t(e1_11, &e1loc_1, 0), _fx_catch_98);
+      _fx_N12Ast__scope_t v_317;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_317, 0), _fx_catch_98);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_317, sc_0, true, &try_sc_0), _fx_catch_98);
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            e1_11, 0, false, try_sc_0, &v_286, 0), _fx_catch_96);
-      FX_COPY_PTR(v_286.t0, &e1_10);
-      FX_COPY_PTR(v_286.t1, &body_code_5);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_10, body_code_5, true, &v_287), _fx_catch_96);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_287, &e1loc_1, &try_body_0, 0),
-         _fx_catch_96);
+            e1_11, 0, false, try_sc_0, &v_308, 0), _fx_catch_98);
+      FX_COPY_PTR(v_308.t0, &e1_10);
+      FX_COPY_PTR(v_308.t1, &body_code_5);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(e1_10, body_code_5, true, &v_309), _fx_catch_98);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_309, &e1loc_1, &try_body_0, 0),
+         _fx_catch_98);
       _fx_R10Ast__loc_t exn_loc_0;
       if (cases_0 != 0) {
-         FX_CALL(_fx_M3AstFM11get_pat_locRM5loc_t1N10Ast__pat_t(cases_0->hd.t0, &exn_loc_0, 0), _fx_catch_94);  _fx_catch_94: ;
+         FX_CALL(_fx_M3AstFM11get_pat_locRM5loc_t1N10Ast__pat_t(cases_0->hd.t0, &exn_loc_0, 0), _fx_catch_96);  _fx_catch_96: ;
       }
       else {
          exn_loc_0 = eloc_0;
       }
-      FX_CHECK_EXN(_fx_catch_96);
+      FX_CHECK_EXN(_fx_catch_98);
       _fx_R9Ast__id_t exn_n_0;
-      fx_str_t slit_34 = FX_MAKE_STR("exn");
-      FX_CALL(_fx_M6K_formFM7gen_idkR9Ast__id_t2iS(km_idx_0, &slit_34, &exn_n_0, 0), _fx_catch_96);
-      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g20K_normalize__KTypExn, &exn_loc_0, &v_288);
+      fx_str_t slit_36 = FX_MAKE_STR("exn");
+      FX_CALL(_fx_M6K_formFM7gen_idkR9Ast__id_t2iS(km_idx_0, &slit_36, &exn_n_0, 0), _fx_catch_98);
+      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(_fx_g20K_normalize__KTypExn, &exn_loc_0, &v_310);
       FX_CALL(
          _fx_M6K_formFM10KExpIntrinN14K_form__kexp_t3N13Ast__intrin_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            &_fx_g25K_normalize__IntrinPopExn, 0, &v_288, &pop_e_0), _fx_catch_96);
-      _fx_N12Ast__scope_t v_296;
-      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_296, 0), _fx_catch_96);
-      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_296, sc_0, true, &catch_sc_0), _fx_catch_96);
-      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_289, 0), _fx_catch_96);
-      _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(pop_e_0, &v_290);
+            &_fx_g25K_normalize__IntrinPopExn, 0, &v_310, &pop_e_0), _fx_catch_98);
+      _fx_N12Ast__scope_t v_318;
+      FX_CALL(_fx_M3AstFM15new_block_scopeN12Ast__scope_t1i(km_idx_0, &v_318, 0), _fx_catch_98);
+      FX_CALL(_fx_cons_LN12Ast__scope_t(&v_318, sc_0, true, &catch_sc_0), _fx_catch_98);
+      FX_CALL(_fx_M3AstFM17default_val_flagsRM11val_flags_t0(&v_311, 0), _fx_catch_98);
+      _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(pop_e_0, &v_312);
       FX_CALL(
          _fx_M6K_formFM14create_kdefvalLN14K_form__kexp_t6R9Ast__id_tN14K_form__ktyp_tR16Ast__val_flags_tNt6option1N14K_form__kexp_tLN14K_form__kexp_tR10Ast__loc_t(
-            &exn_n_0, _fx_g20K_normalize__KTypExn, &v_289, &v_290, 0, &exn_loc_0, &catch_code_0, 0), _fx_catch_96);
-      _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&exn_n_0, &v_291);
+            &exn_n_0, _fx_g20K_normalize__KTypExn, &v_311, &v_312, 0, &exn_loc_0, &catch_code_0, 0), _fx_catch_98);
+      _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&exn_n_0, &v_313);
       FX_CALL(
          _fx_M11K_normalizeFM22transform_pat_matchingT2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t6N14K_form__atom_tLT2N10Ast__pat_tN10Ast__exp_tLN14K_form__kexp_tLN12Ast__scope_tR10Ast__loc_tB(
-            &v_291, cases_0, catch_code_0, catch_sc_0, &exn_loc_0, true, &v_292, 0), _fx_catch_96);
-      FX_COPY_PTR(v_292.t0, &k_cases_1);
-      FX_COPY_PTR(v_292.t1, &catch_code_1);
+            &v_313, cases_0, catch_code_0, catch_sc_0, &exn_loc_0, true, &v_314, 0), _fx_catch_98);
+      FX_COPY_PTR(v_314.t0, &k_cases_1);
+      FX_COPY_PTR(v_314.t1, &catch_code_1);
       if (k_cases_1 != 0) {
          if (k_cases_1->tl == 0) {
-            _fx_T2LN14K_form__kexp_tN14K_form__kexp_t* v_297 = &k_cases_1->hd;
-            if (v_297->t0 == 0) {
-               FX_COPY_PTR(v_297->t1, &handle_exn_0); goto _fx_endmatch_12;
+            _fx_T2LN14K_form__kexp_tN14K_form__kexp_t* v_319 = &k_cases_1->hd;
+            if (v_319->t0 == 0) {
+               FX_COPY_PTR(v_319->t1, &handle_exn_0); goto _fx_endmatch_15;
             }
          }
       }
-      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_298 = {0};
-      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &exn_loc_0, &v_298);
+      _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_320 = {0};
+      _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(ktyp_0, &exn_loc_0, &v_320);
       FX_CALL(
          _fx_M6K_formFM9KExpMatchN14K_form__kexp_t2LT2LN14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            k_cases_1, &v_298, &handle_exn_0), _fx_catch_95);
+            k_cases_1, &v_320, &handle_exn_0), _fx_catch_97);
 
-   _fx_catch_95: ;
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_298);
+   _fx_catch_97: ;
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_320);
 
-   _fx_endmatch_12: ;
-      FX_CHECK_EXN(_fx_catch_96);
-      FX_CALL(_fx_cons_LN14K_form__kexp_t(handle_exn_0, catch_code_1, true, &v_293), _fx_catch_96);
-      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_293, &exn_loc_0, &handle_exn_1, 0),
-         _fx_catch_96);
+   _fx_endmatch_15: ;
+      FX_CHECK_EXN(_fx_catch_98);
+      FX_CALL(_fx_cons_LN14K_form__kexp_t(handle_exn_0, catch_code_1, true, &v_315), _fx_catch_98);
+      FX_CALL(_fx_M6K_formFM10rcode2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_315, &exn_loc_0, &handle_exn_1, 0),
+         _fx_catch_98);
       FX_CALL(
          _fx_M6K_formFM12KExpTryCatchN14K_form__kexp_t3N14K_form__kexp_tN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t(
-            try_body_0, handle_exn_1, &kctx_0, &v_294), _fx_catch_96);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_294, code_0, fx_result);
+            try_body_0, handle_exn_1, &kctx_0, &v_316), _fx_catch_98);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_316, code_0, fx_result);
 
-   _fx_catch_96: ;
-      if (v_294) {
-         _fx_free_N14K_form__kexp_t(&v_294);
+   _fx_catch_98: ;
+      if (v_316) {
+         _fx_free_N14K_form__kexp_t(&v_316);
       }
       if (handle_exn_1) {
          _fx_free_N14K_form__kexp_t(&handle_exn_1);
       }
-      if (v_293) {
-         _fx_free_LN14K_form__kexp_t(&v_293);
+      if (v_315) {
+         _fx_free_LN14K_form__kexp_t(&v_315);
       }
       if (handle_exn_0) {
          _fx_free_N14K_form__kexp_t(&handle_exn_0);
@@ -14384,23 +14621,23 @@ FX_EXTERN_C int
       if (k_cases_1) {
          _fx_free_LT2LN14K_form__kexp_tN14K_form__kexp_t(&k_cases_1);
       }
-      _fx_free_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t(&v_292);
-      _fx_free_N14K_form__atom_t(&v_291);
+      _fx_free_T2LT2LN14K_form__kexp_tN14K_form__kexp_tLN14K_form__kexp_t(&v_314);
+      _fx_free_N14K_form__atom_t(&v_313);
       if (catch_code_0) {
          _fx_free_LN14K_form__kexp_t(&catch_code_0);
       }
-      _fx_free_Nt6option1N14K_form__kexp_t(&v_290);
-      _fx_free_R16Ast__val_flags_t(&v_289);
+      _fx_free_Nt6option1N14K_form__kexp_t(&v_312);
+      _fx_free_R16Ast__val_flags_t(&v_311);
       FX_FREE_LIST_SIMPLE(&catch_sc_0);
       if (pop_e_0) {
          _fx_free_N14K_form__kexp_t(&pop_e_0);
       }
-      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_288);
+      _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_310);
       if (try_body_0) {
          _fx_free_N14K_form__kexp_t(&try_body_0);
       }
-      if (v_287) {
-         _fx_free_LN14K_form__kexp_t(&v_287);
+      if (v_309) {
+         _fx_free_LN14K_form__kexp_t(&v_309);
       }
       if (body_code_5) {
          _fx_free_LN14K_form__kexp_t(&body_code_5);
@@ -14408,186 +14645,186 @@ FX_EXTERN_C int
       if (e1_10) {
          _fx_free_N14K_form__kexp_t(&e1_10);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_286);
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_308);
       FX_FREE_LIST_SIMPLE(&try_sc_0);
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 34) {
-      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_299 = {0};
-      _fx_N14K_form__kexp_t e2_11 = 0;
-      _fx_LN14K_form__kexp_t code_53 = 0;
+      _fx_T2N14K_form__kexp_tLN14K_form__kexp_t v_321 = {0};
+      _fx_N14K_form__kexp_t e2_12 = 0;
+      _fx_LN14K_form__kexp_t code_56 = 0;
       _fx_N14K_form__ktyp_t ktyp_2 = 0;
-      _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t* vcase_31 = &e_0->u.DefVal;
-      _fx_R16Ast__val_flags_t* flags_0 = &vcase_31->t2;
-      _fx_N10Ast__pat_t p_0 = vcase_31->t0;
+      _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t* vcase_34 = &e_0->u.DefVal;
+      _fx_R16Ast__val_flags_t* flags_0 = &vcase_34->t2;
+      _fx_N10Ast__pat_t p_0 = vcase_34->t0;
       FX_CALL(
          _fx_M11K_normalizeFM8exp2kexpT2N14K_form__kexp_tLN14K_form__kexp_t4N10Ast__exp_tLN14K_form__kexp_tBLN12Ast__scope_t(
-            vcase_31->t1, code_0, true, sc_0, &v_299, 0), _fx_catch_99);
-      FX_COPY_PTR(v_299.t0, &e2_11);
-      FX_COPY_PTR(v_299.t1, &code_53);
-      FX_CALL(_fx_M6K_formFM12get_kexp_typN14K_form__ktyp_t1N14K_form__kexp_t(e2_11, &ktyp_2, 0), _fx_catch_99);
+            vcase_34->t1, code_0, true, sc_0, &v_321, 0), _fx_catch_101);
+      FX_COPY_PTR(v_321.t0, &e2_12);
+      FX_COPY_PTR(v_321.t1, &code_56);
+      FX_CALL(_fx_M6K_formFM12get_kexp_typN14K_form__ktyp_t1N14K_form__kexp_t(e2_12, &ktyp_2, 0), _fx_catch_101);
       if (FX_REC_VARIANT_TAG(ktyp_2) == 7) {
          if (FX_REC_VARIANT_TAG(p_0) == 3) {
             _fx_R17K_form__kdefval_t dv_0 = {0};
-            _fx_N15K_form__kinfo_t v_300 = {0};
+            _fx_N15K_form__kinfo_t v_322 = {0};
             _fx_R9Ast__id_t* n_4 = &p_0->u.PatIdent.t0;
-            fx_str_t slit_35 = FX_MAKE_STR("");
-            _fx_make_R17K_form__kdefval_t(n_4, &slit_35, ktyp_2, flags_0, &eloc_0, &dv_0);
-            _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_300);
-            FX_CALL(_fx_M6K_formFM13set_idk_entryv2R9Ast__id_tN15K_form__kinfo_t(n_4, &v_300, 0), _fx_catch_97);
-            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(e2_11, code_53, fx_result);
+            fx_str_t slit_37 = FX_MAKE_STR("");
+            _fx_make_R17K_form__kdefval_t(n_4, &slit_37, ktyp_2, flags_0, &eloc_0, &dv_0);
+            _fx_M6K_formFM4KValN15K_form__kinfo_t1RM9kdefval_t(&dv_0, &v_322);
+            FX_CALL(_fx_M6K_formFM13set_idk_entryv2R9Ast__id_tN15K_form__kinfo_t(n_4, &v_322, 0), _fx_catch_99);
+            _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(e2_12, code_56, fx_result);
 
-         _fx_catch_97: ;
-            _fx_free_N15K_form__kinfo_t(&v_300);
+         _fx_catch_99: ;
+            _fx_free_N15K_form__kinfo_t(&v_322);
             _fx_free_R17K_form__kdefval_t(&dv_0);
-            goto _fx_endmatch_13;
+            goto _fx_endmatch_16;
          }
       }
-      _fx_Nt6option1N14K_form__kexp_t v_301 = {0};
-      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_302 = {0};
-      _fx_LN14K_form__kexp_t code_54 = 0;
-      _fx_N14K_form__kexp_t v_303 = 0;
-      _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(e2_11, &v_301);
-      fx_str_t slit_36 = FX_MAKE_STR("v");
+      _fx_Nt6option1N14K_form__kexp_t v_323 = {0};
+      _fx_T2R9Ast__id_tLN14K_form__kexp_t v_324 = {0};
+      _fx_LN14K_form__kexp_t code_57 = 0;
+      _fx_N14K_form__kexp_t v_325 = 0;
+      _fx_M11K_normalizeFM4SomeNt6option1N14K_form__kexp_t1N14K_form__kexp_t(e2_12, &v_323);
+      fx_str_t slit_38 = FX_MAKE_STR("v");
       FX_CALL(
          _fx_M11K_normalizeFM17pat_simple_unpackT2R9Ast__id_tLN14K_form__kexp_t7N10Ast__pat_tN14K_form__ktyp_tNt6option1N14K_form__kexp_tLN14K_form__kexp_tSR16Ast__val_flags_tLN12Ast__scope_t(
-            p_0, ktyp_2, &v_301, code_53, &slit_36, flags_0, sc_0, &v_302, 0), _fx_catch_98);
-      _fx_R9Ast__id_t v_304 = v_302.t0;
-      FX_COPY_PTR(v_302.t1, &code_54);
-      bool res_20;
-      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_304, &_fx_g9Ast__noid, &res_20, 0), _fx_catch_98);
-      if (res_20) {
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(e2_11, code_54, fx_result);
+            p_0, ktyp_2, &v_323, code_56, &slit_38, flags_0, sc_0, &v_324, 0), _fx_catch_100);
+      _fx_R9Ast__id_t v_326 = v_324.t0;
+      FX_COPY_PTR(v_324.t1, &code_57);
+      bool res_22;
+      FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_326, &_fx_g9Ast__noid, &res_22, 0), _fx_catch_100);
+      if (res_22) {
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(e2_12, code_57, fx_result);
       }
       else {
-         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_303), _fx_catch_98);
-         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_303, code_54, fx_result);
+         FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_325), _fx_catch_100);
+         _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_325, code_57, fx_result);
       }
 
-   _fx_catch_98: ;
-      if (v_303) {
-         _fx_free_N14K_form__kexp_t(&v_303);
+   _fx_catch_100: ;
+      if (v_325) {
+         _fx_free_N14K_form__kexp_t(&v_325);
       }
-      if (code_54) {
-         _fx_free_LN14K_form__kexp_t(&code_54);
+      if (code_57) {
+         _fx_free_LN14K_form__kexp_t(&code_57);
       }
-      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_302);
-      _fx_free_Nt6option1N14K_form__kexp_t(&v_301);
+      _fx_free_T2R9Ast__id_tLN14K_form__kexp_t(&v_324);
+      _fx_free_Nt6option1N14K_form__kexp_t(&v_323);
 
-   _fx_endmatch_13: ;
-      FX_CHECK_EXN(_fx_catch_99);
+   _fx_endmatch_16: ;
+      FX_CHECK_EXN(_fx_catch_101);
 
-   _fx_catch_99: ;
+   _fx_catch_101: ;
       if (ktyp_2) {
          _fx_free_N14K_form__ktyp_t(&ktyp_2);
       }
-      if (code_53) {
-         _fx_free_LN14K_form__kexp_t(&code_53);
+      if (code_56) {
+         _fx_free_LN14K_form__kexp_t(&code_56);
       }
-      if (e2_11) {
-         _fx_free_N14K_form__kexp_t(&e2_11);
+      if (e2_12) {
+         _fx_free_N14K_form__kexp_t(&e2_12);
       }
-      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_299);
-      goto _fx_endmatch_14;
+      _fx_free_T2N14K_form__kexp_tLN14K_form__kexp_t(&v_321);
+      goto _fx_endmatch_17;
    }
    if (tag_0 == 35) {
-      _fx_LN14K_form__kexp_t code_55 = 0;
-      _fx_N14K_form__kexp_t v_305 = 0;
+      _fx_LN14K_form__kexp_t code_58 = 0;
+      _fx_N14K_form__kexp_t v_327 = 0;
       FX_CALL(
          _fx_M11K_normalizeFM13transform_funLN14K_form__kexp_t3rR13Ast__deffun_tLN14K_form__kexp_tLN12Ast__scope_t(
-            e_0->u.DefFun, code_0, sc_0, &code_55, 0), _fx_catch_100);
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_305), _fx_catch_100);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_305, code_55, fx_result);
-
-   _fx_catch_100: ;
-      if (v_305) {
-         _fx_free_N14K_form__kexp_t(&v_305);
-      }
-      if (code_55) {
-         _fx_free_LN14K_form__kexp_t(&code_55);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 37) {
-      _fx_N14K_form__kexp_t v_306 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_306), _fx_catch_101);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_306, code_0, fx_result);
-
-   _fx_catch_101: ;
-      if (v_306) {
-         _fx_free_N14K_form__kexp_t(&v_306);
-      }
-      goto _fx_endmatch_14;
-   }
-   if (tag_0 == 38) {
-      _fx_N14K_form__kexp_t v_307 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_307), _fx_catch_102);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_307, code_0, fx_result);
+            e_0->u.DefFun, code_0, sc_0, &code_58, 0), _fx_catch_102);
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_327), _fx_catch_102);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_327, code_58, fx_result);
 
    _fx_catch_102: ;
-      if (v_307) {
-         _fx_free_N14K_form__kexp_t(&v_307);
+      if (v_327) {
+         _fx_free_N14K_form__kexp_t(&v_327);
       }
-      goto _fx_endmatch_14;
+      if (code_58) {
+         _fx_free_LN14K_form__kexp_t(&code_58);
+      }
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 36) {
-      _fx_N14K_form__kexp_t v_308 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_308), _fx_catch_103);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_308, code_0, fx_result);
+   if (tag_0 == 37) {
+      _fx_N14K_form__kexp_t v_328 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_328), _fx_catch_103);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_328, code_0, fx_result);
 
    _fx_catch_103: ;
-      if (v_308) {
-         _fx_free_N14K_form__kexp_t(&v_308);
+      if (v_328) {
+         _fx_free_N14K_form__kexp_t(&v_328);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 39) {
-      _fx_N14K_form__kexp_t v_309 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_309), _fx_catch_104);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_309, code_0, fx_result);
+   if (tag_0 == 38) {
+      _fx_N14K_form__kexp_t v_329 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_329), _fx_catch_104);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_329, code_0, fx_result);
 
    _fx_catch_104: ;
-      if (v_309) {
-         _fx_free_N14K_form__kexp_t(&v_309);
+      if (v_329) {
+         _fx_free_N14K_form__kexp_t(&v_329);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 40) {
-      _fx_N14K_form__kexp_t v_310 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_310), _fx_catch_105);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_310, code_0, fx_result);
+   if (tag_0 == 36) {
+      _fx_N14K_form__kexp_t v_330 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_330), _fx_catch_105);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_330, code_0, fx_result);
 
    _fx_catch_105: ;
-      if (v_310) {
-         _fx_free_N14K_form__kexp_t(&v_310);
+      if (v_330) {
+         _fx_free_N14K_form__kexp_t(&v_330);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 41) {
-      _fx_N14K_form__kexp_t v_311 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_311), _fx_catch_106);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_311, code_0, fx_result);
+   if (tag_0 == 39) {
+      _fx_N14K_form__kexp_t v_331 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_331), _fx_catch_106);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_331, code_0, fx_result);
 
    _fx_catch_106: ;
-      if (v_311) {
-         _fx_free_N14K_form__kexp_t(&v_311);
+      if (v_331) {
+         _fx_free_N14K_form__kexp_t(&v_331);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
    }
-   if (tag_0 == 42) {
-      _fx_N14K_form__kexp_t v_312 = 0;
-      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_312), _fx_catch_107);
-      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_312, code_0, fx_result);
+   if (tag_0 == 40) {
+      _fx_N14K_form__kexp_t v_332 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_332), _fx_catch_107);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_332, code_0, fx_result);
 
    _fx_catch_107: ;
-      if (v_312) {
-         _fx_free_N14K_form__kexp_t(&v_312);
+      if (v_332) {
+         _fx_free_N14K_form__kexp_t(&v_332);
       }
-      goto _fx_endmatch_14;
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 41) {
+      _fx_N14K_form__kexp_t v_333 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_333), _fx_catch_108);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_333, code_0, fx_result);
+
+   _fx_catch_108: ;
+      if (v_333) {
+         _fx_free_N14K_form__kexp_t(&v_333);
+      }
+      goto _fx_endmatch_17;
+   }
+   if (tag_0 == 42) {
+      _fx_N14K_form__kexp_t v_334 = 0;
+      FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&eloc_0, &v_334), _fx_catch_109);
+      _fx_make_T2N14K_form__kexp_tLN14K_form__kexp_t(v_334, code_0, fx_result);
+
+   _fx_catch_109: ;
+      if (v_334) {
+         _fx_free_N14K_form__kexp_t(&v_334);
+      }
+      goto _fx_endmatch_17;
    }
    FX_FAST_THROW(FX_EXN_NoMatchError, _fx_cleanup);
 
-_fx_endmatch_14: ;
+_fx_endmatch_17: ;
 
 _fx_cleanup: ;
    _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_0);
@@ -14598,6 +14835,12 @@ _fx_cleanup: ;
       _fx_free_N14K_form__ktyp_t(&ktyp_0);
    }
    _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&kctx_0);
+   if (v_1) {
+      _fx_free_N10Ast__typ_t(&v_1);
+   }
+   if (v_2) {
+      _fx_free_N14K_form__ktyp_t(&v_2);
+   }
    return fx_status;
 }
 

--- a/compiler/bootstrap/K_nothrow_wrappers.c
+++ b/compiler/bootstrap/K_nothrow_wrappers.c
@@ -45,19 +45,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -80,6 +67,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -98,6 +103,20 @@ typedef struct _fx_R16Ast__val_flags_t {
    int_ val_flag_ctor;
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
+
+typedef struct _fx_N12Ast__cmpop_t {
+   int tag;
+} _fx_N12Ast__cmpop_t;
+
+typedef struct _fx_N13Ast__binary_t_data_t {
+   int_ rc;
+   int tag;
+   union {
+      struct _fx_N12Ast__cmpop_t OpCmp;
+      struct _fx_N12Ast__cmpop_t OpDotCmp;
+      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
+   } u;
+} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -128,25 +147,6 @@ typedef struct _fx_LR9Ast__id_t_data_t {
    struct _fx_LR9Ast__id_t_data_t* tl;
    struct _fx_R9Ast__id_t hd;
 } _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
-typedef struct _fx_N12Ast__cmpop_t {
-   int tag;
-} _fx_N12Ast__cmpop_t;
-
-typedef struct _fx_N13Ast__binary_t_data_t {
-   int_ rc;
-   int tag;
-   union {
-      struct _fx_N12Ast__cmpop_t OpCmp;
-      struct _fx_N12Ast__cmpop_t OpDotCmp;
-      struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
-   } u;
-} _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -327,145 +327,6 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -501,6 +362,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -766,6 +643,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -811,6 +790,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -877,6 +877,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -930,32 +947,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
-}
-
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -968,6 +959,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1291,150 +1291,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1447,256 +1303,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2715,6 +2321,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2799,6 +2722,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)

--- a/compiler/bootstrap/K_optim_matop.c
+++ b/compiler/bootstrap/K_optim_matop.c
@@ -73,18 +73,26 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
+typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   uint64_t hv;
+   struct _fx_R9Ast__id_t key;
+} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
 
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
+typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
+   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
    int_ t1;
-} _fx_T2R9Ast__id_ti;
+   int_ t2;
+   int_ t3;
+   fx_arr_t t4;
+   fx_arr_t t5;
+} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
+
+typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
+   int_ rc;
+   union {
+      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
+   } u;
+} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
 
 typedef struct _fx_T3BBi {
    bool t0;
@@ -108,6 +116,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -127,38 +153,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   uint64_t hv;
-   struct _fx_R9Ast__id_t key;
-} _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t {
-   struct _fx_Rt24Hashset__hashset_entry_t1R9Ast__id_t t0;
-   int_ t1;
-   int_ t2;
-   int_ t3;
-   fx_arr_t t4;
-   fx_arr_t t5;
-} _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t;
-
-typedef struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t t;
-   } u;
-} _fx_Nt10Hashset__t1R9Ast__id_t_data_t, *_fx_Nt10Hashset__t1R9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
 } _fx_N12Ast__cmpop_t;
@@ -172,6 +166,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -394,6 +394,22 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
+
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
    union {
@@ -418,140 +434,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -571,6 +453,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -836,6 +734,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1053,68 +1053,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t(
    struct _fx_T6Rt24Hashset__hashset_entry_t1R9Ast__id_tiiiA1iA1Rt24Hashset__hashset_entry_t1R9Ast__id_t* dst)
 {
@@ -1177,6 +1115,59 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1189,6 +1180,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1566,119 +1566,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1691,210 +1578,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2911,6 +2594,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t0 = *t0;
    FX_COPY_PTR(t1, &fx_result->t1);
    fx_result->t2 = *t2;
+}
+
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
 }
 
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)

--- a/compiler/bootstrap/K_pp.c
+++ b/compiler/bootstrap/K_pp.c
@@ -40,14 +40,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -70,31 +62,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -126,6 +111,15 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -137,6 +131,12 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -373,56 +373,6 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
 typedef struct _fx_R16Ast__var_flags_t {
    int_ var_flag_class_from;
    bool var_flag_record;
@@ -438,79 +388,6 @@ typedef struct _fx_LN14K_form__ktyp_t_data_t {
    struct _fx_LN14K_form__ktyp_t_data_t* tl;
    struct _fx_N14K_form__ktyp_t_data_t* hd;
 } _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -776,6 +653,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -821,6 +800,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t {
    struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* t0;
@@ -922,24 +922,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -957,6 +939,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -969,6 +960,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1411,150 +1411,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1567,256 +1423,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2835,6 +2441,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2919,6 +2842,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2LT2R9Ast__id_tN14K_form__ktyp_tLR9Ast__id_t(

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -137,77 +137,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
 typedef struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t {
    uint64_t hv;
    struct _fx_R9Ast__id_t key;
@@ -272,15 +201,56 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t {
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t;
 
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
 typedef struct _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t {
    struct _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t_data_t* root;
    struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
 } _fx_Rt6Map__t2R9Ast__id_tR9Ast__id_t;
 
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
    fx_str_t t1;
 } _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
 
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
@@ -295,6 +265,36 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -533,145 +533,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
-
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
 typedef struct _fx_N12Ast__unary_t {
    int tag;
 } _fx_N12Ast__unary_t;
@@ -707,6 +568,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -972,6 +849,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -1017,6 +996,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_R14Ast__pragmas_t {
    bool pragma_cpp;
@@ -1332,24 +1332,6 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
 static void _fx_free_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t(
    struct _fx_Rt20Hashmap__hashentry_t2R9Ast__id_tNt10Hashset__t1R9Ast__id_t* dst)
 {
@@ -1566,6 +1548,15 @@ static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -1578,6 +1569,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1980,150 +1980,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -2136,256 +1992,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -3404,6 +3010,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -3488,6 +3411,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_R14Ast__pragmas_t(struct _fx_R14Ast__pragmas_t* dst)
@@ -5336,6 +5336,20 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       if (res_0) {
          *ispure_0 = false; goto _fx_endmatch_0;
       }
+      bool res_1;
+      if (tag_1 == 16) {
+         res_1 = true;
+      }
+      else if (tag_1 == 17) {
+         res_1 = true;
+      }
+      else {
+         res_1 = false;
+      }
+      FX_CHECK_EXN(_fx_catch_0);
+      if (res_1) {
+         *ispure_0 = false; goto _fx_endmatch_0;
+      }
 
    _fx_endmatch_0: ;
       FX_CHECK_EXN(_fx_catch_0);
@@ -5361,9 +5375,9 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       _fx_T3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t* vcase_1 = &e_0->u.KExpAssign;
       _fx_N14K_form__atom_t* v_1 = &vcase_1->t1;
       if (v_1->tag == 1) {
-         bool res_1;
-         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&vcase_1->t0, &v_1->u.AtomId, &res_1, 0), _fx_cleanup);
-         if (res_1) {
+         bool res_2;
+         FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&vcase_1->t0, &v_1->u.AtomId, &res_2, 0), _fx_cleanup);
+         if (res_2) {
             goto _fx_endmatch_1;
          }
       }

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -5343,6 +5343,9 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       else if (tag_1 == 17) {
          res_1 = true;
       }
+      else if (tag_1 == 18) {
+         res_1 = true;
+      }
       else {
          res_1 = false;
       }

--- a/compiler/bootstrap/K_tailrec.c
+++ b/compiler/bootstrap/K_tailrec.c
@@ -45,19 +45,6 @@ typedef struct _fx_R9Ast__id_t {
    int_ j;
 } _fx_R9Ast__id_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
 typedef struct _fx_T3BBi {
    bool t0;
    bool t1;
@@ -80,6 +67,24 @@ typedef struct _fx_N12Ast__scope_t {
    } u;
 } _fx_N12Ast__scope_t;
 
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
+
+typedef struct _fx_T2R10Ast__loc_tS {
+   struct _fx_R10Ast__loc_t t0;
+   fx_str_t t1;
+} _fx_T2R10Ast__loc_tS;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
 typedef struct _fx_LN12Ast__scope_t_data_t {
    int_ rc;
    struct _fx_LN12Ast__scope_t_data_t* tl;
@@ -99,17 +104,6 @@ typedef struct _fx_R16Ast__val_flags_t {
    struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
 } _fx_R16Ast__val_flags_t;
 
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_T2R10Ast__loc_tS {
-   struct _fx_R10Ast__loc_t t0;
-   fx_str_t t1;
-} _fx_T2R10Ast__loc_tS;
-
 typedef struct _fx_N12Ast__cmpop_t {
    int tag;
 } _fx_N12Ast__cmpop_t;
@@ -123,6 +117,12 @@ typedef struct _fx_N13Ast__binary_t_data_t {
       struct _fx_N13Ast__binary_t_data_t* OpAugBinary;
    } u;
 } _fx_N13Ast__binary_t_data_t, *_fx_N13Ast__binary_t;
+
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
 
 typedef struct _fx_T2SR10Ast__loc_t {
    fx_str_t t0;
@@ -298,13 +298,21 @@ typedef struct _fx_LT2BN14K_form__atom_t_data_t {
    struct _fx_T2BN14K_form__atom_t hd;
 } _fx_LT2BN14K_form__atom_t_data_t, *_fx_LT2BN14K_form__atom_t;
 
-typedef struct _fx_R17K_form__kdefval_t {
-   struct _fx_R9Ast__id_t kv_name;
-   fx_str_t kv_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
-   struct _fx_R16Ast__val_flags_t kv_flags;
-   struct _fx_R10Ast__loc_t kv_loc;
-} _fx_R17K_form__kdefval_t;
+typedef struct _fx_N12Ast__unary_t {
+   int tag;
+} _fx_N12Ast__unary_t;
+
+typedef struct _fx_N12Ast__sctyp_t {
+   int tag;
+} _fx_N12Ast__sctyp_t;
+
+typedef struct _fx_N13Ast__intrin_t {
+   int tag;
+   union {
+      struct _fx_R9Ast__id_t IntrinMath;
+      struct _fx_N12Ast__sctyp_t IntrinSaturate;
+   } u;
+} _fx_N13Ast__intrin_t;
 
 typedef struct _fx_N17Ast__fun_constr_t {
    int tag;
@@ -330,153 +338,6 @@ typedef struct _fx_R16Ast__fun_flags_t {
    bool fun_flag_instance;
 } _fx_R16Ast__fun_flags_t;
 
-typedef struct _fx_R25K_form__kdefclosureinfo_t {
-   struct _fx_R9Ast__id_t kci_arg;
-   struct _fx_R9Ast__id_t kci_fcv_t;
-   struct _fx_R9Ast__id_t kci_fp_typ;
-   struct _fx_R9Ast__id_t kci_make_fp;
-   struct _fx_R9Ast__id_t kci_wrap_f;
-} _fx_R25K_form__kdefclosureinfo_t;
-
-typedef struct _fx_R17K_form__kdeffun_t {
-   struct _fx_R9Ast__id_t kf_name;
-   fx_str_t kf_cname;
-   struct _fx_LR9Ast__id_t_data_t* kf_params;
-   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
-   struct _fx_N14K_form__kexp_t_data_t* kf_body;
-   struct _fx_R16Ast__fun_flags_t kf_flags;
-   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
-   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
-   struct _fx_R10Ast__loc_t kf_loc;
-} _fx_R17K_form__kdeffun_t;
-
-typedef struct _fx_rR17K_form__kdeffun_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeffun_t data;
-} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
-
-typedef struct _fx_R17K_form__kdefexn_t {
-   struct _fx_R9Ast__id_t ke_name;
-   fx_str_t ke_cname;
-   fx_str_t ke_base_cname;
-   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
-   bool ke_std;
-   struct _fx_R9Ast__id_t ke_tag;
-   struct _fx_R9Ast__id_t ke_make;
-   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
-   struct _fx_R10Ast__loc_t ke_loc;
-} _fx_R17K_form__kdefexn_t;
-
-typedef struct _fx_rR17K_form__kdefexn_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdefexn_t data;
-} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_LN14K_form__ktyp_t_data_t {
-   int_ rc;
-   struct _fx_LN14K_form__ktyp_t_data_t* tl;
-   struct _fx_N14K_form__ktyp_t_data_t* hd;
-} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
-
-typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
-
-typedef struct _fx_R21K_form__kdefvariant_t {
-   struct _fx_R9Ast__id_t kvar_name;
-   fx_str_t kvar_cname;
-   struct _fx_R9Ast__id_t kvar_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
-   struct _fx_R16Ast__var_flags_t kvar_flags;
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
-   struct _fx_R10Ast__loc_t kvar_loc;
-} _fx_R21K_form__kdefvariant_t;
-
-typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
-   int_ rc;
-   struct _fx_R21K_form__kdefvariant_t data;
-} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
-
-typedef struct _fx_R17K_form__kdeftyp_t {
-   struct _fx_R9Ast__id_t kt_name;
-   fx_str_t kt_cname;
-   struct _fx_R9Ast__id_t kt_proto;
-   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
-   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
-   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
-   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
-   struct _fx_R10Ast__loc_t kt_loc;
-} _fx_R17K_form__kdeftyp_t;
-
-typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
-   int_ rc;
-   struct _fx_R17K_form__kdeftyp_t data;
-} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
-
-typedef struct _fx_R25K_form__kdefclosurevars_t {
-   struct _fx_R9Ast__id_t kcv_name;
-   fx_str_t kcv_cname;
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
-   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
-   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
-   struct _fx_R10Ast__loc_t kcv_loc;
-} _fx_R25K_form__kdefclosurevars_t;
-
-typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
-   int_ rc;
-   struct _fx_R25K_form__kdefclosurevars_t data;
-} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
-
-typedef struct _fx_N15K_form__kinfo_t {
-   int tag;
-   union {
-      struct _fx_R17K_form__kdefval_t KVal;
-      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
-      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
-      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
-      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
-      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
-      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
-   } u;
-} _fx_N15K_form__kinfo_t;
-
-typedef struct _fx_N12Ast__unary_t {
-   int tag;
-} _fx_N12Ast__unary_t;
-
-typedef struct _fx_N12Ast__sctyp_t {
-   int tag;
-} _fx_N12Ast__sctyp_t;
-
-typedef struct _fx_N13Ast__intrin_t {
-   int tag;
-   union {
-      struct _fx_R9Ast__id_t IntrinMath;
-      struct _fx_N12Ast__sctyp_t IntrinSaturate;
-   } u;
-} _fx_N13Ast__intrin_t;
-
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -496,6 +357,22 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
+
+typedef struct _fx_LN14K_form__ktyp_t_data_t {
+   int_ rc;
+   struct _fx_LN14K_form__ktyp_t_data_t* tl;
+   struct _fx_N14K_form__ktyp_t_data_t* hd;
+} _fx_LN14K_form__ktyp_t_data_t, *_fx_LN14K_form__ktyp_t;
 
 typedef struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t {
    struct _fx_LN14K_form__ktyp_t_data_t* t0;
@@ -761,6 +638,108 @@ typedef struct _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t {
    struct _fx_R10Ast__loc_t t2;
 } _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t;
 
+typedef struct _fx_R25K_form__kdefclosureinfo_t {
+   struct _fx_R9Ast__id_t kci_arg;
+   struct _fx_R9Ast__id_t kci_fcv_t;
+   struct _fx_R9Ast__id_t kci_fp_typ;
+   struct _fx_R9Ast__id_t kci_make_fp;
+   struct _fx_R9Ast__id_t kci_wrap_f;
+} _fx_R25K_form__kdefclosureinfo_t;
+
+typedef struct _fx_R17K_form__kdeffun_t {
+   struct _fx_R9Ast__id_t kf_name;
+   fx_str_t kf_cname;
+   struct _fx_LR9Ast__id_t_data_t* kf_params;
+   struct _fx_N14K_form__ktyp_t_data_t* kf_rt;
+   struct _fx_N14K_form__kexp_t_data_t* kf_body;
+   struct _fx_R16Ast__fun_flags_t kf_flags;
+   struct _fx_R25K_form__kdefclosureinfo_t kf_closure;
+   struct _fx_LN12Ast__scope_t_data_t* kf_scope;
+   struct _fx_R10Ast__loc_t kf_loc;
+} _fx_R17K_form__kdeffun_t;
+
+typedef struct _fx_rR17K_form__kdeffun_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeffun_t data;
+} _fx_rR17K_form__kdeffun_t_data_t, *_fx_rR17K_form__kdeffun_t;
+
+typedef struct _fx_R17K_form__kdefexn_t {
+   struct _fx_R9Ast__id_t ke_name;
+   fx_str_t ke_cname;
+   fx_str_t ke_base_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* ke_typ;
+   bool ke_std;
+   struct _fx_R9Ast__id_t ke_tag;
+   struct _fx_R9Ast__id_t ke_make;
+   struct _fx_LN12Ast__scope_t_data_t* ke_scope;
+   struct _fx_R10Ast__loc_t ke_loc;
+} _fx_R17K_form__kdefexn_t;
+
+typedef struct _fx_rR17K_form__kdefexn_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdefexn_t data;
+} _fx_rR17K_form__kdefexn_t_data_t, *_fx_rR17K_form__kdefexn_t;
+
+typedef struct _fx_T2R9Ast__id_tLR9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LR9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLR9Ast__id_t;
+
+typedef struct _fx_R21K_form__kdefvariant_t {
+   struct _fx_R9Ast__id_t kvar_name;
+   fx_str_t kvar_cname;
+   struct _fx_R9Ast__id_t kvar_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kvar_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kvar_targs;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* kvar_ctors;
+   struct _fx_R16Ast__var_flags_t kvar_flags;
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* kvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* kvar_scope;
+   struct _fx_R10Ast__loc_t kvar_loc;
+} _fx_R21K_form__kdefvariant_t;
+
+typedef struct _fx_rR21K_form__kdefvariant_t_data_t {
+   int_ rc;
+   struct _fx_R21K_form__kdefvariant_t data;
+} _fx_rR21K_form__kdefvariant_t_data_t, *_fx_rR21K_form__kdefvariant_t;
+
+typedef struct _fx_R17K_form__kdeftyp_t {
+   struct _fx_R9Ast__id_t kt_name;
+   fx_str_t kt_cname;
+   struct _fx_R9Ast__id_t kt_proto;
+   struct _fx_Nt6option1R17K_form__ktprops_t kt_props;
+   struct _fx_LN14K_form__ktyp_t_data_t* kt_targs;
+   struct _fx_N14K_form__ktyp_t_data_t* kt_typ;
+   struct _fx_LN12Ast__scope_t_data_t* kt_scope;
+   struct _fx_R10Ast__loc_t kt_loc;
+} _fx_R17K_form__kdeftyp_t;
+
+typedef struct _fx_rR17K_form__kdeftyp_t_data_t {
+   int_ rc;
+   struct _fx_R17K_form__kdeftyp_t data;
+} _fx_rR17K_form__kdeftyp_t_data_t, *_fx_rR17K_form__kdeftyp_t;
+
+typedef struct _fx_R25K_form__kdefclosurevars_t {
+   struct _fx_R9Ast__id_t kcv_name;
+   fx_str_t kcv_cname;
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* kcv_freevars;
+   struct _fx_LR9Ast__id_t_data_t* kcv_orig_freevars;
+   struct _fx_LN12Ast__scope_t_data_t* kcv_scope;
+   struct _fx_R10Ast__loc_t kcv_loc;
+} _fx_R25K_form__kdefclosurevars_t;
+
+typedef struct _fx_rR25K_form__kdefclosurevars_t_data_t {
+   int_ rc;
+   struct _fx_R25K_form__kdefclosurevars_t data;
+} _fx_rR25K_form__kdefclosurevars_t_data_t, *_fx_rR25K_form__kdefclosurevars_t;
+
 typedef struct _fx_N14K_form__kexp_t_data_t {
    int_ rc;
    int tag;
@@ -806,6 +785,27 @@ typedef struct _fx_N14K_form__kexp_t_data_t {
       struct _fx_rR25K_form__kdefclosurevars_t_data_t* KDefClosureVars;
    } u;
 } _fx_N14K_form__kexp_t_data_t, *_fx_N14K_form__kexp_t;
+
+typedef struct _fx_R17K_form__kdefval_t {
+   struct _fx_R9Ast__id_t kv_name;
+   fx_str_t kv_cname;
+   struct _fx_N14K_form__ktyp_t_data_t* kv_typ;
+   struct _fx_R16Ast__val_flags_t kv_flags;
+   struct _fx_R10Ast__loc_t kv_loc;
+} _fx_R17K_form__kdefval_t;
+
+typedef struct _fx_N15K_form__kinfo_t {
+   int tag;
+   union {
+      struct _fx_R17K_form__kdefval_t KVal;
+      struct _fx_rR17K_form__kdeffun_t_data_t* KFun;
+      struct _fx_rR17K_form__kdefexn_t_data_t* KExn;
+      struct _fx_rR21K_form__kdefvariant_t_data_t* KVariant;
+      struct _fx_rR25K_form__kdefclosurevars_t_data_t* KClosureVars;
+      struct _fx_rR23K_form__kdefinterface_t_data_t* KInterface;
+      struct _fx_rR17K_form__kdeftyp_t_data_t* KTyp;
+   } u;
+} _fx_N15K_form__kinfo_t;
 
 typedef struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t {
    struct _fx_N14K_form__atom_t t0;
@@ -887,6 +887,23 @@ static void _fx_make_T2Ta2iS(struct _fx_Ta2i* t0, fx_str_t* t1, struct _fx_T2Ta2
    fx_copy_str(t1, &fx_result->t1);
 }
 
+static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
+{
+   fx_free_str(&dst->t1);
+}
+
+static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
+{
+   dst->t0 = src->t0;
+   fx_copy_str(&src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
+{
+   fx_result->t0 = *t0;
+   fx_copy_str(t1, &fx_result->t1);
+}
+
 static int _fx_cons_LN12Ast__scope_t(
    struct _fx_N12Ast__scope_t* hd,
    struct _fx_LN12Ast__scope_t_data_t* tl,
@@ -940,32 +957,6 @@ static void _fx_make_R16Ast__val_flags_t(
    FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
-{
-   fx_free_str(&dst->t1);
-}
-
-static void _fx_copy_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* src, struct _fx_T2R10Ast__loc_tS* dst)
-{
-   dst->t0 = src->t0;
-   fx_copy_str(&src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R10Ast__loc_tS(struct _fx_R10Ast__loc_t* t0, fx_str_t* t1, struct _fx_T2R10Ast__loc_tS* fx_result)
-{
-   fx_result->t0 = *t0;
-   fx_copy_str(t1, &fx_result->t1);
-}
-
 static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -978,6 +969,15 @@ static void _fx_free_N13Ast__binary_t(struct _fx_N13Ast__binary_t_data_t** dst)
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
 }
 
 static void _fx_free_T2SR10Ast__loc_t(struct _fx_T2SR10Ast__loc_t* dst)
@@ -1303,150 +1303,6 @@ static int _fx_cons_LT2BN14K_form__atom_t(
    FX_MAKE_LIST_IMPL(_fx_LT2BN14K_form__atom_t, _fx_copy_T2BN14K_form__atom_t);
 }
 
-static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
-{
-   fx_free_str(&dst->kv_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
-}
-
-static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
-{
-   dst->kv_name = src->kv_name;
-   fx_copy_str(&src->kv_cname, &dst->kv_cname);
-   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
-   dst->kv_loc = src->kv_loc;
-}
-
-static void _fx_make_R17K_form__kdefval_t(
-   struct _fx_R9Ast__id_t* r_kv_name,
-   fx_str_t* r_kv_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
-   struct _fx_R16Ast__val_flags_t* r_kv_flags,
-   struct _fx_R10Ast__loc_t* r_kv_loc,
-   struct _fx_R17K_form__kdefval_t* fx_result)
-{
-   fx_result->kv_name = *r_kv_name;
-   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
-   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
-   fx_result->kv_loc = *r_kv_loc;
-}
-
-static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
-{
-   fx_free_str(&dst->kf_cname);
-   fx_free_list_simple(&dst->kf_params);
-   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
-   _fx_free_N14K_form__kexp_t(&dst->kf_body);
-   fx_free_list_simple(&dst->kf_scope);
-}
-
-static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
-{
-   dst->kf_name = src->kf_name;
-   fx_copy_str(&src->kf_cname, &dst->kf_cname);
-   FX_COPY_PTR(src->kf_params, &dst->kf_params);
-   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
-   FX_COPY_PTR(src->kf_body, &dst->kf_body);
-   dst->kf_flags = src->kf_flags;
-   dst->kf_closure = src->kf_closure;
-   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
-   dst->kf_loc = src->kf_loc;
-}
-
-static void _fx_make_R17K_form__kdeffun_t(
-   struct _fx_R9Ast__id_t* r_kf_name,
-   fx_str_t* r_kf_cname,
-   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
-   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
-   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
-   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
-   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
-   struct _fx_R10Ast__loc_t* r_kf_loc,
-   struct _fx_R17K_form__kdeffun_t* fx_result)
-{
-   fx_result->kf_name = *r_kf_name;
-   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
-   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
-   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
-   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
-   fx_result->kf_flags = *r_kf_flags;
-   fx_result->kf_closure = *r_kf_closure;
-   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
-   fx_result->kf_loc = *r_kf_loc;
-}
-
-static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
-}
-
-static int _fx_make_rR17K_form__kdeffun_t(
-   struct _fx_R17K_form__kdeffun_t* arg,
-   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
-}
-
-static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
-{
-   fx_free_str(&dst->ke_cname);
-   fx_free_str(&dst->ke_base_cname);
-   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
-   fx_free_list_simple(&dst->ke_scope);
-}
-
-static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
-{
-   dst->ke_name = src->ke_name;
-   fx_copy_str(&src->ke_cname, &dst->ke_cname);
-   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
-   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
-   dst->ke_std = src->ke_std;
-   dst->ke_tag = src->ke_tag;
-   dst->ke_make = src->ke_make;
-   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
-   dst->ke_loc = src->ke_loc;
-}
-
-static void _fx_make_R17K_form__kdefexn_t(
-   struct _fx_R9Ast__id_t* r_ke_name,
-   fx_str_t* r_ke_cname,
-   fx_str_t* r_ke_base_cname,
-   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
-   bool r_ke_std,
-   struct _fx_R9Ast__id_t* r_ke_tag,
-   struct _fx_R9Ast__id_t* r_ke_make,
-   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
-   struct _fx_R10Ast__loc_t* r_ke_loc,
-   struct _fx_R17K_form__kdefexn_t* fx_result)
-{
-   fx_result->ke_name = *r_ke_name;
-   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
-   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
-   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
-   fx_result->ke_std = r_ke_std;
-   fx_result->ke_tag = *r_ke_tag;
-   fx_result->ke_make = *r_ke_make;
-   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
-   fx_result->ke_loc = *r_ke_loc;
-}
-
-static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
-}
-
-static int _fx_make_rR17K_form__kdefexn_t(
-   struct _fx_R17K_form__kdefexn_t* arg,
-   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
-}
-
 static void _fx_free_LN14K_form__ktyp_t(struct _fx_LN14K_form__ktyp_t_data_t** dst)
 {
    FX_FREE_LIST_IMPL(_fx_LN14K_form__ktyp_t, _fx_free_N14K_form__ktyp_t);
@@ -1459,256 +1315,6 @@ static int _fx_cons_LN14K_form__ktyp_t(
    struct _fx_LN14K_form__ktyp_t_data_t** fx_result)
 {
    FX_MAKE_LIST_IMPL(_fx_LN14K_form__ktyp_t, FX_COPY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
-}
-
-static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   fx_free_str(&dst->kvar_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
-   fx_free_list_simple(&dst->kvar_ctors);
-   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
-   fx_free_list_simple(&dst->kvar_scope);
-}
-
-static void _fx_copy_R21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* src,
-   struct _fx_R21K_form__kdefvariant_t* dst)
-{
-   dst->kvar_name = src->kvar_name;
-   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
-   dst->kvar_proto = src->kvar_proto;
-   dst->kvar_props = src->kvar_props;
-   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
-   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
-   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
-   dst->kvar_flags = src->kvar_flags;
-   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
-   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
-   dst->kvar_loc = src->kvar_loc;
-}
-
-static void _fx_make_R21K_form__kdefvariant_t(
-   struct _fx_R9Ast__id_t* r_kvar_name,
-   fx_str_t* r_kvar_cname,
-   struct _fx_R9Ast__id_t* r_kvar_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
-   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
-   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
-   struct _fx_R10Ast__loc_t* r_kvar_loc,
-   struct _fx_R21K_form__kdefvariant_t* fx_result)
-{
-   fx_result->kvar_name = *r_kvar_name;
-   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
-   fx_result->kvar_proto = *r_kvar_proto;
-   fx_result->kvar_props = *r_kvar_props;
-   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
-   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
-   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
-   fx_result->kvar_flags = *r_kvar_flags;
-   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
-   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
-   fx_result->kvar_loc = *r_kvar_loc;
-}
-
-static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
-}
-
-static int _fx_make_rR21K_form__kdefvariant_t(
-   struct _fx_R21K_form__kdefvariant_t* arg,
-   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
-}
-
-static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   fx_free_str(&dst->kt_cname);
-   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
-   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
-   fx_free_list_simple(&dst->kt_scope);
-}
-
-static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
-{
-   dst->kt_name = src->kt_name;
-   fx_copy_str(&src->kt_cname, &dst->kt_cname);
-   dst->kt_proto = src->kt_proto;
-   dst->kt_props = src->kt_props;
-   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
-   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
-   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
-   dst->kt_loc = src->kt_loc;
-}
-
-static void _fx_make_R17K_form__kdeftyp_t(
-   struct _fx_R9Ast__id_t* r_kt_name,
-   fx_str_t* r_kt_cname,
-   struct _fx_R9Ast__id_t* r_kt_proto,
-   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
-   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
-   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
-   struct _fx_R10Ast__loc_t* r_kt_loc,
-   struct _fx_R17K_form__kdeftyp_t* fx_result)
-{
-   fx_result->kt_name = *r_kt_name;
-   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
-   fx_result->kt_proto = *r_kt_proto;
-   fx_result->kt_props = *r_kt_props;
-   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
-   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
-   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
-   fx_result->kt_loc = *r_kt_loc;
-}
-
-static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
-}
-
-static int _fx_make_rR17K_form__kdeftyp_t(
-   struct _fx_R17K_form__kdeftyp_t* arg,
-   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
-}
-
-static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   fx_free_str(&dst->kcv_cname);
-   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
-   fx_free_list_simple(&dst->kcv_orig_freevars);
-   fx_free_list_simple(&dst->kcv_scope);
-}
-
-static void _fx_copy_R25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* src,
-   struct _fx_R25K_form__kdefclosurevars_t* dst)
-{
-   dst->kcv_name = src->kcv_name;
-   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
-   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
-   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
-   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
-   dst->kcv_loc = src->kcv_loc;
-}
-
-static void _fx_make_R25K_form__kdefclosurevars_t(
-   struct _fx_R9Ast__id_t* r_kcv_name,
-   fx_str_t* r_kcv_cname,
-   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
-   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
-   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
-   struct _fx_R10Ast__loc_t* r_kcv_loc,
-   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
-{
-   fx_result->kcv_name = *r_kcv_name;
-   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
-   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
-   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
-   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
-   fx_result->kcv_loc = *r_kcv_loc;
-}
-
-static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
-}
-
-static int _fx_make_rR25K_form__kdefclosurevars_t(
-   struct _fx_R25K_form__kdefclosurevars_t* arg,
-   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
-}
-
-static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
-   case 3:
-      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
-   case 4:
-      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
-   case 5:
-      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
-   case 6:
-      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
-   case 7:
-      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
-   case 8:
-      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
-   case 6:
-      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
-   case 7:
-      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
-   case 8:
-      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
-   default:
-      dst->u = src->u;
-   }
 }
 
 static void _fx_free_T2LN14K_form__ktyp_tN14K_form__ktyp_t(struct _fx_T2LN14K_form__ktyp_tN14K_form__ktyp_t* dst)
@@ -2727,6 +2333,323 @@ static void _fx_make_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t(
    fx_result->t2 = *t2;
 }
 
+static void _fx_free_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* dst)
+{
+   fx_free_str(&dst->kf_cname);
+   fx_free_list_simple(&dst->kf_params);
+   _fx_free_N14K_form__ktyp_t(&dst->kf_rt);
+   _fx_free_N14K_form__kexp_t(&dst->kf_body);
+   fx_free_list_simple(&dst->kf_scope);
+}
+
+static void _fx_copy_R17K_form__kdeffun_t(struct _fx_R17K_form__kdeffun_t* src, struct _fx_R17K_form__kdeffun_t* dst)
+{
+   dst->kf_name = src->kf_name;
+   fx_copy_str(&src->kf_cname, &dst->kf_cname);
+   FX_COPY_PTR(src->kf_params, &dst->kf_params);
+   FX_COPY_PTR(src->kf_rt, &dst->kf_rt);
+   FX_COPY_PTR(src->kf_body, &dst->kf_body);
+   dst->kf_flags = src->kf_flags;
+   dst->kf_closure = src->kf_closure;
+   FX_COPY_PTR(src->kf_scope, &dst->kf_scope);
+   dst->kf_loc = src->kf_loc;
+}
+
+static void _fx_make_R17K_form__kdeffun_t(
+   struct _fx_R9Ast__id_t* r_kf_name,
+   fx_str_t* r_kf_cname,
+   struct _fx_LR9Ast__id_t_data_t* r_kf_params,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kf_rt,
+   struct _fx_N14K_form__kexp_t_data_t* r_kf_body,
+   struct _fx_R16Ast__fun_flags_t* r_kf_flags,
+   struct _fx_R25K_form__kdefclosureinfo_t* r_kf_closure,
+   struct _fx_LN12Ast__scope_t_data_t* r_kf_scope,
+   struct _fx_R10Ast__loc_t* r_kf_loc,
+   struct _fx_R17K_form__kdeffun_t* fx_result)
+{
+   fx_result->kf_name = *r_kf_name;
+   fx_copy_str(r_kf_cname, &fx_result->kf_cname);
+   FX_COPY_PTR(r_kf_params, &fx_result->kf_params);
+   FX_COPY_PTR(r_kf_rt, &fx_result->kf_rt);
+   FX_COPY_PTR(r_kf_body, &fx_result->kf_body);
+   fx_result->kf_flags = *r_kf_flags;
+   fx_result->kf_closure = *r_kf_closure;
+   FX_COPY_PTR(r_kf_scope, &fx_result->kf_scope);
+   fx_result->kf_loc = *r_kf_loc;
+}
+
+static void _fx_free_rR17K_form__kdeffun_t(struct _fx_rR17K_form__kdeffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_free_R17K_form__kdeffun_t);
+}
+
+static int _fx_make_rR17K_form__kdeffun_t(
+   struct _fx_R17K_form__kdeffun_t* arg,
+   struct _fx_rR17K_form__kdeffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeffun_t, _fx_copy_R17K_form__kdeffun_t);
+}
+
+static void _fx_free_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* dst)
+{
+   fx_free_str(&dst->ke_cname);
+   fx_free_str(&dst->ke_base_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->ke_typ);
+   fx_free_list_simple(&dst->ke_scope);
+}
+
+static void _fx_copy_R17K_form__kdefexn_t(struct _fx_R17K_form__kdefexn_t* src, struct _fx_R17K_form__kdefexn_t* dst)
+{
+   dst->ke_name = src->ke_name;
+   fx_copy_str(&src->ke_cname, &dst->ke_cname);
+   fx_copy_str(&src->ke_base_cname, &dst->ke_base_cname);
+   FX_COPY_PTR(src->ke_typ, &dst->ke_typ);
+   dst->ke_std = src->ke_std;
+   dst->ke_tag = src->ke_tag;
+   dst->ke_make = src->ke_make;
+   FX_COPY_PTR(src->ke_scope, &dst->ke_scope);
+   dst->ke_loc = src->ke_loc;
+}
+
+static void _fx_make_R17K_form__kdefexn_t(
+   struct _fx_R9Ast__id_t* r_ke_name,
+   fx_str_t* r_ke_cname,
+   fx_str_t* r_ke_base_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_ke_typ,
+   bool r_ke_std,
+   struct _fx_R9Ast__id_t* r_ke_tag,
+   struct _fx_R9Ast__id_t* r_ke_make,
+   struct _fx_LN12Ast__scope_t_data_t* r_ke_scope,
+   struct _fx_R10Ast__loc_t* r_ke_loc,
+   struct _fx_R17K_form__kdefexn_t* fx_result)
+{
+   fx_result->ke_name = *r_ke_name;
+   fx_copy_str(r_ke_cname, &fx_result->ke_cname);
+   fx_copy_str(r_ke_base_cname, &fx_result->ke_base_cname);
+   FX_COPY_PTR(r_ke_typ, &fx_result->ke_typ);
+   fx_result->ke_std = r_ke_std;
+   fx_result->ke_tag = *r_ke_tag;
+   fx_result->ke_make = *r_ke_make;
+   FX_COPY_PTR(r_ke_scope, &fx_result->ke_scope);
+   fx_result->ke_loc = *r_ke_loc;
+}
+
+static void _fx_free_rR17K_form__kdefexn_t(struct _fx_rR17K_form__kdefexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_free_R17K_form__kdefexn_t);
+}
+
+static int _fx_make_rR17K_form__kdefexn_t(
+   struct _fx_R17K_form__kdefexn_t* arg,
+   struct _fx_rR17K_form__kdefexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdefexn_t, _fx_copy_R17K_form__kdefexn_t);
+}
+
+static void _fx_free_T2R9Ast__id_tLR9Ast__id_t(struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LR9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLR9Ast__id_t(struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_free_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLR9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLR9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLR9Ast__id_t, _fx_copy_T2R9Ast__id_tLR9Ast__id_t);
+}
+
+static void _fx_free_R21K_form__kdefvariant_t(struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   fx_free_str(&dst->kvar_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kvar_targs);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kvar_cases);
+   fx_free_list_simple(&dst->kvar_ctors);
+   _fx_free_LT2R9Ast__id_tLR9Ast__id_t(&dst->kvar_ifaces);
+   fx_free_list_simple(&dst->kvar_scope);
+}
+
+static void _fx_copy_R21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* src,
+   struct _fx_R21K_form__kdefvariant_t* dst)
+{
+   dst->kvar_name = src->kvar_name;
+   fx_copy_str(&src->kvar_cname, &dst->kvar_cname);
+   dst->kvar_proto = src->kvar_proto;
+   dst->kvar_props = src->kvar_props;
+   FX_COPY_PTR(src->kvar_targs, &dst->kvar_targs);
+   FX_COPY_PTR(src->kvar_cases, &dst->kvar_cases);
+   FX_COPY_PTR(src->kvar_ctors, &dst->kvar_ctors);
+   dst->kvar_flags = src->kvar_flags;
+   FX_COPY_PTR(src->kvar_ifaces, &dst->kvar_ifaces);
+   FX_COPY_PTR(src->kvar_scope, &dst->kvar_scope);
+   dst->kvar_loc = src->kvar_loc;
+}
+
+static void _fx_make_R21K_form__kdefvariant_t(
+   struct _fx_R9Ast__id_t* r_kvar_name,
+   fx_str_t* r_kvar_cname,
+   struct _fx_R9Ast__id_t* r_kvar_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kvar_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kvar_targs,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_kvar_ctors,
+   struct _fx_R16Ast__var_flags_t* r_kvar_flags,
+   struct _fx_LT2R9Ast__id_tLR9Ast__id_t_data_t* r_kvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_kvar_scope,
+   struct _fx_R10Ast__loc_t* r_kvar_loc,
+   struct _fx_R21K_form__kdefvariant_t* fx_result)
+{
+   fx_result->kvar_name = *r_kvar_name;
+   fx_copy_str(r_kvar_cname, &fx_result->kvar_cname);
+   fx_result->kvar_proto = *r_kvar_proto;
+   fx_result->kvar_props = *r_kvar_props;
+   FX_COPY_PTR(r_kvar_targs, &fx_result->kvar_targs);
+   FX_COPY_PTR(r_kvar_cases, &fx_result->kvar_cases);
+   FX_COPY_PTR(r_kvar_ctors, &fx_result->kvar_ctors);
+   fx_result->kvar_flags = *r_kvar_flags;
+   FX_COPY_PTR(r_kvar_ifaces, &fx_result->kvar_ifaces);
+   FX_COPY_PTR(r_kvar_scope, &fx_result->kvar_scope);
+   fx_result->kvar_loc = *r_kvar_loc;
+}
+
+static void _fx_free_rR21K_form__kdefvariant_t(struct _fx_rR21K_form__kdefvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_free_R21K_form__kdefvariant_t);
+}
+
+static int _fx_make_rR21K_form__kdefvariant_t(
+   struct _fx_R21K_form__kdefvariant_t* arg,
+   struct _fx_rR21K_form__kdefvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR21K_form__kdefvariant_t, _fx_copy_R21K_form__kdefvariant_t);
+}
+
+static void _fx_free_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   fx_free_str(&dst->kt_cname);
+   _fx_free_LN14K_form__ktyp_t(&dst->kt_targs);
+   _fx_free_N14K_form__ktyp_t(&dst->kt_typ);
+   fx_free_list_simple(&dst->kt_scope);
+}
+
+static void _fx_copy_R17K_form__kdeftyp_t(struct _fx_R17K_form__kdeftyp_t* src, struct _fx_R17K_form__kdeftyp_t* dst)
+{
+   dst->kt_name = src->kt_name;
+   fx_copy_str(&src->kt_cname, &dst->kt_cname);
+   dst->kt_proto = src->kt_proto;
+   dst->kt_props = src->kt_props;
+   FX_COPY_PTR(src->kt_targs, &dst->kt_targs);
+   FX_COPY_PTR(src->kt_typ, &dst->kt_typ);
+   FX_COPY_PTR(src->kt_scope, &dst->kt_scope);
+   dst->kt_loc = src->kt_loc;
+}
+
+static void _fx_make_R17K_form__kdeftyp_t(
+   struct _fx_R9Ast__id_t* r_kt_name,
+   fx_str_t* r_kt_cname,
+   struct _fx_R9Ast__id_t* r_kt_proto,
+   struct _fx_Nt6option1R17K_form__ktprops_t* r_kt_props,
+   struct _fx_LN14K_form__ktyp_t_data_t* r_kt_targs,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kt_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_kt_scope,
+   struct _fx_R10Ast__loc_t* r_kt_loc,
+   struct _fx_R17K_form__kdeftyp_t* fx_result)
+{
+   fx_result->kt_name = *r_kt_name;
+   fx_copy_str(r_kt_cname, &fx_result->kt_cname);
+   fx_result->kt_proto = *r_kt_proto;
+   fx_result->kt_props = *r_kt_props;
+   FX_COPY_PTR(r_kt_targs, &fx_result->kt_targs);
+   FX_COPY_PTR(r_kt_typ, &fx_result->kt_typ);
+   FX_COPY_PTR(r_kt_scope, &fx_result->kt_scope);
+   fx_result->kt_loc = *r_kt_loc;
+}
+
+static void _fx_free_rR17K_form__kdeftyp_t(struct _fx_rR17K_form__kdeftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_free_R17K_form__kdeftyp_t);
+}
+
+static int _fx_make_rR17K_form__kdeftyp_t(
+   struct _fx_R17K_form__kdeftyp_t* arg,
+   struct _fx_rR17K_form__kdeftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17K_form__kdeftyp_t, _fx_copy_R17K_form__kdeftyp_t);
+}
+
+static void _fx_free_R25K_form__kdefclosurevars_t(struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   fx_free_str(&dst->kcv_cname);
+   _fx_free_LT2R9Ast__id_tN14K_form__ktyp_t(&dst->kcv_freevars);
+   fx_free_list_simple(&dst->kcv_orig_freevars);
+   fx_free_list_simple(&dst->kcv_scope);
+}
+
+static void _fx_copy_R25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* src,
+   struct _fx_R25K_form__kdefclosurevars_t* dst)
+{
+   dst->kcv_name = src->kcv_name;
+   fx_copy_str(&src->kcv_cname, &dst->kcv_cname);
+   FX_COPY_PTR(src->kcv_freevars, &dst->kcv_freevars);
+   FX_COPY_PTR(src->kcv_orig_freevars, &dst->kcv_orig_freevars);
+   FX_COPY_PTR(src->kcv_scope, &dst->kcv_scope);
+   dst->kcv_loc = src->kcv_loc;
+}
+
+static void _fx_make_R25K_form__kdefclosurevars_t(
+   struct _fx_R9Ast__id_t* r_kcv_name,
+   fx_str_t* r_kcv_cname,
+   struct _fx_LT2R9Ast__id_tN14K_form__ktyp_t_data_t* r_kcv_freevars,
+   struct _fx_LR9Ast__id_t_data_t* r_kcv_orig_freevars,
+   struct _fx_LN12Ast__scope_t_data_t* r_kcv_scope,
+   struct _fx_R10Ast__loc_t* r_kcv_loc,
+   struct _fx_R25K_form__kdefclosurevars_t* fx_result)
+{
+   fx_result->kcv_name = *r_kcv_name;
+   fx_copy_str(r_kcv_cname, &fx_result->kcv_cname);
+   FX_COPY_PTR(r_kcv_freevars, &fx_result->kcv_freevars);
+   FX_COPY_PTR(r_kcv_orig_freevars, &fx_result->kcv_orig_freevars);
+   FX_COPY_PTR(r_kcv_scope, &fx_result->kcv_scope);
+   fx_result->kcv_loc = *r_kcv_loc;
+}
+
+static void _fx_free_rR25K_form__kdefclosurevars_t(struct _fx_rR25K_form__kdefclosurevars_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_free_R25K_form__kdefclosurevars_t);
+}
+
+static int _fx_make_rR25K_form__kdefclosurevars_t(
+   struct _fx_R25K_form__kdefclosurevars_t* arg,
+   struct _fx_rR25K_form__kdefclosurevars_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR25K_form__kdefclosurevars_t, _fx_copy_R25K_form__kdefclosurevars_t);
+}
+
 static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst)
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
@@ -2811,6 +2734,83 @@ static void _fx_free_N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t** dst
       fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* dst)
+{
+   fx_free_str(&dst->kv_cname);
+   _fx_free_N14K_form__ktyp_t(&dst->kv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->kv_flags);
+}
+
+static void _fx_copy_R17K_form__kdefval_t(struct _fx_R17K_form__kdefval_t* src, struct _fx_R17K_form__kdefval_t* dst)
+{
+   dst->kv_name = src->kv_name;
+   fx_copy_str(&src->kv_cname, &dst->kv_cname);
+   FX_COPY_PTR(src->kv_typ, &dst->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->kv_flags, &dst->kv_flags);
+   dst->kv_loc = src->kv_loc;
+}
+
+static void _fx_make_R17K_form__kdefval_t(
+   struct _fx_R9Ast__id_t* r_kv_name,
+   fx_str_t* r_kv_cname,
+   struct _fx_N14K_form__ktyp_t_data_t* r_kv_typ,
+   struct _fx_R16Ast__val_flags_t* r_kv_flags,
+   struct _fx_R10Ast__loc_t* r_kv_loc,
+   struct _fx_R17K_form__kdefval_t* fx_result)
+{
+   fx_result->kv_name = *r_kv_name;
+   fx_copy_str(r_kv_cname, &fx_result->kv_cname);
+   FX_COPY_PTR(r_kv_typ, &fx_result->kv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_kv_flags, &fx_result->kv_flags);
+   fx_result->kv_loc = *r_kv_loc;
+}
+
+static void _fx_free_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R17K_form__kdefval_t(&dst->u.KVal); break;
+   case 3:
+      _fx_free_rR17K_form__kdeffun_t(&dst->u.KFun); break;
+   case 4:
+      _fx_free_rR17K_form__kdefexn_t(&dst->u.KExn); break;
+   case 5:
+      _fx_free_rR21K_form__kdefvariant_t(&dst->u.KVariant); break;
+   case 6:
+      _fx_free_rR25K_form__kdefclosurevars_t(&dst->u.KClosureVars); break;
+   case 7:
+      _fx_free_rR23K_form__kdefinterface_t(&dst->u.KInterface); break;
+   case 8:
+      _fx_free_rR17K_form__kdeftyp_t(&dst->u.KTyp); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N15K_form__kinfo_t(struct _fx_N15K_form__kinfo_t* src, struct _fx_N15K_form__kinfo_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R17K_form__kdefval_t(&src->u.KVal, &dst->u.KVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.KFun, &dst->u.KFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.KExn, &dst->u.KExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.KVariant, &dst->u.KVariant); break;
+   case 6:
+      FX_COPY_PTR(src->u.KClosureVars, &dst->u.KClosureVars); break;
+   case 7:
+      FX_COPY_PTR(src->u.KInterface, &dst->u.KInterface); break;
+   case 8:
+      FX_COPY_PTR(src->u.KTyp, &dst->u.KTyp); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static void _fx_free_T2N14K_form__atom_tLN14K_form__kexp_t(struct _fx_T2N14K_form__atom_tLN14K_form__kexp_t* dst)

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -223,263 +223,6 @@ typedef struct _fx_Nt6option1N10Ast__exp_t_data_t {
    } u;
 } _fx_Nt6option1N10Ast__exp_t_data_t, *_fx_Nt6option1N10Ast__exp_t;
 
-typedef struct _fx_R10Ast__loc_t {
-   int_ m_idx;
-   int_ line0;
-   int_ col0;
-   int_ line1;
-   int_ col1;
-} _fx_R10Ast__loc_t;
-
-typedef struct _fx_T2R9Ast__id_ti {
-   struct _fx_R9Ast__id_t t0;
-   int_ t1;
-} _fx_T2R9Ast__id_ti;
-
-typedef struct _fx_T3BBi {
-   bool t0;
-   bool t1;
-   int_ t2;
-} _fx_T3BBi;
-
-typedef struct _fx_N12Ast__scope_t {
-   int tag;
-   union {
-      int_ ScBlock;
-      struct _fx_T3BBi ScLoop;
-      int_ ScFold;
-      int_ ScArrMap;
-      int_ ScMap;
-      int_ ScTry;
-      struct _fx_R9Ast__id_t ScFun;
-      struct _fx_R9Ast__id_t ScClass;
-      struct _fx_R9Ast__id_t ScInterface;
-      int_ ScModule;
-   } u;
-} _fx_N12Ast__scope_t;
-
-typedef struct _fx_LN12Ast__scope_t_data_t {
-   int_ rc;
-   struct _fx_LN12Ast__scope_t_data_t* tl;
-   struct _fx_N12Ast__scope_t hd;
-} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
-
-typedef struct _fx_R16Ast__val_flags_t {
-   bool val_flag_arg;
-   bool val_flag_mutable;
-   bool val_flag_temp;
-   bool val_flag_tempref;
-   bool val_flag_private;
-   bool val_flag_subarray;
-   bool val_flag_instance;
-   struct _fx_T2R9Ast__id_ti val_flag_method;
-   int_ val_flag_ctor;
-   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
-} _fx_R16Ast__val_flags_t;
-
-typedef struct _fx_R13Ast__defval_t {
-   struct _fx_R9Ast__id_t dv_name;
-   struct _fx_N10Ast__typ_t_data_t* dv_typ;
-   struct _fx_R16Ast__val_flags_t dv_flags;
-   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
-   struct _fx_R10Ast__loc_t dv_loc;
-} _fx_R13Ast__defval_t;
-
-typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
-   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
-   fx_fcv_t* fcv;
-} _fx_FPi2R9Ast__id_tR9Ast__id_t;
-
-typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
-} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
-
-typedef struct _fx_N17Ast__fun_constr_t {
-   int tag;
-   union {
-      int_ CtorVariant;
-      struct _fx_R9Ast__id_t CtorFP;
-      struct _fx_R9Ast__id_t CtorExn;
-   } u;
-} _fx_N17Ast__fun_constr_t;
-
-typedef struct _fx_R16Ast__fun_flags_t {
-   int_ fun_flag_pure;
-   bool fun_flag_ccode;
-   bool fun_flag_have_keywords;
-   bool fun_flag_inline;
-   bool fun_flag_nothrow;
-   bool fun_flag_really_nothrow;
-   bool fun_flag_private;
-   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
-   struct _fx_R9Ast__id_t fun_flag_method_of;
-   bool fun_flag_uses_fv;
-   bool fun_flag_recursive;
-   bool fun_flag_instance;
-} _fx_R16Ast__fun_flags_t;
-
-typedef struct _fx_LR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* tl;
-   struct _fx_R9Ast__id_t hd;
-} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
-
-typedef struct _fx_LN10Ast__pat_t_data_t {
-   int_ rc;
-   struct _fx_LN10Ast__pat_t_data_t* tl;
-   struct _fx_N10Ast__pat_t_data_t* hd;
-} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
-
-typedef struct _fx_rLR9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LR9Ast__id_t_data_t* data;
-} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
-
-typedef struct _fx_R13Ast__deffun_t {
-   struct _fx_R9Ast__id_t df_name;
-   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
-   struct _fx_LN10Ast__pat_t_data_t* df_args;
-   struct _fx_N10Ast__typ_t_data_t* df_typ;
-   struct _fx_N10Ast__exp_t_data_t* df_body;
-   struct _fx_R16Ast__fun_flags_t df_flags;
-   struct _fx_LN12Ast__scope_t_data_t* df_scope;
-   struct _fx_R10Ast__loc_t df_loc;
-   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
-} _fx_R13Ast__deffun_t;
-
-typedef struct _fx_rR13Ast__deffun_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deffun_t data;
-} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
-
-typedef struct _fx_R13Ast__defexn_t {
-   struct _fx_R9Ast__id_t dexn_name;
-   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
-   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
-   struct _fx_R10Ast__loc_t dexn_loc;
-} _fx_R13Ast__defexn_t;
-
-typedef struct _fx_rR13Ast__defexn_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__defexn_t data;
-} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
-
-typedef struct _fx_R13Ast__deftyp_t {
-   struct _fx_R9Ast__id_t dt_name;
-   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dt_typ;
-   bool dt_finalized;
-   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
-   struct _fx_R10Ast__loc_t dt_loc;
-} _fx_R13Ast__deftyp_t;
-
-typedef struct _fx_rR13Ast__deftyp_t_data_t {
-   int_ rc;
-   struct _fx_R13Ast__deftyp_t data;
-} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
-
-typedef struct _fx_R16Ast__var_flags_t {
-   int_ var_flag_class_from;
-   bool var_flag_record;
-   bool var_flag_recursive;
-   bool var_flag_have_tag;
-   bool var_flag_have_mutable;
-   bool var_flag_opt;
-   bool var_flag_instance;
-} _fx_R16Ast__var_flags_t;
-
-typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-} _fx_T2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
-} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
-
-typedef struct _fx_Ta2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_R9Ast__id_t t1;
-} _fx_Ta2R9Ast__id_t;
-
-typedef struct _fx_LTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LTa2R9Ast__id_t_data_t* tl;
-   struct _fx_Ta2R9Ast__id_t hd;
-} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
-
-typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_LTa2R9Ast__id_t_data_t* t1;
-} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
-   int_ rc;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
-} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
-
-typedef struct _fx_R17Ast__defvariant_t {
-   struct _fx_R9Ast__id_t dvar_name;
-   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
-   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
-   struct _fx_R16Ast__var_flags_t dvar_flags;
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
-   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
-   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
-   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
-   struct _fx_R10Ast__loc_t dvar_loc;
-} _fx_R17Ast__defvariant_t;
-
-typedef struct _fx_rR17Ast__defvariant_t_data_t {
-   int_ rc;
-   struct _fx_R17Ast__defvariant_t data;
-} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
-
-typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
-   struct _fx_R9Ast__id_t t0;
-   struct _fx_N10Ast__typ_t_data_t* t1;
-   struct _fx_R16Ast__fun_flags_t t2;
-} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
-   int_ rc;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
-} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
-
-typedef struct _fx_R19Ast__definterface_t {
-   struct _fx_R9Ast__id_t di_name;
-   struct _fx_R9Ast__id_t di_base;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
-   struct _fx_LN12Ast__scope_t_data_t* di_scope;
-   struct _fx_R10Ast__loc_t di_loc;
-} _fx_R19Ast__definterface_t;
-
-typedef struct _fx_rR19Ast__definterface_t_data_t {
-   int_ rc;
-   struct _fx_R19Ast__definterface_t data;
-} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
-
-typedef struct _fx_N14Ast__id_info_t {
-   int tag;
-   union {
-      struct _fx_R13Ast__defval_t IdDVal;
-      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
-      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
-      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
-      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
-      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
-      int_ IdModule;
-   } u;
-} _fx_N14Ast__id_info_t;
-
 typedef struct _fx_Rt24Hashset__hashset_entry_t1S {
    uint64_t hv;
    fx_str_t key;
@@ -526,6 +269,46 @@ typedef struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t {
          Node;
    } u;
 } _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t, *_fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_FPi2R9Ast__id_tR9Ast__id_t {
+   int (*fp)(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
+   fx_fcv_t* fcv;
+} _fx_FPi2R9Ast__id_tR9Ast__id_t;
+
+typedef struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t {
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* root;
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t cmp;
+} _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t;
+
+typedef struct _fx_T3BBi {
+   bool t0;
+   bool t1;
+   int_ t2;
+} _fx_T3BBi;
+
+typedef struct _fx_N12Ast__scope_t {
+   int tag;
+   union {
+      int_ ScBlock;
+      struct _fx_T3BBi ScLoop;
+      int_ ScFold;
+      int_ ScArrMap;
+      int_ ScMap;
+      int_ ScTry;
+      struct _fx_R9Ast__id_t ScFun;
+      struct _fx_R9Ast__id_t ScClass;
+      struct _fx_R9Ast__id_t ScInterface;
+      int_ ScModule;
+   } u;
+} _fx_N12Ast__scope_t;
+
+typedef struct _fx_R10Ast__loc_t {
+   int_ m_idx;
+   int_ line0;
+   int_ col0;
+   int_ line1;
+   int_ col1;
+} _fx_R10Ast__loc_t;
 
 typedef struct _fx_T2R10Ast__loc_tS {
    struct _fx_R10Ast__loc_t t0;
@@ -580,6 +363,30 @@ typedef struct _fx_T2iN10Ast__typ_t {
    int_ t0;
    struct _fx_N10Ast__typ_t_data_t* t1;
 } _fx_T2iN10Ast__typ_t;
+
+typedef struct _fx_T2R9Ast__id_ti {
+   struct _fx_R9Ast__id_t t0;
+   int_ t1;
+} _fx_T2R9Ast__id_ti;
+
+typedef struct _fx_LN12Ast__scope_t_data_t {
+   int_ rc;
+   struct _fx_LN12Ast__scope_t_data_t* tl;
+   struct _fx_N12Ast__scope_t hd;
+} _fx_LN12Ast__scope_t_data_t, *_fx_LN12Ast__scope_t;
+
+typedef struct _fx_R16Ast__val_flags_t {
+   bool val_flag_arg;
+   bool val_flag_mutable;
+   bool val_flag_temp;
+   bool val_flag_tempref;
+   bool val_flag_private;
+   bool val_flag_subarray;
+   bool val_flag_instance;
+   struct _fx_T2R9Ast__id_ti val_flag_method;
+   int_ val_flag_ctor;
+   struct _fx_LN12Ast__scope_t_data_t* val_flag_global;
+} _fx_R16Ast__val_flags_t;
 
 typedef struct _fx_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t {
    struct _fx_R16Ast__val_flags_t t0;
@@ -661,6 +468,30 @@ typedef struct _fx_N13Ast__intrin_t {
    } u;
 } _fx_N13Ast__intrin_t;
 
+typedef struct _fx_N17Ast__fun_constr_t {
+   int tag;
+   union {
+      int_ CtorVariant;
+      struct _fx_R9Ast__id_t CtorFP;
+      struct _fx_R9Ast__id_t CtorExn;
+   } u;
+} _fx_N17Ast__fun_constr_t;
+
+typedef struct _fx_R16Ast__fun_flags_t {
+   int_ fun_flag_pure;
+   bool fun_flag_ccode;
+   bool fun_flag_have_keywords;
+   bool fun_flag_inline;
+   bool fun_flag_nothrow;
+   bool fun_flag_really_nothrow;
+   bool fun_flag_private;
+   struct _fx_N17Ast__fun_constr_t fun_flag_ctor;
+   struct _fx_R9Ast__id_t fun_flag_method_of;
+   bool fun_flag_uses_fv;
+   bool fun_flag_recursive;
+   bool fun_flag_instance;
+} _fx_R16Ast__fun_flags_t;
+
 typedef struct _fx_N15Ast__for_make_t {
    int tag;
 } _fx_N15Ast__for_make_t;
@@ -680,6 +511,16 @@ typedef struct _fx_N13Ast__border_t {
 typedef struct _fx_N18Ast__interpolate_t {
    int tag;
 } _fx_N18Ast__interpolate_t;
+
+typedef struct _fx_R16Ast__var_flags_t {
+   int_ var_flag_class_from;
+   bool var_flag_record;
+   bool var_flag_recursive;
+   bool var_flag_have_tag;
+   bool var_flag_have_mutable;
+   bool var_flag_opt;
+   bool var_flag_instance;
+} _fx_R16Ast__var_flags_t;
 
 typedef struct _fx_T2BR10Ast__loc_t {
    bool t0;
@@ -876,6 +717,144 @@ typedef struct _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t 
    struct _fx_R10Ast__loc_t t3;
 } _fx_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_t;
 
+typedef struct _fx_LR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* tl;
+   struct _fx_R9Ast__id_t hd;
+} _fx_LR9Ast__id_t_data_t, *_fx_LR9Ast__id_t;
+
+typedef struct _fx_LN10Ast__pat_t_data_t {
+   int_ rc;
+   struct _fx_LN10Ast__pat_t_data_t* tl;
+   struct _fx_N10Ast__pat_t_data_t* hd;
+} _fx_LN10Ast__pat_t_data_t, *_fx_LN10Ast__pat_t;
+
+typedef struct _fx_rLR9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LR9Ast__id_t_data_t* data;
+} _fx_rLR9Ast__id_t_data_t, *_fx_rLR9Ast__id_t;
+
+typedef struct _fx_R13Ast__deffun_t {
+   struct _fx_R9Ast__id_t df_name;
+   struct _fx_LR9Ast__id_t_data_t* df_templ_args;
+   struct _fx_LN10Ast__pat_t_data_t* df_args;
+   struct _fx_N10Ast__typ_t_data_t* df_typ;
+   struct _fx_N10Ast__exp_t_data_t* df_body;
+   struct _fx_R16Ast__fun_flags_t df_flags;
+   struct _fx_LN12Ast__scope_t_data_t* df_scope;
+   struct _fx_R10Ast__loc_t df_loc;
+   struct _fx_rLR9Ast__id_t_data_t* df_templ_inst;
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t df_env;
+} _fx_R13Ast__deffun_t;
+
+typedef struct _fx_rR13Ast__deffun_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deffun_t data;
+} _fx_rR13Ast__deffun_t_data_t, *_fx_rR13Ast__deffun_t;
+
+typedef struct _fx_R13Ast__defexn_t {
+   struct _fx_R9Ast__id_t dexn_name;
+   struct _fx_N10Ast__typ_t_data_t* dexn_typ;
+   struct _fx_LN12Ast__scope_t_data_t* dexn_scope;
+   struct _fx_R10Ast__loc_t dexn_loc;
+} _fx_R13Ast__defexn_t;
+
+typedef struct _fx_rR13Ast__defexn_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__defexn_t data;
+} _fx_rR13Ast__defexn_t_data_t, *_fx_rR13Ast__defexn_t;
+
+typedef struct _fx_R13Ast__deftyp_t {
+   struct _fx_R9Ast__id_t dt_name;
+   struct _fx_LR9Ast__id_t_data_t* dt_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dt_typ;
+   bool dt_finalized;
+   struct _fx_LN12Ast__scope_t_data_t* dt_scope;
+   struct _fx_R10Ast__loc_t dt_loc;
+} _fx_R13Ast__deftyp_t;
+
+typedef struct _fx_rR13Ast__deftyp_t_data_t {
+   int_ rc;
+   struct _fx_R13Ast__deftyp_t data;
+} _fx_rR13Ast__deftyp_t_data_t, *_fx_rR13Ast__deftyp_t;
+
+typedef struct _fx_T2R9Ast__id_tN10Ast__typ_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+} _fx_T2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t hd;
+} _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t, *_fx_LT2R9Ast__id_tN10Ast__typ_t;
+
+typedef struct _fx_Ta2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_R9Ast__id_t t1;
+} _fx_Ta2R9Ast__id_t;
+
+typedef struct _fx_LTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LTa2R9Ast__id_t_data_t* tl;
+   struct _fx_Ta2R9Ast__id_t hd;
+} _fx_LTa2R9Ast__id_t_data_t, *_fx_LTa2R9Ast__id_t;
+
+typedef struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_LTa2R9Ast__id_t_data_t* t1;
+} _fx_T2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t {
+   int_ rc;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl;
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t hd;
+} _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t, *_fx_LT2R9Ast__id_tLTa2R9Ast__id_t;
+
+typedef struct _fx_R17Ast__defvariant_t {
+   struct _fx_R9Ast__id_t dvar_name;
+   struct _fx_LR9Ast__id_t_data_t* dvar_templ_args;
+   struct _fx_N10Ast__typ_t_data_t* dvar_alias;
+   struct _fx_R16Ast__var_flags_t dvar_flags;
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* dvar_cases;
+   struct _fx_LR9Ast__id_t_data_t* dvar_ctors;
+   struct _fx_rLR9Ast__id_t_data_t* dvar_templ_inst;
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* dvar_ifaces;
+   struct _fx_LN12Ast__scope_t_data_t* dvar_scope;
+   struct _fx_R10Ast__loc_t dvar_loc;
+} _fx_R17Ast__defvariant_t;
+
+typedef struct _fx_rR17Ast__defvariant_t_data_t {
+   int_ rc;
+   struct _fx_R17Ast__defvariant_t data;
+} _fx_rR17Ast__defvariant_t_data_t, *_fx_rR17Ast__defvariant_t;
+
+typedef struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t {
+   struct _fx_R9Ast__id_t t0;
+   struct _fx_N10Ast__typ_t_data_t* t1;
+   struct _fx_R16Ast__fun_flags_t t2;
+} _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t {
+   int_ rc;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl;
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t hd;
+} _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t, *_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t;
+
+typedef struct _fx_R19Ast__definterface_t {
+   struct _fx_R9Ast__id_t di_name;
+   struct _fx_R9Ast__id_t di_base;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_new_methods;
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* di_all_methods;
+   struct _fx_LN12Ast__scope_t_data_t* di_scope;
+   struct _fx_R10Ast__loc_t di_loc;
+} _fx_R19Ast__definterface_t;
+
+typedef struct _fx_rR19Ast__definterface_t_data_t {
+   int_ rc;
+   struct _fx_R19Ast__definterface_t data;
+} _fx_rR19Ast__definterface_t_data_t, *_fx_rR19Ast__definterface_t;
+
 typedef struct _fx_T2iR9Ast__id_t {
    int_ t0;
    struct _fx_R9Ast__id_t t1;
@@ -1047,6 +1026,27 @@ typedef struct _fx_N16Ast__env_entry_t_data_t {
       struct _fx_N10Ast__typ_t_data_t* EnvTyp;
    } u;
 } _fx_N16Ast__env_entry_t_data_t, *_fx_N16Ast__env_entry_t;
+
+typedef struct _fx_R13Ast__defval_t {
+   struct _fx_R9Ast__id_t dv_name;
+   struct _fx_N10Ast__typ_t_data_t* dv_typ;
+   struct _fx_R16Ast__val_flags_t dv_flags;
+   struct _fx_LN12Ast__scope_t_data_t* dv_scope;
+   struct _fx_R10Ast__loc_t dv_loc;
+} _fx_R13Ast__defval_t;
+
+typedef struct _fx_N14Ast__id_info_t {
+   int tag;
+   union {
+      struct _fx_R13Ast__defval_t IdDVal;
+      struct _fx_rR13Ast__deffun_t_data_t* IdFun;
+      struct _fx_rR13Ast__defexn_t_data_t* IdExn;
+      struct _fx_rR13Ast__deftyp_t_data_t* IdTyp;
+      struct _fx_rR17Ast__defvariant_t_data_t* IdVariant;
+      struct _fx_rR19Ast__definterface_t_data_t* IdInterface;
+      int_ IdModule;
+   } u;
+} _fx_N14Ast__id_info_t;
 
 typedef struct _fx_Li_data_t {
    int_ rc;
@@ -1882,561 +1882,6 @@ static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_
    *dst = 0;
 }
 
-static int _fx_cons_LN12Ast__scope_t(
-   struct _fx_N12Ast__scope_t* hd,
-   struct _fx_LN12Ast__scope_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN12Ast__scope_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
-{
-   fx_free_list_simple(&dst->val_flag_global);
-}
-
-static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
-{
-   dst->val_flag_arg = src->val_flag_arg;
-   dst->val_flag_mutable = src->val_flag_mutable;
-   dst->val_flag_temp = src->val_flag_temp;
-   dst->val_flag_tempref = src->val_flag_tempref;
-   dst->val_flag_private = src->val_flag_private;
-   dst->val_flag_subarray = src->val_flag_subarray;
-   dst->val_flag_instance = src->val_flag_instance;
-   dst->val_flag_method = src->val_flag_method;
-   dst->val_flag_ctor = src->val_flag_ctor;
-   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
-}
-
-static void _fx_make_R16Ast__val_flags_t(
-   bool r_val_flag_arg,
-   bool r_val_flag_mutable,
-   bool r_val_flag_temp,
-   bool r_val_flag_tempref,
-   bool r_val_flag_private,
-   bool r_val_flag_subarray,
-   bool r_val_flag_instance,
-   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
-   int_ r_val_flag_ctor,
-   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
-   struct _fx_R16Ast__val_flags_t* fx_result)
-{
-   fx_result->val_flag_arg = r_val_flag_arg;
-   fx_result->val_flag_mutable = r_val_flag_mutable;
-   fx_result->val_flag_temp = r_val_flag_temp;
-   fx_result->val_flag_tempref = r_val_flag_tempref;
-   fx_result->val_flag_private = r_val_flag_private;
-   fx_result->val_flag_subarray = r_val_flag_subarray;
-   fx_result->val_flag_instance = r_val_flag_instance;
-   fx_result->val_flag_method = *r_val_flag_method;
-   fx_result->val_flag_ctor = r_val_flag_ctor;
-   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
-}
-
-static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dv_typ);
-   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
-   fx_free_list_simple(&dst->dv_scope);
-}
-
-static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
-{
-   dst->dv_name = src->dv_name;
-   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
-   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
-   dst->dv_loc = src->dv_loc;
-}
-
-static void _fx_make_R13Ast__defval_t(
-   struct _fx_R9Ast__id_t* r_dv_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
-   struct _fx_R16Ast__val_flags_t* r_dv_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
-   struct _fx_R10Ast__loc_t* r_dv_loc,
-   struct _fx_R13Ast__defval_t* fx_result)
-{
-   fx_result->dv_name = *r_dv_name;
-   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
-   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
-   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
-   fx_result->dv_loc = *r_dv_loc;
-}
-
-static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
-   fx_free_fp(&dst->cmp);
-}
-
-static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
-{
-   FX_COPY_PTR(src->root, &dst->root);
-   FX_COPY_FP(&src->cmp, &dst->cmp);
-}
-
-static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
-   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
-{
-   FX_COPY_PTR(r_root, &fx_result->root);
-   FX_COPY_FP(r_cmp, &fx_result->cmp);
-}
-
-static int _fx_cons_LR9Ast__id_t(
-   struct _fx_R9Ast__id_t* hd,
-   struct _fx_LR9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
-}
-
-static int _fx_cons_LN10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* hd,
-   struct _fx_LN10Ast__pat_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LN10Ast__pat_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
-}
-
-static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
-}
-
-static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
-}
-
-static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
-{
-   fx_free_list_simple(&dst->df_templ_args);
-   _fx_free_LN10Ast__pat_t(&dst->df_args);
-   _fx_free_N10Ast__typ_t(&dst->df_typ);
-   _fx_free_N10Ast__exp_t(&dst->df_body);
-   fx_free_list_simple(&dst->df_scope);
-   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
-   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
-}
-
-static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
-{
-   dst->df_name = src->df_name;
-   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
-   FX_COPY_PTR(src->df_args, &dst->df_args);
-   FX_COPY_PTR(src->df_typ, &dst->df_typ);
-   FX_COPY_PTR(src->df_body, &dst->df_body);
-   dst->df_flags = src->df_flags;
-   FX_COPY_PTR(src->df_scope, &dst->df_scope);
-   dst->df_loc = src->df_loc;
-   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
-}
-
-static void _fx_make_R13Ast__deffun_t(
-   struct _fx_R9Ast__id_t* r_df_name,
-   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
-   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
-   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
-   struct _fx_N10Ast__exp_t_data_t* r_df_body,
-   struct _fx_R16Ast__fun_flags_t* r_df_flags,
-   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
-   struct _fx_R10Ast__loc_t* r_df_loc,
-   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
-   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
-   struct _fx_R13Ast__deffun_t* fx_result)
-{
-   fx_result->df_name = *r_df_name;
-   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
-   FX_COPY_PTR(r_df_args, &fx_result->df_args);
-   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
-   FX_COPY_PTR(r_df_body, &fx_result->df_body);
-   fx_result->df_flags = *r_df_flags;
-   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
-   fx_result->df_loc = *r_df_loc;
-   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
-   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
-}
-
-static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
-}
-
-static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
-}
-
-static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
-   fx_free_list_simple(&dst->dexn_scope);
-}
-
-static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
-{
-   dst->dexn_name = src->dexn_name;
-   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
-   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
-   dst->dexn_loc = src->dexn_loc;
-}
-
-static void _fx_make_R13Ast__defexn_t(
-   struct _fx_R9Ast__id_t* r_dexn_name,
-   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
-   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
-   struct _fx_R10Ast__loc_t* r_dexn_loc,
-   struct _fx_R13Ast__defexn_t* fx_result)
-{
-   fx_result->dexn_name = *r_dexn_name;
-   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
-   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
-   fx_result->dexn_loc = *r_dexn_loc;
-}
-
-static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
-}
-
-static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
-}
-
-static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
-{
-   fx_free_list_simple(&dst->dt_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dt_typ);
-   fx_free_list_simple(&dst->dt_scope);
-}
-
-static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
-{
-   dst->dt_name = src->dt_name;
-   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
-   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
-   dst->dt_finalized = src->dt_finalized;
-   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
-   dst->dt_loc = src->dt_loc;
-}
-
-static void _fx_make_R13Ast__deftyp_t(
-   struct _fx_R9Ast__id_t* r_dt_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
-   bool r_dt_finalized,
-   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
-   struct _fx_R10Ast__loc_t* r_dt_loc,
-   struct _fx_R13Ast__deftyp_t* fx_result)
-{
-   fx_result->dt_name = *r_dt_name;
-   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
-   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
-   fx_result->dt_finalized = r_dt_finalized;
-   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
-   fx_result->dt_loc = *r_dt_loc;
-}
-
-static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
-}
-
-static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
-}
-
-static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
-   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
-}
-
-static int _fx_cons_LTa2R9Ast__id_t(
-   struct _fx_Ta2R9Ast__id_t* hd,
-   struct _fx_LTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
-}
-
-static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_LTa2R9Ast__id_t_data_t* t1,
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
-static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
-   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
-}
-
-static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
-{
-   fx_free_list_simple(&dst->dvar_templ_args);
-   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
-   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
-   fx_free_list_simple(&dst->dvar_ctors);
-   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
-   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
-   fx_free_list_simple(&dst->dvar_scope);
-}
-
-static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
-{
-   dst->dvar_name = src->dvar_name;
-   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
-   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
-   dst->dvar_flags = src->dvar_flags;
-   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
-   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
-   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
-   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
-   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
-   dst->dvar_loc = src->dvar_loc;
-}
-
-static void _fx_make_R17Ast__defvariant_t(
-   struct _fx_R9Ast__id_t* r_dvar_name,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
-   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
-   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
-   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
-   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
-   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
-   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
-   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
-   struct _fx_R10Ast__loc_t* r_dvar_loc,
-   struct _fx_R17Ast__defvariant_t* fx_result)
-{
-   fx_result->dvar_name = *r_dvar_name;
-   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
-   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
-   fx_result->dvar_flags = *r_dvar_flags;
-   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
-   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
-   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
-   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
-   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
-   fx_result->dvar_loc = *r_dvar_loc;
-}
-
-static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
-}
-
-static int _fx_make_rR17Ast__defvariant_t(
-   struct _fx_R17Ast__defvariant_t* arg,
-   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
-}
-
-static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   _fx_free_N10Ast__typ_t(&dst->t1);
-}
-
-static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
-{
-   dst->t0 = src->t0;
-   FX_COPY_PTR(src->t1, &dst->t1);
-   dst->t2 = src->t2;
-}
-
-static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_R9Ast__id_t* t0,
-   struct _fx_N10Ast__typ_t_data_t* t1,
-   struct _fx_R16Ast__fun_flags_t* t2,
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
-{
-   fx_result->t0 = *t0;
-   FX_COPY_PTR(t1, &fx_result->t1);
-   fx_result->t2 = *t2;
-}
-
-static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
-{
-   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
-   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
-   bool addref_tl,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
-{
-   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
-      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
-}
-
-static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
-{
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
-   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
-   fx_free_list_simple(&dst->di_scope);
-}
-
-static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
-{
-   dst->di_name = src->di_name;
-   dst->di_base = src->di_base;
-   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
-   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
-   FX_COPY_PTR(src->di_scope, &dst->di_scope);
-   dst->di_loc = src->di_loc;
-}
-
-static void _fx_make_R19Ast__definterface_t(
-   struct _fx_R9Ast__id_t* r_di_name,
-   struct _fx_R9Ast__id_t* r_di_base,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
-   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
-   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
-   struct _fx_R10Ast__loc_t* r_di_loc,
-   struct _fx_R19Ast__definterface_t* fx_result)
-{
-   fx_result->di_name = *r_di_name;
-   fx_result->di_base = *r_di_base;
-   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
-   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
-   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
-   fx_result->di_loc = *r_di_loc;
-}
-
-static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
-{
-   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
-}
-
-static int _fx_make_rR19Ast__definterface_t(
-   struct _fx_R19Ast__definterface_t* arg,
-   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
-{
-   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
-}
-
-static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
-{
-   switch (dst->tag) {
-   case 2:
-      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
-   case 3:
-      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
-   case 4:
-      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
-   case 5:
-      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
-   case 6:
-      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
-   case 7:
-      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
-   default:
-      ;
-   }
-   dst->tag = 0;
-}
-
-static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
-{
-   dst->tag = src->tag;
-   switch (src->tag) {
-   case 2:
-      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
-   case 3:
-      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
-   case 4:
-      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
-   case 5:
-      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
-   case 6:
-      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
-   case 7:
-      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
-   default:
-      dst->u = src->u;
-   }
-}
-
 static void _fx_free_Rt24Hashset__hashset_entry_t1S(struct _fx_Rt24Hashset__hashset_entry_t1S* dst)
 {
    fx_free_str(&dst->key);
@@ -2570,6 +2015,29 @@ static void _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(
    *dst = 0;
 }
 
+static void _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   _fx_free_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t(&dst->root);
+   fx_free_fp(&dst->cmp);
+}
+
+static void _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* src,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* dst)
+{
+   FX_COPY_PTR(src->root, &dst->root);
+   FX_COPY_FP(&src->cmp, &dst->cmp);
+}
+
+static void _fx_make_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+   struct _fx_Nt11Map__tree_t2R9Ast__id_tLN16Ast__env_entry_t_data_t* r_root,
+   struct _fx_FPi2R9Ast__id_tR9Ast__id_t* r_cmp,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* fx_result)
+{
+   FX_COPY_PTR(r_root, &fx_result->root);
+   FX_COPY_FP(r_cmp, &fx_result->cmp);
+}
+
 static void _fx_free_T2R10Ast__loc_tS(struct _fx_T2R10Ast__loc_tS* dst)
 {
    fx_free_str(&dst->t1);
@@ -2673,6 +2141,59 @@ static void _fx_make_T2iN10Ast__typ_t(int_ t0, struct _fx_N10Ast__typ_t_data_t* 
 {
    fx_result->t0 = t0;
    FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static int _fx_cons_LN12Ast__scope_t(
+   struct _fx_N12Ast__scope_t* hd,
+   struct _fx_LN12Ast__scope_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN12Ast__scope_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN12Ast__scope_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* dst)
+{
+   fx_free_list_simple(&dst->val_flag_global);
+}
+
+static void _fx_copy_R16Ast__val_flags_t(struct _fx_R16Ast__val_flags_t* src, struct _fx_R16Ast__val_flags_t* dst)
+{
+   dst->val_flag_arg = src->val_flag_arg;
+   dst->val_flag_mutable = src->val_flag_mutable;
+   dst->val_flag_temp = src->val_flag_temp;
+   dst->val_flag_tempref = src->val_flag_tempref;
+   dst->val_flag_private = src->val_flag_private;
+   dst->val_flag_subarray = src->val_flag_subarray;
+   dst->val_flag_instance = src->val_flag_instance;
+   dst->val_flag_method = src->val_flag_method;
+   dst->val_flag_ctor = src->val_flag_ctor;
+   FX_COPY_PTR(src->val_flag_global, &dst->val_flag_global);
+}
+
+static void _fx_make_R16Ast__val_flags_t(
+   bool r_val_flag_arg,
+   bool r_val_flag_mutable,
+   bool r_val_flag_temp,
+   bool r_val_flag_tempref,
+   bool r_val_flag_private,
+   bool r_val_flag_subarray,
+   bool r_val_flag_instance,
+   struct _fx_T2R9Ast__id_ti* r_val_flag_method,
+   int_ r_val_flag_ctor,
+   struct _fx_LN12Ast__scope_t_data_t* r_val_flag_global,
+   struct _fx_R16Ast__val_flags_t* fx_result)
+{
+   fx_result->val_flag_arg = r_val_flag_arg;
+   fx_result->val_flag_mutable = r_val_flag_mutable;
+   fx_result->val_flag_temp = r_val_flag_temp;
+   fx_result->val_flag_tempref = r_val_flag_tempref;
+   fx_result->val_flag_private = r_val_flag_private;
+   fx_result->val_flag_subarray = r_val_flag_subarray;
+   fx_result->val_flag_instance = r_val_flag_instance;
+   fx_result->val_flag_method = *r_val_flag_method;
+   fx_result->val_flag_ctor = r_val_flag_ctor;
+   FX_COPY_PTR(r_val_flag_global, &fx_result->val_flag_global);
 }
 
 static void _fx_free_T4R16Ast__val_flags_tR9Ast__id_tN10Ast__typ_tN10Ast__exp_t(
@@ -3630,6 +3151,412 @@ static void _fx_make_T4N10Ast__pat_tN10Ast__exp_tR16Ast__val_flags_tR10Ast__loc_
    fx_result->t3 = *t3;
 }
 
+static int _fx_cons_LR9Ast__id_t(
+   struct _fx_R9Ast__id_t* hd,
+   struct _fx_LR9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LR9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_LN10Ast__pat_t(struct _fx_LN10Ast__pat_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LN10Ast__pat_t, _fx_free_N10Ast__pat_t);
+}
+
+static int _fx_cons_LN10Ast__pat_t(
+   struct _fx_N10Ast__pat_t_data_t* hd,
+   struct _fx_LN10Ast__pat_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LN10Ast__pat_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LN10Ast__pat_t, FX_COPY_PTR);
+}
+
+static void _fx_free_rLR9Ast__id_t(struct _fx_rLR9Ast__id_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rLR9Ast__id_t, fx_free_list_simple);
+}
+
+static int _fx_make_rLR9Ast__id_t(struct _fx_LR9Ast__id_t_data_t* arg, struct _fx_rLR9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rLR9Ast__id_t, FX_COPY_PTR);
+}
+
+static void _fx_free_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* dst)
+{
+   fx_free_list_simple(&dst->df_templ_args);
+   _fx_free_LN10Ast__pat_t(&dst->df_args);
+   _fx_free_N10Ast__typ_t(&dst->df_typ);
+   _fx_free_N10Ast__exp_t(&dst->df_body);
+   fx_free_list_simple(&dst->df_scope);
+   _fx_free_rLR9Ast__id_t(&dst->df_templ_inst);
+   _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&dst->df_env);
+}
+
+static void _fx_copy_R13Ast__deffun_t(struct _fx_R13Ast__deffun_t* src, struct _fx_R13Ast__deffun_t* dst)
+{
+   dst->df_name = src->df_name;
+   FX_COPY_PTR(src->df_templ_args, &dst->df_templ_args);
+   FX_COPY_PTR(src->df_args, &dst->df_args);
+   FX_COPY_PTR(src->df_typ, &dst->df_typ);
+   FX_COPY_PTR(src->df_body, &dst->df_body);
+   dst->df_flags = src->df_flags;
+   FX_COPY_PTR(src->df_scope, &dst->df_scope);
+   dst->df_loc = src->df_loc;
+   FX_COPY_PTR(src->df_templ_inst, &dst->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&src->df_env, &dst->df_env);
+}
+
+static void _fx_make_R13Ast__deffun_t(
+   struct _fx_R9Ast__id_t* r_df_name,
+   struct _fx_LR9Ast__id_t_data_t* r_df_templ_args,
+   struct _fx_LN10Ast__pat_t_data_t* r_df_args,
+   struct _fx_N10Ast__typ_t_data_t* r_df_typ,
+   struct _fx_N10Ast__exp_t_data_t* r_df_body,
+   struct _fx_R16Ast__fun_flags_t* r_df_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_df_scope,
+   struct _fx_R10Ast__loc_t* r_df_loc,
+   struct _fx_rLR9Ast__id_t_data_t* r_df_templ_inst,
+   struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t* r_df_env,
+   struct _fx_R13Ast__deffun_t* fx_result)
+{
+   fx_result->df_name = *r_df_name;
+   FX_COPY_PTR(r_df_templ_args, &fx_result->df_templ_args);
+   FX_COPY_PTR(r_df_args, &fx_result->df_args);
+   FX_COPY_PTR(r_df_typ, &fx_result->df_typ);
+   FX_COPY_PTR(r_df_body, &fx_result->df_body);
+   fx_result->df_flags = *r_df_flags;
+   FX_COPY_PTR(r_df_scope, &fx_result->df_scope);
+   fx_result->df_loc = *r_df_loc;
+   FX_COPY_PTR(r_df_templ_inst, &fx_result->df_templ_inst);
+   _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(r_df_env, &fx_result->df_env);
+}
+
+static void _fx_free_rR13Ast__deffun_t(struct _fx_rR13Ast__deffun_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_free_R13Ast__deffun_t);
+}
+
+static int _fx_make_rR13Ast__deffun_t(struct _fx_R13Ast__deffun_t* arg, struct _fx_rR13Ast__deffun_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deffun_t, _fx_copy_R13Ast__deffun_t);
+}
+
+static void _fx_free_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dexn_typ);
+   fx_free_list_simple(&dst->dexn_scope);
+}
+
+static void _fx_copy_R13Ast__defexn_t(struct _fx_R13Ast__defexn_t* src, struct _fx_R13Ast__defexn_t* dst)
+{
+   dst->dexn_name = src->dexn_name;
+   FX_COPY_PTR(src->dexn_typ, &dst->dexn_typ);
+   FX_COPY_PTR(src->dexn_scope, &dst->dexn_scope);
+   dst->dexn_loc = src->dexn_loc;
+}
+
+static void _fx_make_R13Ast__defexn_t(
+   struct _fx_R9Ast__id_t* r_dexn_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dexn_typ,
+   struct _fx_LN12Ast__scope_t_data_t* r_dexn_scope,
+   struct _fx_R10Ast__loc_t* r_dexn_loc,
+   struct _fx_R13Ast__defexn_t* fx_result)
+{
+   fx_result->dexn_name = *r_dexn_name;
+   FX_COPY_PTR(r_dexn_typ, &fx_result->dexn_typ);
+   FX_COPY_PTR(r_dexn_scope, &fx_result->dexn_scope);
+   fx_result->dexn_loc = *r_dexn_loc;
+}
+
+static void _fx_free_rR13Ast__defexn_t(struct _fx_rR13Ast__defexn_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_free_R13Ast__defexn_t);
+}
+
+static int _fx_make_rR13Ast__defexn_t(struct _fx_R13Ast__defexn_t* arg, struct _fx_rR13Ast__defexn_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__defexn_t, _fx_copy_R13Ast__defexn_t);
+}
+
+static void _fx_free_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* dst)
+{
+   fx_free_list_simple(&dst->dt_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dt_typ);
+   fx_free_list_simple(&dst->dt_scope);
+}
+
+static void _fx_copy_R13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* src, struct _fx_R13Ast__deftyp_t* dst)
+{
+   dst->dt_name = src->dt_name;
+   FX_COPY_PTR(src->dt_templ_args, &dst->dt_templ_args);
+   FX_COPY_PTR(src->dt_typ, &dst->dt_typ);
+   dst->dt_finalized = src->dt_finalized;
+   FX_COPY_PTR(src->dt_scope, &dst->dt_scope);
+   dst->dt_loc = src->dt_loc;
+}
+
+static void _fx_make_R13Ast__deftyp_t(
+   struct _fx_R9Ast__id_t* r_dt_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dt_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dt_typ,
+   bool r_dt_finalized,
+   struct _fx_LN12Ast__scope_t_data_t* r_dt_scope,
+   struct _fx_R10Ast__loc_t* r_dt_loc,
+   struct _fx_R13Ast__deftyp_t* fx_result)
+{
+   fx_result->dt_name = *r_dt_name;
+   FX_COPY_PTR(r_dt_templ_args, &fx_result->dt_templ_args);
+   FX_COPY_PTR(r_dt_typ, &fx_result->dt_typ);
+   fx_result->dt_finalized = r_dt_finalized;
+   FX_COPY_PTR(r_dt_scope, &fx_result->dt_scope);
+   fx_result->dt_loc = *r_dt_loc;
+}
+
+static void _fx_free_rR13Ast__deftyp_t(struct _fx_rR13Ast__deftyp_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_free_R13Ast__deftyp_t);
+}
+
+static int _fx_make_rR13Ast__deftyp_t(struct _fx_R13Ast__deftyp_t* arg, struct _fx_rR13Ast__deftyp_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR13Ast__deftyp_t, _fx_copy_R13Ast__deftyp_t);
+}
+
+static void _fx_free_T2R9Ast__id_tN10Ast__typ_t(struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* src,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tN10Ast__typ_t(struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_free_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tN10Ast__typ_t(
+   struct _fx_T2R9Ast__id_tN10Ast__typ_t* hd,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tN10Ast__typ_t, _fx_copy_T2R9Ast__id_tN10Ast__typ_t);
+}
+
+static int _fx_cons_LTa2R9Ast__id_t(
+   struct _fx_Ta2R9Ast__id_t* hd,
+   struct _fx_LTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LTa2R9Ast__id_t, FX_COPY_SIMPLE_BY_PTR);
+}
+
+static void _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   fx_free_list_simple(&dst->t1);
+}
+
+static void _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* src,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+}
+
+static void _fx_make_T2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_LTa2R9Ast__id_t_data_t* t1,
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+}
+
+static void _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_free_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static int _fx_cons_LT2R9Ast__id_tLTa2R9Ast__id_t(
+   struct _fx_T2R9Ast__id_tLTa2R9Ast__id_t* hd,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT2R9Ast__id_tLTa2R9Ast__id_t, _fx_copy_T2R9Ast__id_tLTa2R9Ast__id_t);
+}
+
+static void _fx_free_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* dst)
+{
+   fx_free_list_simple(&dst->dvar_templ_args);
+   _fx_free_N10Ast__typ_t(&dst->dvar_alias);
+   _fx_free_LT2R9Ast__id_tN10Ast__typ_t(&dst->dvar_cases);
+   fx_free_list_simple(&dst->dvar_ctors);
+   _fx_free_rLR9Ast__id_t(&dst->dvar_templ_inst);
+   _fx_free_LT2R9Ast__id_tLTa2R9Ast__id_t(&dst->dvar_ifaces);
+   fx_free_list_simple(&dst->dvar_scope);
+}
+
+static void _fx_copy_R17Ast__defvariant_t(struct _fx_R17Ast__defvariant_t* src, struct _fx_R17Ast__defvariant_t* dst)
+{
+   dst->dvar_name = src->dvar_name;
+   FX_COPY_PTR(src->dvar_templ_args, &dst->dvar_templ_args);
+   FX_COPY_PTR(src->dvar_alias, &dst->dvar_alias);
+   dst->dvar_flags = src->dvar_flags;
+   FX_COPY_PTR(src->dvar_cases, &dst->dvar_cases);
+   FX_COPY_PTR(src->dvar_ctors, &dst->dvar_ctors);
+   FX_COPY_PTR(src->dvar_templ_inst, &dst->dvar_templ_inst);
+   FX_COPY_PTR(src->dvar_ifaces, &dst->dvar_ifaces);
+   FX_COPY_PTR(src->dvar_scope, &dst->dvar_scope);
+   dst->dvar_loc = src->dvar_loc;
+}
+
+static void _fx_make_R17Ast__defvariant_t(
+   struct _fx_R9Ast__id_t* r_dvar_name,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_templ_args,
+   struct _fx_N10Ast__typ_t_data_t* r_dvar_alias,
+   struct _fx_R16Ast__var_flags_t* r_dvar_flags,
+   struct _fx_LT2R9Ast__id_tN10Ast__typ_t_data_t* r_dvar_cases,
+   struct _fx_LR9Ast__id_t_data_t* r_dvar_ctors,
+   struct _fx_rLR9Ast__id_t_data_t* r_dvar_templ_inst,
+   struct _fx_LT2R9Ast__id_tLTa2R9Ast__id_t_data_t* r_dvar_ifaces,
+   struct _fx_LN12Ast__scope_t_data_t* r_dvar_scope,
+   struct _fx_R10Ast__loc_t* r_dvar_loc,
+   struct _fx_R17Ast__defvariant_t* fx_result)
+{
+   fx_result->dvar_name = *r_dvar_name;
+   FX_COPY_PTR(r_dvar_templ_args, &fx_result->dvar_templ_args);
+   FX_COPY_PTR(r_dvar_alias, &fx_result->dvar_alias);
+   fx_result->dvar_flags = *r_dvar_flags;
+   FX_COPY_PTR(r_dvar_cases, &fx_result->dvar_cases);
+   FX_COPY_PTR(r_dvar_ctors, &fx_result->dvar_ctors);
+   FX_COPY_PTR(r_dvar_templ_inst, &fx_result->dvar_templ_inst);
+   FX_COPY_PTR(r_dvar_ifaces, &fx_result->dvar_ifaces);
+   FX_COPY_PTR(r_dvar_scope, &fx_result->dvar_scope);
+   fx_result->dvar_loc = *r_dvar_loc;
+}
+
+static void _fx_free_rR17Ast__defvariant_t(struct _fx_rR17Ast__defvariant_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_free_R17Ast__defvariant_t);
+}
+
+static int _fx_make_rR17Ast__defvariant_t(
+   struct _fx_R17Ast__defvariant_t* arg,
+   struct _fx_rR17Ast__defvariant_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR17Ast__defvariant_t, _fx_copy_R17Ast__defvariant_t);
+}
+
+static void _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->t1);
+}
+
+static void _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* src,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* dst)
+{
+   dst->t0 = src->t0;
+   FX_COPY_PTR(src->t1, &dst->t1);
+   dst->t2 = src->t2;
+}
+
+static void _fx_make_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_R9Ast__id_t* t0,
+   struct _fx_N10Ast__typ_t_data_t* t1,
+   struct _fx_R16Ast__fun_flags_t* t2,
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* fx_result)
+{
+   fx_result->t0 = *t0;
+   FX_COPY_PTR(t1, &fx_result->t1);
+   fx_result->t2 = *t2;
+}
+
+static void _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** dst)
+{
+   FX_FREE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_free_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static int _fx_cons_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(
+   struct _fx_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t* hd,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* tl,
+   bool addref_tl,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t** fx_result)
+{
+   FX_MAKE_LIST_IMPL(_fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t,
+      _fx_copy_T3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t);
+}
+
+static void _fx_free_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* dst)
+{
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_new_methods);
+   _fx_free_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t(&dst->di_all_methods);
+   fx_free_list_simple(&dst->di_scope);
+}
+
+static void _fx_copy_R19Ast__definterface_t(struct _fx_R19Ast__definterface_t* src, struct _fx_R19Ast__definterface_t* dst)
+{
+   dst->di_name = src->di_name;
+   dst->di_base = src->di_base;
+   FX_COPY_PTR(src->di_new_methods, &dst->di_new_methods);
+   FX_COPY_PTR(src->di_all_methods, &dst->di_all_methods);
+   FX_COPY_PTR(src->di_scope, &dst->di_scope);
+   dst->di_loc = src->di_loc;
+}
+
+static void _fx_make_R19Ast__definterface_t(
+   struct _fx_R9Ast__id_t* r_di_name,
+   struct _fx_R9Ast__id_t* r_di_base,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_new_methods,
+   struct _fx_LT3R9Ast__id_tN10Ast__typ_tR16Ast__fun_flags_t_data_t* r_di_all_methods,
+   struct _fx_LN12Ast__scope_t_data_t* r_di_scope,
+   struct _fx_R10Ast__loc_t* r_di_loc,
+   struct _fx_R19Ast__definterface_t* fx_result)
+{
+   fx_result->di_name = *r_di_name;
+   fx_result->di_base = *r_di_base;
+   FX_COPY_PTR(r_di_new_methods, &fx_result->di_new_methods);
+   FX_COPY_PTR(r_di_all_methods, &fx_result->di_all_methods);
+   FX_COPY_PTR(r_di_scope, &fx_result->di_scope);
+   fx_result->di_loc = *r_di_loc;
+}
+
+static void _fx_free_rR19Ast__definterface_t(struct _fx_rR19Ast__definterface_t_data_t** dst)
+{
+   FX_FREE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_free_R19Ast__definterface_t);
+}
+
+static int _fx_make_rR19Ast__definterface_t(
+   struct _fx_R19Ast__definterface_t* arg,
+   struct _fx_rR19Ast__definterface_t_data_t** fx_result)
+{
+   FX_MAKE_REF_IMPL(_fx_rR19Ast__definterface_t, _fx_copy_R19Ast__definterface_t);
+}
+
 static int _fx_cons_LT2iR9Ast__id_t(
    struct _fx_T2iR9Ast__id_t* hd,
    struct _fx_LT2iR9Ast__id_t_data_t* tl,
@@ -4097,6 +4024,79 @@ static void _fx_free_N16Ast__env_entry_t(struct _fx_N16Ast__env_entry_t_data_t**
       switch ((*dst)->tag) { case 2:     _fx_free_N10Ast__typ_t(&(*dst)->u.EnvTyp); break; default:    ; } fx_free(*dst);
    }
    *dst = 0;
+}
+
+static void _fx_free_R13Ast__defval_t(struct _fx_R13Ast__defval_t* dst)
+{
+   _fx_free_N10Ast__typ_t(&dst->dv_typ);
+   _fx_free_R16Ast__val_flags_t(&dst->dv_flags);
+   fx_free_list_simple(&dst->dv_scope);
+}
+
+static void _fx_copy_R13Ast__defval_t(struct _fx_R13Ast__defval_t* src, struct _fx_R13Ast__defval_t* dst)
+{
+   dst->dv_name = src->dv_name;
+   FX_COPY_PTR(src->dv_typ, &dst->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(&src->dv_flags, &dst->dv_flags);
+   FX_COPY_PTR(src->dv_scope, &dst->dv_scope);
+   dst->dv_loc = src->dv_loc;
+}
+
+static void _fx_make_R13Ast__defval_t(
+   struct _fx_R9Ast__id_t* r_dv_name,
+   struct _fx_N10Ast__typ_t_data_t* r_dv_typ,
+   struct _fx_R16Ast__val_flags_t* r_dv_flags,
+   struct _fx_LN12Ast__scope_t_data_t* r_dv_scope,
+   struct _fx_R10Ast__loc_t* r_dv_loc,
+   struct _fx_R13Ast__defval_t* fx_result)
+{
+   fx_result->dv_name = *r_dv_name;
+   FX_COPY_PTR(r_dv_typ, &fx_result->dv_typ);
+   _fx_copy_R16Ast__val_flags_t(r_dv_flags, &fx_result->dv_flags);
+   FX_COPY_PTR(r_dv_scope, &fx_result->dv_scope);
+   fx_result->dv_loc = *r_dv_loc;
+}
+
+static void _fx_free_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* dst)
+{
+   switch (dst->tag) {
+   case 2:
+      _fx_free_R13Ast__defval_t(&dst->u.IdDVal); break;
+   case 3:
+      _fx_free_rR13Ast__deffun_t(&dst->u.IdFun); break;
+   case 4:
+      _fx_free_rR13Ast__defexn_t(&dst->u.IdExn); break;
+   case 5:
+      _fx_free_rR13Ast__deftyp_t(&dst->u.IdTyp); break;
+   case 6:
+      _fx_free_rR17Ast__defvariant_t(&dst->u.IdVariant); break;
+   case 7:
+      _fx_free_rR19Ast__definterface_t(&dst->u.IdInterface); break;
+   default:
+      ;
+   }
+   dst->tag = 0;
+}
+
+static void _fx_copy_N14Ast__id_info_t(struct _fx_N14Ast__id_info_t* src, struct _fx_N14Ast__id_info_t* dst)
+{
+   dst->tag = src->tag;
+   switch (src->tag) {
+   case 2:
+      _fx_copy_R13Ast__defval_t(&src->u.IdDVal, &dst->u.IdDVal); break;
+   case 3:
+      FX_COPY_PTR(src->u.IdFun, &dst->u.IdFun); break;
+   case 4:
+      FX_COPY_PTR(src->u.IdExn, &dst->u.IdExn); break;
+   case 5:
+      FX_COPY_PTR(src->u.IdTyp, &dst->u.IdTyp); break;
+   case 6:
+      FX_COPY_PTR(src->u.IdVariant, &dst->u.IdVariant); break;
+   case 7:
+      FX_COPY_PTR(src->u.IdInterface, &dst->u.IdInterface); break;
+   default:
+      dst->u = src->u;
+   }
 }
 
 static int _fx_cons_Li(int_ hd, struct _fx_Li_data_t* tl, bool addref_tl, struct _fx_Li_data_t** fx_result)
@@ -5909,6 +5909,8 @@ _fx_N12Ast__sctyp_t _fx_g16Parser__ScUInt16 = { 3 };
 _fx_N12Ast__sctyp_t _fx_g15Parser__ScInt16 = { 4 };
 _fx_N13Ast__intrin_t _fx_g21Parser__IntrinGetSize = { 9 };
 _fx_N13Ast__intrin_t _fx_g18Parser__IntrinGEMM = { 13 };
+_fx_N13Ast__intrin_t _fx_g25Parser__IntrinVecPushBack = { 16 };
+_fx_N13Ast__intrin_t _fx_g24Parser__IntrinVecPopBack = { 17 };
 _fx_N15Ast__for_make_t _fx_g19Parser__ForMakeNone = { 1 };
 _fx_N15Ast__for_make_t _fx_g20Parser__ForMakeArray = { 2 };
 _fx_N15Ast__for_make_t _fx_g19Parser__ForMakeList = { 3 };
@@ -12579,18 +12581,26 @@ static int
                      if (fx_streq(&istr_1, &slit_52)) {
                         iop_0 = _fx_g21Parser__IntrinGetSize; goto _fx_endmatch_0;
                      }
-                     fx_str_t slit_53 = FX_MAKE_STR("__intrin_gemm__");
+                     fx_str_t slit_53 = FX_MAKE_STR("__intrin_push__");
                      if (fx_streq(&istr_1, &slit_53)) {
+                        iop_0 = _fx_g25Parser__IntrinVecPushBack; goto _fx_endmatch_0;
+                     }
+                     fx_str_t slit_54 = FX_MAKE_STR("__intrin_pop__");
+                     if (fx_streq(&istr_1, &slit_54)) {
+                        iop_0 = _fx_g24Parser__IntrinVecPopBack; goto _fx_endmatch_0;
+                     }
+                     fx_str_t slit_55 = FX_MAKE_STR("__intrin_gemm__");
+                     if (fx_streq(&istr_1, &slit_55)) {
                         iop_0 = _fx_g18Parser__IntrinGEMM; goto _fx_endmatch_0;
                      }
                      fx_str_t v_44 = {0};
                      fx_str_t v_45 = {0};
                      fx_exn_t v_46 = {0};
                      FX_CALL(_fx_M6ParserFM6stringS1S(&istr_1, &v_44, 0), _fx_catch_26);
-                     fx_str_t slit_54 = FX_MAKE_STR("unknown/unsupported intrinsic \'");
-                     fx_str_t slit_55 = FX_MAKE_STR("\'");
+                     fx_str_t slit_56 = FX_MAKE_STR("unknown/unsupported intrinsic \'");
+                     fx_str_t slit_57 = FX_MAKE_STR("\'");
                      {
-                        const fx_str_t strs_0[] = { slit_54, v_44, slit_55 };
+                        const fx_str_t strs_0[] = { slit_56, v_44, slit_57 };
                         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 3, &v_45), _fx_catch_26);
                      }
                      FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_2, &v_45, &v_46, 0), _fx_catch_26);
@@ -12610,8 +12620,8 @@ static int
                   }
                   else {
                      bool v_47;
-                     fx_str_t slit_56 = FX_MAKE_STR("vector");
-                     if (_fx_F6__eq__B2SS(&istr_1, &slit_56, 0)) {
+                     fx_str_t slit_58 = FX_MAKE_STR("vector");
+                     if (_fx_F6__eq__B2SS(&istr_1, &slit_58, 0)) {
                         if (args_1 != 0) {
                            if (args_1->tl == 0) {
                               if (FX_REC_VARIANT_TAG(args_1->hd) == 27) {
@@ -12648,8 +12658,8 @@ static int
                            }
                         }
                         fx_exn_t v_50 = {0};
-                        fx_str_t slit_57 = FX_MAKE_STR("unexpected \'vector\' comprehension argument");
-                        FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_2, &slit_57, &v_50, 0),
+                        fx_str_t slit_59 = FX_MAKE_STR("unexpected \'vector\' comprehension argument");
+                        FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_2, &slit_59, &v_50, 0),
                            _fx_catch_28);
                         FX_THROW(&v_50, true, _fx_catch_28);
 
@@ -12661,20 +12671,20 @@ static int
                      }
                      else {
                         bool v_51;
-                        fx_str_t slit_58 = FX_MAKE_STR("rrbvec");
+                        fx_str_t slit_60 = FX_MAKE_STR("rrbvec");
                         bool t_0;
-                        if (_fx_F6__eq__B2SS(&istr_1, &slit_58, 0)) {
+                        if (_fx_F6__eq__B2SS(&istr_1, &slit_60, 0)) {
                            t_0 = true;
                         }
                         else {
-                           fx_str_t slit_59 = FX_MAKE_STR("list"); t_0 = _fx_F6__eq__B2SS(&istr_1, &slit_59, 0);
+                           fx_str_t slit_61 = FX_MAKE_STR("list"); t_0 = _fx_F6__eq__B2SS(&istr_1, &slit_61, 0);
                         }
                         bool t_1;
                         if (t_0) {
                            t_1 = true;
                         }
                         else {
-                           fx_str_t slit_60 = FX_MAKE_STR("array"); t_1 = _fx_F6__eq__B2SS(&istr_1, &slit_60, 0);
+                           fx_str_t slit_62 = FX_MAKE_STR("array"); t_1 = _fx_F6__eq__B2SS(&istr_1, &slit_62, 0);
                         }
                         if (t_1) {
                            bool res_1;
@@ -12729,16 +12739,16 @@ static int
                                        vcase_1 = &v_54->u.ExpMap;
                                     _fx_R16Ast__for_flags_t* flags_1 = &vcase_1->t2;
                                     bool v_55;
-                                    fx_str_t slit_61 = FX_MAKE_STR("array");
-                                    v_55 = _fx_F6__eq__B2SS(&istr_1, &slit_61, 0);
+                                    fx_str_t slit_63 = FX_MAKE_STR("array");
+                                    v_55 = _fx_F6__eq__B2SS(&istr_1, &slit_63, 0);
                                     _fx_N15Ast__for_make_t mkflag_0;
                                     if (v_55) {
                                        mkflag_0 = _fx_g20Parser__ForMakeArray;
                                     }
                                     else {
                                        bool v_56;
-                                       fx_str_t slit_62 = FX_MAKE_STR("rrbvec");
-                                       v_56 = _fx_F6__eq__B2SS(&istr_1, &slit_62, 0);
+                                       fx_str_t slit_64 = FX_MAKE_STR("rrbvec");
+                                       v_56 = _fx_F6__eq__B2SS(&istr_1, &slit_64, 0);
                                        if (v_56) {
                                           mkflag_0 = _fx_g21Parser__ForMakeRRBVec;
                                        }
@@ -12784,10 +12794,10 @@ static int
                            fx_str_t v_63 = {0};
                            fx_exn_t v_64 = {0};
                            FX_CALL(_fx_M6ParserFM6stringS1S(&istr_1, &v_62, 0), _fx_catch_30);
-                           fx_str_t slit_63 = FX_MAKE_STR("unexpected \'");
-                           fx_str_t slit_64 = FX_MAKE_STR("\' argument");
+                           fx_str_t slit_65 = FX_MAKE_STR("unexpected \'");
+                           fx_str_t slit_66 = FX_MAKE_STR("\' argument");
                            {
-                              const fx_str_t strs_1[] = { slit_63, v_62, slit_64 };
+                              const fx_str_t strs_1[] = { slit_65, v_62, slit_66 };
                               FX_CALL(fx_strjoin(0, 0, 0, strs_1, 3, &v_63), _fx_catch_30);
                            }
                            FX_CALL(_fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(ts_2, &v_63, &v_64, 0),
@@ -12804,8 +12814,8 @@ static int
                            FX_COPY_PTR(v_59.t0, &el_0);
                            _fx_copy_T2N10Ast__typ_tR10Ast__loc_t(&v_59.t1, &ctx_0);
                            bool v_65;
-                           fx_str_t slit_65 = FX_MAKE_STR("array");
-                           v_65 = _fx_F6__eq__B2SS(&istr_1, &slit_65, 0);
+                           fx_str_t slit_67 = FX_MAKE_STR("array");
+                           v_65 = _fx_F6__eq__B2SS(&istr_1, &slit_67, 0);
                            if (v_65) {
                               FX_CALL(_fx_cons_LLN10Ast__exp_t(el_0, 0, true, &v_60), _fx_catch_31);
                               FX_CALL(
@@ -12814,8 +12824,8 @@ static int
                            }
                            else {
                               bool v_66;
-                              fx_str_t slit_66 = FX_MAKE_STR("rrbvec");
-                              v_66 = _fx_F6__eq__B2SS(&istr_1, &slit_66, 0);
+                              fx_str_t slit_68 = FX_MAKE_STR("rrbvec");
+                              v_66 = _fx_F6__eq__B2SS(&istr_1, &slit_68, 0);
                               if (v_66) {
                                  FX_CALL(
                                     _fx_M3AstFM11ExpMkVectorN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(el_0, &ctx_0,

--- a/compiler/bootstrap/Parser.c
+++ b/compiler/bootstrap/Parser.c
@@ -10,21 +10,6 @@ struct _fx_N20LexerUtils__stream_t_data_t;
 
 static void _fx_free_N20LexerUtils__stream_t(struct _fx_N20LexerUtils__stream_t_data_t**);
 
-struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t;
-
-static void _fx_free_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t**);
-
-struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t;
-
-static void _fx_free_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t**);
-
-struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t;
-
-static void _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t**);
-
 struct _fx_Nt6option1N10Ast__exp_t_data_t;
 
 static void _fx_free_Nt6option1N10Ast__exp_t(struct _fx_Nt6option1N10Ast__exp_t_data_t**);
@@ -160,48 +145,6 @@ typedef struct _fx_N20LexerUtils__stream_t_data_t {
       struct _fx_T4SiiS stream_t;
    } u;
 } _fx_N20LexerUtils__stream_t_data_t, *_fx_N20LexerUtils__stream_t;
-
-typedef struct _fx_R16Ast__ast_callb_t {
-   struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t* ast_cb_typ;
-   struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t* ast_cb_exp;
-   struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t* ast_cb_pat;
-} _fx_R16Ast__ast_callb_t;
-
-typedef struct _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t {
-   int (*fp)(struct _fx_N10Ast__pat_t_data_t*, struct _fx_R16Ast__ast_callb_t*, struct _fx_N10Ast__pat_t_data_t**, void*);
-   fx_fcv_t* fcv;
-} _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t;
-
-typedef struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t Some;
-   } u;
-} _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t, *_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t;
-
-typedef struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t {
-   int (*fp)(struct _fx_N10Ast__exp_t_data_t*, struct _fx_R16Ast__ast_callb_t*, struct _fx_N10Ast__exp_t_data_t**, void*);
-   fx_fcv_t* fcv;
-} _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t;
-
-typedef struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t Some;
-   } u;
-} _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t, *_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t;
-
-typedef struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t {
-   int (*fp)(struct _fx_N10Ast__typ_t_data_t*, struct _fx_R16Ast__ast_callb_t*, struct _fx_N10Ast__typ_t_data_t**, void*);
-   fx_fcv_t* fcv;
-} _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t;
-
-typedef struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t {
-   int_ rc;
-   union {
-      struct _fx_FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t Some;
-   } u;
-} _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t, *_fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t;
 
 typedef struct _fx_R9Ast__id_t {
    int_ m;
@@ -1318,11 +1261,6 @@ typedef struct _fx_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tR16Ast__for_flags_t 
    struct _fx_R16Ast__for_flags_t t3;
 } _fx_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tR16Ast__for_flags_t;
 
-typedef struct _fx_Ta2LR9Ast__id_t {
-   struct _fx_LR9Ast__id_t_data_t* t0;
-   struct _fx_LR9Ast__id_t_data_t* t1;
-} _fx_Ta2LR9Ast__id_t;
-
 typedef struct _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t {
    struct _fx_LT2N14Lexer__token_tR10Ast__loc_t_data_t* t0;
    struct _fx_N10Ast__exp_t_data_t* t1;
@@ -1818,58 +1756,6 @@ static void _fx_free_N20LexerUtils__stream_t(struct _fx_N20LexerUtils__stream_t_
 {
    if (*dst && FX_DECREF((*dst)->rc) == 1) {
       _fx_free_T4SiiS(&(*dst)->u.stream_t); fx_free(*dst);
-   }
-   *dst = 0;
-}
-
-static void _fx_free_R16Ast__ast_callb_t(struct _fx_R16Ast__ast_callb_t* dst)
-{
-   _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(&dst->ast_cb_typ);
-   _fx_free_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(&dst->ast_cb_exp);
-   _fx_free_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(&dst->ast_cb_pat);
-}
-
-static void _fx_copy_R16Ast__ast_callb_t(struct _fx_R16Ast__ast_callb_t* src, struct _fx_R16Ast__ast_callb_t* dst)
-{
-   FX_COPY_PTR(src->ast_cb_typ, &dst->ast_cb_typ);
-   FX_COPY_PTR(src->ast_cb_exp, &dst->ast_cb_exp);
-   FX_COPY_PTR(src->ast_cb_pat, &dst->ast_cb_pat);
-}
-
-static void _fx_make_R16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t* r_ast_cb_typ,
-   struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t* r_ast_cb_exp,
-   struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t* r_ast_cb_pat,
-   struct _fx_R16Ast__ast_callb_t* fx_result)
-{
-   FX_COPY_PTR(r_ast_cb_typ, &fx_result->ast_cb_typ);
-   FX_COPY_PTR(r_ast_cb_exp, &fx_result->ast_cb_exp);
-   FX_COPY_PTR(r_ast_cb_pat, &fx_result->ast_cb_pat);
-}
-
-static void _fx_free_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t_data_t** dst)
-{
-   if (*dst && FX_DECREF((*dst)->rc) == 1) {
-      fx_free_fp(&(*dst)->u.Some); fx_free(*dst);
-   }
-   *dst = 0;
-}
-
-static void _fx_free_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t** dst)
-{
-   if (*dst && FX_DECREF((*dst)->rc) == 1) {
-      fx_free_fp(&(*dst)->u.Some); fx_free(*dst);
-   }
-   *dst = 0;
-}
-
-static void _fx_free_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t(
-   struct _fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t_data_t** dst)
-{
-   if (*dst && FX_DECREF((*dst)->rc) == 1) {
-      fx_free_fp(&(*dst)->u.Some); fx_free(*dst);
    }
    *dst = 0;
 }
@@ -4831,27 +4717,6 @@ static void _fx_make_T4N10Ast__exp_tN10Ast__exp_tN10Ast__exp_tR16Ast__for_flags_
    fx_result->t3 = *t3;
 }
 
-static void _fx_free_Ta2LR9Ast__id_t(struct _fx_Ta2LR9Ast__id_t* dst)
-{
-   fx_free_list_simple(&dst->t0);
-   fx_free_list_simple(&dst->t1);
-}
-
-static void _fx_copy_Ta2LR9Ast__id_t(struct _fx_Ta2LR9Ast__id_t* src, struct _fx_Ta2LR9Ast__id_t* dst)
-{
-   FX_COPY_PTR(src->t0, &dst->t0);
-   FX_COPY_PTR(src->t1, &dst->t1);
-}
-
-static void _fx_make_Ta2LR9Ast__id_t(
-   struct _fx_LR9Ast__id_t_data_t* t0,
-   struct _fx_LR9Ast__id_t_data_t* t1,
-   struct _fx_Ta2LR9Ast__id_t* fx_result)
-{
-   FX_COPY_PTR(t0, &fx_result->t0);
-   FX_COPY_PTR(t1, &fx_result->t1);
-}
-
 static void _fx_free_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(
    struct _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t* dst)
 {
@@ -5819,11 +5684,9 @@ static int _fx_make_rN16Ast__defmodule_t(
 }
 
 _fx_Nt6option1N15Parser__ppval_t _fx_g12Parser__None = { 1 };
-_fx_Nt6option1FPN10Ast__pat_t2N10Ast__pat_tR16Ast__ast_callb_t _fx_g14Parser__None1_ = 0;
-_fx_Nt6option1FPN10Ast__typ_t2N10Ast__typ_tR16Ast__ast_callb_t _fx_g14Parser__None2_ = 0;
-_fx_Nt6option1R9Ast__id_t _fx_g14Parser__None3_ = { 1 };
-_fx_Nt6option1N10Ast__exp_t _fx_g14Parser__None4_ = 0;
-_fx_Nt6option1N10Ast__typ_t _fx_g14Parser__None5_ = 0;
+_fx_Nt6option1R9Ast__id_t _fx_g14Parser__None1_ = { 1 };
+_fx_Nt6option1N10Ast__exp_t _fx_g14Parser__None2_ = 0;
+_fx_Nt6option1N10Ast__typ_t _fx_g14Parser__None3_ = 0;
 _fx_N10Ast__lit_t _fx_g16Parser__LitEmpty = { 8 };
 static _fx_N10Ast__typ_t_data_t TypVarRecord_data_0 = { 1, 4 };
 _fx_N10Ast__typ_t _fx_g20Parser__TypVarRecord = &TypVarRecord_data_0;
@@ -6131,35 +5994,6 @@ FX_EXTERN_C int
    struct _fx_T2N10Ast__typ_tR10Ast__loc_t*,
    struct _fx_N10Ast__exp_t_data_t**);
 
-FX_EXTERN_C int _fx_M6ParserFM7make_fpFPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t3LR9Ast__id_trLR9Ast__id_trLR9Ast__id_t(
-   struct _fx_LR9Ast__id_t_data_t*,
-   struct _fx_rLR9Ast__id_t_data_t*,
-   struct _fx_rLR9Ast__id_t_data_t*,
-   struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t*);
-
-FX_EXTERN_C int _fx_M3AstFM16check_n_walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(
-   struct _fx_N10Ast__exp_t_data_t*,
-   struct _fx_R16Ast__ast_callb_t*,
-   struct _fx_N10Ast__exp_t_data_t**,
-   void*);
-
-FX_EXTERN_C int _fx_M3AstFM15compile_warningv2RM5loc_tS(struct _fx_R10Ast__loc_t*, fx_str_t*, void*);
-
-static int _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   struct _fx_N10Ast__exp_t_data_t*,
-   struct _fx_R16Ast__ast_callb_t*,
-   struct _fx_N10Ast__exp_t_data_t**,
-   void*);
-
-FX_EXTERN_C_VAL(struct _fx_R9Ast__id_t _fx_g12Ast__dummyid)
-FX_EXTERN_C int _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, bool*, void*);
-
-FX_EXTERN_C int _fx_M3AstFM8walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(
-   struct _fx_N10Ast__exp_t_data_t*,
-   struct _fx_R16Ast__ast_callb_t*,
-   struct _fx_N10Ast__exp_t_data_t**,
-   void*);
-
 FX_EXTERN_C int _fx_M3AstFM11loclist2locRM5loc_t2LRM5loc_tRM5loc_t(
    struct _fx_LR10Ast__loc_t_data_t*,
    struct _fx_R10Ast__loc_t*,
@@ -6202,6 +6036,8 @@ FX_EXTERN_C int _fx_M6ParserFM10get_opnameR9Ast__id_t1N14Lexer__token_t(
    void*);
 
 FX_EXTERN_C_VAL(struct _fx_R9Ast__id_t _fx_g9Ast__noid)
+FX_EXTERN_C int _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, bool*, void*);
+
 FX_EXTERN_C int _fx_M6ParserFM11parse_blockT2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t1LT2N14Lexer__token_tR10Ast__loc_t(
    struct _fx_LT2N14Lexer__token_tR10Ast__loc_t_data_t*,
    struct _fx_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t*,
@@ -6634,6 +6470,7 @@ FX_EXTERN_C int _fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(
    struct _fx_rR13Ast__deffun_t_data_t*,
    struct _fx_N10Ast__exp_t_data_t**);
 
+FX_EXTERN_C_VAL(struct _fx_R9Ast__id_t _fx_g12Ast__dummyid)
 FX_EXTERN_C int _fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(
    struct _fx_Nt6option1N10Ast__exp_t_data_t*,
    struct _fx_R10Ast__loc_t*,
@@ -6822,39 +6659,12 @@ FX_EXTERN_C void _fx_free_E18Parser__ParseError(_fx_E18Parser__ParseError_data_t
    fx_free(dst);
 }
 
-typedef struct {
-   int_ rc;
-   fx_free_t free_f;
-   struct _fx_LR9Ast__id_t_data_t* t0;
-   struct _fx_rLR9Ast__id_t_data_t* t1;
-   struct _fx_rLR9Ast__id_t_data_t* t2;
-} _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_cldata_t;
-
-FX_EXTERN_C void _fx_free_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_cldata_t* dst)
-{
-   FX_FREE_LIST_SIMPLE(&dst->t0);
-   _fx_free_rLR9Ast__id_t(&dst->t1);
-   _fx_free_rLR9Ast__id_t(&dst->t2);
-   fx_free(dst);
-}
-
 FX_EXTERN_C void _fx_M6ParserFM4SomeNt6option1N15Parser__ppval_t1N15Parser__ppval_t(
    struct _fx_N15Parser__ppval_t* arg0,
    struct _fx_Nt6option1N15Parser__ppval_t* fx_result)
 {
    fx_result->tag = 2;
    _fx_copy_N15Parser__ppval_t(arg0, &fx_result->u.Some);
-}
-
-FX_EXTERN_C int
-   _fx_M6ParserFM4SomeNt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t* arg0,
-   struct _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_data_t** fx_result)
-{
-   FX_MAKE_RECURSIVE_VARIANT_IMPL_START(_fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t);
-   FX_COPY_FP(arg0, &v->u.Some);
-   return 0;
 }
 
 FX_EXTERN_C void _fx_M6ParserFM4SomeNt6option1R9Ast__id_t1R9Ast__id_t(
@@ -7005,17 +6815,6 @@ FX_EXTERN_C int _fx_M6ParserFM7__add__LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_
       }
    }
    return fx_status;
-}
-
-FX_EXTERN_C void _fx_M6ParserFM5link2LR9Ast__id_t2LR9Ast__id_tLR9Ast__id_t(
-   struct _fx_LR9Ast__id_t_data_t* l1,
-   struct _fx_LR9Ast__id_t_data_t* l2,
-   struct _fx_LR9Ast__id_t_data_t** fx_result,
-   void* fx_fv)
-{
-
-fx_link_lists(l1, l2, fx_result);
-
 }
 
 FX_EXTERN_C int _fx_M6ParserFM6stringS1S(fx_str_t* a_0, fx_str_t* fx_result, void* fx_fv)
@@ -9836,125 +9635,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M6ParserFM12fold_acc_idsLR9Ast__id_t1N10Ast__pat_t(
-   struct _fx_N10Ast__pat_t_data_t* p_0,
-   struct _fx_LR9Ast__id_t_data_t** fx_result,
-   void* fx_fv)
-{
-   _fx_LR9Ast__id_t result_0 = 0;
-   _fx_N10Ast__pat_t p_1 = 0;
-   int fx_status = 0;
-   FX_CALL(fx_check_stack(), _fx_cleanup);
-   FX_COPY_PTR(p_0, &p_1);
-   for (;;) {
-      _fx_N10Ast__pat_t p_2 = 0;
-      FX_COPY_PTR(p_1, &p_2);
-      int tag_0 = FX_REC_VARIANT_TAG(p_2);
-      if (tag_0 == 3) {
-         _fx_LR9Ast__id_t result_1 = 0;
-         FX_CALL(_fx_cons_LR9Ast__id_t(&p_2->u.PatIdent.t0, 0, true, &result_1), _fx_catch_0);
-         FX_FREE_LIST_SIMPLE(&result_0);
-         FX_COPY_PTR(result_1, &result_0);
-         FX_BREAK(_fx_catch_0);
-
-      _fx_catch_0: ;
-         FX_FREE_LIST_SIMPLE(&result_1);
-      }
-      else if (tag_0 == 9) {
-         _fx_N10Ast__pat_t* p_3 = &p_2->u.PatTyped.t0; _fx_free_N10Ast__pat_t(&p_1); FX_COPY_PTR(*p_3, &p_1);
-      }
-      else if (tag_0 == 8) {
-         _fx_LR9Ast__id_t v_0 = 0;
-         _fx_LR9Ast__id_t result_2 = 0;
-         _fx_T3N10Ast__pat_tR9Ast__id_tR10Ast__loc_t* vcase_0 = &p_2->u.PatAs;
-         FX_CALL(_fx_M6ParserFM12fold_acc_idsLR9Ast__id_t1N10Ast__pat_t(vcase_0->t0, &v_0, 0), _fx_catch_1);
-         FX_CALL(_fx_cons_LR9Ast__id_t(&vcase_0->t1, v_0, true, &result_2), _fx_catch_1);
-         FX_FREE_LIST_SIMPLE(&result_0);
-         FX_COPY_PTR(result_2, &result_0);
-         FX_BREAK(_fx_catch_1);
-
-      _fx_catch_1: ;
-         FX_FREE_LIST_SIMPLE(&result_2);
-         FX_FREE_LIST_SIMPLE(&v_0);
-      }
-      else if (tag_0 == 4) {
-         _fx_LR9Ast__id_t acc_0 = 0;
-         _fx_LN10Ast__pat_t pl_0 = 0;
-         FX_COPY_PTR(p_2->u.PatTuple.t0, &pl_0);
-         _fx_LN10Ast__pat_t lst_0 = pl_0;
-         for (; lst_0; lst_0 = lst_0->tl) {
-            _fx_LR9Ast__id_t v_1 = 0;
-            _fx_Ta2LR9Ast__id_t v_2 = {0};
-            _fx_LR9Ast__id_t v_3 = 0;
-            _fx_N10Ast__pat_t pi_0 = lst_0->hd;
-            FX_CALL(_fx_M6ParserFM12fold_acc_idsLR9Ast__id_t1N10Ast__pat_t(pi_0, &v_1, 0), _fx_catch_4);
-            _fx_make_Ta2LR9Ast__id_t(acc_0, v_1, &v_2);
-            if (v_2.t0 == 0) {
-               FX_COPY_PTR(v_1, &v_3);
-            }
-            else if (v_2.t1 == 0) {
-               FX_COPY_PTR(acc_0, &v_3);
-            }
-            else {
-               _fx_LR9Ast__id_t v_4 = 0;
-               _fx_LR9Ast__id_t lstend_0 = 0;
-               _fx_LR9Ast__id_t lst_1 = acc_0;
-               for (; lst_1; lst_1 = lst_1->tl) {
-                  _fx_R9Ast__id_t* x_0 = &lst_1->hd;
-                  _fx_LR9Ast__id_t node_0 = 0;
-                  FX_CALL(_fx_cons_LR9Ast__id_t(x_0, 0, false, &node_0), _fx_catch_2);
-                  FX_LIST_APPEND(v_4, lstend_0, node_0);
-
-               _fx_catch_2: ;
-                  FX_CHECK_EXN(_fx_catch_3);
-               }
-               _fx_M6ParserFM5link2LR9Ast__id_t2LR9Ast__id_tLR9Ast__id_t(v_4, v_1, &v_3, 0);
-
-            _fx_catch_3: ;
-               FX_FREE_LIST_SIMPLE(&v_4);
-            }
-            FX_CHECK_EXN(_fx_catch_4);
-            FX_FREE_LIST_SIMPLE(&acc_0);
-            FX_COPY_PTR(v_3, &acc_0);
-
-         _fx_catch_4: ;
-            FX_FREE_LIST_SIMPLE(&v_3);
-            _fx_free_Ta2LR9Ast__id_t(&v_2);
-            FX_FREE_LIST_SIMPLE(&v_1);
-            FX_CHECK_EXN(_fx_catch_5);
-         }
-         FX_FREE_LIST_SIMPLE(&result_0);
-         FX_COPY_PTR(acc_0, &result_0);
-         FX_BREAK(_fx_catch_5);
-
-      _fx_catch_5: ;
-         if (pl_0) {
-            _fx_free_LN10Ast__pat_t(&pl_0);
-         }
-         FX_FREE_LIST_SIMPLE(&acc_0);
-      }
-      else {
-         FX_FREE_LIST_SIMPLE(&result_0); result_0 = 0; FX_BREAK(_fx_catch_6);  _fx_catch_6: ;
-      }
-      FX_CHECK_EXN(_fx_catch_7);
-
-   _fx_catch_7: ;
-      if (p_2) {
-         _fx_free_N10Ast__pat_t(&p_2);
-      }
-      FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   FX_COPY_PTR(result_0, fx_result);
-
-_fx_cleanup: ;
-   FX_FREE_LIST_SIMPLE(&result_0);
-   if (p_1) {
-      _fx_free_N10Ast__pat_t(&p_1);
-   }
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M6ParserFM22transform_new_fold_expN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tN10Ast__exp_tR10Ast__loc_t(
    struct _fx_N10Ast__pat_t_data_t* fold_pat_0,
    struct _fx_N10Ast__exp_t_data_t* fold_init_exp_0,
@@ -9963,154 +9643,54 @@ FX_EXTERN_C int _fx_M6ParserFM22transform_new_fold_expN10Ast__exp_t4N10Ast__pat_
    struct _fx_N10Ast__exp_t_data_t** fx_result,
    void* fx_fv)
 {
-   _fx_LR9Ast__id_t acc_ids_0 = 0;
-   _fx_rLR9Ast__id_t assigned_ref_0 = 0;
-   _fx_rLR9Ast__id_t suppressed_ref_0 = 0;
-   _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t scan_cb_0 = {0};
-   _fx_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t v_0 = 0;
-   _fx_R16Ast__ast_callb_t callb_0 = {0};
-   _fx_N10Ast__exp_t for_exp_1 = 0;
    _fx_LN10Ast__exp_t var_decls_0 = 0;
    _fx_N10Ast__exp_t result_exp_0 = 0;
+   _fx_LN10Ast__exp_t v_0 = 0;
    _fx_LN10Ast__exp_t v_1 = 0;
-   _fx_LN10Ast__exp_t v_2 = 0;
-   _fx_T2N10Ast__typ_tR10Ast__loc_t v_3 = {0};
+   _fx_T2N10Ast__typ_tR10Ast__loc_t v_2 = {0};
    int fx_status = 0;
    _fx_R10Ast__loc_t acc_loc_0;
    FX_CALL(_fx_M3AstFM11get_pat_locRM5loc_t1N10Ast__pat_t(fold_pat_0, &acc_loc_0, 0), _fx_cleanup);
-   FX_CALL(_fx_M6ParserFM12fold_acc_idsLR9Ast__id_t1N10Ast__pat_t(fold_pat_0, &acc_ids_0, 0), _fx_cleanup);
-   FX_CALL(_fx_make_rLR9Ast__id_t(0, &assigned_ref_0), _fx_cleanup);
-   _fx_LR9Ast__id_t* assigned_0 = &assigned_ref_0->data;
-   FX_CALL(_fx_make_rLR9Ast__id_t(0, &suppressed_ref_0), _fx_cleanup);
-   _fx_LR9Ast__id_t* suppressed_0 = &suppressed_ref_0->data;
-   _fx_M6ParserFM7make_fpFPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t3LR9Ast__id_trLR9Ast__id_trLR9Ast__id_t(acc_ids_0,
-      assigned_ref_0, suppressed_ref_0, &scan_cb_0);
-   FX_CALL(
-      _fx_M6ParserFM4SomeNt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-         &scan_cb_0, &v_0), _fx_cleanup);
-   _fx_make_R16Ast__ast_callb_t(_fx_g14Parser__None2_, v_0, _fx_g14Parser__None1_, &callb_0);
-   FX_CALL(_fx_M3AstFM16check_n_walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(for_exp_0, &callb_0, &for_exp_1, 0),
-      _fx_cleanup);
-   _fx_LR9Ast__id_t lst_0 = acc_ids_0;
-   for (; lst_0; lst_0 = lst_0->tl) {
-      _fx_LR9Ast__id_t assigned_1 = 0;
-      _fx_LR9Ast__id_t suppressed_1 = 0;
-      fx_str_t v_4 = {0};
-      fx_str_t v_5 = {0};
-      fx_str_t v_6 = {0};
-      fx_str_t v_7 = {0};
-      fx_str_t v_8 = {0};
-      _fx_R9Ast__id_t* id_0 = &lst_0->hd;
-      bool __fold_result___0 = false;
-      FX_COPY_PTR(*assigned_0, &assigned_1);
-      _fx_LR9Ast__id_t lst_1 = assigned_1;
-      for (; lst_1; lst_1 = lst_1->tl) {
-         _fx_R9Ast__id_t* b_0 = &lst_1->hd;
-         bool f_0 = true;
-         f_0 = (bool)(f_0 & (id_0->m == b_0->m));
-         f_0 = (bool)(f_0 & (id_0->i == b_0->i));
-         f_0 = (bool)(f_0 & (id_0->j == b_0->j));
-         if (f_0) {
-            __fold_result___0 = true; FX_BREAK(_fx_catch_0);
-         }
-
-      _fx_catch_0: ;
-         FX_CHECK_BREAK();
-         FX_CHECK_EXN(_fx_catch_2);
-      }
-      bool v_9;
-      if (!__fold_result___0) {
-         bool __fold_result___1 = false;
-         FX_COPY_PTR(*suppressed_0, &suppressed_1);
-         _fx_LR9Ast__id_t lst_2 = suppressed_1;
-         for (; lst_2; lst_2 = lst_2->tl) {
-            _fx_R9Ast__id_t* b_1 = &lst_2->hd;
-            bool f_1 = true;
-            f_1 = (bool)(f_1 & (id_0->m == b_1->m));
-            f_1 = (bool)(f_1 & (id_0->i == b_1->i));
-            f_1 = (bool)(f_1 & (id_0->j == b_1->j));
-            if (f_1) {
-               __fold_result___1 = true; FX_BREAK(_fx_catch_1);
-            }
-
-         _fx_catch_1: ;
-            FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_2);
-         }
-         v_9 = !__fold_result___1;
-      }
-      else {
-         v_9 = false;
-      }
-      if (v_9) {
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(id_0, &v_4, 0), _fx_catch_2);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(id_0, &v_5, 0), _fx_catch_2);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(id_0, &v_6, 0), _fx_catch_2);
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(id_0, &v_7, 0), _fx_catch_2);
-         fx_str_t slit_0 = FX_MAKE_STR("\'fold\' accumulator \'");
-         fx_str_t slit_1 =
-            FX_MAKE_STR(
-               "\' is never assigned in the body, so the fold has no effect. The body must UPDATE the accumulator (e.g. \'");
-         fx_str_t slit_2 = FX_MAKE_STR(" = <expr>\' or \'");
-         fx_str_t slit_3 = FX_MAKE_STR(" += ...\'); write \'");
-         fx_str_t slit_4 = FX_MAKE_STR(" = _\' to silence");
-         {
-            const fx_str_t strs_0[] = { slit_0, v_4, slit_1, v_5, slit_2, v_6, slit_3, v_7, slit_4 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_8), _fx_catch_2);
-         }
-         FX_CALL(_fx_M3AstFM15compile_warningv2RM5loc_tS(&acc_loc_0, &v_8, 0), _fx_catch_2);
-      }
-
-   _fx_catch_2: ;
-      FX_FREE_STR(&v_8);
-      FX_FREE_STR(&v_7);
-      FX_FREE_STR(&v_6);
-      FX_FREE_STR(&v_5);
-      FX_FREE_STR(&v_4);
-      FX_FREE_LIST_SIMPLE(&suppressed_1);
-      FX_FREE_LIST_SIMPLE(&assigned_1);
-      FX_CHECK_EXN(_fx_cleanup);
-   }
    if (FX_REC_VARIANT_TAG(fold_init_exp_0) == 13) {
       if (FX_REC_VARIANT_TAG(fold_pat_0) == 4) {
          _fx_LN10Ast__pat_t pl_0 = fold_pat_0->u.PatTuple.t0;
          _fx_LN10Ast__exp_t el_0 = fold_init_exp_0->u.ExpMkTuple.t0;
-         int_ v_10 = _fx_M6ParserFM6lengthi1LN10Ast__pat_t(pl_0, 0);
-         int_ v_11 = _fx_M6ParserFM6lengthi1LN10Ast__exp_t(el_0, 0);
-         if (v_10 == v_11) {
+         int_ v_3 = _fx_M6ParserFM6lengthi1LN10Ast__pat_t(pl_0, 0);
+         int_ v_4 = _fx_M6ParserFM6lengthi1LN10Ast__exp_t(el_0, 0);
+         if (v_3 == v_4) {
             _fx_LN10Ast__pat_t pl_1 = 0;
             _fx_LN10Ast__exp_t el_1 = 0;
             _fx_LN10Ast__exp_t lstend_0 = 0;
             FX_COPY_PTR(pl_0, &pl_1);
-            _fx_LN10Ast__pat_t lst_3 = pl_1;
+            _fx_LN10Ast__pat_t lst_0 = pl_1;
             FX_COPY_PTR(el_0, &el_1);
-            _fx_LN10Ast__exp_t lst_4 = el_1;
-            for (; lst_3 && lst_4; lst_4 = lst_4->tl, lst_3 = lst_3->tl) {
-               _fx_R16Ast__val_flags_t v_12 = {0};
+            _fx_LN10Ast__exp_t lst_1 = el_1;
+            for (; lst_0 && lst_1; lst_1 = lst_1->tl, lst_0 = lst_0->tl) {
+               _fx_R16Ast__val_flags_t v_5 = {0};
                _fx_N10Ast__exp_t res_0 = 0;
-               _fx_N10Ast__exp_t e_0 = lst_4->hd;
-               _fx_N10Ast__pat_t p_0 = lst_3->hd;
-               FX_CALL(_fx_M3AstFM17default_var_flagsRM11val_flags_t0(&v_12, 0), _fx_catch_3);
-               _fx_R10Ast__loc_t v_13;
-               FX_CALL(_fx_M3AstFM11get_pat_locRM5loc_t1N10Ast__pat_t(p_0, &v_13, 0), _fx_catch_3);
+               _fx_N10Ast__exp_t e_0 = lst_1->hd;
+               _fx_N10Ast__pat_t p_0 = lst_0->hd;
+               FX_CALL(_fx_M3AstFM17default_var_flagsRM11val_flags_t0(&v_5, 0), _fx_catch_0);
+               _fx_R10Ast__loc_t v_6;
+               FX_CALL(_fx_M3AstFM11get_pat_locRM5loc_t1N10Ast__pat_t(p_0, &v_6, 0), _fx_catch_0);
                FX_CALL(
-                  _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p_0, e_0, &v_12, &v_13,
-                     &res_0), _fx_catch_3);
+                  _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p_0, e_0, &v_5, &v_6,
+                     &res_0), _fx_catch_0);
                _fx_LN10Ast__exp_t node_0 = 0;
-               FX_CALL(_fx_cons_LN10Ast__exp_t(res_0, 0, false, &node_0), _fx_catch_3);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(res_0, 0, false, &node_0), _fx_catch_0);
                FX_LIST_APPEND(var_decls_0, lstend_0, node_0);
 
-            _fx_catch_3: ;
+            _fx_catch_0: ;
                if (res_0) {
                   _fx_free_N10Ast__exp_t(&res_0);
                }
-               _fx_free_R16Ast__val_flags_t(&v_12);
-               FX_CHECK_EXN(_fx_catch_4);
+               _fx_free_R16Ast__val_flags_t(&v_5);
+               FX_CHECK_EXN(_fx_catch_1);
             }
-            int s_0 = !lst_3 + !lst_4;
-            FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_4);
+            int s_0 = !lst_0 + !lst_1;
+            FX_CHECK_EQ_SIZE(s_0 == 0 || s_0 == 2, _fx_catch_1);
 
-         _fx_catch_4: ;
+         _fx_catch_1: ;
             if (el_1) {
                _fx_free_LN10Ast__exp_t(&el_1);
             }
@@ -10121,325 +9701,70 @@ FX_EXTERN_C int _fx_M6ParserFM22transform_new_fold_expN10Ast__exp_t4N10Ast__pat_
          }
       }
    }
-   _fx_R16Ast__val_flags_t v_14 = {0};
-   _fx_N10Ast__exp_t v_15 = 0;
-   FX_CALL(_fx_M3AstFM17default_var_flagsRM11val_flags_t0(&v_14, 0), _fx_catch_5);
+   _fx_R16Ast__val_flags_t v_7 = {0};
+   _fx_N10Ast__exp_t v_8 = 0;
+   FX_CALL(_fx_M3AstFM17default_var_flagsRM11val_flags_t0(&v_7, 0), _fx_catch_2);
    FX_CALL(
-      _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(fold_pat_0, fold_init_exp_0, &v_14,
-         &acc_loc_0, &v_15), _fx_catch_5);
-   FX_CALL(_fx_cons_LN10Ast__exp_t(v_15, 0, true, &var_decls_0), _fx_catch_5);
+      _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(fold_pat_0, fold_init_exp_0, &v_7,
+         &acc_loc_0, &v_8), _fx_catch_2);
+   FX_CALL(_fx_cons_LN10Ast__exp_t(v_8, 0, true, &var_decls_0), _fx_catch_2);
 
-_fx_catch_5: ;
-   if (v_15) {
-      _fx_free_N10Ast__exp_t(&v_15);
+_fx_catch_2: ;
+   if (v_8) {
+      _fx_free_N10Ast__exp_t(&v_8);
    }
-   _fx_free_R16Ast__val_flags_t(&v_14);
+   _fx_free_R16Ast__val_flags_t(&v_7);
 
 _fx_endmatch_0: ;
    FX_CHECK_EXN(_fx_cleanup);
    FX_CALL(_fx_M6ParserFM15fold_pat_to_expN10Ast__exp_t1N10Ast__pat_t(fold_pat_0, &result_exp_0, 0), _fx_cleanup);
-   FX_CALL(_fx_cons_LN10Ast__exp_t(result_exp_0, 0, true, &v_1), _fx_cleanup);
-   FX_CALL(_fx_cons_LN10Ast__exp_t(for_exp_1, v_1, false, &v_1), _fx_cleanup);
+   FX_CALL(_fx_cons_LN10Ast__exp_t(result_exp_0, 0, true, &v_0), _fx_cleanup);
+   FX_CALL(_fx_cons_LN10Ast__exp_t(for_exp_0, v_0, false, &v_0), _fx_cleanup);
    if (var_decls_0 == 0) {
-      FX_COPY_PTR(v_1, &v_2);
+      FX_COPY_PTR(v_0, &v_1);
    }
-   else if (v_1 == 0) {
-      FX_COPY_PTR(var_decls_0, &v_2);
+   else if (v_0 == 0) {
+      FX_COPY_PTR(var_decls_0, &v_1);
    }
    else {
-      _fx_LN10Ast__exp_t v_16 = 0;
+      _fx_LN10Ast__exp_t v_9 = 0;
       _fx_LN10Ast__exp_t lstend_1 = 0;
-      _fx_LN10Ast__exp_t lst_5 = var_decls_0;
-      for (; lst_5; lst_5 = lst_5->tl) {
-         _fx_N10Ast__exp_t x_0 = lst_5->hd;
+      _fx_LN10Ast__exp_t lst_2 = var_decls_0;
+      for (; lst_2; lst_2 = lst_2->tl) {
+         _fx_N10Ast__exp_t x_0 = lst_2->hd;
          _fx_LN10Ast__exp_t node_1 = 0;
-         FX_CALL(_fx_cons_LN10Ast__exp_t(x_0, 0, false, &node_1), _fx_catch_6);
-         FX_LIST_APPEND(v_16, lstend_1, node_1);
+         FX_CALL(_fx_cons_LN10Ast__exp_t(x_0, 0, false, &node_1), _fx_catch_3);
+         FX_LIST_APPEND(v_9, lstend_1, node_1);
 
-      _fx_catch_6: ;
-         FX_CHECK_EXN(_fx_catch_7);
+      _fx_catch_3: ;
+         FX_CHECK_EXN(_fx_catch_4);
       }
-      _fx_M6ParserFM5link2LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(v_16, v_1, &v_2, 0);
+      _fx_M6ParserFM5link2LN10Ast__exp_t2LN10Ast__exp_tLN10Ast__exp_t(v_9, v_0, &v_1, 0);
 
-   _fx_catch_7: ;
-      if (v_16) {
-         _fx_free_LN10Ast__exp_t(&v_16);
+   _fx_catch_4: ;
+      if (v_9) {
+         _fx_free_LN10Ast__exp_t(&v_9);
       }
    }
    FX_CHECK_EXN(_fx_cleanup);
-   FX_CALL(_fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(fold_loc_0, &v_3, 0), _fx_cleanup);
-   FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_2, &v_3, fx_result), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(fold_loc_0, &v_2, 0), _fx_cleanup);
+   FX_CALL(_fx_M3AstFM6ExpSeqN10Ast__exp_t2LN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(v_1, &v_2, fx_result), _fx_cleanup);
 
 _fx_cleanup: ;
-   FX_FREE_LIST_SIMPLE(&acc_ids_0);
-   if (assigned_ref_0) {
-      _fx_free_rLR9Ast__id_t(&assigned_ref_0);
-   }
-   if (suppressed_ref_0) {
-      _fx_free_rLR9Ast__id_t(&suppressed_ref_0);
-   }
-   FX_FREE_FP(&scan_cb_0);
-   if (v_0) {
-      _fx_free_Nt6option1FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(&v_0);
-   }
-   _fx_free_R16Ast__ast_callb_t(&callb_0);
-   if (for_exp_1) {
-      _fx_free_N10Ast__exp_t(&for_exp_1);
-   }
    if (var_decls_0) {
       _fx_free_LN10Ast__exp_t(&var_decls_0);
    }
    if (result_exp_0) {
       _fx_free_N10Ast__exp_t(&result_exp_0);
    }
+   if (v_0) {
+      _fx_free_LN10Ast__exp_t(&v_0);
+   }
    if (v_1) {
       _fx_free_LN10Ast__exp_t(&v_1);
    }
-   if (v_2) {
-      _fx_free_LN10Ast__exp_t(&v_2);
-   }
-   _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_3);
+   _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_2);
    return fx_status;
-}
-
-static int _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t(
-   struct _fx_N10Ast__exp_t_data_t* e_0,
-   struct _fx_R16Ast__ast_callb_t* callb_0,
-   struct _fx_N10Ast__exp_t_data_t** fx_result,
-   void* fx_fv)
-{
-   _fx_LR9Ast__id_t acc_ids_0 = 0;
-   _fx_LR9Ast__id_t acc_ids_1 = 0;
-   _fx_LR9Ast__id_t acc_ids_2 = 0;
-   int fx_status = 0;
-   _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_cldata_t* cv_0 =
-      (_fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_cldata_t*)fx_fv;
-   _fx_LR9Ast__id_t acc_ids_3 = cv_0->t0;
-   _fx_LR9Ast__id_t* assigned_0 = &cv_0->t1->data;
-   _fx_LR9Ast__id_t* suppressed_0 = &cv_0->t2->data;
-   int tag_0 = FX_REC_VARIANT_TAG(e_0);
-   if (tag_0 == 20) {
-      _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_0 = &e_0->u.ExpAssign;
-      _fx_N10Ast__exp_t v_0 = vcase_0->t1;
-      if (FX_REC_VARIANT_TAG(v_0) == 7) {
-         _fx_N10Ast__exp_t v_1 = vcase_0->t0;
-         if (FX_REC_VARIANT_TAG(v_1) == 7) {
-            _fx_R9Ast__id_t* id_0 = &v_1->u.ExpIdent.t0;
-            bool __fold_result___0 = false;
-            FX_COPY_PTR(acc_ids_3, &acc_ids_0);
-            _fx_LR9Ast__id_t lst_0 = acc_ids_0;
-            for (; lst_0; lst_0 = lst_0->tl) {
-               _fx_R9Ast__id_t* b_0 = &lst_0->hd;
-               bool f_0 = true;
-               f_0 = (bool)(f_0 & (id_0->m == b_0->m));
-               f_0 = (bool)(f_0 & (id_0->i == b_0->i));
-               f_0 = (bool)(f_0 & (id_0->j == b_0->j));
-               if (f_0) {
-                  __fold_result___0 = true; FX_BREAK(_fx_catch_0);
-               }
-
-            _fx_catch_0: ;
-               FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_cleanup);
-            }
-            bool t_0;
-            if (__fold_result___0) {
-               FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&v_0->u.ExpIdent.t0, &_fx_g12Ast__dummyid, &t_0, 0), _fx_cleanup);
-            }
-            else {
-               t_0 = false;
-            }
-            if (t_0) {
-               _fx_LR9Ast__id_t suppressed_1 = 0;
-               _fx_LR9Ast__id_t v_2 = 0;
-               bool __fold_result___1 = false;
-               FX_COPY_PTR(*suppressed_0, &suppressed_1);
-               _fx_LR9Ast__id_t lst_1 = suppressed_1;
-               for (; lst_1; lst_1 = lst_1->tl) {
-                  _fx_R9Ast__id_t* b_1 = &lst_1->hd;
-                  bool f_1 = true;
-                  f_1 = (bool)(f_1 & (id_0->m == b_1->m));
-                  f_1 = (bool)(f_1 & (id_0->i == b_1->i));
-                  f_1 = (bool)(f_1 & (id_0->j == b_1->j));
-                  if (f_1) {
-                     __fold_result___1 = true; FX_BREAK(_fx_catch_1);
-                  }
-
-               _fx_catch_1: ;
-                  FX_CHECK_BREAK();
-                  FX_CHECK_EXN(_fx_catch_2);
-               }
-               if (!__fold_result___1) {
-                  FX_CALL(_fx_cons_LR9Ast__id_t(id_0, *suppressed_0, true, &v_2), _fx_catch_2);
-                  FX_FREE_LIST_SIMPLE(suppressed_0);
-                  FX_COPY_PTR(v_2, suppressed_0);
-               }
-               FX_CALL(_fx_M3AstFM6ExpNopN10Ast__exp_t1RM5loc_t(&vcase_0->t2, fx_result), _fx_catch_2);
-
-            _fx_catch_2: ;
-               FX_FREE_LIST_SIMPLE(&v_2);
-               FX_FREE_LIST_SIMPLE(&suppressed_1);
-               goto _fx_endmatch_0;
-            }
-         }
-      }
-   }
-   if (tag_0 == 20) {
-      _fx_T3N10Ast__exp_tN10Ast__exp_tR10Ast__loc_t* vcase_1 = &e_0->u.ExpAssign;
-      _fx_N10Ast__exp_t lhs_0 = vcase_1->t0;
-      if (FX_REC_VARIANT_TAG(lhs_0) == 7) {
-         _fx_R9Ast__id_t* id_1 = &lhs_0->u.ExpIdent.t0;
-         bool __fold_result___2 = false;
-         FX_COPY_PTR(acc_ids_3, &acc_ids_1);
-         _fx_LR9Ast__id_t lst_2 = acc_ids_1;
-         for (; lst_2; lst_2 = lst_2->tl) {
-            _fx_R9Ast__id_t* b_2 = &lst_2->hd;
-            bool f_2 = true;
-            f_2 = (bool)(f_2 & (id_1->m == b_2->m));
-            f_2 = (bool)(f_2 & (id_1->i == b_2->i));
-            f_2 = (bool)(f_2 & (id_1->j == b_2->j));
-            if (f_2) {
-               __fold_result___2 = true; FX_BREAK(_fx_catch_3);
-            }
-
-         _fx_catch_3: ;
-            FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_cleanup);
-         }
-         if (__fold_result___2) {
-            _fx_LR9Ast__id_t assigned_1 = 0;
-            _fx_LR9Ast__id_t v_3 = 0;
-            _fx_N10Ast__exp_t v_4 = 0;
-            bool __fold_result___3 = false;
-            FX_COPY_PTR(*assigned_0, &assigned_1);
-            _fx_LR9Ast__id_t lst_3 = assigned_1;
-            for (; lst_3; lst_3 = lst_3->tl) {
-               _fx_R9Ast__id_t* b_3 = &lst_3->hd;
-               bool f_3 = true;
-               f_3 = (bool)(f_3 & (id_1->m == b_3->m));
-               f_3 = (bool)(f_3 & (id_1->i == b_3->i));
-               f_3 = (bool)(f_3 & (id_1->j == b_3->j));
-               if (f_3) {
-                  __fold_result___3 = true; FX_BREAK(_fx_catch_4);
-               }
-
-            _fx_catch_4: ;
-               FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_catch_5);
-            }
-            if (!__fold_result___3) {
-               FX_CALL(_fx_cons_LR9Ast__id_t(id_1, *assigned_0, true, &v_3), _fx_catch_5);
-               FX_FREE_LIST_SIMPLE(assigned_0);
-               FX_COPY_PTR(v_3, assigned_0);
-            }
-            FX_CALL(_fx_M3AstFM16check_n_walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(vcase_1->t1, callb_0, &v_4, 0),
-               _fx_catch_5);
-            FX_CALL(_fx_M3AstFM9ExpAssignN10Ast__exp_t3N10Ast__exp_tN10Ast__exp_tRM5loc_t(lhs_0, v_4, &vcase_1->t2, fx_result),
-               _fx_catch_5);
-
-         _fx_catch_5: ;
-            if (v_4) {
-               _fx_free_N10Ast__exp_t(&v_4);
-            }
-            FX_FREE_LIST_SIMPLE(&v_3);
-            FX_FREE_LIST_SIMPLE(&assigned_1);
-            goto _fx_endmatch_0;
-         }
-      }
-   }
-   if (tag_0 == 8) {
-      _fx_T4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tR10Ast__loc_t* vcase_2 = &e_0->u.ExpBinary;
-      _fx_N10Ast__exp_t lhs_1 = vcase_2->t1;
-      if (FX_REC_VARIANT_TAG(lhs_1) == 7) {
-         _fx_R9Ast__id_t* id_2 = &lhs_1->u.ExpIdent.t0;
-         _fx_N13Ast__binary_t bop_0 = vcase_2->t0;
-         if (FX_REC_VARIANT_TAG(bop_0) == 27) {
-            bool __fold_result___4 = false;
-            FX_COPY_PTR(acc_ids_3, &acc_ids_2);
-            _fx_LR9Ast__id_t lst_4 = acc_ids_2;
-            for (; lst_4; lst_4 = lst_4->tl) {
-               _fx_R9Ast__id_t* b_4 = &lst_4->hd;
-               bool f_4 = true;
-               f_4 = (bool)(f_4 & (id_2->m == b_4->m));
-               f_4 = (bool)(f_4 & (id_2->i == b_4->i));
-               f_4 = (bool)(f_4 & (id_2->j == b_4->j));
-               if (f_4) {
-                  __fold_result___4 = true; FX_BREAK(_fx_catch_6);
-               }
-
-            _fx_catch_6: ;
-               FX_CHECK_BREAK();
-               FX_CHECK_EXN(_fx_cleanup);
-            }
-            if (__fold_result___4) {
-               _fx_LR9Ast__id_t assigned_2 = 0;
-               _fx_LR9Ast__id_t v_5 = 0;
-               _fx_N10Ast__exp_t v_6 = 0;
-               bool __fold_result___5 = false;
-               FX_COPY_PTR(*assigned_0, &assigned_2);
-               _fx_LR9Ast__id_t lst_5 = assigned_2;
-               for (; lst_5; lst_5 = lst_5->tl) {
-                  _fx_R9Ast__id_t* b_5 = &lst_5->hd;
-                  bool f_5 = true;
-                  f_5 = (bool)(f_5 & (id_2->m == b_5->m));
-                  f_5 = (bool)(f_5 & (id_2->i == b_5->i));
-                  f_5 = (bool)(f_5 & (id_2->j == b_5->j));
-                  if (f_5) {
-                     __fold_result___5 = true; FX_BREAK(_fx_catch_7);
-                  }
-
-               _fx_catch_7: ;
-                  FX_CHECK_BREAK();
-                  FX_CHECK_EXN(_fx_catch_8);
-               }
-               if (!__fold_result___5) {
-                  FX_CALL(_fx_cons_LR9Ast__id_t(id_2, *assigned_0, true, &v_5), _fx_catch_8);
-                  FX_FREE_LIST_SIMPLE(assigned_0);
-                  FX_COPY_PTR(v_5, assigned_0);
-               }
-               FX_CALL(_fx_M3AstFM16check_n_walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(vcase_2->t2, callb_0, &v_6, 0),
-                  _fx_catch_8);
-               FX_CALL(
-                  _fx_M3AstFM9ExpBinaryN10Ast__exp_t4N13Ast__binary_tN10Ast__exp_tN10Ast__exp_tT2N10Ast__typ_tRM5loc_t(bop_0,
-                     lhs_1, v_6, &vcase_2->t3, fx_result), _fx_catch_8);
-
-            _fx_catch_8: ;
-               if (v_6) {
-                  _fx_free_N10Ast__exp_t(&v_6);
-               }
-               FX_FREE_LIST_SIMPLE(&v_5);
-               FX_FREE_LIST_SIMPLE(&assigned_2);
-               goto _fx_endmatch_0;
-            }
-         }
-      }
-   }
-   FX_CALL(_fx_M3AstFM8walk_expN10Ast__exp_t2N10Ast__exp_tRM11ast_callb_t(e_0, callb_0, fx_result, 0), _fx_catch_9);
-
-_fx_catch_9: ;
-
-_fx_endmatch_0: ;
-
-_fx_cleanup: ;
-   FX_FREE_LIST_SIMPLE(&acc_ids_0);
-   FX_FREE_LIST_SIMPLE(&acc_ids_1);
-   FX_FREE_LIST_SIMPLE(&acc_ids_2);
-   return fx_status;
-}
-
-FX_EXTERN_C int _fx_M6ParserFM7make_fpFPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t3LR9Ast__id_trLR9Ast__id_trLR9Ast__id_t(
-   struct _fx_LR9Ast__id_t_data_t* arg0,
-   struct _fx_rLR9Ast__id_t_data_t* arg1,
-   struct _fx_rLR9Ast__id_t_data_t* arg2,
-   struct _fx_FPN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t* fx_result)
-{
-   FX_MAKE_FP_IMPL_START(_fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t_cldata_t,
-      _fx_free_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t,
-      _fx_M6ParserFM7scan_cbN10Ast__exp_t2N10Ast__exp_tR16Ast__ast_callb_t);
-   FX_COPY_PTR(arg0, &fcv->t0);
-   FX_COPY_PTR(arg1, &fcv->t1);
-   FX_COPY_PTR(arg2, &fcv->t2);
-   return 0;
 }
 
 FX_EXTERN_C int _fx_M6ParserFM9parse_errE2LT2N14Lexer__token_tR10Ast__loc_tS(
@@ -15053,7 +14378,7 @@ FX_EXTERN_C int
                if ((v_3->hd != 0) + 1 == 1) {
                   FX_CALL(
                      _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                        _fx_g14Parser__None4_, _fx_g14Parser__None4_, _fx_g14Parser__None4_, &ctx_0, &e_0), _fx_catch_1);
+                        _fx_g14Parser__None2_, _fx_g14Parser__None2_, _fx_g14Parser__None2_, &ctx_0, &e_0), _fx_catch_1);
 
                _fx_catch_1: ;
                   goto _fx_endmatch_1;
@@ -15134,7 +14459,7 @@ _fx_endmatch_0: ;
             if ((v_8->hd != 0) + 1 == 1) {
                FX_CALL(
                   _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                     elist_0->hd, _fx_g14Parser__None4_, _fx_g14Parser__None4_, &ctx_0, &e_0), _fx_catch_4);
+                     elist_0->hd, _fx_g14Parser__None2_, _fx_g14Parser__None2_, &ctx_0, &e_0), _fx_catch_4);
 
             _fx_catch_4: ;
                goto _fx_endmatch_1;
@@ -15148,7 +14473,7 @@ _fx_endmatch_0: ;
          if (v_9->tl == 0) {
             FX_CALL(
                _fx_M3AstFM8ExpRangeN10Ast__exp_t4Nt6option1N10Ast__exp_tNt6option1N10Ast__exp_tNt6option1N10Ast__exp_tT2N10Ast__typ_tRM5loc_t(
-                  elist_0->hd, v_9->hd, _fx_g14Parser__None4_, &ctx_0, &e_0), _fx_catch_5);
+                  elist_0->hd, v_9->hd, _fx_g14Parser__None2_, &ctx_0, &e_0), _fx_catch_5);
 
          _fx_catch_5: ;
             goto _fx_endmatch_1;
@@ -15245,11 +14570,11 @@ static int
             _fx_LNt6option1N10Ast__exp_t result_4 = 0;
             _fx_LNt6option1N10Ast__exp_t v_0 = 0;
             if (expect_sep_2) {
-               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None4_, result_3, true, &result_4), _fx_catch_0);
+               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None2_, result_3, true, &result_4), _fx_catch_0);
             }
             else {
-               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None4_, result_3, true, &v_0), _fx_catch_0);
-               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None4_, v_0, true, &result_4), _fx_catch_0);
+               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None2_, result_3, true, &v_0), _fx_catch_0);
+               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None2_, v_0, true, &result_4), _fx_catch_0);
             }
             _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_0 = &ts_2->tl;
             _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
@@ -15275,7 +14600,7 @@ static int
                FX_COPY_PTR(result_3, &result_5);
             }
             else {
-               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None4_, result_3, true, &result_5), _fx_catch_1);
+               FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None2_, result_3, true, &result_5), _fx_catch_1);
             }
             _fx_LT2N14Lexer__token_tR10Ast__loc_t* rest_1 = &ts_2->tl;
             _fx_free_LT2N14Lexer__token_tR10Ast__loc_t(&ts_1);
@@ -15351,7 +14676,7 @@ static int
             FX_COPY_PTR(result_3, &result_6);
          }
          else {
-            FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None4_, result_3, true, &result_6), _fx_catch_3);
+            FX_CALL(_fx_cons_LNt6option1N10Ast__exp_t(_fx_g14Parser__None2_, result_3, true, &result_6), _fx_catch_3);
          }
          _fx_LNt6option1N10Ast__exp_t lst_0 = result_6;
          for (; lst_0; lst_0 = lst_0->tl) {
@@ -17064,7 +16389,7 @@ FX_EXTERN_C int
             goto _fx_endmatch_2;
          }
       }
-      _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tNt6option1N10Ast__exp_t(ts_2, _fx_g14Parser__None4_, &v_6);
+      _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tNt6option1N10Ast__exp_t(ts_2, _fx_g14Parser__None2_, &v_6);
 
    _fx_endmatch_2: ;
       FX_CHECK_EXN(_fx_catch_7);
@@ -20559,7 +19884,7 @@ _fx_endmatch_0: ;
          FX_CHECK_EXN(_fx_cleanup);
       }
       FX_CALL(
-         _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&_fx_g14Parser__None3_, v_5,
+         _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&_fx_g14Parser__None1_, v_5,
             &loc_0, &recpat_0), _fx_cleanup);
       FX_CALL(_fx_M3AstFM12make_new_ctxT2N10Ast__typ_tRM5loc_t1RM5loc_t(&loc_0, &v_6, 0), _fx_cleanup);
       FX_CALL(_fx_M3AstFM8ExpIdentN10Ast__exp_t2RM4id_tT2N10Ast__typ_tRM5loc_t(&_fx_g18Ast__std__kwargs__, &v_6, &v_7),
@@ -21361,7 +20686,7 @@ FX_EXTERN_C int _fx_M6ParserFM10parse_stmtT2LT2N14Lexer__token_tR10Ast__loc_tN10
       if (v_10->tag == 34) {
          if (v_10->u.RETURN == false) {
             _fx_N10Ast__exp_t v_11 = 0;
-            FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(_fx_g14Parser__None4_, &v_9->t1, &v_11),
+            FX_CALL(_fx_M3AstFM9ExpReturnN10Ast__exp_t2Nt6option1N10Ast__exp_tRM5loc_t(_fx_g14Parser__None2_, &v_9->t1, &v_11),
                _fx_catch_3);
             _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__exp_t(ts_0->tl, v_11, fx_result);
 
@@ -22730,7 +22055,7 @@ FX_EXTERN_C int
          FX_COPY_PTR(v_46.t0, &ts_6);
          FX_COPY_PTR(v_46.t1, &ipl_1);
          FX_CALL(
-            _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&_fx_g14Parser__None3_, ipl_1,
+            _fx_M3AstFM9PatRecordN10Ast__pat_t3Nt6option1RM4id_tLT2RM4id_tN10Ast__pat_tRM5loc_t(&_fx_g14Parser__None1_, ipl_1,
                &v_45->t1, &v_47), _fx_catch_11);
          _fx_make_T2LT2N14Lexer__token_tR10Ast__loc_tN10Ast__pat_t(ts_6, v_47, fx_result);
 
@@ -24335,7 +23660,7 @@ FX_EXTERN_C int
                      _fx_N10Ast__typ_t v_1 = 0;
                      _fx_Nt6option1N10Ast__typ_t v_2 = 0;
                      _fx_rNt6option1N10Ast__typ_t v_3 = 0;
-                     FX_CALL(_fx_M3AstFM11TypVarTupleN10Ast__typ_t1Nt6option1N10Ast__typ_t(_fx_g14Parser__None5_, &v_1),
+                     FX_CALL(_fx_M3AstFM11TypVarTupleN10Ast__typ_t1Nt6option1N10Ast__typ_t(_fx_g14Parser__None3_, &v_1),
                         _fx_catch_0);
                      FX_CALL(_fx_M6ParserFM4SomeNt6option1N10Ast__typ_t1N10Ast__typ_t(v_1, &v_2), _fx_catch_0);
                      FX_CALL(_fx_make_rNt6option1N10Ast__typ_t(v_2, &v_3), _fx_catch_0);

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -323,3 +323,36 @@ type, so this is a legal and common pattern in ML-family languages. Current
 limitation (worked around by splitting into two arms, e.g. in the vector-iteration
 read-lock codegen in C_gen_code.fx). Should be fixed — allow a variable bound
 identically across all alternatives of an or-pattern.
+
+## FB-027  `ignore(coll[i])` swallows the out-of-range exception  [OPEN — soundness]
+An element read whose result does not escape is dead-code-eliminated together
+with its bounds check, so an out-of-bounds/empty access that *should* raise
+`OutOfRangeError` silently does nothing:
+```
+val e: int vector = []
+ignore(e[.-1])          // expected OutOfRangeError; actually NO throw
+val ea: int [] = []
+ignore(ea[.-1])         // same — arrays too
+```
+`ignore(x)` is the "evaluate for the side effects, discard the value" idiom, and
+a bounds check is exactly such a side effect (it can throw), so dropping it is a
+soundness surprise, not just a missed diagnostic.
+- **Affects every checked container read** — `array`, `vector`, `string`,
+  `rrbvec` — because they all lower to `KExpAt`. Independent of opt level (repro
+  at both `-O0` and `-O3`).
+- **Root cause**: `pure_kexp_` in `compiler/K_remove_unused.fx` does not list
+  `KExpAt` among the impure forms (`| _ => {}` leaves `ispure = true`), so an
+  element read with an unused result is removed before C-gen ever emits its
+  `FX_VEC_CHKIDX`/`FX_CHKIDX`. Note the *separate* `IntrinCheckIdx` /
+  `IntrinCheckIdxRange` intrinsics ARE marked impure there — but the plain
+  `KExpAt` read path emits its check inline in C-gen, so eliminating the whole
+  `KExpAt` at the K level drops the check.
+- **Contrast**: an *escaping* store keeps the read live and the check fires —
+  `outer_sink = coll[i]` (an outer `var`) throws; `{ var s=0; s = coll[i] }`
+  (local, dead) does not. This is why `test/test_vec.fx` fcvector.pushpop_edge
+  asserts `back()`-on-empty via a captured `sink`, not `ignore(v.back())`.
+- **Fix direction (not done — general compiler soundness, out of scope for
+  newvec-2)**: mark a *bounds-checked* `KExpAt` (i.e. `BorderNone`, which emits a
+  throwing check) impure in `pure_kexp_`, so it survives DCE. Border reads
+  (`.clip`/`.wrap`/`.zero`) never throw and can stay pure and eliminable; gating
+  on `BorderNone` avoids inhibiting legitimate DCE of genuinely-safe reads.

--- a/examples/fst.fx
+++ b/examples/fst.fx
@@ -175,7 +175,7 @@ fun is_prime(n: int)
     }
 }
 
-println(f"primes <100: {rrbvec(for i <- 0:100 when is_prime(i) {i})}")
+println(f"primes <100: {vector(for i <- 0:100 when is_prime(i) {i})}")
 
 val a = ['🥚', '🐔']
 a.sort((<))

--- a/examples/knucleotide.fx
+++ b/examples/knucleotide.fx
@@ -99,7 +99,7 @@ while !f.eof() {
     val line = f.readln()
     if line.startswith('>') {break}
     val converted = [for c <- line.rstrip() {encrypt_char(c)}]
-    all_data.push(converted)
+    all_data.append(converted)
 }
 
 val all_data = array(all_data)

--- a/examples/knucleotide.fx
+++ b/examples/knucleotide.fx
@@ -93,7 +93,7 @@ while !f.eof() {
     }
 }
 
-var all_data = Vector.make(0, 0u8)
+var all_data = vector(0, 0u8)
 
 while !f.eof() {
     val line = f.readln()

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -1214,6 +1214,13 @@ fun rrbvec(l: 't list): 't rrbvec = rrbvec(for x <- l {x})
 fun rrbvec(a: 't [+]): 't rrbvec = rrbvec(for x <- a {x})
 fun rrbvec(s: string): char rrbvec = rrbvec(for x <- s {x})
 
+fun vector(): 't vector = []
+fun vector(n: int, x: 't): 't vector = vector(for i <- 0:n {x})
+fun vector(a: 't []): 't vector = vector(for x <- a {x})
+fun vector(l: 't list): 't vector = vector(for x <- l {x})
+fun vector(v: 't rrbvec): 't vector = vector(for x <- v {x})
+fun vector(s: string): char vector = vector(for x <- s {x})
+
 fun size(a: 't rrbvec): int = __intrin_size__(a)
 fun size(a: 't vector): int = __intrin_size__(a)
 fun empty(a: 't vector): bool = __intrin_size__(a) == 0

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -1214,7 +1214,19 @@ fun rrbvec(l: 't list): 't rrbvec = rrbvec(for x <- l {x})
 fun rrbvec(a: 't [+]): 't rrbvec = rrbvec(for x <- a {x})
 fun rrbvec(s: string): char rrbvec = rrbvec(for x <- s {x})
 
-fun vector(): 't vector = []
+// low-level reserve primitive; Vector.reserve is a thin wrapper over it. It
+// lives here so the vector(~capacity) constructor can join the rest of the
+// family without a cyclic dependency on Vector.fx (which is compiled later).
+fun __vec_reserve__(v: 't vector, capacity: int): void
+@ccode {
+    if (!v)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
+    return fx_vec_reserve(v, capacity);
+}
+
+// the no-arg / capacity constructor: `vector()` gives an empty vector,
+// `vector(capacity=n)` an empty vector pre-reserved to n elements.
+fun vector(~capacity: int=0): 't vector { val v: 't vector = []; __vec_reserve__(v, capacity); v }
 fun vector(n: int, x: 't): 't vector = vector(for i <- 0:n {x})
 fun vector(a: 't []): 't vector = vector(for x <- a {x})
 fun vector(l: 't list): 't vector = vector(for x <- l {x})

--- a/lib/NN/BufferAllocator.fx
+++ b/lib/NN/BufferAllocator.fx
@@ -66,8 +66,8 @@ fun assign_buffers(model: Ast.nnmodel_t)
     val nargs = model.args.size()
     val usecounts = model.use_counts()
     var nbufs = 0
-    val freebufs = Vector.make(0, 0)
-    val buf_usecounts = Vector.make(0, 0)
+    val freebufs = vector(0, 0)
+    val buf_usecounts = vector(0, 0)
     val bufidxs = array(nargs, -1)
 
     /*

--- a/lib/NN/ConstFold.fx
+++ b/lib/NN/ConstFold.fx
@@ -20,7 +20,7 @@ fun cfold(model: Ast.nnmodel_t)
 
 fun cfold_graph(model: Ast.nnmodel_t, graph: Ast.nngraph_t, usecounts: int [])
 {
-    val new_prog = Vector.make(0, Ast.NN_Nop)
+    val new_prog = vector(0, Ast.NN_Nop)
     var have_changes = false
     for op <- graph.prog {
         val opt_op = match op {

--- a/lib/NN/FromOnnx.fx
+++ b/lib/NN/FromOnnx.fx
@@ -184,8 +184,8 @@ fun convert(onnx_model: OAst.model_t): Ast.nnmodel_t
     })
 
     val args = [ empty_arg ]
-    val vargs = Vector.make(args)
-    val vtensors = Vector.make([ empty_tensor ])
+    val vargs = vector(args)
+    val vtensors = vector([ empty_tensor ])
     dimnames.add("?", -1)
 
     fun get_const_tensor_arg(name: string, data: Ast.nndata_t) =

--- a/lib/NN/FuseBasic.fx
+++ b/lib/NN/FuseBasic.fx
@@ -16,7 +16,7 @@ fun fuse_conv_elemwise(model: Ast.nnmodel_t, graph: Ast.nngraph_t, usecounts: in
     val nargs = model.args.size()
     val produced_by = array(nargs, -1)
     val prog = graph.prog
-    val new_prog = Vector.make(0, Ast.NN_Nop)
+    val new_prog = vector(0, Ast.NN_Nop)
     var modified = false
     fun get_op(op_idx: int) =
         if op_idx >= 0 {new_prog[op_idx]} else {Ast.NN_Nop}

--- a/lib/NN/OpDetect.fx
+++ b/lib/NN/OpDetect.fx
@@ -27,7 +27,7 @@ fun collect_boxes(yolo_outputs: Ast.nntensor_t [],
     orig_image_size: (int*2), input_size: int, score_threshold: float)
 {
     val CLS0 = 5
-    val boxes = Vector.make(0, (0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
+    val boxes = vector(0, (0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
     val org_h = float(orig_image_size.0)
     val org_w = float(orig_image_size.1)
     val resize_ratio = min(input_size/org_w, input_size/org_h)

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -108,15 +108,11 @@ fun append(v: 't vector, src: 't vector): void
 // real allocated empty vector.
 fun concat(vs: ('t vector) []): 't vector {
     val total = fold s = 0 for v <- vs { s += v.size() }
-    val r: 't vector = vector(capacity=total)
-    for v <- vs { r.append(v) }
-    r
+    fold r: 't vector = vector(capacity=total) for v <- vs { r.append(v) }
 }
 fun concat(vs: ('t vector) vector): 't vector {
     val total = fold s = 0 for v <- vs { s += v.size() }
-    val r: 't vector = vector(capacity=total)
-    for v <- vs { r.append(v) }
-    r
+    fold r: 't vector = vector(capacity=total) for v <- vs { r.append(v) }
 }
 
 // NB: ==, <=>, string, print for `vector` live in Builtins.fx next to their

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -11,10 +11,11 @@
 // Note: the element ops read the element size / free / copy from the vector's
 // own header (fx_vecinfo_t, set when the vector is constructed), so they need no
 // compile-time element metadata. Construction goes through `[]` (the compiler
-// emits fx_make_vec with the correct metadata), and make(n,...) then resizes it.
+// emits fx_make_vec with the correct metadata).
 
 // construction is via the vector() family in Builtins.fx (mirrors array()):
-// vector(), vector(n, x), vector(a: 't []), vector(l), vector(rrbvec), vector(s).
+// vector(~capacity=0), vector(n, x), vector(a: 't []), vector(l), vector(rrbvec),
+// vector(s). `vector()` is the empty one; `vector(capacity=n)` pre-reserves n.
 
 // ------------------------- capacity / size -------------------------
 
@@ -46,12 +47,9 @@ fun assign(v: 't vector, size: int, val0: 't): void
     resize(v, size, val0)
 }
 
-fun reserve(v: 't vector, capacity: int): void
-@ccode {
-    if (!v)
-        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-    return fx_vec_reserve(v, capacity);
-}
+// reserve is a thin wrapper over the Builtins __vec_reserve__ primitive (which
+// the vector(~capacity) constructor also uses).
+fun reserve(v: 't vector, capacity: int): void = __vec_reserve__(v, capacity)
 
 // ------------------------- element push/pop -------------------------
 
@@ -109,18 +107,14 @@ fun append(v: 't vector, src: 't vector): void
 // so no input vector is needed to supply metadata and an empty input yields a
 // real allocated empty vector.
 fun concat(vs: ('t vector) []): 't vector {
-    val r: 't vector = []
-    var total = 0
-    for v <- vs { total += v.size() }
-    r.reserve(total)
+    val total = fold s = 0 for v <- vs { s += v.size() }
+    val r: 't vector = vector(capacity=total)
     for v <- vs { r.append(v) }
     r
 }
 fun concat(vs: ('t vector) vector): 't vector {
-    val r: 't vector = []
-    var total = 0
-    for v <- vs { total += v.size() }
-    r.reserve(total)
+    val total = fold s = 0 for v <- vs { s += v.size() }
+    val r: 't vector = vector(capacity=total)
     for v <- vs { r.append(v) }
     r
 }

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -13,33 +13,13 @@
 // compile-time element metadata. Construction goes through `[]` (the compiler
 // emits fx_make_vec with the correct metadata), and make(n,...) then resizes it.
 
-// ------------------------- construction -------------------------
-
-// a vector of `n` copies of val0
-fun make(n: int, val0: 't): 't vector
-{
-    val v: 't vector = []
-    resize(v, n, val0)
-    v
-}
-
-// a vector with the elements of an array
-fun make(arr: 't []): 't vector = vector(for x <- arr {x})
-
-// a vector of `n` default-initialized elements
-fun make(n: int): 't vector
-{
-    val any: 't = __any_element__()
-    make(n, any)
-}
+// construction is via the vector() family in Builtins.fx (mirrors array()):
+// vector(), vector(n, x), vector(a: 't []), vector(l), vector(rrbvec), vector(s).
 
 // ------------------------- capacity / size -------------------------
 
-fun capacity(v: 't vector): int
-@ccode {
-    *fx_result = v ? v->capacity : 0;
-    return FX_OK;
-}
+@nothrow fun capacity(v: 't vector): int
+@ccode { return v ? v->capacity : 0; }
 
 fun clear(v: 't vector): void
 @ccode {
@@ -141,17 +121,8 @@ fun pop_back(v: 't vector): void
     return FX_OK;
 }
 
-// ------------------------- conversion / compare / print -------------------------
-
-// map each element through f into a fresh vector
-fun map(v: 't vector, f: 't -> 'r): 'r vector = vector(for x <- v {f(x)})
-
-// map each (element, index) through f into a fresh vector
-fun mapi(v: 't vector, f: ('t, int) -> 'r): 'r vector = vector(for x@i <- v {f(x, i)})
-
-// left fold: res = f(v[n-1], ... f(v[1], f(v[0], init)))
-fun foldl(v: 't vector, f: ('t, 'r) -> 'r, init: 'r): 'r =
-    fold res = init for x <- v { res = f(x, res) }
+// map/mapi/foldl are gone: `vector(for x <- v {..})`, `vector(for x@i <- v {..})`
+// and `fold acc=init for x <- v {..}` express them directly.
 
 // NB: ==, <=>, string, print for `vector` live in Builtins.fx next to their
 // rrbvec counterparts. They compare/format elements generically (a[i] <=> b[i],

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -58,18 +58,11 @@ fun reserve(v: 't vector, capacity: int): void
 // append one element in place. The vector must already be allocated (e.g. via
 // `[]`); a growth reallocates the internal data buffer inside the shared header,
 // so the caller's binding keeps pointing at the same (updated) header.
-fun push_back(v: 't vector, elem: 't): void
-{
-    fun push_back_(v: 't vector, elem_: ('t, bool)): void
-    @ccode {
-        if (!v)
-            FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-        return fx_vec_append(v, elem_, 1);
-    }
-    // the (elem, true) tuple is always passed by reference, so elem_ is a
-    // pointer to the element (its first field) regardless of 't.
-    push_back_(v, (elem, true))
-}
+// __intrin_push__ inlines the append: for POD elements the common in-capacity,
+// not-being-iterated case is a raw slot write (no call); every other case (grow,
+// empty, locked, NULL) falls through to fx_vec_append. See FX_VEC_PUSH_BACK* in
+// ficus.h.
+@inline fun push_back(v: 't vector, elem: 't): void = __intrin_push__(v, elem)
 
 // append x and return its index (v.push_back returns void); used by the code
 // migrated off the retired Dynvec.t where the index is needed
@@ -103,23 +96,11 @@ fun back(v: 't vector): 't
     return FX_OK;
 }
 
-// drop the last element (freeing it if it is a complex type)
-fun pop_back(v: 't vector): void
-@ccode {
-    if (!v)
-        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-    if (v->nlocks != 0)
-        FX_FAST_THROW_RET(FX_EXN_VecModifiedError);
-    int_ size = v->size;
-    if (size == 0)
-        FX_FAST_THROW_RET(FX_EXN_SizeError);
-    v->size = --size;
-    fx_free_t free_f = v->info.free_elem;
-    if (free_f) {
-        free_f((char*)v->data + size*v->info.elemsize);
-    }
-    return FX_OK;
-}
+// drop the last element (freeing it if it is a complex type). __intrin_pop__
+// inlines the fast path: for POD elements a present, not-being-iterated last
+// slot is dropped with a bare size decrement; every other case (empty, locked,
+// NULL, or a complex element that must be freed) goes through fx_vec_pop_back.
+@inline fun pop_back(v: 't vector): void = __intrin_pop__(v)
 
 // map/mapi/foldl are gone: `vector(for x <- v {..})`, `vector(for x@i <- v {..})`
 // and `fold acc=init for x <- v {..}` express them directly.

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -64,16 +64,9 @@ fun reserve(v: 't vector, capacity: int): void
 // ficus.h.
 @inline fun push_back(v: 't vector, elem: 't): void = __intrin_push__(v, elem)
 
-// append x and return its index (v.push_back returns void); used by the code
-// migrated off the retired Dynvec.t where the index is needed
+// append x and return its index (unlike push_back / append, which are void);
+// used by the code migrated off the retired Dynvec.t where the index is needed
 fun push(v: 't vector, x: 't): int { push_back(v, x); size(v) - 1 }
-// append all elements of an array in one shot
-fun push(v: 't vector, arr: 't []): void
-@ccode {
-    if (!v)
-        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-    return fx_vec_append(v, arr->data, arr->dim[0].size);
-}
 // remove the last element and return it
 fun pop(v: 't vector): 't { val r = back(v); pop_back(v); r }
 
@@ -107,7 +100,17 @@ fun back(v: 't vector): 't
 
 // ------------------------- append / concat -------------------------
 
-// append all elements of another vector in one shot (elements are copied)
+// append one element (a void synonym for push_back; the overloads below append
+// all elements of an array or of another vector in one shot, copying them). The
+// three argument kinds ('t / 't [] / 't vector) never overlap for a resolved
+// call, so the family is unambiguous.
+@inline fun append(v: 't vector, elem: 't): void = push_back(v, elem)
+fun append(v: 't vector, arr: 't []): void
+@ccode {
+    if (!v)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
+    return fx_vec_append(v, arr->data, arr->dim[0].size);
+}
 fun append(v: 't vector, src: 't vector): void
 @ccode {
     if (!v)

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -70,24 +70,9 @@ fun push(v: 't vector, x: 't): int { push_back(v, x); size(v) - 1 }
 // remove the last element and return it
 fun pop(v: 't vector): 't { val r = back(v); pop_back(v); r }
 
-// the last element
-fun back(v: 't vector): 't
-@ccode {
-    if (!v)
-        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
-    int_ size = v->size;
-    if (size == 0)
-        FX_FAST_THROW_RET(FX_EXN_SizeError);
-    size_t elemsize = sizeof(*fx_result);
-    const void* src = (const char*)v->data + (size - 1)*elemsize;
-    fx_copy_t copy_f = v->info.copy_elem;
-    if (!copy_f) {
-        memcpy(fx_result, src, elemsize);
-    } else {
-        fx_copy_arr_elems(src, fx_result, 1, elemsize, copy_f);
-    }
-    return FX_OK;
-}
+// the last element. `v[.-1]` desugars to `v[__intrin_size__(v) - 1]`, so the
+// bounds check (FX_VEC_CHKIDX) yields OutOfRangeError on an empty/NULL vector.
+@inline fun back(v: 't vector): 't = v[.-1]
 
 // drop the last element (freeing it if it is a complex type). __intrin_pop__
 // inlines the fast path: for POD elements a present, not-being-iterated last

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -124,6 +124,38 @@ fun pop_back(v: 't vector): void
 // map/mapi/foldl are gone: `vector(for x <- v {..})`, `vector(for x@i <- v {..})`
 // and `fold acc=init for x <- v {..}` express them directly.
 
+// ------------------------- append / concat -------------------------
+
+// append all elements of another vector in one shot (elements are copied)
+fun append(v: 't vector, src: 't vector): void
+@ccode {
+    if (!v)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
+    return fx_vec_append(v, src ? src->data : 0, src ? src->size : 0);
+}
+
+// concatenate several vectors into one fresh vector (elements are copied). The
+// result vector is created here (via `[]`, which carries the correct element
+// metadata), reserved to the total size up front, then filled by bulk appends;
+// so no input vector is needed to supply metadata and an empty input yields a
+// real allocated empty vector.
+fun concat(vs: ('t vector) []): 't vector {
+    val r: 't vector = []
+    var total = 0
+    for v <- vs { total += v.size() }
+    r.reserve(total)
+    for v <- vs { r.append(v) }
+    r
+}
+fun concat(vs: ('t vector) vector): 't vector {
+    val r: 't vector = []
+    var total = 0
+    for v <- vs { total += v.size() }
+    r.reserve(total)
+    for v <- vs { r.append(v) }
+    r
+}
+
 // NB: ==, <=>, string, print for `vector` live in Builtins.fx next to their
 // rrbvec counterparts. They compare/format elements generically (a[i] <=> b[i],
 // string(v[i])), and compiling that in a context with many <=> / string

--- a/newvec2_pr.md
+++ b/newvec2_pr.md
@@ -1,0 +1,65 @@
+# newvec-2: vector performance & ergonomics
+
+Follow-up to newvec-1 (#41). Makes the first-class mutable `vector` faster and
+nicer to use, and consolidates the API. No change to program semantics beyond
+the new features; all green on the fxtest ladder + ASan/UBSan + self-hosting
+fixpoint.
+
+## Highlights
+
+- **`vector()` constructor family** (mirrors `array()`): `vector()`,
+  `vector(capacity=n)`, `vector(n, x)`, `vector(arr)`, `vector(list)`,
+  `vector(rrbvec)`, `vector(string)`. `Vector.make` removed everywhere;
+  `map`/`mapi`/`foldl` dropped (comprehensions + `fold` replace them);
+  `capacity()` is `@nothrow`.
+- **Inline `push_back` / `pop_back`** via `__intrin_push__` / `__intrin_pop__`:
+  a raw slot write / size-decrement inline for POD elements on the fast path,
+  the runtime (with element copy/free) otherwise.
+- **In-place slice assignment**: `vec[a:b] = vector(...)` (grow/shrink),
+  `vec[a:b:k] = []` (delete), `vec[:] = []` (clear), `vec[i:i] = ...` (insert).
+  Was silently a no-op before. Strided replace with a non-empty vector is a
+  compile error (caret).
+- **`fx_vec_reserve` uses `realloc`** instead of malloc+memcpy+free.
+- **`append` family** unifies the void appenders: `append(elem)` /
+  `append(arr)` / `append(vector)`; `push(elem): int` keeps its index return.
+  `concat(('t vector)[])` and `concat(('t vector) vector)` added.
+- **`back()` = `v[.-1]`** (from-end index); empty `back`/`pop_back`/`pop` now
+  throw `OutOfRangeError` (was `SizeError`), consistent with element access.
+- **fold-1 "accumulator never assigned" warning removed** — it false-positived on
+  a reference-mutable accumulator updated in place (`fold r = vector(...) for v {
+  r.append(v) }`); the void fold body already makes the old-style value-yielding
+  body a type error, so the warning was redundant.
+
+## Compiler changes
+
+New intrinsics `IntrinVecPushBack` / `IntrinVecPopBack` / `IntrinVecSplice`
+through Parser → typecheck → K-normalize → C-gen, all marked impure in
+`K_remove_unused`. Runtime: `FX_VEC_PUSH_BACK*/POP_BACK*` macros,
+`fx_vec_pop_back`, `fx_vec_splice`, `fx_realloc`-based grow; `fx_vec_concat`
+removed. Bootstrap regenerated; fixpoint holds.
+
+## Tests
+
+`fcvector` suite → 13 tests (`pushpop_edge`, `splice`, `append`, extended
+`concat`/`str`); negative golden `507_vec_strided_replace`. Full ladder green;
+ASan+UBSan clean.
+
+## Found (fenced, not fixed)
+
+**FB-027** — `ignore(coll[i])` swallows `OutOfRangeError`: a bounds-checked
+element read with an unused result is DCE'd along with its check (`KExpAt` not
+marked impure in `pure_kexp_`). Affects array/vector/string/rrbvec. Fix
+direction recorded in `docs/found_bugs.md`.
+
+## Commits
+
+- vector() constructors in Builtins; drop Vector.make/map/mapi/foldl
+- fx_vec_reserve grows via fx_realloc
+- Vector.append + Vector.concat (multi-vector concatenation)
+- inline push_back/pop_back via __intrin_push__/__intrin_pop__
+- in-place vector slice assignment (delete / replace / clear)
+- unify the void appenders under append(); push() stays index-returning
+- back() = v[.-1]; empty pop_back/back throw OutOfRangeError
+- docs(found_bugs): FB-027 — ignore(coll[i]) swallows OutOfRangeError
+- vector(~capacity) constructor; reserve over a Builtins primitive
+- remove the fold "accumulator never assigned" warning

--- a/newvec2_report.md
+++ b/newvec2_report.md
@@ -1,0 +1,148 @@
+# newvec-2 — `vector` performance & ergonomics
+
+Follow-up work package to **newvec-1** (the first-class mutable `vector`, merged
+as PR #41). This branch makes the vector faster (inline push/pop, `realloc`
+growth) and more ergonomic (a `vector()` constructor family, in-place slice
+assignment, a unified `append` family, from-end `back`), and consolidates the
+API. Everything is on branch `newvec-2`; nine feature/doc commits, all green
+against the full fxtest ladder + ASan/UBSan + the self-hosting fixpoint.
+
+## What changed, by area
+
+### 1. `vector()` constructor family (Builtins.fx)
+`vector()` now mirrors `array()` instead of the old `Vector.make`:
+
+| form | meaning |
+|---|---|
+| `vector()` / `vector(capacity=n)` | empty; optionally pre-reserved to `n` |
+| `vector(n, x)` | `n` copies of `x` |
+| `vector(a: 't [])` | from an array |
+| `vector(l: 't list)` | from a list |
+| `vector(v: 't rrbvec)` | from an rrbvec |
+| `vector(s: string)` | `char vector` from a string |
+
+`Vector.make` is gone everywhere (compiler symbol tables, NN, examples, tests).
+`map`/`mapi`/`foldl` are removed too — comprehensions (`vector(for x <- v {..})`,
+`vector(for x@i <- v {..})`) and `fold` express them directly. `capacity()` is
+now `@nothrow`.
+
+The `~capacity` overload needs `reserve`, which lives in Vector.fx (compiled
+*after* Builtins). To keep the whole family in Builtins (a `vector()` split
+across two modules confuses overload resolution), the reserve primitive was
+factored into `Builtins.__vec_reserve__` (an `@ccode` wrapper over
+`fx_vec_reserve`); `Vector.reserve` is now a thin wrapper over it. The
+keywordless `vector()` was removed because it is ambiguous against the
+all-defaulted-keyword `vector(~capacity=0)`, which subsumes it.
+
+### 2. `fx_vec_reserve` grows via `fx_realloc`
+The malloc + memcpy + swap + free dance became a single `fx_realloc`. Same pure
+move of the live bytes (growth needs no copy-constructors), same NULL-first-grow
+handling (realloc-of-NULL is malloc).
+
+### 3. In-place slice assignment `vec[a:b:delta] = rhs`
+Previously `vec[a:b] = rhs` silently built a discarded slice copy (a no-op). Now
+it mutates in place:
+
+- `vec[a:b] = vector(...)` — replace a contiguous range; sizes may differ (the
+  tail is shifted, the removed elements freed).
+- `vec[a:b:k] = []` — delete the selected elements (any step); survivors compacted.
+- `vec[:] = []` — clear (a real allocated, still-pushable vector).
+- `vec[i:i] = vector(...)` — insert at `i`.
+
+A strided replace with a **non-empty** vector (`delta != 1` and `rhs != []`) is a
+**compile error** with a caret (`test/negative/507`).
+
+Pipeline: `K_normalize` intercepts `ExpAssign(ExpAt(vec, [range]), rhs)` for a
+vector LHS and lowers it to `KExpIntrin(IntrinVecSplice, …)` (the legality check
+lives here, so it carries a caret); `C_gen_code` emits `fx_vec_splice(vec, a, b,
+delta, mask, rhs)`, the missing-bound mask computed exactly as for a slice read.
+The runtime `fx_vec_splice` frees the removed elements, moves survivors with a
+pure `memmove`, deep-copies `rhs` in (`copy_elem`), reserves up front (OOM leaves
+the vector intact), and zeroes any shrink-vacated tail so no aliased pointer
+lingers past the new size.
+
+### 4/5. Inline `push_back` / `pop_back`
+Both are now `@inline` wrappers over new intrinsics `__intrin_push__` /
+`__intrin_pop__`, so the common case is emitted at the call site:
+
+- POD element types → `FX_VEC_PUSH_BACK_FAST` / `FX_VEC_POP_BACK_FAST`: a raw slot
+  write / bare size-decrement on the in-capacity, not-being-iterated path.
+- Complex element types → `FX_VEC_PUSH_BACK` / `FX_VEC_POP_BACK`: always through
+  the runtime (which runs the element copy/free).
+
+POD-ness is decided at C-gen from `get_ktprops(elem).ktp_complex`; the catch
+label is the call site's. Both intrinsics are marked **impure** in
+`K_remove_unused` — otherwise the void-result push/pop calls (and the loops
+around them) would be dead-code eliminated.
+
+### 6/7. `append` family and `concat`
+Every void appender is now spelled `append`, differing only by source kind:
+
+    push(v, x: 't): int          // adds one element, returns its index
+    append(v, elem: 't): void    // synonym for push_back
+    append(v, arr: 't []): void
+    append(v, src: 't vector): void
+
+The three argument kinds (`'t` / `'t []` / `'t vector`) never overlap for a
+resolved call, so the family is unambiguous — even for vectors-of-vectors, where
+appending one `'x vector` element vs concatenating an `('x vector) vector` pick
+different overloads. `Vector.concat` (`('t vector) []` and `('t vector) vector`)
+builds the result via `vector(capacity=total)` and bulk `append`s.
+
+The runtime `fx_vec_concat` was dropped: it derived element metadata from its
+inputs, which is unavailable when every input is empty. Concatenation now lives
+entirely in Ficus over `fx_vec_append`; the result is created via `[]` (which
+carries `'t`'s metadata), so an all-empty input still yields a real allocated
+vector. A future `fx_vec_compose` will cover heterogeneous compose.
+
+### Polish
+- `back()` is now `@inline fun back(v) = v[.-1]` — the from-end index `[.-1]`
+  desugars to `v[__intrin_size__(v) - 1]` and already works for vectors
+  (`IntrinGetSize` supports them). The hand-written `@ccode` is gone.
+- Operating on an empty vector now consistently throws **`OutOfRangeError`**, not
+  `SizeError`: `fx_vec_pop_back`'s empty case, `back()`, and `pop()` all agree
+  with element access (`SizeError` stays only for genuine negative-size errors in
+  make/resize/append).
+
+## API summary (Vector + Builtins)
+
+- Construct: `vector()`, `vector(capacity=n)`, `vector(n, x)`, `vector(arr)`,
+  `vector(list)`, `vector(rrbvec)`, `vector(string)`, `vector(for …)`.
+- Grow/shrink: `push_back`, `pop_back`, `push` (→ index), `append` (elem/array/
+  vector), `resize`, `reserve`, `clear`, `assign`.
+- Read: `v[i]`, `v[.-k]` (from end), `back`, `size`, `empty`, `capacity`,
+  borders `v.clip/wrap/zero[i]`, slices `v[a:b:k]` (copy).
+- Mutate slice: `v[a:b] = vector(...)`, `v[a:b:k] = []`, `v[:] = []`.
+- Bulk: `concat(('t vector) [])`, `concat(('t vector) vector)`.
+- `==`, `<=>`, `string`, `print`, comprehensions, `for`-iteration (variant-D
+  read-lock), `array(v)`.
+
+## Testing
+
+- `test/test_vec.fx`: the `fcvector` suite grew to **13** tests, adding
+  `pushpop_edge`, `splice`, `append` (and extending `concat`, `str`).
+- `test/negative/507_vec_strided_replace`: golden caret diagnostic for the
+  strided-replace error.
+- Full ladder green (`fxtest.py all`: unit + negative + ir + cfold +
+  corpus O0/O3), ASan+UBSan clean, self-hosting fixpoint holds (33 bootstrap
+  modules regenerated across the intrinsic commits).
+
+## Compiler bug found (fenced, not fixed)
+
+**FB-027 — `ignore(coll[i])` swallows `OutOfRangeError`.** An element read whose
+result does not escape is dead-code-eliminated together with its bounds check, so
+`ignore(e[.-1])` on an empty vector/array does not throw. Root cause:
+`pure_kexp_` in `K_remove_unused.fx` does not mark `KExpAt` impure. Affects
+array/vector/string/rrbvec at both `-O0` and `-O3`. Fix direction noted in
+`docs/found_bugs.md` (mark a bounds-checked `BorderNone` `KExpAt` impure; border
+reads stay pure). Surfaced while simplifying `back` to `v[.-1]`.
+
+## Notes for a future pass
+
+- The 2-fold `concat` (`fold r = vector(capacity=total) for v { r.append(v) }`)
+  was tried and dropped: an in-place `append` accumulator triggers the fold-1
+  "accumulator never assigned" warning, and an unpinned `r` makes `r.append(v)`
+  ambiguous between the element and vector overloads. Both could be candidates
+  for future fold-1 / resolver refinement.
+- `fx_vec_compose` for heterogeneous vector construction (`[\a, \b, 3.14, \c]`)
+  remains to be implemented; `fx_vec_concat` was removed in anticipation of it.

--- a/newvec2_report.md
+++ b/newvec2_report.md
@@ -87,7 +87,12 @@ The three argument kinds (`'t` / `'t []` / `'t vector`) never overlap for a
 resolved call, so the family is unambiguous — even for vectors-of-vectors, where
 appending one `'x vector` element vs concatenating an `('x vector) vector` pick
 different overloads. `Vector.concat` (`('t vector) []` and `('t vector) vector`)
-builds the result via `vector(capacity=total)` and bulk `append`s.
+is two folds — one sums the total size, one fills a capacity-reserved result:
+
+    fun concat(vs: ('t vector) []): 't vector {
+        val total = fold s = 0 for v <- vs { s += v.size() }
+        fold r: 't vector = vector(capacity=total) for v <- vs { r.append(v) }
+    }
 
 The runtime `fx_vec_concat` was dropped: it derived element metadata from its
 inputs, which is unavailable when every input is empty. Concatenation now lives
@@ -137,12 +142,20 @@ array/vector/string/rrbvec at both `-O0` and `-O3`. Fix direction noted in
 `docs/found_bugs.md` (mark a bounds-checked `BorderNone` `KExpAt` impure; border
 reads stay pure). Surfaced while simplifying `back` to `v[.-1]`.
 
+### fold-1: "accumulator never assigned" warning removed
+
+The 2-fold `concat` needs a `fold r = vector(capacity=total) for v { r.append(v)
+}` whose accumulator is a reference-mutable vector updated *in place*, never
+reassigned. The old fold-1 "accumulator never assigned" warning false-positived
+on this (no syntactic scan can tell in-place mutation from a genuine no-op), so
+the warning was **removed**: the fold body is void, so the mistake it targeted —
+an old-style body that yields a value (`fold s=0 for x {s+x}`) — is already a
+type error. `test/negative/708` (warning-only) is deleted; `709` keeps the
+old-style body but its golden is now the void-body type error. The accumulator's
+`: 't vector` annotation is still required (an unpinned `r` makes `r.append(v)`
+ambiguous between the element and vector `append` overloads).
+
 ## Notes for a future pass
 
-- The 2-fold `concat` (`fold r = vector(capacity=total) for v { r.append(v) }`)
-  was tried and dropped: an in-place `append` accumulator triggers the fold-1
-  "accumulator never assigned" warning, and an unpinned `r` makes `r.append(v)`
-  ambiguous between the element and vector overloads. Both could be candidates
-  for future fold-1 / resolver refinement.
 - `fx_vec_compose` for heterogeneous vector construction (`[\a, \b, 3.14, \c]`)
   remains to be implemented; `fx_vec_concat` was removed in anticipation of it.

--- a/runtime/ficus/ficus.h
+++ b/runtime/ficus/ficus.h
@@ -1114,9 +1114,6 @@ int fx_compose_vec( size_t elemsize, fx_free_t free_elem, fx_copy_t copy_elem,
 int fx_vec_reserve(fx_vec_t vec, int_ new_capacity);
 int fx_vec_resize(fx_vec_t vec, int_ new_size, const void* fillelem);
 int fx_vec_append(fx_vec_t vec, const void* elems, int_ nelems);
-int fx_vec_concat(const fx_vec_t* vecs, int_ nvecs,
-                  size_t elemsize, fx_free_t free_elem, fx_copy_t copy_elem,
-                  fx_vec_t* vec);
 int fx_vec_slice(fx_vec_t vec, int_ start, int_ end, int_ delta, int mask, fx_vec_t* subvec);
 
 ////////////////////////// RRB Vectors /////////////////////////////

--- a/runtime/ficus/ficus.h
+++ b/runtime/ficus/ficus.h
@@ -1094,6 +1094,35 @@ typedef struct fx_vechdr_t
 #define FX_VEC_ELEM_ZERO(typ, vec, idx) (*FX_VEC_PTR_ZERO(typ, vec, idx))
 #define FX_VEC_ELEM_WRAP(typ, vec, idx) (*FX_VEC_PTR_WRAP(typ, vec, idx))
 
+int fx_vec_pop_back(fx_vec_t vec);
+
+// push_back / pop_back fast paths, emitted by the __intrin_push__/__intrin_pop__
+// intrinsics (see lib/Vector.fx). The _FAST variants are used for POD element
+// types: the common in-capacity, not-being-iterated case is a raw slot write /
+// size decrement done inline; every other case (grow, empty, locked, NULL) falls
+// through to the runtime, which throws the right error and, for complex types,
+// invokes the element copy/free. The plain variants have no inline fast path and
+// always go through the runtime (its fx_copy_arr_elems / free_elem handle the
+// element metadata). `elem` is copied into a local so it may be any expression
+// (incl. a literal) and is taken by address without evaluating it twice.
+#define FX_VEC_PUSH_BACK_FAST(typ, vec, elem, catch_label) \
+    { fx_vec_t __vec__ = (vec); typ __elem__ = (elem); \
+      if (__vec__ && __vec__->nlocks == 0 && __vec__->size < __vec__->capacity) \
+          ((typ*)__vec__->data)[__vec__->size++] = __elem__; \
+      else FX_CALL(fx_vec_append(__vec__, &__elem__, 1), catch_label); }
+
+#define FX_VEC_PUSH_BACK(typ, vec, elem, catch_label) \
+    { fx_vec_t __vec__ = (vec); typ __elem__ = (elem); \
+      FX_CALL(fx_vec_append(__vec__, &__elem__, 1), catch_label); }
+
+#define FX_VEC_POP_BACK_FAST(vec, catch_label) \
+    { fx_vec_t __vec__ = (vec); \
+      if (__vec__ && __vec__->nlocks == 0 && __vec__->size > 0) __vec__->size--; \
+      else FX_CALL(fx_vec_pop_back(__vec__), catch_label); }
+
+#define FX_VEC_POP_BACK(vec, catch_label) \
+    FX_CALL(fx_vec_pop_back(vec), catch_label)
+
 void fx_free_vec(fx_vec_t* vec);
 // pvec is fx_vec_t* (the address of the fx_vec_t variable), matching the
 // FX_FREE_ARR / FX_FREE_LIST_SIMPLE convention the compiler emits (&var).

--- a/runtime/ficus/ficus.h
+++ b/runtime/ficus/ficus.h
@@ -1095,6 +1095,7 @@ typedef struct fx_vechdr_t
 #define FX_VEC_ELEM_WRAP(typ, vec, idx) (*FX_VEC_PTR_WRAP(typ, vec, idx))
 
 int fx_vec_pop_back(fx_vec_t vec);
+int fx_vec_splice(fx_vec_t vec, int_ start, int_ end, int_ delta, int mask, fx_vec_t rhs);
 
 // push_back / pop_back fast paths, emitted by the __intrin_push__/__intrin_pop__
 // intrinsics (see lib/Vector.fx). The _FAST variants are used for POD element

--- a/runtime/ficus/impl/vec.impl.h
+++ b/runtime/ficus/impl/vec.impl.h
@@ -103,20 +103,16 @@ int fx_vec_reserve(fx_vec_t vec, int_ new_capacity)
         return FX_OK;
     size_t esz = vec->info.elemsize;
     size_t total = new_capacity * esz;
-    void *data = fx_malloc(total), *temp;
+    // realloc performs a pure move of the existing bytes (no copy-constructors
+    // needed) and frees the old buffer; it treats vec->data==NULL (an empty
+    // vector grown for the first time) as malloc. Only the first vec->size
+    // elements are live; the freshly grown tail is set/filled by the caller
+    // (fx_vec_resize / fx_vec_append) before use.
+    void *data = fx_realloc(vec->data, total);
     if (!data)
         FX_FAST_THROW_RET(FX_EXN_OutOfMemError);
-    // regardless of whether the data is complex or POD,
-    // we 'move' it, so no need to invoke copy-constructors.
-    // guard against vec->data==NULL (an empty vector grown for the first time):
-    // memcpy(dst, NULL, 0) is undefined behaviour.
-    if (vec->size > 0)
-        memcpy(data, vec->data, (size_t)vec->size*esz);
-    // make it a little bit more atomic
-    // more robust implementation should use CAS (atomic compare-and-swap)
-    FX_SWAP(data, vec->data, temp);
+    vec->data = data;
     vec->capacity = new_capacity;
-    fx_free(data);
     return FX_OK;
 }
 

--- a/runtime/ficus/impl/vec.impl.h
+++ b/runtime/ficus/impl/vec.impl.h
@@ -245,6 +245,85 @@ int fx_vec_slice(fx_vec_t vec, int_ start, int_ end, int_ delta, int mask, fx_ve
     return FX_OK;
 }
 
+// In-place slice assignment `vec[start:end:delta] = rhs`.
+//   - rhs == NULL or empty  => deletion of the selected elements (any delta);
+//     the survivors are compacted and the freed/vacated slots zeroed.
+//   - rhs non-empty         => contiguous replacement (delta == 1, guaranteed by
+//     the compiler: a strided replace with a non-empty vector is a compile error).
+//     The sizes may differ; the tail is shifted with memmove (a pure move — no
+//     copy/free of the moved elements), the removed elements are freed first, and
+//     any slot vacated by a shrink is zeroed so no aliased pointer lingers.
+// Elements are never aliased into `vec`: rhs is deep-copied in (copy_elem).
+int fx_vec_splice(fx_vec_t vec, int_ start, int_ end, int_ delta, int mask, fx_vec_t rhs)
+{
+    if (!vec)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
+    if (vec->nlocks != 0)
+        FX_FAST_THROW_RET(FX_EXN_VecModifiedError);
+    if (delta == 0)
+        FX_FAST_THROW_RET(FX_EXN_ZeroStepError);
+    int_ size = vec->size;
+    start = !(mask & 1) ? start : delta > 0 ? 0 : size-1;
+    end = !(mask & 2) ? end : delta > 0 ? size : -1;
+    if ((delta > 0 && (start < 0 || start > end || end > size)) ||
+        (delta < 0 && (end < -1 || start < end || start >= size)))
+        FX_FAST_THROW_RET(FX_EXN_OutOfRangeError);
+    size_t esz = vec->info.elemsize;
+    fx_free_t free_f = vec->info.free_elem;
+    fx_copy_t copy_f = vec->info.copy_elem;
+    int_ nrhs = rhs ? rhs->size : 0;
+    char* data;
+
+    if (nrhs == 0) {
+        // deletion (any delta): free selected elements, compact the survivors
+        // down with a pure move, then zero the vacated tail.
+        data = (char*)vec->data;
+        int_ j = 0;
+        for (int_ i = 0; i < size; i++) {
+            int selected = delta > 0
+                ? (i >= start && i < end && (i - start) % delta == 0)
+                : (i <= start && i > end && (start - i) % (-delta) == 0);
+            if (selected) {
+                if (free_f) free_f(data + i*esz);
+            } else {
+                if (j != i) memmove(data + j*esz, data + i*esz, esz);
+                j++;
+            }
+        }
+        if (j < size)
+            memset(data + j*esz, 0, (size - j)*esz);
+        vec->size = j;
+        return FX_OK;
+    }
+
+    // contiguous replacement (delta == 1 guaranteed by the compiler)
+    int_ nremove = end - start;
+    int_ newsize = size - nremove + nrhs;
+    // reserve first so an OOM leaves the vector untouched
+    if (newsize > vec->capacity) {
+        int fx_status = fx_vec_reserve(vec, newsize);
+        if (fx_status < 0) {
+            FX_UPDATE_BT();
+            return fx_status;
+        }
+    }
+    data = (char*)vec->data;
+    // free the elements being removed/overwritten
+    if (free_f)
+        fx_free_arr_elems(data + start*esz, nremove, esz, free_f);
+    // shift the surviving tail to its new position (pure move, overlap-safe)
+    int_ tail = size - end;
+    if (tail > 0 && nrhs != nremove)
+        memmove(data + (start+nrhs)*esz, data + end*esz, tail*esz);
+    // deep-copy the replacement elements in (rhs keeps ownership)
+    fx_copy_arr_elems(rhs->data, data + start*esz, nrhs, esz, copy_f);
+    // on a shrink, zero the vacated tail so no aliased pointer lingers past size
+    if (newsize < size)
+        memset(data + newsize*esz, 0, (size - newsize)*esz);
+    vec->size = newsize;
+    return FX_OK;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/ficus/impl/vec.impl.h
+++ b/runtime/ficus/impl/vec.impl.h
@@ -177,34 +177,6 @@ int fx_vec_append(fx_vec_t vec, const void* elems, int_ nelems)
     return FX_OK;
 }
 
-int fx_vec_concat(const fx_vec_t* vecs, int_ nvecs,
-                size_t elemsize, fx_free_t free_elem, fx_copy_t copy_elem,
-                fx_vec_t* vec_)
-{
-    int_ size = 0;
-    for (int_ i = 0; i < nvecs; i++) {
-        if (vecs[i]->info.elemsize != elemsize ||
-            vecs[i]->info.copy_elem != copy_elem ||
-            vecs[i]->info.free_elem != free_elem )
-            FX_FAST_THROW_RET(FX_EXN_TypeMismatchError);
-        size += vecs[i]->size;
-    }
-    int fx_status = fx_make_vec(size, size, elemsize, free_elem, copy_elem, 0, vec_);
-    if (fx_status < 0) {
-        FX_UPDATE_BT();
-        return fx_status;
-    }
-    fx_vec_t vec = *vec_;
-    size = 0;
-    for (int_ i = 0; i < nvecs; i++) {
-        int_ sizei = vecs[i]->size;
-        fx_copy_arr_elems(vecs[i]->data, (char*)vec->data + size*elemsize,
-                        sizei, elemsize, copy_elem);
-        size += sizei;
-    }
-    return FX_OK;
-}
-
 // just like in Python, we always create a copy of the slice, we don' create a 'view'
 // to the existing vector. And this behavior is different from string or rrbvec,
 // which are immutable structures and where creating a view is very safe.

--- a/runtime/ficus/impl/vec.impl.h
+++ b/runtime/ficus/impl/vec.impl.h
@@ -150,6 +150,8 @@ int fx_vec_append(fx_vec_t vec, const void* elems, int_ nelems)
 {
     if (nelems == 0)
         return FX_OK;
+    if (!vec)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
     if (vec->nlocks != 0)
         FX_FAST_THROW_RET(FX_EXN_VecModifiedError);
     if (nelems < 0)
@@ -174,6 +176,24 @@ int fx_vec_append(fx_vec_t vec, const void* elems, int_ nelems)
         memset(dst, 0, nelems*elemsize);
     }
     vec->size = new_size;
+    return FX_OK;
+}
+
+// drop the last element (freeing it if it is a complex type). Used by the slow
+// path of the __intrin_pop__ intrinsic (FX_VEC_POP_BACK / FX_VEC_POP_BACK_FAST).
+int fx_vec_pop_back(fx_vec_t vec)
+{
+    if (!vec)
+        FX_FAST_THROW_RET(FX_EXN_NullPtrError);
+    if (vec->nlocks != 0)
+        FX_FAST_THROW_RET(FX_EXN_VecModifiedError);
+    int_ size = vec->size;
+    if (size == 0)
+        FX_FAST_THROW_RET(FX_EXN_SizeError);
+    vec->size = --size;
+    fx_free_t free_f = vec->info.free_elem;
+    if (free_f)
+        free_f((char*)vec->data + size*vec->info.elemsize);
     return FX_OK;
 }
 

--- a/runtime/ficus/impl/vec.impl.h
+++ b/runtime/ficus/impl/vec.impl.h
@@ -189,7 +189,7 @@ int fx_vec_pop_back(fx_vec_t vec)
         FX_FAST_THROW_RET(FX_EXN_VecModifiedError);
     int_ size = vec->size;
     if (size == 0)
-        FX_FAST_THROW_RET(FX_EXN_SizeError);
+        FX_FAST_THROW_RET(FX_EXN_OutOfRangeError);
     vec->size = --size;
     fx_free_t free_f = vec->info.free_elem;
     if (free_f)

--- a/test/negative/507_vec_strided_replace.err
+++ b/test/negative/507_vec_strided_replace.err
@@ -1,0 +1,3 @@
+507_vec_strided_replace.fx:3:8: error: a strided vector slice (step != 1) can only be deleted by assigning '[]'; replacing strided elements with a non-empty vector is not supported
+ 3 | v[::2] = vector([9, 9, 9])
+   |        ^

--- a/test/negative/507_vec_strided_replace.fx
+++ b/test/negative/507_vec_strided_replace.fx
@@ -1,0 +1,3 @@
+// expect: replacing strided elements with a non-empty vector is not supported
+val v = vector([0, 1, 2, 3, 4, 5])
+v[::2] = vector([9, 9, 9])

--- a/test/negative/708_fold2_unused_accumulator.err
+++ b/test/negative/708_fold2_unused_accumulator.err
@@ -1,5 +1,0 @@
-708_fold2_unused_accumulator.fx:6:14: warning: 'fold' accumulator 's' is never assigned in the body, so the fold has no effect. The body must UPDATE the accumulator (e.g. 's = <expr>' or 's += ...'); write 's = _' to silence
- 6 | val s = fold s = 0 for x <- [1, 2, 3] { println(x) }
-   |              ^
-
-1 warning generated (treated as errors due to -Werror).

--- a/test/negative/708_fold2_unused_accumulator.fx
+++ b/test/negative/708_fold2_unused_accumulator.fx
@@ -1,7 +1,0 @@
-// expect: never assigned
-// flags: -Werror
-// fold-1 Phase 1: a fold whose accumulator is never assigned in the body
-// is almost certainly a mistake; warn (promoted to an error here via -Werror).
-// Writing 's = _' in the body would silence it.
-val s = fold s = 0 for x <- [1, 2, 3] { println(x) }
-println(s)

--- a/test/negative/709_fold_old_style_body.err
+++ b/test/negative/709_fold_old_style_body.err
@@ -1,13 +1,8 @@
-709_fold_old_style_body.fx:5:14: warning: 'fold' accumulator 's' is never assigned in the body, so the fold has no effect. The body must UPDATE the accumulator (e.g. 's = <expr>' or 's += ...'); write 's = _' to silence
- 5 | val s = fold s = 0 for x <- [1, 2, 3] { s + x }
-   |              ^
-709_fold_old_style_body.fx:5:43: error: improper type of the arithmetic operation result
- 5 | val s = fold s = 0 for x <- [1, 2, 3] { s + x }
+709_fold_old_style_body.fx:6:43: error: improper type of the arithmetic operation result
+ 6 | val s = fold s = 0 for x <- [1, 2, 3] { s + x }
    |                                           ^
-709_fold_old_style_body.fx:6:9: error: the appropriate match for 's' of type '<unknown>' is not found.
- 6 | println(s)
+709_fold_old_style_body.fx:7:9: error: the appropriate match for 's' of type '<unknown>' is not found.
+ 7 | println(s)
    |         ^
 
 2 errors occured during type checking.
-
-1 warning generated.

--- a/test/negative/709_fold_old_style_body.fx
+++ b/test/negative/709_fold_old_style_body.fx
@@ -1,6 +1,7 @@
-// expect: must UPDATE the accumulator
-// fold-1 flip: after `fold` became the new imperative form, an OLD-style body
-// that yields a value instead of updating the accumulator is a mistake; the
-// 'never assigned' diagnostic points the way ('s += x' here).
+// expect: improper type of the arithmetic operation result
+// fold-1: the fold body is now void, so an OLD-style body that yields a value
+// instead of updating the accumulator (`s + x` here, meant to be `s += x`) is a
+// type error — the value has nowhere to go. (There is no longer a separate
+// 'never assigned' warning; the void-body type error is the diagnostic.)
 val s = fold s = 0 for x <- [1, 2, 3] { s + x }
 println(s)

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -225,3 +225,34 @@ TEST("fcvector.str", fun()
     EXPECT_EQ(array(vecstr[::-1]), ["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"])
     EXPECT_EQ(vecstr[::-1], vector(["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"]))
 })
+
+TEST("fcvector.concat", fun()
+{
+    val a = vector([1, 2, 3])
+    val b = vector([4, 5])
+    val c: int vector = []
+    val d = vector([6, 7, 8, 9])
+    // array of vectors
+    EXPECT_EQ(`array(Vector.concat([a, b, d]))`, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    // empty inputs contribute nothing
+    EXPECT_EQ(`array(Vector.concat([a, c, b]))`, [1, 2, 3, 4, 5])
+    // all-empty / empty list -> empty result that is still a real allocated
+    // (pushable) vector, not the NULL/default vector
+    EXPECT_EQ(`size(Vector.concat([c, c]))`, 0)
+    val e = Vector.concat(([]: (int vector) []))
+    EXPECT_EQ(`size(e)`, 0)
+    e.push_back(42)
+    EXPECT_EQ(`array(e)`, [42])
+    // vector of vectors
+    val vv = vector([a, b, d])
+    EXPECT_EQ(`array(Vector.concat(vv))`, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    // complex elements (strings) are copied — ASan-checked
+    val s1 = vector(["a", "bc"])
+    val s2 = vector(["def"])
+    EXPECT_EQ(`array(Vector.concat([s1, s2]))`, ["a", "bc", "def"])
+    // the result is independent of the inputs (a real fresh vector)
+    val r = Vector.concat([a, b])
+    r.push_back(99)
+    EXPECT_EQ(`size(a)`, 3)
+    EXPECT_EQ(`r[5]`, 99)
+})

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -51,7 +51,7 @@ TEST("fcvector.write", fun()
 
 TEST("fcvector.ops", fun()
 {
-    val v = Vector.make(3, 7)
+    val v = vector(3, 7)
     EXPECT_EQ(`size(v)`, 3)
     EXPECT_EQ(`Vector.capacity(v) >= 3`, true)
     EXPECT_EQ(`array(v)`, [7, 7, 7])
@@ -65,16 +65,16 @@ TEST("fcvector.ops", fun()
     EXPECT_EQ(`size(v)`, 0)
     EXPECT_EQ(`empty(v)`, true)
 
-    val a = Vector.make([1, 2, 3])
-    val b = Vector.make([1, 2, 3])
-    val c = Vector.make([1, 2, 4])
+    val a = vector([1, 2, 3])
+    val b = vector([1, 2, 3])
+    val c = vector([1, 2, 4])
     EXPECT_EQ(`a == b`, true)
     EXPECT_EQ(`a == c`, false)
     EXPECT_EQ(`a <=> c`, -1)
     EXPECT_EQ(`string(a)`, "[1, 2, 3]")
 
     // complex-element resize (grow with fill, shrink freeing elements) — ASan
-    val s = Vector.make(2, "ab")
+    val s = vector(2, "ab")
     s.push_back("cd")
     s.resize(5, "zz")
     EXPECT_EQ(`size(s)`, 5)
@@ -114,14 +114,12 @@ TEST("fcvector.binomial", fun()
     val myvecs: (float vector) vector = []
     for i <- 1:10 {
         val last = if empty(myvecs) {emptyvec} else {myvecs.back()}
-        // curr annotated to sidestep FB-024 (order-dependent generic-return
-        // inference pollution across tests); see docs/found_bugs.md
-        val curr: float vector = last.mapi(fun(x, j) { if j == 0 {1.f} else {last[j-1] + last[j]} })
+        val curr = vector(for x@j <- last { if j == 0 {1.f} else {last[j-1] + last[j]} })
         curr.push_back(1.f)
         myvecs.push_back(curr)
     }
 
-    fun sum(v: 't vector, v0: 'r): 'r = v.foldl(fun (x, s) {x + s}, v0)
+    fun sum(v: 't vector, v0: 'r): 'r = fold s = v0 for x <- v {s = x + s}
     for i <- 0:size(myvecs) {
         val expected_sum = double(1 << i)
         EXPECT_EQ(`sum(myvecs[i], 0.)`, expected_sum)
@@ -223,7 +221,7 @@ TEST("fcvector.str", fun()
         vecstr.push_back(w)
     }
     EXPECT_EQ(array(vecstr[::2]), ["a", "def", "klmno", "vwxyz"])
-    EXPECT_EQ(vecstr[::2], Vector.make(["a", "def", "klmno", "vwxyz"]))
+    EXPECT_EQ(vecstr[::2], vector(["a", "def", "klmno", "vwxyz"]))
     EXPECT_EQ(array(vecstr[::-1]), ["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"])
-    EXPECT_EQ(vecstr[::-1], Vector.make(["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"]))
+    EXPECT_EQ(vecstr[::-1], vector(["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"]))
 })

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -4,7 +4,8 @@
 */
 
 // first-class mutable vector ('t vector) tests: element access v[i], v[i]=a,
-// size/empty, push_back/pop_back/back, resize/reserve/clear, slices, map/foldl.
+// size/empty, push_back/pop_back/back/push, append (elem/array/vector), concat,
+// resize/reserve/clear, comprehensions/iteration, slices, slice-assign (splice).
 
 from UTest import *
 
@@ -311,6 +312,34 @@ TEST("fcvector.str", fun()
     EXPECT_EQ(vecstr[::2], vector(["a", "def", "klmno", "vwxyz"]))
     EXPECT_EQ(array(vecstr[::-1]), ["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"])
     EXPECT_EQ(vecstr[::-1], vector(["vwxyz", "pqrstu", "klmno", "ghij", "def", "bc", "a"]))
+})
+
+TEST("fcvector.append", fun()
+{
+    // the append family: element / array / vector, all void and unambiguous
+    val v: int vector = []
+    v.append(1)                        // single element (push_back synonym)
+    v.append(2)
+    v.append([3, 4, 5])                // whole array
+    v.append(vector([6, 7]))           // whole vector
+    EXPECT_EQ(`array(v)`, [1, 2, 3, 4, 5, 6, 7])
+
+    // vector-of-vectors: element-append vs vector-append pick different overloads
+    val vv: (int vector) vector = []
+    vv.append(vector([1, 2]))                              // one element
+    vv.append(vector([vector([3]), vector([4])]))         // two elements
+    EXPECT_EQ(`[for x <- vv {array(x)}]`, [[1, 2], [3], [4]])
+
+    // push keeps its index-returning semantics
+    val p: string vector = []
+    EXPECT_EQ(`p.push("a")`, 0)
+    EXPECT_EQ(`p.push("b")`, 1)
+    EXPECT_EQ(`array(p)`, ["a", "b"])
+
+    // appending an empty array/vector is a no-op
+    v.append(([]: int []))
+    v.append((vector(): int vector))
+    EXPECT_EQ(`size(v)`, 7)
 })
 
 TEST("fcvector.concat", fun()

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -106,6 +106,70 @@ TEST("fcvector.pushpop_edge", fun()
     EXPECT_EQ(`g[0]`, 0)
 })
 
+TEST("fcvector.splice", fun()
+{
+    // contiguous replace, grow (2 elems -> 3)
+    val v = vector([0,1,2,3,4,5,6,7,8,9])
+    v[3:5] = vector([100,200,300])
+    EXPECT_EQ(`array(v)`, [0,1,2,100,200,300,5,6,7,8,9])
+
+    // contiguous replace, shrink (6 elems -> 1)
+    val w = vector([0,1,2,3,4,5,6,7,8,9])
+    w[2:8] = vector([99])
+    EXPECT_EQ(`array(w)`, [0,1,99,8,9])
+
+    // contiguous replace, same size (in place)
+    val u = vector([0,1,2,3,4])
+    u[1:4] = vector([10,20,30])
+    EXPECT_EQ(`array(u)`, [0,10,20,30,4])
+
+    // range delete (rhs [])
+    val e = vector([0,1,2,3,4,5,6,7,8,9])
+    e[3:6] = []
+    EXPECT_EQ(`array(e)`, [0,1,2,6,7,8,9])
+
+    // strided delete (even indices)
+    val d = vector([0,1,2,3,4,5,6,7,8,9])
+    d[::2] = []
+    EXPECT_EQ(`array(d)`, [1,3,5,7,9])
+
+    // strided delete with explicit bounds
+    val d2 = vector([0,1,2,3,4,5,6,7,8,9])
+    d2[1:8:3] = []                      // remove indices 1,4,7
+    EXPECT_EQ(`array(d2)`, [0,2,3,5,6,8,9])
+
+    // clear via the full slice
+    val c = vector([1,2,3,4,5])
+    c[:] = []
+    EXPECT_EQ(`size(c)`, 0)
+    c.push_back(42)                     // still an allocated (pushable) vector
+    EXPECT_EQ(`array(c)`, [42])
+
+    // insert into an empty vector via [0:0]
+    val f: int vector = []
+    f[0:0] = vector([7,8,9])
+    EXPECT_EQ(`array(f)`, [7,8,9])
+
+    // prepend / append via zero-width ranges
+    val g = vector([3,4])
+    g[0:0] = vector([1,2])
+    g[4:4] = vector([5,6])
+    EXPECT_EQ(`array(g)`, [1,2,3,4,5,6])
+
+    // complex (string) elements: replace shrink frees the removed strings (ASan)
+    val s = vector(["a","b","c","d","e"])
+    s[1:4] = vector(["X"])
+    EXPECT_EQ(`array(s)`, ["a","X","e"])
+    // string strided delete
+    val s2 = vector(["a","b","c","d","e","f"])
+    s2[::2] = []
+    EXPECT_EQ(`array(s2)`, ["b","d","f"])
+
+    // out-of-range slice throws
+    val r = vector([1,2,3])
+    EXPECT_THROWS(fun() { r[2:9] = vector([0]) }, OutOfRangeError)
+})
+
 TEST("fcvector.slice", fun()
 {
     val v: int vector = []

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -86,12 +86,17 @@ TEST("fcvector.ops", fun()
 
 TEST("fcvector.pushpop_edge", fun()
 {
-    // __intrin_pop__ slow path: popping an empty vector throws SizeError
+    // __intrin_pop__ slow path: popping an empty vector throws OutOfRangeError
+    // (consistent with back() / element access on an empty vector)
     val v: int vector = []
-    EXPECT_THROWS(fun() { v.pop_back() }, SizeError)
+    EXPECT_THROWS(fun() { v.pop_back() }, OutOfRangeError)
     v.push_back(1); v.push_back(2)
     v.pop_back(); v.pop_back()
-    EXPECT_THROWS(fun() { v.pop_back() }, SizeError)
+    EXPECT_THROWS(fun() { v.pop_back() }, OutOfRangeError)
+    // back() on an empty vector likewise throws OutOfRangeError
+    var sink = 0
+    EXPECT_THROWS(fun() { sink = v.back() }, OutOfRangeError)
+    ignore(sink)
 
     // complex-element push/pop frees correctly (ASan-checked), fast path bypassed
     val s: string vector = []

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -83,6 +83,29 @@ TEST("fcvector.ops", fun()
     EXPECT_EQ(`array(s)`, ["ab", "ab"])
 })
 
+TEST("fcvector.pushpop_edge", fun()
+{
+    // __intrin_pop__ slow path: popping an empty vector throws SizeError
+    val v: int vector = []
+    EXPECT_THROWS(fun() { v.pop_back() }, SizeError)
+    v.push_back(1); v.push_back(2)
+    v.pop_back(); v.pop_back()
+    EXPECT_THROWS(fun() { v.pop_back() }, SizeError)
+
+    // complex-element push/pop frees correctly (ASan-checked), fast path bypassed
+    val s: string vector = []
+    for w <- ["aa", "bb", "cc"] { s.push_back(w) }
+    s.pop_back()
+    EXPECT_EQ(`array(s)`, ["aa", "bb"])
+
+    // growth (capacity exceeded) goes through the slow path and keeps all elements
+    val g: int vector = []
+    for i <- 0:1000 { g.push_back(i) }
+    EXPECT_EQ(`size(g)`, 1000)
+    EXPECT_EQ(`g[999]`, 999)
+    EXPECT_EQ(`g[0]`, 0)
+})
+
 TEST("fcvector.slice", fun()
 {
     val v: int vector = []


### PR DESCRIPTION
Follow-up to newvec-1 (#41). Makes the first-class mutable `vector` faster and
nicer to use, and consolidates the API. No change to program semantics beyond
the new features; all green on the fxtest ladder + ASan/UBSan + self-hosting
fixpoint.

## Highlights

- **`vector()` constructor family** (mirrors `array()`): `vector()`,
  `vector(capacity=n)`, `vector(n, x)`, `vector(arr)`, `vector(list)`,
  `vector(rrbvec)`, `vector(string)`. `Vector.make` removed everywhere;
  `map`/`mapi`/`foldl` dropped (comprehensions + `fold` replace them);
  `capacity()` is `@nothrow`.
- **Inline `push_back` / `pop_back`** via `__intrin_push__` / `__intrin_pop__`:
  a raw slot write / size-decrement inline for POD elements on the fast path,
  the runtime (with element copy/free) otherwise.
- **In-place slice assignment**: `vec[a:b] = vector(...)` (grow/shrink),
  `vec[a:b:k] = []` (delete), `vec[:] = []` (clear), `vec[i:i] = ...` (insert).
  Was silently a no-op before. Strided replace with a non-empty vector is a
  compile error (caret).
- **`fx_vec_reserve` uses `realloc`** instead of malloc+memcpy+free.
- **`append` family** unifies the void appenders: `append(elem)` /
  `append(arr)` / `append(vector)`; `push(elem): int` keeps its index return.
  `concat(('t vector)[])` and `concat(('t vector) vector)` added.
- **`back()` = `v[.-1]`** (from-end index); empty `back`/`pop_back`/`pop` now
  throw `OutOfRangeError` (was `SizeError`), consistent with element access.
- **fold-1 "accumulator never assigned" warning removed** — it false-positived on
  a reference-mutable accumulator updated in place (`fold r = vector(...) for v {
  r.append(v) }`); the void fold body already makes the old-style value-yielding
  body a type error, so the warning was redundant.

## Compiler changes

New intrinsics `IntrinVecPushBack` / `IntrinVecPopBack` / `IntrinVecSplice`
through Parser → typecheck → K-normalize → C-gen, all marked impure in
`K_remove_unused`. Runtime: `FX_VEC_PUSH_BACK*/POP_BACK*` macros,
`fx_vec_pop_back`, `fx_vec_splice`, `fx_realloc`-based grow; `fx_vec_concat`
removed. Bootstrap regenerated; fixpoint holds.

## Tests

`fcvector` suite → 13 tests (`pushpop_edge`, `splice`, `append`, extended
`concat`/`str`); negative golden `507_vec_strided_replace`. Full ladder green;
ASan+UBSan clean.

## Found (fenced, not fixed)

**FB-027** — `ignore(coll[i])` swallows `OutOfRangeError`: a bounds-checked
element read with an unused result is DCE'd along with its check (`KExpAt` not
marked impure in `pure_kexp_`). Affects array/vector/string/rrbvec. Fix
direction recorded in `docs/found_bugs.md`.

## Commits

- vector() constructors in Builtins; drop Vector.make/map/mapi/foldl
- fx_vec_reserve grows via fx_realloc
- Vector.append + Vector.concat (multi-vector concatenation)
- inline push_back/pop_back via __intrin_push__/__intrin_pop__
- in-place vector slice assignment (delete / replace / clear)
- unify the void appenders under append(); push() stays index-returning
- back() = v[.-1]; empty pop_back/back throw OutOfRangeError
- docs(found_bugs): FB-027 — ignore(coll[i]) swallows OutOfRangeError
- vector(~capacity) constructor; reserve over a Builtins primitive
- remove the fold "accumulator never assigned" warning
