### PR TITLE
fuse-move-1: FB-028 fusion move hazard + fusion in function bodies

### DIFF
--- a/compiler/K_fuse_loops.fx
+++ b/compiler/K_fuse_loops.fx
@@ -27,24 +27,6 @@ type arr_info_t =
 type ainfo_map_t = (id_t, arr_info_t ref) Map.t
 type arr_fuse_map_t = (id_t, id_t) Map.t
 
-fun fuse_loops(code: kcode_t)
-{
-    var nmaps = 0, nfors = 0
-    for e <- code {
-        match e {
-        | KDefVal(_, KExpMap _, _) => nmaps += 1
-        | KExpMap _ => nmaps += 1
-        | KExpFor _ => nfors += 1
-        | _ => {}
-        }
-    }
-    if nmaps >= 1 && nmaps + nfors >= 2 {
-        fuse_loops_(code)
-    } else {
-        code
-    }
-}
-
 fun fuse_loops_(code: kcode_t)
 {
     var counters: ainfo_map_t = Map.empty(cmp_id)
@@ -84,12 +66,13 @@ fun fuse_loops_(code: kcode_t)
         fold_kexp(e, process_callb)
         match e {
         | KDefVal (i, KExpMap ([:: (_, idl, [])], body, flags, (KTypArray _, _)), loc) =>
-            // removal grade preserves the pre-existing fusion criterion (a body
-            // that reads mutable memory is still a fusion candidate; fusion of a
-            // single-use comprehension replays the body in the consumer loop,
-            // preserving iteration). Whether fusion also needs movement-grade
-            // safety is a separate question -- see docs/purity1_report.md.
-            if K_remove_unused.pure_kexp(body, mut_read_is_impure=false) && !flags.for_flag_unzip {
+            // FB-028: fusion REPLAYS the producer body inside the consumer loop,
+            // so a read of mutable memory in the body is MOVED across the
+            // consumer's stores. If the consumer writes memory the body reads
+            // (e.g. an in-place stencil), the fused reads see the wrong values.
+            // Hence the movement grade: a body that reads mutable memory is not a
+            // fusion candidate. (Bodies reading only immutable data still fuse.)
+            if K_remove_unused.pure_kexp(body, mut_read_is_impure=true) && !flags.for_flag_unzip {
                 val ainfo = ref (arr_info_t {
                     arr_nused=0, arr_nused_for=0,
                     arr_idl=idl, arr_body=body, arr_map_flags=flags})
@@ -187,28 +170,36 @@ fun fuse_loops_(code: kcode_t)
     }
 
     fun fuse_ktyp_(t: ktyp_t, loc: loc_t, callb: k_callb_t) = t
-    fun fuse_kexp_(e: kexp_t, callb: k_callb_t)
-    {
-        val e = walk_kexp(e, callb)
+    fun fuse_kexp_(e: kexp_t, callb: k_callb_t) =
         match e {
-        | KExpSeq(elist, (t, loc)) => code2kexp(fuse_loops(elist), loc)
-        | KDefVal(i, KExpMap ([:: (e0, idl, idxs)], body, _, _), loc) =>
-            match arrs_to_fuse.find_opt(i) {
-            | Some ainfo =>
-                ainfo->arr_idl = idl
-                ainfo->arr_body = body
-                KExpNop(loc)
+        | KExpSeq(elist, (_, loc)) =>
+            // A basic block: run this block's OWN fusion analysis, exactly once.
+            // Crucially do NOT walk_kexp(e) first -- walk_kexp already descends
+            // into these same elements, so combined with fuse_loops_ every block
+            // would be traversed twice, i.e. 2^depth times overall (the old code
+            // avoided this only because the fuse_loops gate short-circuited nearly
+            // always). fuse_loops_ itself transforms each element via fuse_kexp_.
+            code2kexp(fuse_loops_(elist), loc)
+        | _ =>
+            val e = walk_kexp(e, callb)
+            match e {
+            | KDefVal(i, KExpMap ([:: (e0, idl, idxs)], body, _, _), loc) =>
+                match arrs_to_fuse.find_opt(i) {
+                | Some ainfo =>
+                    ainfo->arr_idl = idl
+                    ainfo->arr_body = body
+                    KExpNop(loc)
+                | _ => e
+                }
+            | KExpFor (idl, [], body, flags, loc) =>
+                val (new_idl, new_body) = fuse_for(idl, body, loc)
+                KExpFor(new_idl.rev(), [], new_body, flags, loc)
+            | KExpMap ([:: (e0, idl, [])], body, flags, (map_result_type, loc)) =>
+                val (new_idl, new_body) = fuse_for(idl, body, loc)
+                KExpMap([:: (e0, new_idl.rev(), [])], new_body, flags, (map_result_type, loc))
             | _ => e
             }
-        | KExpFor (idl, [], body, flags, loc) =>
-            val (new_idl, new_body) = fuse_for(idl, body, loc)
-            KExpFor(new_idl.rev(), [], new_body, flags, loc)
-        | KExpMap ([:: (e0, idl, [])], body, flags, (map_result_type, loc)) =>
-            val (new_idl, new_body) = fuse_for(idl, body, loc)
-            KExpMap([:: (e0, new_idl.rev(), [])], new_body, flags, (map_result_type, loc))
-        | _ => e
         }
-    }
 
     val fuse_callb = k_callb_t {
         kcb_ktyp=Some(fuse_ktyp_),
@@ -221,6 +212,6 @@ fun fuse_loops_(code: kcode_t)
 fun fuse_loops_all(kmods: kmodule_t list) =
     [:: for km <- kmods {
         val {km_top} = km
-        val new_top = fuse_loops(km_top)
+        val new_top = fuse_loops_(km_top)
         km.{km_top=new_top}
     }]

--- a/compiler/bootstrap/K_fuse_loops.c
+++ b/compiler/bootstrap/K_fuse_loops.c
@@ -3384,11 +3384,6 @@ _fx_N12Map__color_t _fx_g17K_fuse_loops__Red = { 1 };
 _fx_N12Map__color_t _fx_g19K_fuse_loops__Black = { 2 };
 _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t _fx_g19K_fuse_loops__Empty = 0;
 _fx_Nt11Map__tree_t2R9Ast__id_tR9Ast__id_t _fx_g21K_fuse_loops__Empty1_ = 0;
-FX_EXTERN_C int _fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form__kexp_t(
-   struct _fx_LN14K_form__kexp_t_data_t*,
-   struct _fx_LN14K_form__kexp_t_data_t**,
-   void*);
-
 FX_EXTERN_C int _fx_M3AstFM6cmp_idi2RM4id_tRM4id_t(struct _fx_R9Ast__id_t*, struct _fx_R9Ast__id_t*, int_*, void*);
 
 FX_EXTERN_C int
@@ -3469,15 +3464,15 @@ static int _fx_M12K_fuse_loopsFM10fuse_kexp_N14K_form__kexp_t2N14K_form__kexp_tR
    struct _fx_N14K_form__kexp_t_data_t**,
    void*);
 
-FX_EXTERN_C int _fx_M6K_formFM9walk_kexpN14K_form__kexp_t2N14K_form__kexp_tRM9k_callb_t(
-   struct _fx_N14K_form__kexp_t_data_t*,
-   struct _fx_R17K_form__k_callb_t*,
-   struct _fx_N14K_form__kexp_t_data_t**,
-   void*);
-
 FX_EXTERN_C int _fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(
    struct _fx_LN14K_form__kexp_t_data_t*,
    struct _fx_R10Ast__loc_t*,
+   struct _fx_N14K_form__kexp_t_data_t**,
+   void*);
+
+FX_EXTERN_C int _fx_M6K_formFM9walk_kexpN14K_form__kexp_t2N14K_form__kexp_tRM9k_callb_t(
+   struct _fx_N14K_form__kexp_t_data_t*,
+   struct _fx_R17K_form__k_callb_t*,
    struct _fx_N14K_form__kexp_t_data_t**,
    void*);
 
@@ -4442,54 +4437,6 @@ _fx_cleanup: ;
    return fx_status;
 }
 
-FX_EXTERN_C int _fx_M12K_fuse_loopsFM10fuse_loopsLN14K_form__kexp_t1LN14K_form__kexp_t(
-   struct _fx_LN14K_form__kexp_t_data_t* code_0,
-   struct _fx_LN14K_form__kexp_t_data_t** fx_result,
-   void* fx_fv)
-{
-   int fx_status = 0;
-   int_ nmaps_0 = 0;
-   int_ nfors_0 = 0;
-   _fx_LN14K_form__kexp_t lst_0 = code_0;
-   for (; lst_0; lst_0 = lst_0->tl) {
-      _fx_N14K_form__kexp_t e_0 = lst_0->hd;
-      int tag_0 = FX_REC_VARIANT_TAG(e_0);
-      if (tag_0 == 31) {
-         if (FX_REC_VARIANT_TAG(e_0->u.KDefVal.t1) == 26) {
-            nmaps_0 = nmaps_0 + 1; goto _fx_endmatch_0;
-         }
-      }
-      if (tag_0 == 26) {
-         nmaps_0 = nmaps_0 + 1; goto _fx_endmatch_0;
-      }
-      if (tag_0 == 27) {
-         nfors_0 = nfors_0 + 1; goto _fx_endmatch_0;
-      }
-
-   _fx_endmatch_0: ;
-      FX_CHECK_EXN(_fx_catch_0);
-
-   _fx_catch_0: ;
-      FX_CHECK_EXN(_fx_cleanup);
-   }
-   bool t_0;
-   if (nmaps_0 >= 1) {
-      t_0 = nmaps_0 + nfors_0 >= 2;
-   }
-   else {
-      t_0 = false;
-   }
-   if (t_0) {
-      FX_CALL(_fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form__kexp_t(code_0, fx_result, 0), _fx_cleanup);
-   }
-   else {
-      FX_COPY_PTR(code_0, fx_result);
-   }
-
-_fx_cleanup: ;
-   return fx_status;
-}
-
 FX_EXTERN_C int _fx_M12K_fuse_loopsFM13process_ktyp_v3N14K_form__ktyp_tR10Ast__loc_tR22K_form__k_fold_callb_t(
    struct _fx_N14K_form__ktyp_t_data_t* t_0,
    struct _fx_R10Ast__loc_t* loc_0,
@@ -4598,7 +4545,7 @@ FX_EXTERN_C int _fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form_
                         _fx_N14K_form__kexp_t body_0 = vcase_1->t1;
                         bool v_9;
                         bool res_0;
-                        FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(body_0, false, &res_0, 0), _fx_catch_0);
+                        FX_CALL(_fx_M15K_remove_unusedFM9pure_kexpB2N14K_form__kexp_tB(body_0, true, &res_0, 0), _fx_catch_0);
                         if (res_0) {
                            v_9 = !flags_0->for_flag_unzip;
                         }
@@ -5575,17 +5522,14 @@ static int _fx_M12K_fuse_loopsFM10fuse_kexp_N14K_form__kexp_t2N14K_form__kexp_tR
    struct _fx_N14K_form__kexp_t_data_t** fx_result,
    void* fx_fv)
 {
-   _fx_N14K_form__kexp_t e_1 = 0;
    int fx_status = 0;
    _fx_M12K_fuse_loopsFM10fuse_kexp_N14K_form__kexp_t2N14K_form__kexp_tR17K_form__k_callb_t_cldata_t* cv_0 =
       (_fx_M12K_fuse_loopsFM10fuse_kexp_N14K_form__kexp_t2N14K_form__kexp_tR17K_form__k_callb_t_cldata_t*)fx_fv;
    _fx_Rt6Map__t2R9Ast__id_trR24K_fuse_loops__arr_info_t* arrs_to_fuse_0 = &cv_0->t0;
-   FX_CALL(_fx_M6K_formFM9walk_kexpN14K_form__kexp_t2N14K_form__kexp_tRM9k_callb_t(e_0, callb_0, &e_1, 0), _fx_cleanup);
-   int tag_0 = FX_REC_VARIANT_TAG(e_1);
-   if (tag_0 == 10) {
+   if (FX_REC_VARIANT_TAG(e_0) == 10) {
       _fx_LN14K_form__kexp_t v_0 = 0;
-      _fx_T2LN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_0 = &e_1->u.KExpSeq;
-      FX_CALL(_fx_M12K_fuse_loopsFM10fuse_loopsLN14K_form__kexp_t1LN14K_form__kexp_t(vcase_0->t0, &v_0, 0), _fx_catch_0);
+      _fx_T2LN14K_form__kexp_tT2N14K_form__ktyp_tR10Ast__loc_t* vcase_0 = &e_0->u.KExpSeq;
+      FX_CALL(_fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form__kexp_t(vcase_0->t0, &v_0, 0), _fx_catch_0);
       FX_CALL(_fx_M6K_formFM9code2kexpN14K_form__kexp_t2LN14K_form__kexp_tR10Ast__loc_t(v_0, &vcase_0->t1.t1, fx_result, 0),
          _fx_catch_0);
 
@@ -5593,249 +5537,254 @@ static int _fx_M12K_fuse_loopsFM10fuse_kexp_N14K_form__kexp_t2N14K_form__kexp_tR
       if (v_0) {
          _fx_free_LN14K_form__kexp_t(&v_0);
       }
-      goto _fx_endmatch_0;
    }
-   if (tag_0 == 31) {
-      _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_1 = &e_1->u.KDefVal;
-      _fx_N14K_form__kexp_t v_1 = vcase_1->t1;
-      if (FX_REC_VARIANT_TAG(v_1) == 26) {
-         _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
-            vcase_2 = &v_1->u.KExpMap;
-         _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_2 = vcase_2->t0;
-         if (v_2 != 0) {
-            if (v_2->tl == 0) {
-               _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t v_3 = 0;
-               _fx_FPi2R9Ast__id_tR9Ast__id_t v_4 = {0};
-               _fx_Nt6option1rR24K_fuse_loops__arr_info_t result_0 = {0};
-               _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t t_0 = 0;
-               _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_0 = {0};
-               _fx_Nt6option1rR24K_fuse_loops__arr_info_t v_5 = {0};
-               FX_COPY_PTR(arrs_to_fuse_0->root, &v_3);
-               FX_COPY_FP(&arrs_to_fuse_0->cmp, &v_4);
-               FX_COPY_PTR(v_3, &t_0);
-               _fx_R9Ast__id_t xk_0 = vcase_1->t0;
-               FX_COPY_FP(&v_4, &cmp_0);
-               for (;;) {
-                  _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t t_1 = 0;
-                  _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_1 = {0};
-                  FX_COPY_PTR(t_0, &t_1);
-                  _fx_R9Ast__id_t xk_1 = xk_0;
-                  FX_COPY_FP(&cmp_0, &cmp_1);
-                  if ((t_1 != 0) + 1 == 2) {
-                     _fx_Nt6option1rR24K_fuse_loops__arr_info_t result_1 = {0};
-                     _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_tR9Ast__id_trR24K_fuse_loops__arr_info_tNt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t*
-                        vcase_3 = &t_1->u.Node;
-                     int_ c_0;
-                     FX_CALL(cmp_1.fp(&xk_1, &vcase_3->t2, &c_0, cmp_1.fcv), _fx_catch_1);
-                     if (c_0 < 0) {
-                        _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t* l_0 = &vcase_3->t1;
-                        _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
-                        FX_COPY_PTR(*l_0, &t_0);
-                        xk_0 = xk_1;
-                        FX_FREE_FP(&cmp_0);
-                        FX_COPY_FP(&cmp_1, &cmp_0);
-                     }
-                     else if (c_0 > 0) {
-                        _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t* r_0 = &vcase_3->t4;
-                        _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
-                        FX_COPY_PTR(*r_0, &t_0);
-                        xk_0 = xk_1;
-                        FX_FREE_FP(&cmp_0);
-                        FX_COPY_FP(&cmp_1, &cmp_0);
+   else {
+      _fx_N14K_form__kexp_t e_1 = 0;
+      FX_CALL(_fx_M6K_formFM9walk_kexpN14K_form__kexp_t2N14K_form__kexp_tRM9k_callb_t(e_0, callb_0, &e_1, 0), _fx_catch_10);
+      int tag_0 = FX_REC_VARIANT_TAG(e_1);
+      if (tag_0 == 31) {
+         _fx_T3R9Ast__id_tN14K_form__kexp_tR10Ast__loc_t* vcase_1 = &e_1->u.KDefVal;
+         _fx_N14K_form__kexp_t v_1 = vcase_1->t1;
+         if (FX_REC_VARIANT_TAG(v_1) == 26) {
+            _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
+               vcase_2 = &v_1->u.KExpMap;
+            _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_2 = vcase_2->t0;
+            if (v_2 != 0) {
+               if (v_2->tl == 0) {
+                  _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t v_3 = 0;
+                  _fx_FPi2R9Ast__id_tR9Ast__id_t v_4 = {0};
+                  _fx_Nt6option1rR24K_fuse_loops__arr_info_t result_0 = {0};
+                  _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t t_0 = 0;
+                  _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_0 = {0};
+                  _fx_Nt6option1rR24K_fuse_loops__arr_info_t v_5 = {0};
+                  FX_COPY_PTR(arrs_to_fuse_0->root, &v_3);
+                  FX_COPY_FP(&arrs_to_fuse_0->cmp, &v_4);
+                  FX_COPY_PTR(v_3, &t_0);
+                  _fx_R9Ast__id_t xk_0 = vcase_1->t0;
+                  FX_COPY_FP(&v_4, &cmp_0);
+                  for (;;) {
+                     _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t t_1 = 0;
+                     _fx_FPi2R9Ast__id_tR9Ast__id_t cmp_1 = {0};
+                     FX_COPY_PTR(t_0, &t_1);
+                     _fx_R9Ast__id_t xk_1 = xk_0;
+                     FX_COPY_FP(&cmp_0, &cmp_1);
+                     if ((t_1 != 0) + 1 == 2) {
+                        _fx_Nt6option1rR24K_fuse_loops__arr_info_t result_1 = {0};
+                        _fx_T5N12Map__color_tNt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_tR9Ast__id_trR24K_fuse_loops__arr_info_tNt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t*
+                           vcase_3 = &t_1->u.Node;
+                        int_ c_0;
+                        FX_CALL(cmp_1.fp(&xk_1, &vcase_3->t2, &c_0, cmp_1.fcv), _fx_catch_1);
+                        if (c_0 < 0) {
+                           _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t* l_0 = &vcase_3->t1;
+                           _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
+                           FX_COPY_PTR(*l_0, &t_0);
+                           xk_0 = xk_1;
+                           FX_FREE_FP(&cmp_0);
+                           FX_COPY_FP(&cmp_1, &cmp_0);
+                        }
+                        else if (c_0 > 0) {
+                           _fx_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t* r_0 = &vcase_3->t4;
+                           _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
+                           FX_COPY_PTR(*r_0, &t_0);
+                           xk_0 = xk_1;
+                           FX_FREE_FP(&cmp_0);
+                           FX_COPY_FP(&cmp_1, &cmp_0);
+                        }
+                        else {
+                           _fx_M12K_fuse_loopsFM4SomeNt6option1rRM10arr_info_t1rRM10arr_info_t(vcase_3->t3, &result_1);
+                           _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0);
+                           _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&result_1, &result_0);
+                           FX_BREAK(_fx_catch_1);
+                        }
+
+                     _fx_catch_1: ;
+                        _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_1);
                      }
                      else {
-                        _fx_M12K_fuse_loopsFM4SomeNt6option1rRM10arr_info_t1rRM10arr_info_t(vcase_3->t3, &result_1);
                         _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0);
-                        _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&result_1, &result_0);
-                        FX_BREAK(_fx_catch_1);
-                     }
+                        _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&_fx_g20K_fuse_loops__None1_, &result_0);
+                        FX_BREAK(_fx_catch_2);
 
-                  _fx_catch_1: ;
-                     _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_1);
+                     _fx_catch_2: ;
+                     }
+                     FX_CHECK_EXN(_fx_catch_3);
+
+                  _fx_catch_3: ;
+                     FX_FREE_FP(&cmp_1);
+                     if (t_1) {
+                        _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_1);
+                     }
+                     FX_CHECK_BREAK();
+                     FX_CHECK_EXN(_fx_catch_5);
+                  }
+                  _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0, &v_5);
+                  if (v_5.tag == 2) {
+                     _fx_rR24K_fuse_loops__arr_info_t ainfo_0 = v_5.u.Some;
+                     _fx_R24K_fuse_loops__arr_info_t* v_6 = &ainfo_0->data;
+                     _fx_LT2R9Ast__id_tN13K_form__dom_t* v_7 = &v_6->arr_idl;
+                     _fx_LT2R9Ast__id_tN13K_form__dom_t* idl_0 = &v_2->hd.t1;
+                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(v_7);
+                     FX_COPY_PTR(*idl_0, v_7);
+                     _fx_R24K_fuse_loops__arr_info_t* v_8 = &ainfo_0->data;
+                     _fx_N14K_form__kexp_t* v_9 = &v_8->arr_body;
+                     _fx_N14K_form__kexp_t* body_0 = &vcase_2->t1;
+                     _fx_free_N14K_form__kexp_t(v_9);
+                     FX_COPY_PTR(*body_0, v_9);
+                     FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&vcase_1->t2, fx_result), _fx_catch_4);
+
+                  _fx_catch_4: ;
                   }
                   else {
-                     _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0);
-                     _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&_fx_g20K_fuse_loops__None1_, &result_0);
-                     FX_BREAK(_fx_catch_2);
-
-                  _fx_catch_2: ;
+                     FX_COPY_PTR(e_1, fx_result);
                   }
-                  FX_CHECK_EXN(_fx_catch_3);
-
-               _fx_catch_3: ;
-                  FX_FREE_FP(&cmp_1);
-                  if (t_1) {
-                     _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_1);
-                  }
-                  FX_CHECK_BREAK();
                   FX_CHECK_EXN(_fx_catch_5);
-               }
-               _fx_copy_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0, &v_5);
-               if (v_5.tag == 2) {
-                  _fx_rR24K_fuse_loops__arr_info_t ainfo_0 = v_5.u.Some;
-                  _fx_R24K_fuse_loops__arr_info_t* v_6 = &ainfo_0->data;
-                  _fx_LT2R9Ast__id_tN13K_form__dom_t* v_7 = &v_6->arr_idl;
-                  _fx_LT2R9Ast__id_tN13K_form__dom_t* idl_0 = &v_2->hd.t1;
-                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(v_7);
-                  FX_COPY_PTR(*idl_0, v_7);
-                  _fx_R24K_fuse_loops__arr_info_t* v_8 = &ainfo_0->data;
-                  _fx_N14K_form__kexp_t* v_9 = &v_8->arr_body;
-                  _fx_N14K_form__kexp_t* body_0 = &vcase_2->t1;
-                  _fx_free_N14K_form__kexp_t(v_9);
-                  FX_COPY_PTR(*body_0, v_9);
-                  FX_CALL(_fx_M6K_formFM7KExpNopN14K_form__kexp_t1R10Ast__loc_t(&vcase_1->t2, fx_result), _fx_catch_4);
 
-               _fx_catch_4: ;
-               }
-               else {
-                  FX_COPY_PTR(e_1, fx_result);
-               }
-               FX_CHECK_EXN(_fx_catch_5);
-
-            _fx_catch_5: ;
-               _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&v_5);
-               FX_FREE_FP(&cmp_0);
-               if (t_0) {
-                  _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
-               }
-               _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0);
-               FX_FREE_FP(&v_4);
-               if (v_3) {
-                  _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&v_3);
-               }
-               goto _fx_endmatch_0;
-            }
-         }
-      }
-   }
-   if (tag_0 == 27) {
-      _fx_T5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_4 =
-         &e_1->u.KExpFor;
-      if (vcase_4->t1 == 0) {
-         _fx_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t v_10 = {0};
-         _fx_LT2R9Ast__id_tN13K_form__dom_t new_idl_0 = 0;
-         _fx_N14K_form__kexp_t new_body_0 = 0;
-         _fx_LT2R9Ast__id_tN13K_form__dom_t res_0 = 0;
-         _fx_LT2R9Ast__id_tN13K_form__dom_t v_11 = 0;
-         _fx_R10Ast__loc_t* loc_0 = &vcase_4->t4;
-         FX_CALL(
-            _fx_M12K_fuse_loopsFM8fuse_forT2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t4LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_tR10Ast__loc_tRt6Map__t2R9Ast__id_trRM10arr_info_t(
-               vcase_4->t0, vcase_4->t2, loc_0, arrs_to_fuse_0, &v_10, 0), _fx_catch_7);
-         FX_COPY_PTR(v_10.t0, &new_idl_0);
-         FX_COPY_PTR(v_10.t1, &new_body_0);
-         _fx_LT2R9Ast__id_tN13K_form__dom_t lst_0 = new_idl_0;
-         for (; lst_0; lst_0 = lst_0->tl) {
-            _fx_LT2R9Ast__id_tN13K_form__dom_t v_12 = 0;
-            _fx_T2R9Ast__id_tN13K_form__dom_t* a_0 = &lst_0->hd;
-            FX_CALL(_fx_cons_LT2R9Ast__id_tN13K_form__dom_t(a_0, res_0, true, &v_12), _fx_catch_6);
-            _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_0);
-            FX_COPY_PTR(v_12, &res_0);
-
-         _fx_catch_6: ;
-            if (v_12) {
-               _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_12);
-            }
-            FX_CHECK_EXN(_fx_catch_7);
-         }
-         FX_COPY_PTR(res_0, &v_11);
-         FX_CALL(
-            _fx_M6K_formFM7KExpForN14K_form__kexp_t5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t(
-               v_11, 0, new_body_0, &vcase_4->t3, loc_0, fx_result), _fx_catch_7);
-
-      _fx_catch_7: ;
-         if (v_11) {
-            _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_11);
-         }
-         if (res_0) {
-            _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_0);
-         }
-         if (new_body_0) {
-            _fx_free_N14K_form__kexp_t(&new_body_0);
-         }
-         if (new_idl_0) {
-            _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&new_idl_0);
-         }
-         _fx_free_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t(&v_10);
-         goto _fx_endmatch_0;
-      }
-   }
-   if (tag_0 == 26) {
-      _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
-         vcase_5 = &e_1->u.KExpMap;
-      _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_13 = vcase_5->t0;
-      if (v_13 != 0) {
-         if (v_13->tl == 0) {
-            _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t* v_14 = &v_13->hd;
-            if (v_14->t2 == 0) {
-               _fx_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t v_15 = {0};
-               _fx_LT2R9Ast__id_tN13K_form__dom_t new_idl_1 = 0;
-               _fx_N14K_form__kexp_t new_body_1 = 0;
-               _fx_LT2R9Ast__id_tN13K_form__dom_t res_1 = 0;
-               _fx_LT2R9Ast__id_tN13K_form__dom_t v_16 = 0;
-               _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_17 = {0};
-               _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_18 = 0;
-               _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_19 = {0};
-               _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_20 = &vcase_5->t3;
-               _fx_R10Ast__loc_t* loc_1 = &v_20->t1;
-               FX_CALL(
-                  _fx_M12K_fuse_loopsFM8fuse_forT2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t4LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_tR10Ast__loc_tRt6Map__t2R9Ast__id_trRM10arr_info_t(
-                     v_14->t1, vcase_5->t1, loc_1, arrs_to_fuse_0, &v_15, 0), _fx_catch_9);
-               FX_COPY_PTR(v_15.t0, &new_idl_1);
-               FX_COPY_PTR(v_15.t1, &new_body_1);
-               _fx_LT2R9Ast__id_tN13K_form__dom_t lst_1 = new_idl_1;
-               for (; lst_1; lst_1 = lst_1->tl) {
-                  _fx_LT2R9Ast__id_tN13K_form__dom_t v_21 = 0;
-                  _fx_T2R9Ast__id_tN13K_form__dom_t* a_1 = &lst_1->hd;
-                  FX_CALL(_fx_cons_LT2R9Ast__id_tN13K_form__dom_t(a_1, res_1, true, &v_21), _fx_catch_8);
-                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_1);
-                  FX_COPY_PTR(v_21, &res_1);
-
-               _fx_catch_8: ;
-                  if (v_21) {
-                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_21);
+               _fx_catch_5: ;
+                  _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&v_5);
+                  FX_FREE_FP(&cmp_0);
+                  if (t_0) {
+                     _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&t_0);
                   }
-                  FX_CHECK_EXN(_fx_catch_9);
+                  _fx_free_Nt6option1rR24K_fuse_loops__arr_info_t(&result_0);
+                  FX_FREE_FP(&v_4);
+                  if (v_3) {
+                     _fx_free_Nt11Map__tree_t2R9Ast__id_trR24K_fuse_loops__arr_info_t(&v_3);
+                  }
+                  goto _fx_endmatch_0;
                }
-               FX_COPY_PTR(res_1, &v_16);
-               _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(v_14->t0, v_16, 0, &v_17);
-               FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_17, 0, true, &v_18),
-                  _fx_catch_9);
-               _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(v_20->t0, loc_1, &v_19);
-               FX_CALL(
-                  _fx_M6K_formFM7KExpMapN14K_form__kexp_t4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t(
-                     v_18, new_body_1, &vcase_5->t2, &v_19, fx_result), _fx_catch_9);
-
-            _fx_catch_9: ;
-               _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_19);
-               if (v_18) {
-                  _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_18);
-               }
-               _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_17);
-               if (v_16) {
-                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_16);
-               }
-               if (res_1) {
-                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_1);
-               }
-               if (new_body_1) {
-                  _fx_free_N14K_form__kexp_t(&new_body_1);
-               }
-               if (new_idl_1) {
-                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&new_idl_1);
-               }
-               _fx_free_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t(&v_15);
-               goto _fx_endmatch_0;
             }
          }
       }
-   }
-   FX_COPY_PTR(e_1, fx_result);
+      if (tag_0 == 27) {
+         _fx_T5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t* vcase_4 =
+            &e_1->u.KExpFor;
+         if (vcase_4->t1 == 0) {
+            _fx_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t v_10 = {0};
+            _fx_LT2R9Ast__id_tN13K_form__dom_t new_idl_0 = 0;
+            _fx_N14K_form__kexp_t new_body_0 = 0;
+            _fx_LT2R9Ast__id_tN13K_form__dom_t res_0 = 0;
+            _fx_LT2R9Ast__id_tN13K_form__dom_t v_11 = 0;
+            _fx_R10Ast__loc_t* loc_0 = &vcase_4->t4;
+            FX_CALL(
+               _fx_M12K_fuse_loopsFM8fuse_forT2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t4LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_tR10Ast__loc_tRt6Map__t2R9Ast__id_trRM10arr_info_t(
+                  vcase_4->t0, vcase_4->t2, loc_0, arrs_to_fuse_0, &v_10, 0), _fx_catch_7);
+            FX_COPY_PTR(v_10.t0, &new_idl_0);
+            FX_COPY_PTR(v_10.t1, &new_body_0);
+            _fx_LT2R9Ast__id_tN13K_form__dom_t lst_0 = new_idl_0;
+            for (; lst_0; lst_0 = lst_0->tl) {
+               _fx_LT2R9Ast__id_tN13K_form__dom_t v_12 = 0;
+               _fx_T2R9Ast__id_tN13K_form__dom_t* a_0 = &lst_0->hd;
+               FX_CALL(_fx_cons_LT2R9Ast__id_tN13K_form__dom_t(a_0, res_0, true, &v_12), _fx_catch_6);
+               _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_0);
+               FX_COPY_PTR(v_12, &res_0);
 
-_fx_endmatch_0: ;
+            _fx_catch_6: ;
+               if (v_12) {
+                  _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_12);
+               }
+               FX_CHECK_EXN(_fx_catch_7);
+            }
+            FX_COPY_PTR(res_0, &v_11);
+            FX_CALL(
+               _fx_M6K_formFM7KExpForN14K_form__kexp_t5LT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tR10Ast__loc_t(
+                  v_11, 0, new_body_0, &vcase_4->t3, loc_0, fx_result), _fx_catch_7);
 
-_fx_cleanup: ;
-   if (e_1) {
-      _fx_free_N14K_form__kexp_t(&e_1);
+         _fx_catch_7: ;
+            if (v_11) {
+               _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_11);
+            }
+            if (res_0) {
+               _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_0);
+            }
+            if (new_body_0) {
+               _fx_free_N14K_form__kexp_t(&new_body_0);
+            }
+            if (new_idl_0) {
+               _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&new_idl_0);
+            }
+            _fx_free_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t(&v_10);
+            goto _fx_endmatch_0;
+         }
+      }
+      if (tag_0 == 26) {
+         _fx_T4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t*
+            vcase_5 = &e_1->u.KExpMap;
+         _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_13 = vcase_5->t0;
+         if (v_13 != 0) {
+            if (v_13->tl == 0) {
+               _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t* v_14 = &v_13->hd;
+               if (v_14->t2 == 0) {
+                  _fx_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t v_15 = {0};
+                  _fx_LT2R9Ast__id_tN13K_form__dom_t new_idl_1 = 0;
+                  _fx_N14K_form__kexp_t new_body_1 = 0;
+                  _fx_LT2R9Ast__id_tN13K_form__dom_t res_1 = 0;
+                  _fx_LT2R9Ast__id_tN13K_form__dom_t v_16 = 0;
+                  _fx_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_17 = {0};
+                  _fx_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t v_18 = 0;
+                  _fx_T2N14K_form__ktyp_tR10Ast__loc_t v_19 = {0};
+                  _fx_T2N14K_form__ktyp_tR10Ast__loc_t* v_20 = &vcase_5->t3;
+                  _fx_R10Ast__loc_t* loc_1 = &v_20->t1;
+                  FX_CALL(
+                     _fx_M12K_fuse_loopsFM8fuse_forT2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t4LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_tR10Ast__loc_tRt6Map__t2R9Ast__id_trRM10arr_info_t(
+                        v_14->t1, vcase_5->t1, loc_1, arrs_to_fuse_0, &v_15, 0), _fx_catch_9);
+                  FX_COPY_PTR(v_15.t0, &new_idl_1);
+                  FX_COPY_PTR(v_15.t1, &new_body_1);
+                  _fx_LT2R9Ast__id_tN13K_form__dom_t lst_1 = new_idl_1;
+                  for (; lst_1; lst_1 = lst_1->tl) {
+                     _fx_LT2R9Ast__id_tN13K_form__dom_t v_21 = 0;
+                     _fx_T2R9Ast__id_tN13K_form__dom_t* a_1 = &lst_1->hd;
+                     FX_CALL(_fx_cons_LT2R9Ast__id_tN13K_form__dom_t(a_1, res_1, true, &v_21), _fx_catch_8);
+                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_1);
+                     FX_COPY_PTR(v_21, &res_1);
+
+                  _fx_catch_8: ;
+                     if (v_21) {
+                        _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_21);
+                     }
+                     FX_CHECK_EXN(_fx_catch_9);
+                  }
+                  FX_COPY_PTR(res_1, &v_16);
+                  _fx_make_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(v_14->t0, v_16, 0, &v_17);
+                  FX_CALL(_fx_cons_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_17, 0, true, &v_18),
+                     _fx_catch_9);
+                  _fx_make_T2N14K_form__ktyp_tR10Ast__loc_t(v_20->t0, loc_1, &v_19);
+                  FX_CALL(
+                     _fx_M6K_formFM7KExpMapN14K_form__kexp_t4LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_tN14K_form__kexp_tR16Ast__for_flags_tT2N14K_form__ktyp_tR10Ast__loc_t(
+                        v_18, new_body_1, &vcase_5->t2, &v_19, fx_result), _fx_catch_9);
+
+               _fx_catch_9: ;
+                  _fx_free_T2N14K_form__ktyp_tR10Ast__loc_t(&v_19);
+                  if (v_18) {
+                     _fx_free_LT3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_18);
+                  }
+                  _fx_free_T3N14K_form__kexp_tLT2R9Ast__id_tN13K_form__dom_tLR9Ast__id_t(&v_17);
+                  if (v_16) {
+                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&v_16);
+                  }
+                  if (res_1) {
+                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&res_1);
+                  }
+                  if (new_body_1) {
+                     _fx_free_N14K_form__kexp_t(&new_body_1);
+                  }
+                  if (new_idl_1) {
+                     _fx_free_LT2R9Ast__id_tN13K_form__dom_t(&new_idl_1);
+                  }
+                  _fx_free_T2LT2R9Ast__id_tN13K_form__dom_tN14K_form__kexp_t(&v_15);
+                  goto _fx_endmatch_0;
+               }
+            }
+         }
+      }
+      FX_COPY_PTR(e_1, fx_result);
+
+   _fx_endmatch_0: ;
+      FX_CHECK_EXN(_fx_catch_10);
+
+   _fx_catch_10: ;
+      if (e_1) {
+         _fx_free_N14K_form__kexp_t(&e_1);
+      }
    }
    return fx_status;
 }
@@ -5866,7 +5815,7 @@ FX_EXTERN_C int _fx_M12K_fuse_loopsFM14fuse_loops_allLR17K_form__kmodule_t1LR17K
       _fx_R17K_form__kmodule_t rec_0 = {0};
       _fx_R17K_form__kmodule_t* km_0 = &lst_0->hd;
       FX_COPY_PTR(km_0->km_top, &km_top_0);
-      FX_CALL(_fx_M12K_fuse_loopsFM10fuse_loopsLN14K_form__kexp_t1LN14K_form__kexp_t(km_top_0, &new_top_0, 0), _fx_catch_0);
+      FX_CALL(_fx_M12K_fuse_loopsFM11fuse_loops_LN14K_form__kexp_t1LN14K_form__kexp_t(km_top_0, &new_top_0, 0), _fx_catch_0);
       _fx_make_R17K_form__kmodule_t(&km_0->km_name, km_0->km_idx, km_0->km_toposort_idx, &km_0->km_cname, new_top_0,
          km_0->km_deps, km_0->km_skip, km_0->km_main, &km_0->km_pragmas, &rec_0);
       _fx_LR17K_form__kmodule_t node_0 = 0;

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -373,3 +373,42 @@ soundness surprise, not just a missed diagnostic.
   preserving, coalesced by the C compiler. Phase 2 (purity-1) folds this into a
   parameterized `pure_kexp(~mut_read_is_impure)` so the throw-impurity and the
   FB-023 movement guard share one classification.
+
+## FB-028  loop fusion moves a mutable-memory read past the consumer's stores  [FIXED — fuse-move-1]
+Sibling of FB-023, in `K_fuse_loops`. Fusion takes a single-use comprehension
+`val tmp = [for i <- A {body(i)}]` consumed by exactly one for-loop
+`for x <- tmp {bar(x)}` and REPLAYS the body inside the consumer:
+`for i <- A { val x = body(i); bar(x) }`. If `body` reads mutable memory and the
+consumer `bar` writes it, the fused reads see values written earlier in the SAME
+pass — the unfused meaning reads the original array (tmp is materialized first).
+Minimal repro (an in-place 3-tap smoothing filter):
+```
+val arr = [30, 60, 90, 120, 150]
+val n = size(arr)
+val smoothed = [for i <- 0:n { (arr.clip[i-1] + arr.clip[i] + arr.clip[i+1]) / 3 }]
+var k = 0
+for s <- smoothed { arr[k] = s; k += 1 }   // write-back in place
+// unfused (O0): [40, 60, 90, 120, 140]; fused (O3): [40, 63, 91, 120, 140]
+```
+- **Post-purity-1 reachability**: a plain `arr[i]` read is `BorderNone` → impure
+  → already blocks fusion; the bug survives only through a NON-throwing mutable
+  read — a border read (`.clip`/`.wrap`/`.zero`), `*ref`, or a mutable field.
+- **Fix**: the fusion criterion asks `pure_kexp` for its MOVEMENT grade
+  (`mut_read_is_impure=true`) — a body that reads mutable memory is not a fusion
+  candidate (bodies reading only immutable data still fuse). Conservative (blocks
+  even when the consumer provably doesn't alias), but measured zero corpus fusion
+  loss for it.
+- **Driver fix (bonus)**: while adding a regression test we found fusion **never
+  fired inside function or lambda bodies** — `fuse_loops_all` only ran the pass
+  on each module's top-level code, and the recursive descent (`fuse_kexp_`) only
+  started once the *top-level* gate (`≥1 map`, `≥2 map+for`) passed; a module
+  whose top level is only `KDefFun`s (every UTest file, all modular code) got no
+  fusion at all. Killed the gate (`fuse_loops` → always `fuse_loops_`) and made
+  `fuse_kexp_` process a `KExpSeq` with `fuse_loops_(elist)` directly WITHOUT a
+  preceding `walk_kexp` (which also descends → every block would be traversed
+  2^depth times; the gate had been masking that). Net: fusion now fires in
+  function/lambda bodies too (25 test_all modules newly fuse; benchmark C
+  unchanged), compiler front-end +4.5%, and the FB-028 regression is now
+  observable from a UTest (`test/test_array.fx` `array.fuse_inplace_stencil`;
+  positive companion `array.fuse_map_reduce`). So: trying to DISABLE fusion in
+  unsafe places, we ENABLED it in safe ones.

--- a/docs/fuse_move1_report.md
+++ b/docs/fuse_move1_report.md
@@ -1,0 +1,121 @@
+# fuse-move-1 report — FB-028 (fusion move hazard) + fusion in function bodies
+
+Branch `fuse-move-1` off master (post-`purity-1`). One commit (`1045983`). This
+closes the open item flagged in `docs/purity1_report.md` (the K_fuse_loops
+STOP-rule finding) and, in the course of making it testable, fixes a second
+long-standing limitation of the fusion pass.
+
+Green on the full ladder (`fxtest.py all`), `sanitize` (ASan+UBSan),
+`determinism`, and the self-hosting fixpoint (`update_compiler.py`).
+
+## FB-028 — loop fusion moves a mutable-memory read past the consumer's stores
+
+`K_fuse_loops` takes a single-use comprehension consumed by exactly one for-loop
+
+```
+val tmp = [for i <- A { body(i) }]
+for x <- tmp { bar(x) }
+```
+
+and REPLAYS the body inside the consumer:
+
+```
+for i <- A { val x = body(i); bar(x) }
+```
+
+Unfused, `tmp` is fully materialized first, so every `body(i)` reads the source
+in its original state. Fused, each `body(i)` runs inside the consumer loop, so if
+`bar` writes memory that `body` reads, later reads see earlier writes. This is
+FB-023's hazard (a read of mutable memory moved past an aliasing store), now in
+the fusion pass instead of single-use-temp inlining.
+
+**Repro — an in-place 3-tap smoothing filter** (`test/test_array.fx`
+`array.fuse_inplace_stencil`):
+
+```
+val arr = [30, 60, 90, 120, 150]
+val n = size(arr)
+val smoothed = [for i <- 0:n { (arr.clip[i-1] + arr.clip[i] + arr.clip[i+1]) / 3 }]
+var k = 0
+for s <- smoothed { arr[k] = s; k += 1 }   // write-back in place
+```
+
+Unfused (O0): `[40, 60, 90, 120, 140]`. Fused (O3): `[40, 63, 91, 120, 140]` —
+the write-back at index `i` corrupts the neighbour a later tap reads.
+
+**Post-purity-1 reachability.** A plain `arr[i]` read is a `BorderNone` `KExpAt`,
+which purity-1 already made impure (throwing) → it never was a fusion candidate.
+The hazard survives ONLY through a NON-throwing mutable read: a border read
+(`.clip`/`.wrap`/`.zero`), a `*ref` deref, or a mutable record field — exactly the
+class the movement grade governs.
+
+**Fix.** The fusion criterion now asks `pure_kexp` for its movement grade:
+
+```
+K_remove_unused.pure_kexp(body, mut_read_is_impure=true)
+```
+
+so a body that reads mutable memory is not a fusion candidate (bodies reading
+only immutable data still fuse). Conservative — it blocks fusion even when the
+consumer provably doesn't alias the read — but the alias analysis that would be
+needed to be precise is not worth it: measured **zero corpus fusion loss** from
+the flip alone.
+
+## Driver fix — fusion now fires inside function and lambda bodies
+
+Making the bug observable from a UTest test surfaced a second problem: **fusion
+never fired inside a function or lambda body.**
+
+Root cause: `fuse_loops_all` ran the pass only on each module's top-level code
+(`km_top`). The recursive descent into nested blocks lived inside `fuse_kexp_`,
+which only ran once the *top-level* gate `fuse_loops` passed (`≥1 map`, `≥2
+map+for`), and `KDefFun` was not counted toward that gate. So a module whose top
+level is only function definitions — **every UTest file, and essentially all
+modular (non-script) code** — got no fusion at all. Fusion effectively only
+helped top-level script code (or code inlined into it).
+
+The naive fix (remove the gate, always recurse) is a trap: `fuse_kexp_` did
+`walk_kexp(e)` **and then** `fuse_loops(elist)` for a `KExpSeq`, and `walk_kexp`
+already descends into the same elements — so together they traverse every block
+twice, i.e. **2^depth** times overall. The gate had been masking this by
+short-circuiting almost always. (This is the ~100× blow-up to avoid.)
+
+Two changes give single-pass fusion of every block:
+
+1. **Killed `fuse_loops` (the gate).** `fuse_loops_all` and the `KExpSeq` arm call
+   `fuse_loops_` directly — every block is analysed.
+2. **`fuse_kexp_` handles `KExpSeq` via `fuse_loops_(elist)` directly, with NO
+   preceding `walk_kexp`.** Non-`KExpSeq` nodes still `walk_kexp` (to recurse into
+   their sub-blocks) and then match. Each block is now visited exactly once.
+
+## Measurements
+
+| aspect | result |
+|--------|--------|
+| corpus C (`test_all`) | **25 modules newly fuse** (test/NN/etc.) — fusion now reaches modular code |
+| benchmark C (spectralnorm / nbody / mandelbrot / btree) | **byte-identical** to baseline → perf unchanged (spectralnorm N=5500 0.86 s both) |
+| compiler front-end | `-no-c -O3` on `fx.fx`: 7.81 s → **8.15 s (+4.5%)** — the cost of analysing every block; no 2^depth blow-up |
+| bootstrap fixpoint | holds; only `K_fuse_loops.c` regenerates |
+| ladder / sanitize / determinism | all green |
+
+So: in trying to DISABLE fusion in unsafe places we ENABLED it in safe ones — a
+net codegen improvement (fusion finally helps library/modular code), with the
+movement grade keeping the newly-reachable fusion sound.
+
+## Tests (`test/test_array.fx`)
+
+- **`array.fuse_inplace_stencil`** (negative) — the smoothing repro. VALIDATED as a
+  real guard: temporarily reverting the criterion to the removal grade and
+  rebuilding makes it **FAIL at O3** (`[40,63,91,120,140]`); with the fix it
+  passes. Observable from a UTest only because of the driver fix (the test's
+  closure is now itself a fusion site).
+- **`array.fuse_map_reduce`** (positive) — a comprehension fused into a reduce
+  (`sum(i*i)`), and a range comprehension consumed by a product loop. Confirmed a
+  fusion site via `-pr-k` (the `squares`/`evens` arrays disappear between `-pr-k0`
+  and `-O3 -pr-k`). Guards fusion's correctness where it fires.
+
+## Registry
+
+`docs/found_bugs.md`: FB-028 added, `FIXED — fuse-move-1`, with the repro, the
+movement-grade fix, and the driver-fix write-up. Supersedes the open STOP-rule
+item in `docs/purity1_report.md`.

--- a/docs/purity1_report.md
+++ b/docs/purity1_report.md
@@ -107,6 +107,13 @@ practice.
 
 ## STOP-rule item — `K_fuse_loops` and movement grade
 
+> **Resolved in `fuse-move-1` (FB-028).** The audit question below was confirmed
+> a real correctness bug: `K_fuse_loops` on the removal grade fuses a
+> mutable-memory-reading body into a consumer that writes it (an in-place
+> stencil), corrupting the result. Fixed by flipping the criterion to the
+> movement grade; the fix also uncovered and repaired that fusion never fired
+> inside function/lambda bodies. See `docs/fuse_move1_report.md`.
+
 Per the brief: *if Phase 2's audit finds a consumer whose migration would CHANGE
 optimization behaviour — report, don't decide.* `K_fuse_loops` is that consumer.
 

--- a/test/test_array.fx
+++ b/test/test_array.fx
@@ -162,3 +162,40 @@ TEST("array.bounding_box", fun() {
 
     EXPECT_EQ(bounding_box(img), (2, 1, 5, 4))
 })
+
+TEST("array.fuse_inplace_stencil", fun() {
+    // FB-028: a single-use comprehension whose body reads mutable memory via a
+    // non-throwing .clip read is a loop-fusion candidate. Fusing it into a
+    // consumer loop that writes that array IN PLACE would replay the reads across
+    // the consumer's stores (K_fuse_loops' sibling of the FB-023 move hazard):
+    // a 3-tap smoothing filter must read the ORIGINAL array for every tap. The
+    // fusion criterion uses pure_kexp's movement grade so this body (mutable read)
+    // is NOT fused; without it the in-place write-back corrupts later taps at O3.
+    // (Regression is observable here because fusion now fires inside lambda
+    // bodies too, so this UTest closure is itself a fusion site.)
+    val arr = [30, 60, 90, 120, 150]
+    val n = size(arr)
+    val smoothed = [for i <- 0:n { (arr.clip[i-1] + arr.clip[i] + arr.clip[i+1]) / 3 }]
+    var k = 0
+    for s <- smoothed { arr[k] = s; k += 1 }
+    EXPECT_EQ(arr, [40, 60, 90, 120, 140])
+})
+
+TEST("array.fuse_map_reduce", fun() {
+    // positive: a single-use comprehension consumed by exactly one for-loop is
+    // fused -- the intermediate `squares` array is never materialized, the map
+    // body is replayed inside the reduce loop. The body reads no mutable memory,
+    // so it fuses under the movement grade; the result must equal the unfused
+    // meaning. Confirmed a fusion site via -pr-k. Guards fusion correctness on a
+    // case where it fires (complement of fuse_inplace_stencil, where it must not).
+    val n = 10
+    val squares = [for i <- 0:n { i * i }]
+    var s = 0
+    for x <- squares { s += x }
+    EXPECT_EQ(s, 285)                        // 0+1+4+9+...+81 = 285
+    // a second fusable shape: comprehension over a range, consumed once
+    val evens = [for i <- 0:n { i * 2 }]
+    var prod1 = 1
+    for x <- evens { if x > 0 { prod1 *= x } }
+    EXPECT_EQ(prod1, 2*4*6*8*10*12*14*16*18) // product of the positive evens
+})


### PR DESCRIPTION
Follow-up to purity-1 (#43): closes the K_fuse_loops movement question flagged
there, and — while making it testable — fixes a second long-standing limitation
of the fusion pass.

## FB-028 — fusion moves a mutable read past the consumer's stores

`K_fuse_loops` fuses a single-use comprehension into its one consumer loop by
REPLAYING the producer body inside it:

```
val tmp = [for i <- A { body(i) }]      for i <- A {
for x <- tmp { bar(x) }          -->        val x = body(i)
                                            bar(x)
                                        }
```

Unfused, `tmp` is materialized first, so every `body(i)` reads the source in its
original state. Fused, if `bar` writes memory that `body` reads, later reads see
earlier writes — FB-023's read-past-store hazard, now in the fusion pass.

Repro — an in-place 3-tap smoothing filter:

```
val arr = [30, 60, 90, 120, 150]
val n = size(arr)
val smoothed = [for i <- 0:n { (arr.clip[i-1] + arr.clip[i] + arr.clip[i+1]) / 3 }]
var k = 0
for s <- smoothed { arr[k] = s; k += 1 }   // write-back in place
// unfused (O0): [40, 60, 90, 120, 140];  fused (O3): [40, 63, 91, 120, 140]
```

Post-purity-1 the hazard survives only through a NON-throwing mutable read
(a `.clip`/`.wrap`/`.zero` border read, `*ref`, or a mutable field) — a plain
`arr[i]` read is already impure (throwing) and never fused.

**Fix:** the fusion criterion asks `pure_kexp` for its movement grade
(`mut_read_is_impure=true`), so a body reading mutable memory is not a fusion
candidate. Immutable-body comprehensions still fuse. Zero corpus fusion loss.

## Driver fix — fusion now fires in function/lambda bodies

Making the bug UTest-observable surfaced that **fusion never fired inside a
function or lambda body**: `fuse_loops_all` ran the pass only on module top-level
code, and the recursive descent started only after a top-level gate passed
(`≥1 map`), which `KDefFun` never satisfies. Any module whose top level is only
function definitions — every UTest file, all modular code — got no fusion.

Naively removing the gate is a trap: `fuse_kexp_` did `walk_kexp(e)` **and then**
`fuse_loops(elist)` for a `KExpSeq`, and `walk_kexp` already descends into those
elements — together they traverse every block **2^depth** times (the gate had
masked this). So:

1. Killed `fuse_loops` (the gate); `fuse_loops_all` and the `KExpSeq` arm call
   `fuse_loops_` directly.
2. `fuse_kexp_` handles a `KExpSeq` via `fuse_loops_(elist)` directly, with **no**
   preceding `walk_kexp` — each block is visited exactly once.

Net: fusion now reaches modular code. **In trying to disable fusion in unsafe
places, we enabled it in safe ones.**

## Measurements

- **25 `test_all` modules newly fuse**; benchmark C (spectralnorm / nbody /
  mandelbrot / btree) **byte-identical** → perf unchanged.
- Compiler front-end `-no-c -O3 fx.fx`: 7.81 s → **8.15 s (+4.5%)** — no 2^depth
  blow-up.
- Bootstrap fixpoint holds (only `K_fuse_loops.c` regenerates).
- Full ladder + `sanitize` (ASan+UBSan) + `determinism` green.

## Tests (`test/test_array.fx`)

- `array.fuse_inplace_stencil` (negative) — the smoothing repro. **Validated**: on
  the pre-fix removal grade it FAILS at O3; with the fix it passes. Observable
  from a UTest only because of the driver fix.
- `array.fuse_map_reduce` (positive) — a comprehension fused into a reduce;
  confirmed a fusion site via `-pr-k` (the intermediate array disappears between
  `-pr-k0` and `-O3 -pr-k`).

## Registry / docs

`docs/found_bugs.md` FB-028 (`FIXED — fuse-move-1`); `docs/fuse_move1_report.md`
(full write-up); resolution note added to `docs/purity1_report.md`'s STOP-rule
section.
