### PR TITLE
purity-1: fix FB-027 + parameterize the purity predicate

### DIFF
--- a/compiler/C_gen_code.fx
+++ b/compiler/C_gen_code.fx
@@ -109,35 +109,15 @@ type count_map_t = (id_t, int) Hashmap.t
 */
 /* A single-use temp is inlined by folding its initializer into the use site,
    which MOVES the computation forward across whatever code sits between the
-   definition and the use. `pure_kexp` guarantees no side effects, but that is
-   not enough for a *read of mutable memory*: an array element, a ref cell or a
-   mutable record field can be overwritten by an intervening store, so moving
-   the read past that store changes its value. This exact hazard is exposed by
-   simultaneous tuple/array assignment, e.g. `(arr[i], arr[j]) = (arr[j],
-   arr[i])`. Such reads are pure yet not movement-invariant, so we keep them
-   materialized (they cost one named C temp, which the C compiler coalesces
-   anyway). See docs/found_bugs.md FB-023. */
-fun movement_unsafe_read(e0: kexp_t): bool
-{
-    var unsafe = false
-    // fold over the whole initializer: a compound one (KExpIf/KExpSeq/KExpMatch
-    // /...) may hide a mutable-memory read that inlining would move past a store.
-    fun chk_kexp_(e: kexp_t, callb: k_fold_callb_t): void =
-        if !unsafe {
-            match e {
-            | KExpAt _ => unsafe = true                        // array element (arrays are mutable)
-            | KExpUnary(OpDeref, _, _) => unsafe = true         // ref-cell dereference
-            | KExpMem(base, _, (_, loc)) =>                     // field of a mutable record/var
-                if is_mutable(base, loc) { unsafe = true }
-            | KExpMap _ => unsafe = true                        // comprehension: never safe to move
-            | _ => fold_kexp(e, callb)
-            }
-        }
-    val callb = k_fold_callb_t { kcb_fold_atom=None, kcb_fold_ktyp=None, kcb_fold_kexp=Some(chk_kexp_) }
-    chk_kexp_(e0, callb)
-    unsafe
-}
-
+   definition and the use. Plain purity is not enough for a *read of mutable
+   memory*: an array element, a ref cell or a mutable record field can be
+   overwritten by an intervening store, so moving the read past that store
+   changes its value (exposed by simultaneous tuple/array assignment, e.g.
+   `(arr[i], arr[j]) = (arr[j], arr[i])`). We therefore ask `pure_kexp` for its
+   movement grade (`~mut_read_is_impure=true`, the default), which classifies
+   such reads AND comprehensions as non-movable in the single point of truth; the
+   temp stays materialized (one named C temp, coalesced by the C compiler where
+   legal). See docs/found_bugs.md FB-023. */
 fun find_single_use_vals(topcode: kcode_t)
 {
     var count_map: count_map_t = Hashmap.empty(1024, noid, 0)
@@ -160,8 +140,7 @@ fun find_single_use_vals(topcode: kcode_t)
             /* We only replace those values with expressions which are temporary
                 and computed using pure expressions */
             val good_temp = kv_flags.val_flag_tempref || kv_flags.val_flag_temp
-            if good_temp && K_remove_unused.pure_kexp(e1) &&
-               !movement_unsafe_read(e1) {
+            if good_temp && K_remove_unused.pure_kexp(e1, mut_read_is_impure=true) {
                 decl_const_vals.add(k)
             }
             count_kexp(e1, callb)

--- a/compiler/K_fuse_loops.fx
+++ b/compiler/K_fuse_loops.fx
@@ -84,7 +84,12 @@ fun fuse_loops_(code: kcode_t)
         fold_kexp(e, process_callb)
         match e {
         | KDefVal (i, KExpMap ([:: (_, idl, [])], body, flags, (KTypArray _, _)), loc) =>
-            if K_remove_unused.pure_kexp(body) && !flags.for_flag_unzip {
+            // removal grade preserves the pre-existing fusion criterion (a body
+            // that reads mutable memory is still a fusion candidate; fusion of a
+            // single-use comprehension replays the body in the consumer loop,
+            // preserving iteration). Whether fusion also needs movement-grade
+            // safety is a separate question -- see docs/purity1_report.md.
+            if K_remove_unused.pure_kexp(body, mut_read_is_impure=false) && !flags.for_flag_unzip {
                 val ainfo = ref (arr_info_t {
                     arr_nused=0, arr_nused_for=0,
                     arr_idl=idl, arr_body=body, arr_map_flags=flags})

--- a/compiler/K_loop_inv.fx
+++ b/compiler/K_loop_inv.fx
@@ -45,8 +45,10 @@ fun move_loop_invs(code: kcode_t)
         }
 
         is_ktyp_scalar(get_kexp_typ(e)) &&
-        K_remove_unused.pure_kexp(e) &&
-        (match e { | KExpAt _ => false | _ => true }) &&
+        // hoisting out of a loop is a MOVE: ask for the movement grade, which
+        // classifies every mutable-memory read (KExpAt included) as non-movable
+        // in one place -- replacing the old explicit `KExpAt => false` guard.
+        K_remove_unused.pure_kexp(e, mut_read_is_impure=true) &&
         ({
             isinv_kexp_(e, isinv_callb)
             isinv

--- a/compiler/K_remove_unused.fx
+++ b/compiler/K_remove_unused.fx
@@ -63,6 +63,12 @@ fun pure_kexp(e: kexp_t): bool
         | KExpTryCatch _ => ispure = false
         | KExpThrow _ => ispure = false
         | KExpCCode _ => ispure = false
+        // FB-027: a bounds-checked element read (BorderNone) emits a throwing
+        // FX_CHKIDX/FX_VEC_CHKIDX in C-gen; removing the KExpAt at the K level
+        // drops the check and swallows OutOfRangeError. So a BorderNone read is
+        // NOT eliminable. Border reads (.clip/.wrap/.zero) never throw and stay
+        // pure and removable.
+        | KExpAt (_, BorderNone, _, _, _) => ispure = false
         | KExpSeq (elist, (_, loc)) =>
             /*
                 if we have a block of code, this block,

--- a/compiler/K_remove_unused.fx
+++ b/compiler/K_remove_unused.fx
@@ -34,7 +34,22 @@ from K_form import *
 import Options
 import Map, Set, Hashmap, Hashset
 
-fun pure_kexp(e: kexp_t): bool
+/* `pure_kexp` answers "does this expression have no observable effect?", but two
+   consumers need two different grades of that question and conflating them caused
+   FB-023 and FB-027 (see docs/found_bugs.md). The single classification below is
+   the one point of truth; `~mut_read_is_impure` selects the grade:
+
+   - Throwing is impure UNCONDITIONALLY (not the flag): a bounds-checked
+     (BorderNone) `KExpAt` emits a throwing check in C-gen, and throwing
+     intrinsics likewise -- removing one swallows the exception (FB-027), moving
+     one reorders the throw. Neither eliminable nor movable.
+   - `~mut_read_is_impure` governs NON-throwing reads of mutable memory as a
+     class -- border-mode `KExpAt`, ref-cell `OpDeref`, a mutable-record
+     `KExpMem`, and comprehensions (`KExpMap`): `false` = removable (a dead read
+     has no effect -- DCE keeps its power), `true` = not movable (moving a read
+     past an aliasing store changes its value, FB-023). Default `true` is the
+     safe, movement-grade reading for any caller that does not think about it. */
+fun pure_kexp(e: kexp_t, ~mut_read_is_impure: bool = true): bool
 {
     var ispure = true
     var local_vars = empty_id_hashset(8)
@@ -63,12 +78,17 @@ fun pure_kexp(e: kexp_t): bool
         | KExpTryCatch _ => ispure = false
         | KExpThrow _ => ispure = false
         | KExpCCode _ => ispure = false
-        // FB-027: a bounds-checked element read (BorderNone) emits a throwing
-        // FX_CHKIDX/FX_VEC_CHKIDX in C-gen; removing the KExpAt at the K level
-        // drops the check and swallows OutOfRangeError. So a BorderNone read is
-        // NOT eliminable. Border reads (.clip/.wrap/.zero) never throw and stay
-        // pure and removable.
+        // throwing, unconditional (FB-027): a bounds-checked read raises
+        // OutOfRangeError, so it can be neither removed nor moved.
         | KExpAt (_, BorderNone, _, _, _) => ispure = false
+        // non-throwing reads of mutable memory + comprehensions: pure to REMOVE,
+        // not to MOVE (FB-023). The grade decides; see the function header.
+        | KExpAt _ | KExpUnary (OpDeref, _, _) | KExpMap _ =>
+            if mut_read_is_impure { ispure = false }
+            else if ispure { fold_kexp(e, callb) }
+        | KExpMem (base, _, (_, loc)) =>
+            if is_mutable(base, loc) && mut_read_is_impure { ispure = false }
+            else if ispure { fold_kexp(e, callb) }
         | KExpSeq (elist, (_, loc)) =>
             /*
                 if we have a block of code, this block,
@@ -140,7 +160,10 @@ fun pure_fun(f: id_t, loc: loc_t) =
         else if kf_flags.fun_flag_pure == 0 || kf_flags.fun_flag_ccode { false }
         else {
             *df = df->{kf_flags=kf_flags.{fun_flag_pure=1}}
-            val ispure = pure_kexp(kf_body)
+            // removal grade: a function is "pure" (its unused call is removable)
+            // if its body has no effect to remove; a read of mutable memory has
+            // none. Throwing reads stay impure (handled unconditionally).
+            val ispure = pure_kexp(kf_body, mut_read_is_impure=false)
             *df = df->{kf_flags=kf_flags.{fun_flag_pure=int(ispure)}}
             ispure
         }
@@ -218,7 +241,7 @@ fun remove_unused(kmods: kmodule_t list, initial: bool)
                    !kv_flags.val_flag_temp && !kv_flags.val_flag_tempref {
                     compile_warning(loc, f"'{pp(i)}' is declared but not used")
                 }
-                if !pure_kexp(e) {
+                if !pure_kexp(e, mut_read_is_impure=false) {
                     e
                 } else {
                     KExpNop(loc)
@@ -309,7 +332,7 @@ fun remove_unused(kmods: kmodule_t list, initial: bool)
             | KDefTyp _ | KDefClosureVars _ | KDefInterface _ =>
                 e :: result
             | _ =>
-                if rest != [] && pure_kexp(e) { result }
+                if rest != [] && pure_kexp(e, mut_read_is_impure=false) { result }
                 else { e :: result }
             }
             remove_unused_(rest, result, callb)

--- a/compiler/bootstrap/C_gen_code.c
+++ b/compiler/bootstrap/C_gen_code.c
@@ -7615,10 +7615,8 @@ static int _fx_cons_LT4R17K_form__kmodule_tLN15C_form__cstmt_tLN15C_form__cstmt_
 _fx_Nt6option1rR23C_gen_code__block_ctx_t _fx_g16C_gen_code__None = { 1 };
 _fx_Nt6option1N14C_form__ctyp_t _fx_g18C_gen_code__None1_ = { 1 };
 _fx_Nt6option1N14C_form__cexp_t _fx_g18C_gen_code__None2_ = { 1 };
-_fx_Nt6option1FPv3N14K_form__atom_tR10Ast__loc_tR22K_form__k_fold_callb_t _fx_g18C_gen_code__None3_ = 0;
-_fx_Nt6option1FPv3N14K_form__ktyp_tR10Ast__loc_tR22K_form__k_fold_callb_t _fx_g18C_gen_code__None4_ = 0;
-_fx_Nt6option1R9Ast__id_t _fx_g18C_gen_code__None5_ = { 1 };
-_fx_Nt6option1i _fx_g18C_gen_code__None6_ = { 1 };
+_fx_Nt6option1R9Ast__id_t _fx_g18C_gen_code__None3_ = { 1 };
+_fx_Nt6option1i _fx_g18C_gen_code__None4_ = { 1 };
 _fx_N12Ast__cmpop_t _fx_g17C_gen_code__CmpEQ = { 1 };
 _fx_N12Ast__cmpop_t _fx_g17C_gen_code__CmpNE = { 2 };
 _fx_N12Ast__cmpop_t _fx_g17C_gen_code__CmpLT = { 3 };
@@ -7717,26 +7715,6 @@ FX_EXTERN_C int _fx_F6assertv1B(bool, void*);
 
 FX_EXTERN_C int _fx_M7HashsetFM9makeindexA1i1i(int_, fx_arr_t*, void*);
 
-FX_EXTERN_C int _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
-   struct _fx_rB_data_t*,
-   struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t*);
-
-FX_EXTERN_C int _fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(
-   struct _fx_R9Ast__id_t*,
-   struct _fx_R10Ast__loc_t*,
-   bool*,
-   void*);
-
-FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
-   struct _fx_N14K_form__kexp_t_data_t*,
-   struct _fx_R22K_form__k_fold_callb_t*,
-   void*);
-
-static int _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(
-   struct _fx_N14K_form__kexp_t_data_t*,
-   struct _fx_R22K_form__k_fold_callb_t*,
-   void*);
-
 FX_EXTERN_C_VAL(struct _fx_R9Ast__id_t _fx_g9Ast__noid)
 FX_EXTERN_C int _fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(
    int_,
@@ -7778,16 +7756,25 @@ FX_EXTERN_C int _fx_M6K_formFM8get_kvalRM9kdefval_t2R9Ast__id_tR10Ast__loc_t(
    struct _fx_R17K_form__kdefval_t*,
    void*);
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t*, bool*, void*);
+FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   bool,
+   bool*,
+   void*);
 
 FX_EXTERN_C void _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(struct _fx_R9Ast__id_t*, struct _fx_N14K_form__atom_t*);
+
+FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   struct _fx_R22K_form__k_fold_callb_t*,
+   void*);
 
 FX_EXTERN_C int _fx_M10C_gen_codeFM7make_fpFPv3N14K_form__atom_tR10Ast__loc_tR22K_form__k_fold_callb_t2R9Ast__id_trB(
    struct _fx_R9Ast__id_t*,
    struct _fx_rB_data_t*,
    struct _fx_FPv3N14K_form__atom_tR10Ast__loc_tR22K_form__k_fold_callb_t*);
 
-FX_EXTERN_C int _fx_M10C_gen_codeFM9make_fp1_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
+FX_EXTERN_C int _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
    struct _fx_rB_data_t*,
    struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t*);
 
@@ -8641,6 +8628,12 @@ static int
    struct _fx_T2N14C_form__cexp_tLN15C_form__cstmt_t*,
    void*);
 
+FX_EXTERN_C int _fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(
+   struct _fx_R9Ast__id_t*,
+   struct _fx_R10Ast__loc_t*,
+   bool*,
+   void*);
+
 static int
    _fx_M10C_gen_codeFM8form_mapTa2LN15C_form__cstmt_t36LN15C_form__cstmt_tiLT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tLN14C_form__cexp_tLN14C_form__cexp_trLrRM11block_ctx_tLN15C_form__cstmt_trNt10Hashset__t1R9Ast__id_tLT5N14C_form__ctyp_tN14C_form__ctyp_tN14C_form__cexp_tN14C_form__cexp_tN14C_form__cexp_tR10Ast__loc_tN15Ast__for_make_tLSR10Ast__loc_trrNt6option1N14C_form__cexp_trLN15C_form__cstmt_tR9Ast__id_trLN15C_form__cstmt_trNt10Hashmap__t2R9Ast__id_tN14C_form__cexp_tBR10Ast__loc_tiN14C_form__cexp_tLN12Ast__scope_trLN15C_form__cstmt_triBBBN14C_form__cexp_tiN14C_form__cexp_tBrirLN15C_form__cstmt_tNt10Hashset__t1R9Ast__id_tB(
    struct _fx_LN15C_form__cstmt_t_data_t*,
@@ -8704,19 +8697,6 @@ FX_EXTERN_C int
    struct _fx_LN15C_form__cstmt_t_data_t*,
    struct _fx_LN15C_form__cstmt_t_data_t**,
    void*);
-
-typedef struct {
-   int_ rc;
-   fx_free_t free_f;
-   struct _fx_rB_data_t* t0;
-} _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t;
-
-FX_EXTERN_C void _fx_free_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(
-   _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t* dst)
-{
-   FX_FREE_REF_SIMPLE(&dst->t0);
-   fx_free(dst);
-}
 
 typedef struct {
    int_ rc;
@@ -11717,7 +11697,7 @@ FX_EXTERN_C int _fx_M10C_gen_codeFM8find_optNt6option1R9Ast__id_t2Rt6Map__t2R9As
       _fx_catch_0: ;
       }
       else {
-         result_0 = _fx_g18C_gen_code__None5_; FX_BREAK(_fx_catch_1);  _fx_catch_1: ;
+         result_0 = _fx_g18C_gen_code__None3_; FX_BREAK(_fx_catch_1);  _fx_catch_1: ;
       }
       FX_CHECK_EXN(_fx_catch_2);
 
@@ -11749,122 +11729,6 @@ FX_EXTERN_C void _fx_M10C_gen_codeFM13BlockKind_FunN24C_gen_code__block_kind_t1R
 {
    fx_result->tag = 2;
    fx_result->u.BlockKind_Fun = *arg0;
-}
-
-FX_EXTERN_C int _fx_M10C_gen_codeFM20movement_unsafe_readB1N14K_form__kexp_t(
-   struct _fx_N14K_form__kexp_t_data_t* e0_0,
-   bool* fx_result,
-   void* fx_fv)
-{
-   _fx_rB unsafe_ref_0 = 0;
-   _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t chk_kexp__0 = {0};
-   _fx_Nt6option1FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t v_0 = 0;
-   _fx_R22K_form__k_fold_callb_t callb_0 = {0};
-   int fx_status = 0;
-   FX_CALL(_fx_make_rB(false, &unsafe_ref_0), _fx_cleanup);
-   bool* unsafe_0 = &unsafe_ref_0->data;
-   _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(unsafe_ref_0, &chk_kexp__0);
-   FX_CALL(
-      _fx_M10C_gen_codeFM4SomeNt6option1FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t(
-         &chk_kexp__0, &v_0), _fx_cleanup);
-   _fx_make_R22K_form__k_fold_callb_t(_fx_g18C_gen_code__None4_, v_0, _fx_g18C_gen_code__None3_, &callb_0);
-   if (!*unsafe_0) {
-      int tag_0 = FX_REC_VARIANT_TAG(e0_0);
-      if (tag_0 == 19) {
-         *unsafe_0 = true; goto _fx_endmatch_0;
-      }
-      if (tag_0 == 7) {
-         if (e0_0->u.KExpUnary.t0.tag == 7) {
-            *unsafe_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (tag_0 == 20) {
-         _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_0 = &e0_0->u.KExpMem;
-         bool v_1;
-         FX_CALL(_fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(&vcase_0->t0, &vcase_0->t2.t1, &v_1, 0), _fx_catch_0);
-         if (v_1) {
-            *unsafe_0 = true;
-         }
-
-      _fx_catch_0: ;
-         goto _fx_endmatch_0;
-      }
-      if (tag_0 == 26) {
-         *unsafe_0 = true; goto _fx_endmatch_0;
-      }
-      FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e0_0, &callb_0, 0), _fx_catch_1);
-
-   _fx_catch_1: ;
-
-   _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   *fx_result = *unsafe_0;
-
-_fx_cleanup: ;
-   FX_FREE_REF_SIMPLE(&unsafe_ref_0);
-   FX_FREE_FP(&chk_kexp__0);
-   if (v_0) {
-      _fx_free_Nt6option1FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t(&v_0);
-   }
-   _fx_free_R22K_form__k_fold_callb_t(&callb_0);
-   return fx_status;
-}
-
-static int _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(
-   struct _fx_N14K_form__kexp_t_data_t* e_0,
-   struct _fx_R22K_form__k_fold_callb_t* callb_0,
-   void* fx_fv)
-{
-   int fx_status = 0;
-   _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t* cv_0 =
-      (_fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t*)fx_fv;
-   bool* unsafe_0 = &cv_0->t0->data;
-   if (!*unsafe_0) {
-      int tag_0 = FX_REC_VARIANT_TAG(e_0);
-      if (tag_0 == 19) {
-         *unsafe_0 = true; goto _fx_endmatch_0;
-      }
-      if (tag_0 == 7) {
-         if (e_0->u.KExpUnary.t0.tag == 7) {
-            *unsafe_0 = true; goto _fx_endmatch_0;
-         }
-      }
-      if (tag_0 == 20) {
-         _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_0 = &e_0->u.KExpMem;
-         bool v_0;
-         FX_CALL(_fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(&vcase_0->t0, &vcase_0->t2.t1, &v_0, 0), _fx_catch_0);
-         if (v_0) {
-            *unsafe_0 = true;
-         }
-
-      _fx_catch_0: ;
-         goto _fx_endmatch_0;
-      }
-      if (tag_0 == 26) {
-         *unsafe_0 = true; goto _fx_endmatch_0;
-      }
-      FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, callb_0, 0), _fx_catch_1);
-
-   _fx_catch_1: ;
-
-   _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-
-_fx_cleanup: ;
-   return fx_status;
-}
-
-FX_EXTERN_C int _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
-   struct _fx_rB_data_t* arg0,
-   struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t* fx_result)
-{
-   FX_MAKE_FP_IMPL_START(_fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t,
-      _fx_free_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t,
-      _fx_M10C_gen_codeFM9chk_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t);
-   FX_COPY_PTR(arg0, &fcv->t0);
-   return 0;
 }
 
 FX_EXTERN_C int _fx_M10C_gen_codeFM10count_ktypv3N14K_form__ktyp_tR10Ast__loc_tR22K_form__k_fold_callb_t(
@@ -12095,17 +11959,8 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
             good_temp_0 = kv_flags_0.val_flag_temp;
          }
          bool v_1;
-         bool t_0;
          if (good_temp_0) {
-            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(e1_0, &t_0, 0), _fx_catch_0);
-         }
-         else {
-            t_0 = false;
-         }
-         if (t_0) {
-            bool v_2;
-            FX_CALL(_fx_M10C_gen_codeFM20movement_unsafe_readB1N14K_form__kexp_t(e1_0, &v_2, 0), _fx_catch_0);
-            v_1 = !v_2;
+            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(e1_0, true, &v_1, 0), _fx_catch_0);
          }
          else {
             v_1 = false;
@@ -12132,10 +11987,10 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
          _fx_free_R17K_form__kdefval_t(&v_0);
       }
       else if (tag_0 == 12) {
-         _fx_N14K_form__atom_t v_3 = {0};
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&e_2->u.KExpCall.t0, &v_3);
-         if (v_3.tag == 1) {
-            _fx_R9Ast__id_t* i_0 = &v_3.u.AtomId;
+         _fx_N14K_form__atom_t v_2 = {0};
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&e_2->u.KExpCall.t0, &v_2);
+         if (v_2.tag == 1) {
+            _fx_R9Ast__id_t* i_0 = &v_2.u.AtomId;
             uint64_t h_1 = 14695981039346656037ULL;
             h_1 = h_1 ^ ((uint64_t)i_0->m ^ 14695981039346656037ULL);
             h_1 = h_1 * 1099511628211ULL;
@@ -12143,22 +11998,22 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
             h_1 = h_1 * 1099511628211ULL;
             h_1 = h_1 ^ ((uint64_t)i_0->j ^ 14695981039346656037ULL);
             h_1 = h_1 * 1099511628211ULL;
-            _fx_Ta2i v_4;
+            _fx_Ta2i v_3;
             FX_CALL(
                _fx_M10C_gen_codeFM9find_idx_Ta2i3Nt10Hashset__t1R9Ast__id_tR9Ast__id_tq(*decl_const_vals_0, i_0,
-                  h_1 & 9223372036854775807ULL, &v_4, 0), _fx_catch_1);
-            if (v_4.t1 >= 0) {
+                  h_1 & 9223372036854775807ULL, &v_3, 0), _fx_catch_1);
+            if (v_3.t1 >= 0) {
                int_ idx_0;
                FX_CALL(
                   _fx_M10C_gen_codeFM18find_idx_or_inserti2Nt10Hashmap__t2R9Ast__id_tiR9Ast__id_t(*count_map_0, i_0, &idx_0, 0),
                   _fx_catch_1);
                FX_CHKIDX(FX_CHKIDX1((*count_map_0)->u.t.t5, 0, idx_0), _fx_catch_1);
-               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_5 =
+               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_4 =
                   FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti, (*count_map_0)->u.t.t5, idx_0);
                FX_CHKIDX(FX_CHKIDX1((*count_map_0)->u.t.t5, 0, idx_0), _fx_catch_1);
-               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_6 =
+               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_5 =
                   FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti, (*count_map_0)->u.t.t5, idx_0);
-               v_6->data = v_5->data + 1;
+               v_5->data = v_4->data + 1;
             }
 
          _fx_catch_1: ;
@@ -12168,13 +12023,13 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
          FX_BREAK(_fx_catch_2);
 
       _fx_catch_2: ;
-         _fx_free_N14K_form__atom_t(&v_3);
+         _fx_free_N14K_form__atom_t(&v_2);
       }
       else if (tag_0 == 13) {
-         _fx_N14K_form__atom_t v_7 = {0};
-         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&e_2->u.KExpICall.t0, &v_7);
-         if (v_7.tag == 1) {
-            _fx_R9Ast__id_t* i_1 = &v_7.u.AtomId;
+         _fx_N14K_form__atom_t v_6 = {0};
+         _fx_M6K_formFM6AtomIdN14K_form__atom_t1R9Ast__id_t(&e_2->u.KExpICall.t0, &v_6);
+         if (v_6.tag == 1) {
+            _fx_R9Ast__id_t* i_1 = &v_6.u.AtomId;
             uint64_t h_2 = 14695981039346656037ULL;
             h_2 = h_2 ^ ((uint64_t)i_1->m ^ 14695981039346656037ULL);
             h_2 = h_2 * 1099511628211ULL;
@@ -12182,22 +12037,22 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
             h_2 = h_2 * 1099511628211ULL;
             h_2 = h_2 ^ ((uint64_t)i_1->j ^ 14695981039346656037ULL);
             h_2 = h_2 * 1099511628211ULL;
-            _fx_Ta2i v_8;
+            _fx_Ta2i v_7;
             FX_CALL(
                _fx_M10C_gen_codeFM9find_idx_Ta2i3Nt10Hashset__t1R9Ast__id_tR9Ast__id_tq(*decl_const_vals_0, i_1,
-                  h_2 & 9223372036854775807ULL, &v_8, 0), _fx_catch_3);
-            if (v_8.t1 >= 0) {
+                  h_2 & 9223372036854775807ULL, &v_7, 0), _fx_catch_3);
+            if (v_7.t1 >= 0) {
                int_ idx_1;
                FX_CALL(
                   _fx_M10C_gen_codeFM18find_idx_or_inserti2Nt10Hashmap__t2R9Ast__id_tiR9Ast__id_t(*count_map_0, i_1, &idx_1, 0),
                   _fx_catch_3);
                FX_CHKIDX(FX_CHKIDX1((*count_map_0)->u.t.t5, 0, idx_1), _fx_catch_3);
-               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_9 =
+               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_8 =
                   FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti, (*count_map_0)->u.t.t5, idx_1);
                FX_CHKIDX(FX_CHKIDX1((*count_map_0)->u.t.t5, 0, idx_1), _fx_catch_3);
-               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_10 =
+               _fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti* v_9 =
                   FX_PTR_1D(_fx_Rt20Hashmap__hashentry_t2R9Ast__id_ti, (*count_map_0)->u.t.t5, idx_1);
-               v_10->data = v_9->data + 1;
+               v_9->data = v_8->data + 1;
             }
 
          _fx_catch_3: ;
@@ -12207,7 +12062,7 @@ static int _fx_M10C_gen_codeFM10count_kexpv2N14K_form__kexp_tR22K_form__k_fold_c
          FX_BREAK(_fx_catch_4);
 
       _fx_catch_4: ;
-         _fx_free_N14K_form__atom_t(&v_7);
+         _fx_free_N14K_form__atom_t(&v_6);
       }
       else {
          FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_2, &callb_2, 0), _fx_catch_5);
@@ -12267,7 +12122,7 @@ static int _fx_M10C_gen_codeFM10__lambda__v3R9Ast__id_trNt10Hashmap__t2R9Ast__id
       _fx_M10C_gen_codeFM4SomeNt6option1i1i(v_2->data, &v_1);
    }
    else {
-      v_1 = _fx_g18C_gen_code__None6_;
+      v_1 = _fx_g18C_gen_code__None4_;
    }
    if (v_1.tag == 2) {
       if (v_1.u.Some == 1) {
@@ -12323,7 +12178,7 @@ FX_EXTERN_C int _fx_M10C_gen_codeFM14occurs_id_kexpB2R9Ast__id_tN14K_form__kexp_
    bool* id_occurs_0 = &id_occurs_ref_0->data;
    _fx_M10C_gen_codeFM7make_fpFPv3N14K_form__atom_tR10Ast__loc_tR22K_form__k_fold_callb_t2R9Ast__id_trB(i0_0, id_occurs_ref_0,
       &occurs_atom_0);
-   _fx_M10C_gen_codeFM9make_fp1_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(id_occurs_ref_0, &occurs_kexp_0);
+   _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(id_occurs_ref_0, &occurs_kexp_0);
    _fx_R10Ast__loc_t loc_0;
    FX_CALL(_fx_M6K_formFM12get_kexp_locR10Ast__loc_t1N14K_form__kexp_t(e_0, &loc_0, 0), _fx_cleanup);
    FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i0_0, &loc_0, &v_0, 0), _fx_cleanup);
@@ -12429,7 +12284,7 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M10C_gen_codeFM9make_fp1_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
+FX_EXTERN_C int _fx_M10C_gen_codeFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t1rB(
    struct _fx_rB_data_t* arg0,
    struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t* fx_result)
 {

--- a/compiler/bootstrap/K_fuse_loops.c
+++ b/compiler/bootstrap/K_fuse_loops.c
@@ -3401,7 +3401,11 @@ FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
    struct _fx_R22K_form__k_fold_callb_t*,
    void*);
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t*, bool*, void*);
+FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   bool,
+   bool*,
+   void*);
 
 static int _fx_M12K_fuse_loopsFM11process_idlv3BLT2R9Ast__id_tN13K_form__dom_trRt6Map__t2R9Ast__id_trRM10arr_info_t(
    bool,
@@ -4594,7 +4598,7 @@ FX_EXTERN_C int _fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form_
                         _fx_N14K_form__kexp_t body_0 = vcase_1->t1;
                         bool v_9;
                         bool res_0;
-                        FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(body_0, &res_0, 0), _fx_catch_0);
+                        FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(body_0, false, &res_0, 0), _fx_catch_0);
                         if (res_0) {
                            v_9 = !flags_0->for_flag_unzip;
                         }

--- a/compiler/bootstrap/K_loop_inv.c
+++ b/compiler/bootstrap/K_loop_inv.c
@@ -3011,7 +3011,11 @@ FX_EXTERN_C int _fx_M6K_formFM12get_kexp_typN14K_form__ktyp_t1N14K_form__kexp_t(
 
 FX_EXTERN_C int _fx_M6K_formFM14is_ktyp_scalarB1N14K_form__ktyp_t(struct _fx_N14K_form__ktyp_t_data_t*, bool*, void*);
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(struct _fx_N14K_form__kexp_t_data_t*, bool*, void*);
+FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   bool,
+   bool*,
+   void*);
 
 FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
    struct _fx_N14K_form__kexp_t_data_t*,
@@ -3676,25 +3680,12 @@ static int _fx_M10K_loop_invFM17is_loop_invariantB2N14K_form__kexp_trNt10Hashset
    FX_CALL(_fx_M6K_formFM14is_ktyp_scalarB1N14K_form__ktyp_t(v_3, &res_0, 0), _fx_cleanup);
    bool t_0;
    if (res_0) {
-      FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(e_0, &t_0, 0), _fx_cleanup);
+      FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(e_0, true, &t_0, 0), _fx_cleanup);
    }
    else {
       t_0 = false;
    }
-   bool t_1;
    if (t_0) {
-      if (FX_REC_VARIANT_TAG(e_0) == 19) {
-         t_1 = false;
-      }
-      else {
-         t_1 = true;
-      }
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   else {
-      t_1 = false;
-   }
-   if (t_1) {
       if (*isinv_0) {
          FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, &isinv_callb_0, 0), _fx_cleanup);
       }

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -3713,9 +3713,10 @@ FX_EXTERN_C int _fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(
    struct _fx_Nt10Hashset__t1R9Ast__id_t_data_t**,
    void*);
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t2rBrNt10Hashset__t1R9Ast__id_t(
+FX_EXTERN_C int _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t3rBrNt10Hashset__t1R9Ast__id_tB(
    struct _fx_rB_data_t*,
    struct _fx_rNt10Hashset__t1R9Ast__id_t_data_t*,
+   bool,
    struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t*);
 
 static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(
@@ -3731,15 +3732,21 @@ FX_EXTERN_C int _fx_M15K_remove_unusedFM8pure_funB2R9Ast__id_tR10Ast__loc_t(
 
 FX_EXTERN_C int _fx_M3AstFM6__eq__B2RM4id_tRM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, bool*, void*);
 
+FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   struct _fx_R22K_form__k_fold_callb_t*,
+   void*);
+
+FX_EXTERN_C int _fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(
+   struct _fx_R9Ast__id_t*,
+   struct _fx_R10Ast__loc_t*,
+   bool*,
+   void*);
+
 FX_EXTERN_C int _fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(
    struct _fx_R9Ast__id_t*,
    struct _fx_R10Ast__loc_t*,
    struct _fx_N15K_form__kinfo_t*,
-   void*);
-
-FX_EXTERN_C int _fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(
-   struct _fx_N14K_form__kexp_t_data_t*,
-   struct _fx_R22K_form__k_fold_callb_t*,
    void*);
 
 FX_EXTERN_C int _fx_M6K_formFM7used_byNt10Hashset__t1R9Ast__id_t2LN14K_form__kexp_ti(
@@ -3853,6 +3860,7 @@ typedef struct {
    fx_free_t free_f;
    struct _fx_rB_data_t* t0;
    struct _fx_rNt10Hashset__t1R9Ast__id_t_data_t* t1;
+   bool t2;
 } _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t;
 
 FX_EXTERN_C void _fx_free_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(
@@ -5243,8 +5251,9 @@ FX_EXTERN_C int _fx_M15K_remove_unusedFM10pure_ktyp_v3N14K_form__ktyp_tR10Ast__l
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(
+FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(
    struct _fx_N14K_form__kexp_t_data_t* e_0,
+   bool mut_read_is_impure_0,
    bool* fx_result,
    void* fx_fv)
 {
@@ -5261,8 +5270,8 @@ FX_EXTERN_C int _fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(
    bool* ispure_0 = &ispure_ref_0->data;
    FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(8, &local_vars_arg_0, 0), _fx_cleanup);
    FX_CALL(_fx_make_rNt10Hashset__t1R9Ast__id_t(local_vars_arg_0, &local_vars_ref_0), _fx_cleanup);
-   _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t2rBrNt10Hashset__t1R9Ast__id_t(ispure_ref_0,
-      local_vars_ref_0, &pure_kexp__0);
+   _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t3rBrNt10Hashset__t1R9Ast__id_tB(ispure_ref_0,
+      local_vars_ref_0, mut_read_is_impure_0, &pure_kexp__0);
    _fx_FPv3N14K_form__ktyp_tR10Ast__loc_tR22K_form__k_fold_callb_t pure_ktyp__fp_0 =
       { _fx_M15K_remove_unusedFM10pure_ktyp_v3N14K_form__ktyp_tR10Ast__loc_tR22K_form__k_fold_callb_t, 0 };
    FX_COPY_FP(&pure_ktyp__fp_0, &pure_ktyp__0);
@@ -5305,17 +5314,18 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
    FX_CALL(fx_check_stack(), _fx_cleanup);
    _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t* cv_0 =
       (_fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t*)fx_fv;
+   bool* mut_read_is_impure_0 = &cv_0->t2;
    bool* ispure_0 = &cv_0->t0->data;
    _fx_Nt10Hashset__t1R9Ast__id_t* local_vars_0 = &cv_0->t1->data;
    int tag_0 = FX_REC_VARIANT_TAG(e_0);
    if (tag_0 == 2) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 3) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 4) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 8) {
       int tag_1 = e_0->u.KExpIntrin.t0.tag;
@@ -5358,7 +5368,7 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       FX_CHECK_EXN(_fx_catch_0);
 
    _fx_catch_0: ;
-      goto _fx_endmatch_1;
+      goto _fx_endmatch_2;
    }
    if (tag_0 == 12) {
       _fx_T3R9Ast__id_tLN14K_form__atom_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_0 = &e_0->u.KExpCall;
@@ -5369,10 +5379,10 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       }
 
    _fx_catch_1: ;
-      goto _fx_endmatch_1;
+      goto _fx_endmatch_2;
    }
    if (tag_0 == 13) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 21) {
       _fx_T3R9Ast__id_tN14K_form__atom_tR10Ast__loc_t* vcase_1 = &e_0->u.KExpAssign;
@@ -5381,7 +5391,7 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
          bool res_2;
          FX_CALL(_fx_M3AstFM6__eq__B2RM4id_tRM4id_t(&vcase_1->t0, &v_1->u.AtomId, &res_2, 0), _fx_cleanup);
          if (res_2) {
-            goto _fx_endmatch_1;
+            goto _fx_endmatch_2;
          }
       }
    }
@@ -5403,44 +5413,92 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
       }
 
    _fx_catch_2: ;
-      goto _fx_endmatch_1;
+      goto _fx_endmatch_2;
    }
    if (tag_0 == 23) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 24) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 30) {
-      *ispure_0 = false; goto _fx_endmatch_1;
+      *ispure_0 = false; goto _fx_endmatch_2;
    }
    if (tag_0 == 19) {
       if (e_0->u.KExpAt.t1.tag == 1) {
-         *ispure_0 = false; goto _fx_endmatch_1;
+         *ispure_0 = false; goto _fx_endmatch_2;
       }
+   }
+   bool res_3;
+   if (tag_0 == 19) {
+      res_3 = true; goto _fx_endmatch_1;
+   }
+   if (tag_0 == 7) {
+      if (e_0->u.KExpUnary.t0.tag == 7) {
+         res_3 = true; goto _fx_endmatch_1;
+      }
+   }
+   if (tag_0 == 26) {
+      res_3 = true; goto _fx_endmatch_1;
+   }
+   res_3 = false;
+
+_fx_endmatch_1: ;
+   FX_CHECK_EXN(_fx_cleanup);
+   if (res_3) {
+      if (*mut_read_is_impure_0) {
+         *ispure_0 = false;
+      }
+      else if (*ispure_0) {
+         FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, callb_0, 0), _fx_catch_3);
+      }
+
+   _fx_catch_3: ;
+      goto _fx_endmatch_2;
+   }
+   if (tag_0 == 20) {
+      _fx_T3R9Ast__id_tiT2N14K_form__ktyp_tR10Ast__loc_t* vcase_2 = &e_0->u.KExpMem;
+      bool v_3;
+      bool res_4;
+      FX_CALL(_fx_M6K_formFM10is_mutableB2R9Ast__id_tR10Ast__loc_t(&vcase_2->t0, &vcase_2->t2.t1, &res_4, 0), _fx_catch_4);
+      if (res_4) {
+         v_3 = *mut_read_is_impure_0;
+      }
+      else {
+         v_3 = false;
+      }
+      if (v_3) {
+         *ispure_0 = false;
+      }
+      else if (*ispure_0) {
+         FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, callb_0, 0), _fx_catch_4);
+      }
+
+   _fx_catch_4: ;
+      goto _fx_endmatch_2;
    }
    if (tag_0 == 10) {
       _fx_Nt10Hashset__t1R9Ast__id_t saved_local_vars_0 = 0;
-      _fx_Nt10Hashset__t1R9Ast__id_t v_3 = 0;
+      _fx_Nt10Hashset__t1R9Ast__id_t v_4 = 0;
       _fx_LN14K_form__kexp_t elist_0 = 0;
       _fx_LN14K_form__kexp_t elist_1 = 0;
       _fx_LN14K_form__kexp_t elist_2 = e_0->u.KExpSeq.t0;
       FX_COPY_PTR(*local_vars_0, &saved_local_vars_0);
-      int_ v_4 = _fx_M15K_remove_unusedFM6lengthi1LN14K_form__kexp_t(elist_2, 0);
-      FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(v_4, &v_3, 0), _fx_catch_7);
+      int_ v_5 = _fx_M15K_remove_unusedFM6lengthi1LN14K_form__kexp_t(elist_2, 0);
+      FX_CALL(_fx_M3AstFM16empty_id_hashsetNt10Hashset__t1RM4id_t1i(v_5, &v_4, 0), _fx_catch_9);
       _fx_free_Nt10Hashset__t1R9Ast__id_t(local_vars_0);
-      FX_COPY_PTR(v_3, local_vars_0);
+      FX_COPY_PTR(v_4, local_vars_0);
       FX_COPY_PTR(elist_2, &elist_0);
       _fx_LN14K_form__kexp_t lst_0 = elist_0;
       for (; lst_0; lst_0 = lst_0->tl) {
          _fx_N14K_form__kexp_t e_1 = lst_0->hd;
          if (FX_REC_VARIANT_TAG(e_1) == 31) {
-            _fx_N15K_form__kinfo_t v_5 = {0};
-            _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_2 = &e_1->u.KDefVal;
-            _fx_R9Ast__id_t* i_1 = &vcase_2->t0;
-            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_1, &vcase_2->t2, &v_5, 0), _fx_catch_4);
-            if (v_5.tag == 2) {
-               _fx_R16Ast__val_flags_t* kv_flags_0 = &v_5.u.KVal.kv_flags;
+            _fx_N15K_form__kinfo_t v_6 = {0};
+            _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_3 = &e_1->u.KDefVal;
+            _fx_R9Ast__id_t* i_1 = &vcase_3->t0;
+            FX_CALL(_fx_M6K_formFM6kinfo_N15K_form__kinfo_t2R9Ast__id_tR10Ast__loc_t(i_1, &vcase_3->t2, &v_6, 0), _fx_catch_6);
+            if (v_6.tag == 2) {
+               _fx_R16Ast__val_flags_t* kv_flags_0 = &v_6.u.KVal.kv_flags;
                bool t_0;
                if (kv_flags_0->val_flag_mutable) {
                   t_0 = !kv_flags_0->val_flag_tempref;
@@ -5458,68 +5516,69 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
                   h_1 = h_1 * 1099511628211ULL;
                   FX_CALL(
                      _fx_M15K_remove_unusedFM4add_v3Nt10Hashset__t1R9Ast__id_tR9Ast__id_tq(*local_vars_0, i_1,
-                        h_1 & 9223372036854775807ULL, 0), _fx_catch_3);
+                        h_1 & 9223372036854775807ULL, 0), _fx_catch_5);
                }
 
-            _fx_catch_3: ;
+            _fx_catch_5: ;
             }
-            FX_CHECK_EXN(_fx_catch_4);
+            FX_CHECK_EXN(_fx_catch_6);
 
-         _fx_catch_4: ;
-            _fx_free_N15K_form__kinfo_t(&v_5);
+         _fx_catch_6: ;
+            _fx_free_N15K_form__kinfo_t(&v_6);
          }
-         FX_CHECK_EXN(_fx_catch_5);
-
-      _fx_catch_5: ;
          FX_CHECK_EXN(_fx_catch_7);
+
+      _fx_catch_7: ;
+         FX_CHECK_EXN(_fx_catch_9);
       }
       FX_COPY_PTR(elist_2, &elist_1);
       _fx_LN14K_form__kexp_t lst_1 = elist_1;
       for (; lst_1; lst_1 = lst_1->tl) {
          _fx_N14K_form__kexp_t e_2 = lst_1->hd;
          FX_CALL(_fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t(e_2, callb_0, fx_fv),
-            _fx_catch_6);
+            _fx_catch_8);
          if (!*ispure_0) {
-            FX_BREAK(_fx_catch_6);
+            FX_BREAK(_fx_catch_8);
          }
 
-      _fx_catch_6: ;
+      _fx_catch_8: ;
          FX_CHECK_BREAK();
-         FX_CHECK_EXN(_fx_catch_7);
+         FX_CHECK_EXN(_fx_catch_9);
       }
       _fx_free_Nt10Hashset__t1R9Ast__id_t(local_vars_0);
       FX_COPY_PTR(saved_local_vars_0, local_vars_0);
 
-   _fx_catch_7: ;
+   _fx_catch_9: ;
       if (elist_1) {
          _fx_free_LN14K_form__kexp_t(&elist_1);
       }
       if (elist_0) {
          _fx_free_LN14K_form__kexp_t(&elist_0);
       }
-      if (v_3) {
-         _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_3);
+      if (v_4) {
+         _fx_free_Nt10Hashset__t1R9Ast__id_t(&v_4);
       }
       if (saved_local_vars_0) {
          _fx_free_Nt10Hashset__t1R9Ast__id_t(&saved_local_vars_0);
       }
-      goto _fx_endmatch_1;
+      goto _fx_endmatch_2;
    }
    if (*ispure_0) {
-      FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, callb_0, 0), _fx_catch_8);
+      FX_CALL(_fx_M6K_formFM9fold_kexpv2N14K_form__kexp_tRM14k_fold_callb_t(e_0, callb_0, 0), _fx_catch_10);
    }
 
-_fx_catch_8: ;
+_fx_catch_10: ;
 
-_fx_endmatch_1: ;
+_fx_endmatch_2: ;
 
 _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t2rBrNt10Hashset__t1R9Ast__id_t(
+FX_EXTERN_C int _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__k_fold_callb_t3rBrNt10Hashset__t1R9Ast__id_tB(
    struct _fx_rB_data_t* arg0,
    struct _fx_rNt10Hashset__t1R9Ast__id_t_data_t* arg1,
+   bool arg2,
    struct _fx_FPv2N14K_form__kexp_tR22K_form__k_fold_callb_t* fx_result)
 {
    FX_MAKE_FP_IMPL_START(_fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t_cldata_t,
@@ -5527,6 +5586,7 @@ FX_EXTERN_C int _fx_M15K_remove_unusedFM7make_fpFPv2N14K_form__kexp_tR22K_form__
       _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_fold_callb_t);
    FX_COPY_PTR(arg0, &fcv->t0);
    FX_COPY_PTR(arg1, &fcv->t1);
+   fcv->t2 = arg2;
    return 0;
 }
 
@@ -5589,7 +5649,7 @@ FX_EXTERN_C int _fx_M15K_remove_unusedFM8pure_funB2R9Ast__id_tR10Ast__loc_t(
             _fx_free_R17K_form__kdeffun_t(v_7);
             _fx_copy_R17K_form__kdeffun_t(&v_1, v_7);
             bool ispure_0;
-            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(kf_body_0, &ispure_0, 0), _fx_catch_0);
+            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(kf_body_0, false, &ispure_0, 0), _fx_catch_0);
             _fx_R17K_form__kdeffun_t* v_8 = &df_0->data;
             _fx_R16Ast__fun_flags_t v_9 =
                { (int_)ispure_0, kf_flags_0.fun_flag_ccode, kf_flags_0.fun_flag_have_keywords, kf_flags_0.fun_flag_inline,
@@ -6089,7 +6149,7 @@ static int _fx_M15K_remove_unusedFM19remove_unused_kexp_N14K_form__kexp_t2N14K_f
             FX_CALL(_fx_M3AstFM15compile_warningv2RM5loc_tS(loc_0, &v_2, 0), _fx_catch_2);
          }
          bool v_14;
-         FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(e_1, &v_14, 0), _fx_catch_2);
+         FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(e_1, false, &v_14, 0), _fx_catch_2);
          if (!v_14) {
             FX_COPY_PTR(e_1, fx_result);
          }
@@ -6584,7 +6644,7 @@ static int
          }
          bool v_6;
          if (rest_0 != 0) {
-            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB1N14K_form__kexp_t(e_0, &v_6, 0), _fx_catch_5);
+            FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(e_0, false, &v_6, 0), _fx_catch_5);
          }
          else {
             v_6 = false;

--- a/compiler/bootstrap/K_remove_unused.c
+++ b/compiler/bootstrap/K_remove_unused.c
@@ -5414,6 +5414,11 @@ static int _fx_M15K_remove_unusedFM10pure_kexp_v2N14K_form__kexp_tR22K_form__k_f
    if (tag_0 == 30) {
       *ispure_0 = false; goto _fx_endmatch_1;
    }
+   if (tag_0 == 19) {
+      if (e_0->u.KExpAt.t1.tag == 1) {
+         *ispure_0 = false; goto _fx_endmatch_1;
+      }
+   }
    if (tag_0 == 10) {
       _fx_Nt10Hashset__t1R9Ast__id_t saved_local_vars_0 = 0;
       _fx_Nt10Hashset__t1R9Ast__id_t v_3 = 0;

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -324,7 +324,7 @@ limitation (worked around by splitting into two arms, e.g. in the vector-iterati
 read-lock codegen in C_gen_code.fx). Should be fixed — allow a variable bound
 identically across all alternatives of an or-pattern.
 
-## FB-027  `ignore(coll[i])` swallows the out-of-range exception  [OPEN — soundness]
+## FB-027  `ignore(coll[i])` swallows the out-of-range exception  [FIXED — purity-1]
 An element read whose result does not escape is dead-code-eliminated together
 with its bounds check, so an out-of-bounds/empty access that *should* raise
 `OutOfRangeError` silently does nothing:
@@ -351,8 +351,19 @@ soundness surprise, not just a missed diagnostic.
   `outer_sink = coll[i]` (an outer `var`) throws; `{ var s=0; s = coll[i] }`
   (local, dead) does not. This is why `test/test_vec.fx` fcvector.pushpop_edge
   asserts `back()`-on-empty via a captured `sink`, not `ignore(v.back())`.
-- **Fix direction (not done — general compiler soundness, out of scope for
-  newvec-2)**: mark a *bounds-checked* `KExpAt` (i.e. `BorderNone`, which emits a
-  throwing check) impure in `pure_kexp_`, so it survives DCE. Border reads
-  (`.clip`/`.wrap`/`.zero`) never throw and can stay pure and eliminable; gating
-  on `BorderNone` avoids inhibiting legitimate DCE of genuinely-safe reads.
+- **Fix (purity-1 Phase 1)**: `pure_kexp_` in `K_remove_unused.fx` now lists
+  `KExpAt(_, BorderNone, _, _, _) => ispure = false` — a bounds-checked read
+  (which emits a throwing `FX_CHKIDX`/`FX_VEC_CHKIDX` in C-gen) is impure and
+  survives DCE. Border reads (`.clip`/`.wrap`/`.zero`) never throw and stay pure
+  and eliminable (verified: `test/ir/checked_read.k.golden` shows a dead `.clip`
+  read removed while the dead checked read is retained). Repro now throws
+  `OutOfRangeError` for array/vector/string/rrbvec at both `-O0` and `-O3`
+  (`test/test_basic.fx` `basic.checked_read_side_effect`; `test/test_vec.fx`
+  `fcvector.pushpop_edge` restored to the natural `ignore(v.back())` spelling).
+  Churn: only `K_remove_unused.c` regenerated among the 55 compiler modules;
+  generated C for spectralnorm/mandelbrot/btree/nbody byte-identical to master
+  (perf within noise); a single test scaffold (`test_matrix.c`) materializes a
+  few extra named temps around checked reads it no longer inlines — behavior-
+  preserving, coalesced by the C compiler. Phase 2 (purity-1) folds this into a
+  parameterized `pure_kexp(~mut_read_is_impure)` so the throw-impurity and the
+  FB-023 movement guard share one classification.

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -237,7 +237,13 @@ CLAUDE.md and (at rewrite time) the tutorial state it plainly; the annotate-2
   follow-up would extend the DefVal recovery to poison the pattern regardless of
   RHS shape.
 
-## FB-023  single-use temp memory read inlined PAST an aliasing store  [FIXED — fold-1]
+## FB-023  single-use temp memory read inlined PAST an aliasing store  [FIXED — fold-1; refactored — purity-1]
+- **purity-1 update**: the local `movement_unsafe_read` guard described below was
+  removed; its `{KExpAt, OpDeref, mutable KExpMem, KExpMap}` set is now the
+  `~mut_read_is_impure=true` grade of the shared `pure_kexp` predicate
+  (`K_remove_unused.fx`). C-gen's `find_single_use_vals` calls
+  `pure_kexp(e1, mut_read_is_impure=true)`; behaviour byte-identical. See FB-027
+  and `docs/purity1_report.md`.
 - repro (via fold-1 tuple assignment): `(arr[i], arr[j]) = (arr[j], arr[i])`
   desugars to `val __t = (arr[j], arr[i]); arr[i] = __t.0; arr[j] = __t.1`.
   The dealiaser (`K_cfold_dealias`, `mktup_map`) flattens `__t.k` to its

--- a/docs/purity1_brief.md
+++ b/docs/purity1_brief.md
@@ -1,0 +1,79 @@
+# Brief: purity-1 — FB-027 + the effect-facet predicate (Opus)
+
+**You are Claude Code (Opus) working in the Ficus repo.** Branch `purity-1`
+off master. Context: `docs/found_bugs.md` FB-027 (the bug) and FB-023 (its
+sibling — read the pair together), `docs/newvec2_report.md` (§4/5: the new
+push/pop intrinsics had to be HAND-marked impure — the third reminder this
+class needs an API), repo CLAUDE.md.
+
+## The pattern being killed
+
+`pure_kexp` answers one question ("no side effects for dead-code REMOVAL")
+but has been consumed for three different ones, producing two soundness bugs:
+- FB-023: purity ≠ movement-invariance (a pure read of mutable memory changes
+  value when moved past an aliasing store) — fixed by a local
+  `movement_unsafe_read` guard in C_gen;
+- FB-027: purity ≠ effect-freedom (a bounds-checked read can THROW; removing
+  it swallows `OutOfRangeError`) — open, this brief fixes it;
+- newvec-2: every new intrinsic author must REMEMBER to mark impure or DCE
+  eats their calls.
+
+## Phase 1 — the precise FB-027 fix
+
+Per the registry's fix direction: in `K_remove_unused.fx` `pure_kexp_`, a
+`KExpAt` with `BorderNone` (the throwing-check read path) is IMPURE; border
+reads (`.clip/.wrap/.zero` — never throw) stay pure and eliminable.
+
+Tests (`test/test_vec.fx` + a small `basic.` case): `ignore(e[.-1])` /
+`ignore(e[0])` on an EMPTY container throws `OutOfRangeError` for all four —
+array, vector, string, rrbvec — at **-O0 and -O3**; a dead `.clip` read still
+disappears from `-pr-k` (lock the non-regression of legitimate DCE with an IR
+golden); `test_vec.fx` `pushpop_edge` switches back to the natural
+`ignore(v.back())` spelling — the in-tree proof. Measure: bootstrap churn
+(expected: some — dead checked reads stop being removed) and the perf budget
+(±2% on spectralnorm + compiler self-parse, the FB-023 methodology).
+
+## Phase 2 — the parameterized predicate (so there is no FB-0XX member three)
+
+Design (Vadim): keep the single short-circuiting fold — do NOT build an
+all-facets record collector (no consumer needs all facets; the lazy boolean
+query preserves the first-impure-early-exit). Instead, parameterize what
+counts:
+
+```
+fun pure_kexp(e: kexp_t, ~mut_read_is_impure: bool = true): bool
+```
+
+Semantics:
+- **Throwing is impure UNCONDITIONALLY** (not a flag): checked `BorderNone`
+  `KExpAt`, throwing intrinsics — cannot be removed (swallows the exception,
+  FB-027) and cannot be moved (reorders throws). This is Phase 1 baked in.
+- `~mut_read_is_impure` governs NON-throwing reads of mutable memory as a
+  class — border-mode `KExpAt`, `OpDeref`, `KExpMem` on an `is_mutable`
+  base: `false` = removable (a dead read has no effect — DCE keeps today's
+  power), `true` = not movable (FB-023). Default `true` = the safe,
+  movement-grade interpretation for any caller that doesn't think.
+
+The classification stays in ONE match inside `pure_kexp` (the single point
+of truth this phase exists for). Re-express the consumers:
+- DCE (`K_remove_unused`): explicit `~mut_read_is_impure=false`;
+- C_gen `find_single_use_vals`' FB-023 `movement_unsafe_read` guard: the
+  default-true call replaces the local guard;
+- the hand-marked intrinsics (`__intrin_push__`/`__intrin_pop__`,
+  `IntrinCheckIdx*`, `IntrinVecSplice`, ...): classified in the one match,
+  ad-hoc marks removed.
+Audit OTHER `pure_kexp` call sites (grep) and give each an EXPLICIT argument
+declaring its intent; anything ambiguous — leave as-is and LIST it in the
+report (no speculative rewrites of optimization passes).
+
+Acceptance: Phase-1 tests still green; bootstrap fixpoint; the full ladder +
+sanitize; behavior-identical to Phase 1 (the refactor is expression, not
+policy — generated C byte-identical between Phase-1 and Phase-2 commits
+except modules whose source changed).
+
+## Ground rules
+House standard: ladder per phase, `update_compiler.py` fixpoint,
+`-pr-resolve` census unchanged, found_bugs for discoveries, don't push. STOP:
+if Phase 2's audit finds a consumer whose migration would CHANGE optimization
+behavior — report, don't decide. Report `docs/purity1_report.md` with the
+consumer-audit table and the FB-027 → fixed registry update.

--- a/docs/purity1_report.md
+++ b/docs/purity1_report.md
@@ -1,0 +1,138 @@
+# purity-1 report — FB-027 fix + the effect-facet predicate
+
+Branch `purity-1` (off master `fbb985f`). Two commits:
+
+- **Phase 1** `03775b8` — the precise FB-027 fix (checked reads survive DCE).
+- **Phase 2** `c9baefe` — parameterize `pure_kexp` with `~mut_read_is_impure`,
+  fold the three "is it pure?" questions into one classification, migrate every
+  consumer to declare its grade.
+
+Both green on the full ladder (`fxtest.py all`), `sanitize` (ASan+UBSan),
+`determinism`, and the self-hosting fixpoint (`update_compiler.py`).
+
+## The pattern being killed
+
+`pure_kexp` answered one question — "no side effects, safe to REMOVE for DCE" —
+but three consumers asked three different things, and the conflation produced two
+soundness bugs plus a recurring authoring trap:
+
+| # | question | consumer | what went wrong |
+|---|----------|----------|-----------------|
+| 1 | no effect to **remove**? | DCE (`K_remove_unused`) | correct baseline, but see FB-027 |
+| 2 | safe to **move**? | C-gen temp inlining, loop-invariant hoisting | purity ≠ movement-invariance → **FB-023** (read moved past an aliasing store) |
+| 3 | **effect-free** incl. throwing? | DCE of a discarded checked read | purity ≠ effect-freedom → **FB-027** (dead `coll[i]` dropped its bounds check, swallowing `OutOfRangeError`) |
+
+FB-023 was patched with a *local* `movement_unsafe_read` guard in C-gen; FB-027
+was open; and every new intrinsic author (newvec-2: push/pop/splice) had to
+*remember* to hand-mark impurity or DCE ate their void-result calls.
+
+## Phase 1 — the precise FB-027 fix
+
+A bounds-checked element read lowers to `KExpAt(_, BorderNone, …)` and emits a
+throwing `FX_CHKIDX`/`FX_VEC_CHKIDX` **inline** in C-gen. `pure_kexp_` did not
+list `KExpAt`, so a read whose result was discarded (`ignore(coll[i])`, a dead
+`val`) was eliminated at the K level — *before* C-gen ever emitted the check —
+silently swallowing the exception. (The separate `IntrinCheckIdx*` intrinsics
+were already marked impure, but the plain `KExpAt` path was not.)
+
+Fix: `pure_kexp_` classifies `KExpAt(_, BorderNone, _, _, _)` as impure. Border
+reads (`.clip`/`.wrap`/`.zero`) never throw and stay pure and eliminable — gating
+on `BorderNone` keeps legitimate DCE intact.
+
+**Tests**
+- `test/test_basic.fx` `basic.checked_read_side_effect` — `ignore(e[0])` and
+  `ignore(e[.-1])` on an empty **array / vector / string / rrbvec** each throw
+  `OutOfRangeError` (T2 corpus runs the suite at both `-O0` and `-O3`); a dead
+  `.clip` read does not throw.
+- `test/test_vec.fx` `fcvector.pushpop_edge` — restored to the natural
+  `ignore(v.back())` spelling; the captured-`sink` workaround the bug forced is
+  gone.
+- `test/ir/checked_read.*` — IR golden locking the DCE contrast: at `-O3 -pr-k`
+  the dead `.clip[100]` read is **removed** while the dead checked `a[7]` read is
+  **retained** (`v@14[7]`), the returned `a[0]` stays live.
+
+**Churn / perf (Phase 1 vs master).** Only `K_remove_unused.c` regenerated among
+the 55 bootstrap modules (fixpoint holds). Generated C for
+`spectralnorm` / `mandelbrot` / `btree` / `nbody` is **byte-identical** to master
+(nbody 50M iters 1.53 s → 1.53 s; spectralnorm N=5500 0.86 s → 0.85 s — within
+noise, ≪ the ±2 % budget). The only corpus C change is `test_matrix.c`: it
+materializes a few extra named temps (`fx_arr_t arr_0…arr_7`) around checked
+reads C-gen no longer inlines — behaviour-preserving, coalesced by the C compiler
+where legal, and confined to test scaffolding (not the `refmul` hot loop).
+
+## Phase 2 — the parameterized predicate
+
+```
+fun pure_kexp(e: kexp_t, ~mut_read_is_impure: bool = true): bool
+```
+
+One short-circuiting fold, one `match` that is the single point of truth:
+
+- **Throwing is impure UNCONDITIONALLY** (not the flag): `KExpAt(_, BorderNone,
+  …)` and the throwing/mutating intrinsics (`IntrinCheckIdx`,
+  `IntrinCheckIdxRange`, `IntrinPopExn`, `IntrinVecPushBack`, `IntrinVecPopBack`,
+  `IntrinVecSplice`). Neither removable nor movable. This is Phase 1 baked in.
+- **`~mut_read_is_impure`** governs non-throwing reads of mutable memory as a
+  class — border-mode `KExpAt`, `KExpUnary(OpDeref, …)`, `KExpMem` on an
+  `is_mutable` base, and `KExpMap` (a comprehension is never safe to move):
+  `false` = removable (a dead read has no effect — DCE keeps today's power),
+  `true` = not movable (FB-023). Default `true` = the safe, movement-grade
+  reading for any caller that does not think.
+
+The FB-023 `movement_unsafe_read` helper in `C_gen_code.fx` is **deleted**: its
+`{KExpAt, OpDeref, mutable KExpMem, KExpMap}` set is exactly the `true`-grade of
+the one predicate, so `pure_kexp(e1, mut_read_is_impure=true)` replaces
+`pure_kexp(e1) && !movement_unsafe_read(e1)` verbatim.
+
+### Consumer audit (every `pure_kexp` call site)
+
+| call site | grade | intent | rationale |
+|-----------|-------|--------|-----------|
+| `K_remove_unused` `pure_fun` (body purity cache) | `false` | removal | a function whose unused call we might delete is "pure" if its body has no effect to remove; a mutable read has none. Throwing stays impure (unconditional). |
+| `K_remove_unused` unused-`KDefVal` (`if !pure_kexp(e)`) | `false` | removal | the canonical DCE test — keep a dead binding's RHS only if impure. |
+| `K_remove_unused` mid-sequence (`pure_kexp(e)` in `remove_unused_`) | `false` | removal | drop a pure statement in the middle of a block. |
+| `C_gen_code` `find_single_use_vals` | `true` | movement | single-use temp inlining MOVES the initializer to its use site — FB-023. Replaces the deleted `movement_unsafe_read`. |
+| `K_loop_inv` `is_loop_invariant` | `true` | movement | hoisting out of a loop is a MOVE; replaces the explicit `KExpAt => false` guard (now subsumed — every mutable read is non-movable). |
+| `K_fuse_loops` fusion candidate | `false` | removal (preserved) | **see below** — audit observation, behaviour left unchanged. |
+
+**Byte-identity.** Phase 2 is expression, not policy: generated C is
+**byte-identical to Phase 1 across the whole corpus** — `test_all` (including
+`test_matrix`), `spectralnorm`, `nbody`, `mandelbrot`, `btree` all diff clean.
+The bootstrap regenerates only the four edited modules (`K_remove_unused`,
+`C_gen_code`, `K_loop_inv`, `K_fuse_loops`); fixpoint holds. Notably K_loop_inv's
+migration from `pure_kexp && (KExpAt => false)` to `pure_kexp(…, true)` — which
+on paper *also* excludes `OpDeref`/mutable-`KExpMem`/`KExpMap` from hoisting —
+changed no corpus output, i.e. no such non-KExpAt read was being hoisted in
+practice.
+
+## STOP-rule item — `K_fuse_loops` and movement grade
+
+Per the brief: *if Phase 2's audit finds a consumer whose migration would CHANGE
+optimization behaviour — report, don't decide.* `K_fuse_loops` is that consumer.
+
+`K_fuse_loops` fuses a single-use comprehension `arr = [for … {body}]` into the
+one `for`-loop that consumes it (guarded by `arr_nused == 1 && arr_nused_for ==
+1`). It gates on `pure_kexp(body)`. Fusion *replays* the body inside the
+consumer loop, so it is arguably a **move** of the body's reads — which would
+argue for `mut_read_is_impure=true`. But:
+
+1. It has always used the removal-grade reading (bare `pure_kexp`), so switching
+   to `true` would make fewer comprehensions fusable — a real optimization
+   change, not a bug fix.
+2. Fusion's safety today rests on the single-use / single-consumer counters, not
+   on `pure_kexp`'s movement grade; whether those counters fully cover the
+   read-past-an-aliasing-store hazard is a separate question this brief did not
+   scope.
+
+So Phase 2 passes `mut_read_is_impure=false` to **preserve** existing behaviour
+(byte-identity confirmed) and flags the movement question here rather than
+silently changing fusion. Recommended follow-up: a focused audit of whether a
+fused comprehension body can read memory the consumer loop writes earlier in the
+same iteration; if so, that is a fusion-specific FB in the FB-023 family and
+should be fixed in `K_fuse_loops` (grade flip + a repro), not folded in here.
+
+## Registry
+
+`docs/found_bugs.md` FB-027 updated `OPEN → FIXED — purity-1`, with the fix, the
+tests, and the churn note. FB-023 remains `FIXED`; its C-gen local guard is now
+expressed through the shared predicate (no behaviour change).

--- a/test/ir/checked_read.ast.golden
+++ b/test/ir/checked_read.ast.golden
@@ -1,0 +1,17 @@
+from Builtins import *
+from Math import *
+from Complex import *
+from Array import *
+import List
+import Rrbvec
+import Vector
+import Char
+import String
+fun checked_read.probe@g0(checked_read.a@g1: int []): (int [] -> int) =
+{
+   <(int -> void)>Builtins.ignore@g2(<int []>checked_read.a@g1..clip[100])
+   <(int -> void)>Builtins.ignore@g2(<int []>checked_read.a@g1[7])
+   <int []>checked_read.a@g1[0]
+}
+
+<(int -> void)>Builtins.println@g3(<(int [] -> int)>checked_read.probe@g0([1, 2, 3, 4, 5]))

--- a/test/ir/checked_read.fx
+++ b/test/ir/checked_read.fx
@@ -1,0 +1,11 @@
+// IR snapshot: FB-027 -- purity vs effect-freedom in dead-code elimination.
+// A border read (.clip) never throws, so a dead one is eliminated; a checked
+// (BorderNone) read can raise OutOfRangeError, so a dead one is retained (its
+// bounds check is a side effect).  See docs/found_bugs.md FB-027.
+fun probe(a: int []): int
+{
+    ignore(a.clip[100])   // never throws  -> removed by DCE
+    ignore(a[7])          // BorderNone    -> retained (checked read may throw)
+    a[0]
+}
+println(probe([1, 2, 3, 4, 5]))

--- a/test/ir/checked_read.k.golden
+++ b/test/ir/checked_read.k.golden
@@ -1,0 +1,5 @@
+@temp val v@g0: int [] = [ 1, 2, 3, 4, 5 ]
+v@g0[7]
+@temp val v@g1: int = v@g0[0]
+_fx_F5printv1i(v@g1)
+_fx_F12print_stringv1S("\n")

--- a/test/ir/checked_read.k0.golden
+++ b/test/ir/checked_read.k0.golden
@@ -1,0 +1,7 @@
+fun checked_read.probe@g0(a@g1: int []): int
+{ @temp val v@g2: int = a@g1..clip[100]; ignore@g3(v@g2); @temp val v@g4: int = a@g1[7]; ignore@g3(v@g4); a@g1[0]
+}
+
+@temp val v@g5: int [] = [ 1, 2, 3, 4, 5 ]
+@temp val v@g6: int = checked_read.probe@g0(v@g5)
+println@g7(v@g6)

--- a/test/test_basic.fx
+++ b/test/test_basic.fx
@@ -897,3 +897,24 @@ TEST("basic.int64_min", fun() {
     arr[1] = -9223372036854775808
     EXPECT_EQ(arr[1], min64)
 })
+
+TEST("basic.checked_read_side_effect", fun() {
+    // FB-027: an element read whose result is discarded (via ignore) must still
+    // perform its bounds check -- dropping it would swallow OutOfRangeError.
+    // Holds for every checked (BorderNone) container read: array, vector,
+    // string, rrbvec; independent of opt level (T2 runs O0 and O3).
+    val ea: int [] = []
+    val ev: int vector = []
+    val es: string = ""
+    val er: int rrbvec = []
+    EXPECT_THROWS(fun() { ignore(ea[0]) },   OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(ea[.-1]) }, OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(ev[0]) },   OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(ev[.-1]) }, OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(es[0]) },   OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(es[.-1]) }, OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(er[0]) },   OutOfRangeError)
+    EXPECT_THROWS(fun() { ignore(er[.-1]) }, OutOfRangeError)
+    // a border read (.clip) never throws and stays eliminable -- no exception
+    EXPECT_EQ(ea.clip[0], 0)   // clip on empty -> clamps, returns default 0
+})

--- a/test/test_vec.fx
+++ b/test/test_vec.fx
@@ -93,10 +93,10 @@ TEST("fcvector.pushpop_edge", fun()
     v.push_back(1); v.push_back(2)
     v.pop_back(); v.pop_back()
     EXPECT_THROWS(fun() { v.pop_back() }, OutOfRangeError)
-    // back() on an empty vector likewise throws OutOfRangeError
-    var sink = 0
-    EXPECT_THROWS(fun() { sink = v.back() }, OutOfRangeError)
-    ignore(sink)
+    // back() on an empty vector likewise throws OutOfRangeError. FB-027 fixed:
+    // ignore() of a checked read no longer swallows the exception, so the
+    // natural spelling works (no captured-sink workaround needed).
+    EXPECT_THROWS(fun() { ignore(v.back()) }, OutOfRangeError)
 
     // complex-element push/pop frees correctly (ASan-checked), fast path bypassed
     val s: string vector = []


### PR DESCRIPTION
## Summary

`pure_kexp` answered one question — "no side effects, safe to REMOVE for DCE" —
but three consumers were quietly asking three different things, and the
conflation produced two soundness bugs:

- **FB-027** (fixed here): a bounds-checked element read (`KExpAt` with
  `BorderNone`) emits a throwing `FX_CHKIDX`/`FX_VEC_CHKIDX` **inline** in C-gen.
  `pure_kexp_` didn't list `KExpAt`, so a read whose result was discarded —
  `ignore(coll[i])`, a dead `val` — was eliminated at the K level *before* C-gen
  emitted the check, silently swallowing `OutOfRangeError`.
- **FB-023** (already fixed, now refactored): purity ≠ movement-invariance — a
  pure read of mutable memory changes value if moved past an aliasing store. It
  had been patched with a *local* `movement_unsafe_read` guard in C-gen.

This PR fixes FB-027 and folds both facets into a single classification with a
grade knob, so there is one point of truth instead of three ad-hoc predicates.

## Phase 1 — the precise FB-027 fix (`03775b8`)

`pure_kexp_` (in `K_remove_unused.fx`) now classifies
`KExpAt(_, BorderNone, …)` as impure: a checked read with an unused result is
retained through DCE. Border reads (`.clip`/`.wrap`/`.zero`) never throw and stay
pure and eliminable — gating on `BorderNone` keeps legitimate DCE intact.

Tests:
- `test/test_basic.fx` `basic.checked_read_side_effect` — `ignore(e[0])` /
  `ignore(e[.-1])` on an empty **array / vector / string / rrbvec** each throw
  `OutOfRangeError` (the T2 corpus runs this at both `-O0` and `-O3`); a dead
  `.clip` read does not throw.
- `test/test_vec.fx` `fcvector.pushpop_edge` — restored to the natural
  `ignore(v.back())` spelling; the captured-`sink` workaround the bug forced is
  gone.
- `test/ir/checked_read.*` — IR golden locking the DCE contrast: at `-O3 -pr-k`
  the dead `.clip[100]` read is removed while the dead checked `a[7]` read is
  retained.

## Phase 2 — parameterized predicate (`c9baefe`)

```
fun pure_kexp(e: kexp_t, ~mut_read_is_impure: bool = true): bool
```

- **Throwing is impure UNCONDITIONALLY** (not the flag): `BorderNone` `KExpAt`
  and the throwing/mutating intrinsics — neither removable nor movable.
- **`~mut_read_is_impure`** governs non-throwing reads of mutable memory as a
  class (border `KExpAt`, `OpDeref`, mutable `KExpMem`, `KExpMap`): `false` =
  removable (DCE keeps its power), `true` = not movable (FB-023). Default `true`
  is the safe, movement-grade reading.

C-gen's local `movement_unsafe_read` helper is **deleted** — its
`{KExpAt, OpDeref, mutable KExpMem, KExpMap}` set is exactly the `true`-grade of
the one predicate. Every consumer now declares its intent explicitly:

| call site | grade | why |
|-----------|-------|-----|
| DCE (`pure_fun`, unused-`KDefVal`, mid-sequence) | `false` | removal — a dead read has no effect |
| `C_gen` `find_single_use_vals` | `true` | temp inlining MOVES the initializer (FB-023) |
| `K_loop_inv` `is_loop_invariant` | `true` | hoisting is a move; replaces the old `KExpAt => false` guard |
| `K_fuse_loops` | `false` | preserves existing fusion (see below) |

## Verification

- **Phase 2 is a pure refactor**: generated C is **byte-identical to Phase 1**
  across the whole corpus (`spectralnorm`, `nbody`, `mandelbrot`, `btree`,
  `test_all` incl. `test_matrix`). The bootstrap regenerates only the four edited
  modules; the self-hosting fixpoint holds.
- **Phase 1 churn is minimal**: only `K_remove_unused.c` regenerates among the 55
  compiler modules; `spectralnorm`/`nbody`/`mandelbrot`/`btree` C byte-identical
  to master (nbody 50M iters 1.53 s → 1.53 s; spectralnorm N=5500 0.86 s →
  0.85 s — within noise, ≪ the ±2 % budget). The sole corpus C change is
  `test_matrix.c`, which materializes a few extra named temps around checked
  reads C-gen no longer inlines — behaviour-preserving, in test scaffolding.
- Full ladder (`fxtest.py all`), `sanitize` (ASan+UBSan), and `determinism`
  green on both phases.

## Open item (reported, not decided)

`K_fuse_loops` replays a single-use comprehension body in its consumer loop —
arguably a MOVE, so movement-grade `true` would be more correct. But flipping it
reduces fusion (an optimization change, not a bug fix), so it's left on `false`
to preserve behaviour; whether fusion needs its own FB-023-style movement guard
is a separate audit. Details in `docs/purity1_report.md`.

## Registry

`docs/found_bugs.md`: FB-027 `OPEN → FIXED`; FB-023 cross-referenced (its local
guard now expressed through the shared predicate). Full write-up in
`docs/purity1_report.md`.
