### PR TITLE
resolve-3: recovery inside block expressions (FB-022) + resolver self-recursion on an under-constrained tie (FB-025)

### DIFF
--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -3351,20 +3351,34 @@ fun check_eseq(eseq: exp_t list, env: env_t, sc: scope_t list, create_sc: bool):
                                                         sc, false, true, is_mutable)
                     (DefVal(p1, e1, flags, loc) :: eseq_acc, env1)
                 } catch {
-                | CompileError(_, _) as err =>
-                    push_compile_err(err)
-                    // Poison every name the pattern binds. With an explicit
-                    // annotation, poison with THAT type -- the §1.7 firewall:
-                    // callers keep checking against the declared type. Without
-                    // one, poison with TypErr so later uses are suppressed
-                    // (structural cascade suppression), not cascaded.
-                    val poison_t = match p {
-                        | PatTyped(_, t1, tloc) =>
-                            (try { check_typ(t1, env, sc, tloc) } catch { | CompileError(_, _) => TypErr })
-                        | _ => TypErr
+                | (CompileError(_, _) | PropagateCompileError) as err =>
+                    // A direct RHS failure arrives as CompileError. A failure
+                    // INSIDE a block-valued RHS -- e.g. the fold desugar
+                    // `val (a,b): (..) = { ..failed stmt..; (a,b) }` (FB-022) --
+                    // has already been reported by the block's own check_eseq
+                    // and reaches us as PropagateCompileError; don't re-push it.
+                    match err { | CompileError(_, _) => push_compile_err(err) | _ => {} }
+                    // Bind every name the pattern introduces so later statements
+                    // don't cascade into spurious "undefined". With a usable
+                    // annotation, bind each name to its ANNOTATED type -- the
+                    // §1.7 firewall (callers keep checking against the declared
+                    // interface). check_pat destructures a tuple/record
+                    // annotation per-field, so `val (a,b): (int,bool)` yields
+                    // a:int, b:bool (not both the whole tuple, which would
+                    // itself cascade). Without a usable annotation, poison with
+                    // TypErr so later uses are structurally suppressed.
+                    val env1 = match p {
+                        | PatTyped(p1, t1, tloc) =>
+                            (try {
+                                val t1 = check_typ(t1, env, sc, tloc)
+                                val (_, env1, _, _, _) =
+                                    check_pat(p1, t1, env, empty_idset, empty_idset,
+                                              sc, false, true, is_mutable)
+                                env1
+                            } catch { | CompileError(_, _) | PropagateCompileError =>
+                                poison_pattern_vars(p1, TypErr, flags, sc, curr_m_idx, env) })
+                        | _ => poison_pattern_vars(p, TypErr, flags, sc, curr_m_idx, env)
                         }
-                    val env1 = poison_pattern_vars(pat_skip_typed(p), poison_t, flags,
-                                                   sc, curr_m_idx, env)
                     (DefVal(p, e, flags, loc) :: eseq_acc, env1)
                 }
             | DefFun(df) =>

--- a/compiler/Ast_typecheck.fx
+++ b/compiler/Ast_typecheck.fx
@@ -1376,9 +1376,27 @@ fun lookup_id_opt(n: id_t, t: typ_t, env: env_t, sc: scope_t list, loc: loc_t): 
                     throw compile_err(loc, f"ambiguous call of overloaded '{pp(n)}': \
                         {why}. Candidates:\n    {cand_lines}\n{hint}")
                 } else {
-                    // under-constrained tie: keep today's env-order first-match
-                    // semantics until deferral lands (session 2)
-                    val (i, df) = viable.hd()
+                    // under-constrained tie: env-order first-match (a documented
+                    // stopgap until deferral lands, session 2) -- BUT prefer a
+                    // concrete (non-template) candidate over a template one.
+                    // This is a fully under-determined call (all arg types free);
+                    // whichever candidate we commit is a speculative choice that
+                    // is redone per real use with concrete args. Committing a
+                    // TEMPLATE here instantiates it with the still-free args, and
+                    // for a self-recursive generic operator -- a container `<=>`
+                    // whose body compares its still-free elements -- that
+                    // instantiation re-issues the same free compare and picks the
+                    // template again, self-instantiating without bound (FB-025
+                    // StackOverflow, formerly the "failed to re-unify at commit"
+                    // internal error). A concrete candidate fixes the arg types
+                    // in this speculative check and cannot self-instantiate, so
+                    // the placement of a generic container operator (Vector.fx vs
+                    // Builtins.fx) no longer decides whether the compiler builds.
+                    val concrete_opt = find_opt(for idf <- viable { idf.1->df_templ_args == [] })
+                    val (i, df) = match concrete_opt {
+                        | Some(idf) => idf
+                        | _ => viable.hd()
+                        }
                     commit_fun(i, df)
                 }
             }

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -7012,6 +7012,7 @@ FX_EXTERN_C int
    struct _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t*,
    void*);
 
+FX_EXTERN_C_VAL(int _FX_EXN_E26Ast__PropagateCompileError)
 FX_EXTERN_C int _fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(
    struct _fx_rR13Ast__deffun_t_data_t*,
    bool*,
@@ -7030,7 +7031,6 @@ FX_EXTERN_C int _fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(
    struct _fx_rR13Ast__deffun_t_data_t*,
    struct _fx_N10Ast__exp_t_data_t**);
 
-FX_EXTERN_C_VAL(int _FX_EXN_E26Ast__PropagateCompileError)
 FX_EXTERN_C int _fx_M3AstFM18check_compile_errsv0(void*);
 
 static int _fx_M13Ast_typecheckFM10__lambda__B5N16Ast__env_entry_tR9Ast__id_tBR10Ast__loc_ti(
@@ -31913,7 +31913,7 @@ _fx_endmatch_0: ;
       else {
          res_1 = false;
       }
-      FX_CHECK_EXN(_fx_catch_17);
+      FX_CHECK_EXN(_fx_catch_20);
       if (res_1) {
          fx_exn_t v_4 = {0};
          _fx_LN10Ast__exp_t v_5 = 0;
@@ -31939,7 +31939,7 @@ _fx_endmatch_0: ;
             _fx_free_LN10Ast__exp_t(&v_5);
          }
          fx_free_exn(&v_4);
-         goto _fx_endmatch_4;
+         goto _fx_endmatch_6;
       }
       if (tag_1 == 34) {
          fx_exn_t v_7 = {0};
@@ -31959,11 +31959,11 @@ _fx_endmatch_0: ;
          }
          if (t_2) {
             fx_str_t slit_1 = FX_MAKE_STR("value definition occurs in the end of block; put some expression after it");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_1, &v_7, 0), _fx_catch_9);
-            FX_THROW(&v_7, false, _fx_catch_9);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &slit_1, &v_7, 0), _fx_catch_12);
+            FX_THROW(&v_7, false, _fx_catch_12);
          }
          bool is_mutable_0 = flags_0->val_flag_mutable;
-         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_2, &t_1, 0), _fx_catch_9);
+         FX_CALL(_fx_M3AstFM11get_exp_typN10Ast__typ_t1N10Ast__exp_t(e_2, &t_1, 0), _fx_catch_12);
          _fx_T2N10Ast__pat_tN10Ast__typ_t v_8 = {0};
          _fx_N10Ast__pat_t p_1 = 0;
          _fx_N10Ast__exp_t e1_0 = 0;
@@ -31974,26 +31974,18 @@ _fx_endmatch_0: ;
          _fx_LN10Ast__exp_t v_11 = 0;
          if (FX_REC_VARIANT_TAG(p_0) == 9) {
             _fx_N10Ast__typ_t t1_0 = 0;
-            fx_exn_t v_12 = {0};
             _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_1 = &p_0->u.PatTyped;
             _fx_R10Ast__loc_t* loc_1 = &vcase_1->t2;
             FX_CALL(
                _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
                   vcase_1->t1, &env_5, sc_1, loc_1, &t1_0, 0), _fx_catch_4);
-            bool v_13;
-            FX_CALL(
-               _fx_M13Ast_typecheckFM11maybe_unifyB4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tB(t_1, t1_0, loc_1, true, &v_13, 0),
+            fx_str_t slit_2 =
+               FX_MAKE_STR("explicit type specification of the defined value does not match the assigned expression type");
+            FX_CALL(_fx_M13Ast_typecheckFM5unifyv4N10Ast__typ_tN10Ast__typ_tR10Ast__loc_tS(t_1, t1_0, loc_1, &slit_2, 0),
                _fx_catch_4);
-            if (!v_13) {
-               fx_str_t slit_2 =
-                  FX_MAKE_STR("explicit type specification of the defined value does not match the assigned expression type");
-               FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_1, &slit_2, &v_12, 0), _fx_catch_4);
-               FX_THROW(&v_12, false, _fx_catch_4);
-            }
             _fx_make_T2N10Ast__pat_tN10Ast__typ_t(vcase_1->t0, t1_0, &v_8);
 
          _fx_catch_4: ;
-            fx_free_exn(&v_12);
             if (t1_0) {
                _fx_free_N10Ast__typ_t(&t1_0);
             }
@@ -32041,90 +32033,128 @@ _fx_endmatch_0: ;
             fx_exn_get_and_reset(fx_status, &exn_1);
             fx_status = 0;
             _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3);
-            if (exn_1.tag == _FX_EXN_E17Ast__CompileError) {
-               _fx_N10Ast__typ_t poison_t_0 = 0;
-               _fx_N10Ast__pat_t v_14 = 0;
+            int tag_2 = exn_1.tag;
+            bool res_2;
+            if (tag_2 == _FX_EXN_E17Ast__CompileError) {
+               res_2 = true;
+            }
+            else if (tag_2 == _FX_EXN_E26Ast__PropagateCompileError) {
+               res_2 = true;
+            }
+            else {
+               res_2 = false;
+            }
+            FX_CHECK_EXN(_fx_catch_12);
+            if (res_2) {
                _fx_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t env1_2 = {0};
-               _fx_N10Ast__exp_t v_15 = 0;
-               _fx_LN10Ast__exp_t v_16 = 0;
-               FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_1, 0), _fx_catch_8);
+               _fx_N10Ast__exp_t v_12 = 0;
+               _fx_LN10Ast__exp_t v_13 = 0;
+               if (exn_1.tag == _FX_EXN_E17Ast__CompileError) {
+                  FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_1, 0), _fx_catch_6);  _fx_catch_6: ;
+               }
+               FX_CHECK_EXN(_fx_catch_11);
                if (FX_REC_VARIANT_TAG(p_0) == 9) {
                   fx_exn_t exn_2 = {0};
                   _fx_T3N10Ast__pat_tN10Ast__typ_tR10Ast__loc_t* vcase_2 = &p_0->u.PatTyped;
+                  _fx_N10Ast__pat_t p1_1 = vcase_2->t0;
+                  _fx_N10Ast__typ_t t1_1 = 0;
+                  _fx_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB v_14 =
+                     {0};
                   FX_CALL(
                      _fx_M13Ast_typecheckFM9check_typN10Ast__typ_t4N10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_tR10Ast__loc_t(
-                        vcase_2->t1, &env_5, sc_1, &vcase_2->t2, &poison_t_0, 0), _fx_catch_6);
+                        vcase_2->t1, &env_5, sc_1, &vcase_2->t2, &t1_1, 0), _fx_catch_7);
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM9check_patT5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB9N10Ast__pat_tN10Ast__typ_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tLN12Ast__scope_tBBB(
+                        p1_1, t1_1, &env_5, &_fx_g16Ast__empty_idset, &_fx_g16Ast__empty_idset, sc_1, false, true, is_mutable_0,
+                        &v_14, 0), _fx_catch_7);
+                  _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_14.t1, &env1_2);
 
-               _fx_catch_6: ;
+               _fx_catch_7: ;
+                  if (t1_1) {
+                     _fx_free_N10Ast__typ_t(&t1_1);
+                  }
+                  _fx_free_T5N10Ast__pat_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tRt6Set__t1R9Ast__id_tRt6Set__t1R9Ast__id_tB(
+                     &v_14);
                   if (fx_status < 0) {
                      fx_exn_get_and_reset(fx_status, &exn_2);
                      fx_status = 0;
-                     if (poison_t_0) {
-                        _fx_free_N10Ast__typ_t(&poison_t_0);
+                     _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_2);
+                     int tag_3 = exn_2.tag;
+                     bool res_3;
+                     if (tag_3 == _FX_EXN_E17Ast__CompileError) {
+                        res_3 = true;
                      }
-                     if (exn_2.tag == _FX_EXN_E17Ast__CompileError) {
-                        FX_COPY_PTR(_fx_g21Ast_typecheck__TypErr, &poison_t_0);
+                     else if (tag_3 == _FX_EXN_E26Ast__PropagateCompileError) {
+                        res_3 = true;
                      }
                      else {
-                        FX_RETHROW(&exn_2, _fx_catch_7);
+                        res_3 = false;
                      }
-                     FX_CHECK_EXN(_fx_catch_7);
+                     FX_CHECK_EXN(_fx_catch_9);
+                     if (res_3) {
+                        FX_CALL(
+                           _fx_M13Ast_typecheckFM19poison_pattern_varsRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__pat_tN10Ast__typ_tR16Ast__val_flags_tLN12Ast__scope_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+                              p1_1, _fx_g21Ast_typecheck__TypErr, flags_0, sc_1, curr_m_idx_0, &env_5, &env1_2, 0),
+                           _fx_catch_8);
+
+                     _fx_catch_8: ;
+                        goto _fx_endmatch_1;
+                     }
+                     FX_RETHROW(&exn_2, _fx_catch_9);
+
+                  _fx_endmatch_1: ;
+                     FX_CHECK_EXN(_fx_catch_9);
                   }
 
-               _fx_catch_7: ;
+               _fx_catch_9: ;
                   fx_free_exn(&exn_2);
                }
                else {
-                  FX_COPY_PTR(_fx_g21Ast_typecheck__TypErr, &poison_t_0);
+                  FX_CALL(
+                     _fx_M13Ast_typecheckFM19poison_pattern_varsRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__pat_tN10Ast__typ_tR16Ast__val_flags_tLN12Ast__scope_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
+                        p_0, _fx_g21Ast_typecheck__TypErr, flags_0, sc_1, curr_m_idx_0, &env_5, &env1_2, 0), _fx_catch_10);
+
+               _fx_catch_10: ;
                }
-               FX_CHECK_EXN(_fx_catch_8);
-               FX_CALL(_fx_M3AstFM14pat_skip_typedN10Ast__pat_t1N10Ast__pat_t(p_0, &v_14, 0), _fx_catch_8);
-               FX_CALL(
-                  _fx_M13Ast_typecheckFM19poison_pattern_varsRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t6N10Ast__pat_tN10Ast__typ_tR16Ast__val_flags_tLN12Ast__scope_tiRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                     v_14, poison_t_0, flags_0, sc_1, curr_m_idx_0, &env_5, &env1_2, 0), _fx_catch_8);
+               FX_CHECK_EXN(_fx_catch_11);
                FX_CALL(
                   _fx_M3AstFM6DefValN10Ast__exp_t4N10Ast__pat_tN10Ast__exp_tRM11val_flags_tRM5loc_t(p_0, e_2, flags_0, loc_0,
-                     &v_15), _fx_catch_8);
-               FX_CALL(_fx_cons_LN10Ast__exp_t(v_15, eseq_acc_0, true, &v_16), _fx_catch_8);
-               _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_16, &env1_2, &v_3);
+                     &v_12), _fx_catch_11);
+               FX_CALL(_fx_cons_LN10Ast__exp_t(v_12, eseq_acc_0, true, &v_13), _fx_catch_11);
+               _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_13, &env1_2, &v_3);
 
-            _fx_catch_8: ;
-               if (v_16) {
-                  _fx_free_LN10Ast__exp_t(&v_16);
+            _fx_catch_11: ;
+               if (v_13) {
+                  _fx_free_LN10Ast__exp_t(&v_13);
                }
-               if (v_15) {
-                  _fx_free_N10Ast__exp_t(&v_15);
+               if (v_12) {
+                  _fx_free_N10Ast__exp_t(&v_12);
                }
                _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_2);
-               if (v_14) {
-                  _fx_free_N10Ast__pat_t(&v_14);
-               }
-               if (poison_t_0) {
-                  _fx_free_N10Ast__typ_t(&poison_t_0);
-               }
+               goto _fx_endmatch_2;
             }
-            else {
-               FX_RETHROW(&exn_1, _fx_catch_9);
-            }
-            FX_CHECK_EXN(_fx_catch_9);
+            FX_RETHROW(&exn_1, _fx_catch_12);
+
+         _fx_endmatch_2: ;
+            FX_CHECK_EXN(_fx_catch_12);
          }
 
-      _fx_catch_9: ;
+      _fx_catch_12: ;
          fx_free_exn(&exn_1);
          if (t_1) {
             _fx_free_N10Ast__typ_t(&t_1);
          }
          fx_free_exn(&v_7);
-         goto _fx_endmatch_4;
+         goto _fx_endmatch_6;
       }
       if (tag_1 == 35) {
-         fx_exn_t v_17 = {0};
-         _fx_LR9Ast__id_t v_18 = 0;
+         fx_exn_t v_15 = {0};
+         _fx_LR9Ast__id_t v_16 = 0;
          _fx_rR13Ast__deffun_t df_0 = 0;
          fx_exn_t exn_3 = {0};
-         _fx_R13Ast__deffun_t v_19 = {0};
-         _fx_N10Ast__exp_t v_20 = 0;
-         _fx_LN10Ast__exp_t v_21 = 0;
+         _fx_R13Ast__deffun_t v_17 = {0};
+         _fx_N10Ast__exp_t v_18 = 0;
+         _fx_LN10Ast__exp_t v_19 = 0;
          _fx_rR13Ast__deffun_t df_1 = e_1->u.DefFun;
          bool t_3;
          if (idx_0 == nexps_0 - 1) {
@@ -32134,27 +32164,27 @@ _fx_endmatch_0: ;
             t_3 = false;
          }
          if (t_3) {
-            _fx_R13Ast__deffun_t* v_22 = &df_1->data;
-            _fx_R10Ast__loc_t v_23 = v_22->df_loc;
+            _fx_R13Ast__deffun_t* v_20 = &df_1->data;
+            _fx_R10Ast__loc_t v_21 = v_20->df_loc;
             fx_str_t slit_3 = FX_MAKE_STR("function definition occurs in the end of block; put some expression after it");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_23, &slit_3, &v_17, 0), _fx_catch_12);
-            FX_THROW(&v_17, false, _fx_catch_12);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&v_21, &slit_3, &v_15, 0), _fx_catch_15);
+            FX_THROW(&v_15, false, _fx_catch_15);
          }
          bool warn_rettype_0;
          if (_fx_g12Options__opt.W_implicit_rettype) {
-            FX_CALL(_fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(df_1, &warn_rettype_0, 0), _fx_catch_12);
+            FX_CALL(_fx_M13Ast_typecheckFM20has_implicit_rettypeB1rR13Ast__deffun_t(df_1, &warn_rettype_0, 0), _fx_catch_15);
          }
          else {
             warn_rettype_0 = false;
          }
-         _fx_R13Ast__deffun_t* v_24 = &df_1->data;
-         FX_COPY_PTR(v_24->df_templ_args, &v_18);
-         if (v_18 == 0) {
+         _fx_R13Ast__deffun_t* v_22 = &df_1->data;
+         FX_COPY_PTR(v_22->df_templ_args, &v_16);
+         if (v_16 == 0) {
             FX_CALL(
                _fx_M13Ast_typecheckFM12check_deffunrR13Ast__deffun_t2rR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(
-                  df_1, &env_5, &df_0, 0), _fx_catch_10);
+                  df_1, &env_5, &df_0, 0), _fx_catch_13);
 
-         _fx_catch_10: ;
+         _fx_catch_13: ;
             if (fx_status < 0) {
                fx_exn_get_and_reset(fx_status, &exn_3);
                fx_status = 0;
@@ -32162,64 +32192,64 @@ _fx_endmatch_0: ;
                   _fx_free_rR13Ast__deffun_t(&df_0);
                }
                if (exn_3.tag == _FX_EXN_E17Ast__CompileError) {
-                  _fx_N10Ast__typ_t v_25 = 0;
-                  FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_11);
-                  _fx_R13Ast__deffun_t* v_26 = &df_1->data;
-                  FX_COPY_PTR(v_26->df_typ, &v_25);
-                  FX_CALL(_fx_M13Ast_typecheckFM17poison_result_typv1N10Ast__typ_t(v_25, 0), _fx_catch_11);
+                  _fx_N10Ast__typ_t v_23 = 0;
+                  FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_3, 0), _fx_catch_14);
+                  _fx_R13Ast__deffun_t* v_24 = &df_1->data;
+                  FX_COPY_PTR(v_24->df_typ, &v_23);
+                  FX_CALL(_fx_M13Ast_typecheckFM17poison_result_typv1N10Ast__typ_t(v_23, 0), _fx_catch_14);
                   FX_COPY_PTR(df_1, &df_0);
 
-               _fx_catch_11: ;
-                  if (v_25) {
-                     _fx_free_N10Ast__typ_t(&v_25);
+               _fx_catch_14: ;
+                  if (v_23) {
+                     _fx_free_N10Ast__typ_t(&v_23);
                   }
                }
                else {
-                  FX_RETHROW(&exn_3, _fx_catch_12);
+                  FX_RETHROW(&exn_3, _fx_catch_15);
                }
-               FX_CHECK_EXN(_fx_catch_12);
+               FX_CHECK_EXN(_fx_catch_15);
             }
          }
          else {
-            _fx_R13Ast__deffun_t* v_27 = &df_1->data;
-            _fx_make_R13Ast__deffun_t(&v_27->df_name, v_27->df_templ_args, v_27->df_args, v_27->df_typ, v_27->df_body,
-               &v_27->df_flags, v_27->df_scope, &v_27->df_loc, v_27->df_templ_inst, &env_5, &v_19);
-            _fx_R13Ast__deffun_t* v_28 = &df_1->data;
-            _fx_free_R13Ast__deffun_t(v_28);
-            _fx_copy_R13Ast__deffun_t(&v_19, v_28);
+            _fx_R13Ast__deffun_t* v_25 = &df_1->data;
+            _fx_make_R13Ast__deffun_t(&v_25->df_name, v_25->df_templ_args, v_25->df_args, v_25->df_typ, v_25->df_body,
+               &v_25->df_flags, v_25->df_scope, &v_25->df_loc, v_25->df_templ_inst, &env_5, &v_17);
+            _fx_R13Ast__deffun_t* v_26 = &df_1->data;
+            _fx_free_R13Ast__deffun_t(v_26);
+            _fx_copy_R13Ast__deffun_t(&v_17, v_26);
             FX_COPY_PTR(df_1, &df_0);
          }
          if (warn_rettype_0) {
-            FX_CALL(_fx_M13Ast_typecheckFM21warn_implicit_rettypev1rR13Ast__deffun_t(df_0, 0), _fx_catch_12);
+            FX_CALL(_fx_M13Ast_typecheckFM21warn_implicit_rettypev1rR13Ast__deffun_t(df_0, 0), _fx_catch_15);
          }
-         FX_CALL(_fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(df_0, &v_20), _fx_catch_12);
-         FX_CALL(_fx_cons_LN10Ast__exp_t(v_20, eseq_acc_0, true, &v_21), _fx_catch_12);
-         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_21, &env_5, &v_3);
+         FX_CALL(_fx_M3AstFM6DefFunN10Ast__exp_t1rRM8deffun_t(df_0, &v_18), _fx_catch_15);
+         FX_CALL(_fx_cons_LN10Ast__exp_t(v_18, eseq_acc_0, true, &v_19), _fx_catch_15);
+         _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_19, &env_5, &v_3);
 
-      _fx_catch_12: ;
-         if (v_21) {
-            _fx_free_LN10Ast__exp_t(&v_21);
+      _fx_catch_15: ;
+         if (v_19) {
+            _fx_free_LN10Ast__exp_t(&v_19);
          }
-         if (v_20) {
-            _fx_free_N10Ast__exp_t(&v_20);
+         if (v_18) {
+            _fx_free_N10Ast__exp_t(&v_18);
          }
-         _fx_free_R13Ast__deffun_t(&v_19);
+         _fx_free_R13Ast__deffun_t(&v_17);
          fx_free_exn(&exn_3);
          if (df_0) {
             _fx_free_rR13Ast__deffun_t(&df_0);
          }
-         FX_FREE_LIST_SIMPLE(&v_18);
-         fx_free_exn(&v_17);
-         goto _fx_endmatch_4;
+         FX_FREE_LIST_SIMPLE(&v_16);
+         fx_free_exn(&v_15);
+         goto _fx_endmatch_6;
       }
       _fx_N10Ast__exp_t e_3 = 0;
       _fx_N10Ast__exp_t e_4 = 0;
-      _fx_T2N10Ast__typ_tR10Ast__loc_t v_29 = {0};
+      _fx_T2N10Ast__typ_tR10Ast__loc_t v_27 = {0};
       _fx_N10Ast__typ_t etyp_0 = 0;
-      _fx_LN10Ast__exp_t v_30 = 0;
+      _fx_LN10Ast__exp_t v_28 = 0;
       if (FX_REC_VARIANT_TAG(e_1) == 4) {
-         _fx_Nt6option1N10Ast__exp_t v_31 = e_1->u.ExpReturn.t0;
-         if ((v_31 != 0) + 1 == 2) {
+         _fx_Nt6option1N10Ast__exp_t v_29 = e_1->u.ExpReturn.t0;
+         if ((v_29 != 0) + 1 == 2) {
             bool t_4;
             if (idx_0 == nexps_0 - 1) {
                t_4 = is_func_scope_0;
@@ -32228,119 +32258,119 @@ _fx_endmatch_0: ;
                t_4 = false;
             }
             if (t_4) {
-               FX_COPY_PTR(v_31->u.Some, &e_3);
+               FX_COPY_PTR(v_29->u.Some, &e_3);
             }
             else {
                FX_COPY_PTR(e_1, &e_3);
             }
-            goto _fx_endmatch_1;
+            goto _fx_endmatch_3;
          }
       }
       FX_COPY_PTR(e_1, &e_3);
 
-   _fx_endmatch_1: ;
-      FX_CHECK_EXN(_fx_catch_16);
+   _fx_endmatch_3: ;
+      FX_CHECK_EXN(_fx_catch_19);
       FX_CALL(
          _fx_M13Ast_typecheckFM9check_expN10Ast__exp_t3N10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tLN12Ast__scope_t(
-            e_3, &env_5, sc_1, &e_4, 0), _fx_catch_16);
-      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_4, &v_29, 0), _fx_catch_16);
-      FX_COPY_PTR(v_29.t0, &etyp_0);
-      _fx_R10Ast__loc_t eloc_0 = v_29.t1;
-      int tag_2 = FX_REC_VARIANT_TAG(e_4);
-      if (tag_2 == 1) {
-         goto _fx_endmatch_3;
+            e_3, &env_5, sc_1, &e_4, 0), _fx_catch_19);
+      FX_CALL(_fx_M3AstFM11get_exp_ctxT2N10Ast__typ_tRM5loc_t1N10Ast__exp_t(e_4, &v_27, 0), _fx_catch_19);
+      FX_COPY_PTR(v_27.t0, &etyp_0);
+      _fx_R10Ast__loc_t eloc_0 = v_27.t1;
+      int tag_4 = FX_REC_VARIANT_TAG(e_4);
+      if (tag_4 == 1) {
+         goto _fx_endmatch_5;
       }
-      bool res_2;
-      if (tag_2 == 2) {
-         res_2 = true;
+      bool res_4;
+      if (tag_4 == 2) {
+         res_4 = true;
       }
-      else if (tag_2 == 3) {
-         res_2 = true;
+      else if (tag_4 == 3) {
+         res_4 = true;
       }
-      else if (tag_2 == 4) {
-         res_2 = true;
+      else if (tag_4 == 4) {
+         res_4 = true;
       }
       else {
-         res_2 = false;
+         res_4 = false;
       }
-      FX_CHECK_EXN(_fx_catch_16);
-      if (res_2) {
-         fx_exn_t v_32 = {0};
+      FX_CHECK_EXN(_fx_catch_19);
+      if (res_4) {
+         fx_exn_t v_30 = {0};
          if (idx_0 != nexps_0 - 1) {
             fx_str_t slit_4 =
                FX_MAKE_STR(
                   "break/continue/return operator should not be followed by any other operators in the same linear code sequence");
-            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_32, 0), _fx_catch_13);
-            FX_THROW(&v_32, false, _fx_catch_13);
+            FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_4, &v_30, 0), _fx_catch_16);
+            FX_THROW(&v_30, false, _fx_catch_16);
          }
 
-      _fx_catch_13: ;
-         fx_free_exn(&v_32);
-         goto _fx_endmatch_3;
+      _fx_catch_16: ;
+         fx_free_exn(&v_30);
+         goto _fx_endmatch_5;
       }
-      if (tag_2 == 32) {
-         goto _fx_endmatch_3;
+      if (tag_4 == 32) {
+         goto _fx_endmatch_5;
       }
-      _fx_N10Ast__typ_t v_33 = 0;
-      _fx_Nt6option1N10Ast__typ_t v_34 = 0;
-      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_33, 0), _fx_catch_15);
-      int tag_3 = FX_REC_VARIANT_TAG(v_33);
-      bool res_3;
-      if (tag_3 == 14) {
-         res_3 = true;
+      _fx_N10Ast__typ_t v_31 = 0;
+      _fx_Nt6option1N10Ast__typ_t v_32 = 0;
+      FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(etyp_0, &v_31, 0), _fx_catch_18);
+      int tag_5 = FX_REC_VARIANT_TAG(v_31);
+      bool res_5;
+      if (tag_5 == 14) {
+         res_5 = true;
       }
-      else if (tag_3 == 27) {
-         res_3 = true;
+      else if (tag_5 == 27) {
+         res_5 = true;
       }
       else {
-         res_3 = false;
+         res_5 = false;
       }
-      FX_CHECK_EXN(_fx_catch_15);
-      if (res_3) {
-         goto _fx_endmatch_2;
+      FX_CHECK_EXN(_fx_catch_18);
+      if (res_5) {
+         goto _fx_endmatch_4;
       }
-      if (tag_3 == 1) {
-         FX_COPY_PTR(v_33->u.TypVar->data, &v_34);
-         if ((v_34 != 0) + 1 == 1) {
-            goto _fx_endmatch_2;
+      if (tag_5 == 1) {
+         FX_COPY_PTR(v_31->u.TypVar->data, &v_32);
+         if ((v_32 != 0) + 1 == 1) {
+            goto _fx_endmatch_4;
          }
       }
-      fx_exn_t v_35 = {0};
+      fx_exn_t v_33 = {0};
       if (idx_0 != nexps_0 - 1) {
          fx_str_t slit_5 =
             FX_MAKE_STR(
                "non-void expression occurs before the end of code block. Check the line breaks; if it\'s valid, use ignore() function to dismiss the error");
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_35, 0), _fx_catch_14);
-         FX_THROW(&v_35, false, _fx_catch_14);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(&eloc_0, &slit_5, &v_33, 0), _fx_catch_17);
+         FX_THROW(&v_33, false, _fx_catch_17);
       }
 
-   _fx_catch_14: ;
-      fx_free_exn(&v_35);
+   _fx_catch_17: ;
+      fx_free_exn(&v_33);
 
-   _fx_endmatch_2: ;
-      FX_CHECK_EXN(_fx_catch_15);
+   _fx_endmatch_4: ;
+      FX_CHECK_EXN(_fx_catch_18);
 
-   _fx_catch_15: ;
-      if (v_34) {
-         _fx_free_Nt6option1N10Ast__typ_t(&v_34);
+   _fx_catch_18: ;
+      if (v_32) {
+         _fx_free_Nt6option1N10Ast__typ_t(&v_32);
       }
-      if (v_33) {
-         _fx_free_N10Ast__typ_t(&v_33);
+      if (v_31) {
+         _fx_free_N10Ast__typ_t(&v_31);
       }
 
-   _fx_endmatch_3: ;
-      FX_CHECK_EXN(_fx_catch_16);
-      FX_CALL(_fx_cons_LN10Ast__exp_t(e_4, eseq_acc_0, true, &v_30), _fx_catch_16);
-      _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_30, &env_5, &v_3);
+   _fx_endmatch_5: ;
+      FX_CHECK_EXN(_fx_catch_19);
+      FX_CALL(_fx_cons_LN10Ast__exp_t(e_4, eseq_acc_0, true, &v_28), _fx_catch_19);
+      _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_28, &env_5, &v_3);
 
-   _fx_catch_16: ;
-      if (v_30) {
-         _fx_free_LN10Ast__exp_t(&v_30);
+   _fx_catch_19: ;
+      if (v_28) {
+         _fx_free_LN10Ast__exp_t(&v_28);
       }
       if (etyp_0) {
          _fx_free_N10Ast__typ_t(&etyp_0);
       }
-      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_29);
+      _fx_free_T2N10Ast__typ_tR10Ast__loc_t(&v_27);
       if (e_4) {
          _fx_free_N10Ast__exp_t(&e_4);
       }
@@ -32348,40 +32378,40 @@ _fx_endmatch_0: ;
          _fx_free_N10Ast__exp_t(&e_3);
       }
 
-   _fx_endmatch_4: ;
-      FX_CHECK_EXN(_fx_catch_17);
+   _fx_endmatch_6: ;
+      FX_CHECK_EXN(_fx_catch_20);
 
-   _fx_catch_17: ;
+   _fx_catch_20: ;
       if (fx_status < 0) {
          fx_exn_get_and_reset(fx_status, &exn_0);
          fx_status = 0;
          _fx_free_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3);
-         int tag_4 = exn_0.tag;
-         if (tag_4 == _FX_EXN_E17Ast__CompileError) {
-            _fx_LN10Ast__exp_t v_36 = 0;
-            FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_0, 0), _fx_catch_18);
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_acc_0, true, &v_36), _fx_catch_18);
-            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_36, &env_5, &v_3);
+         int tag_6 = exn_0.tag;
+         if (tag_6 == _FX_EXN_E17Ast__CompileError) {
+            _fx_LN10Ast__exp_t v_34 = 0;
+            FX_CALL(_fx_M3AstFM16push_compile_errv1E(&exn_0, 0), _fx_catch_21);
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_acc_0, true, &v_34), _fx_catch_21);
+            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_34, &env_5, &v_3);
 
-         _fx_catch_18: ;
-            if (v_36) {
-               _fx_free_LN10Ast__exp_t(&v_36);
+         _fx_catch_21: ;
+            if (v_34) {
+               _fx_free_LN10Ast__exp_t(&v_34);
             }
          }
-         else if (tag_4 == _FX_EXN_E26Ast__PropagateCompileError) {
-            _fx_LN10Ast__exp_t v_37 = 0;
-            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_acc_0, true, &v_37), _fx_catch_19);
-            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_37, &env_5, &v_3);
+         else if (tag_6 == _FX_EXN_E26Ast__PropagateCompileError) {
+            _fx_LN10Ast__exp_t v_35 = 0;
+            FX_CALL(_fx_cons_LN10Ast__exp_t(e_1, eseq_acc_0, true, &v_35), _fx_catch_22);
+            _fx_make_T2LN10Ast__exp_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(v_35, &env_5, &v_3);
 
-         _fx_catch_19: ;
-            if (v_37) {
-               _fx_free_LN10Ast__exp_t(&v_37);
+         _fx_catch_22: ;
+            if (v_35) {
+               _fx_free_LN10Ast__exp_t(&v_35);
             }
          }
          else {
-            FX_THROW(&exn_0, false, _fx_catch_20);
+            FX_THROW(&exn_0, false, _fx_catch_23);
          }
-         FX_CHECK_EXN(_fx_catch_20);
+         FX_CHECK_EXN(_fx_catch_23);
       }
       FX_COPY_PTR(v_3.t0, &eseq1_0);
       _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&v_3.t1, &env1_0);
@@ -32390,7 +32420,7 @@ _fx_endmatch_0: ;
       _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env_5);
       _fx_copy_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0, &env_5);
 
-   _fx_catch_20: ;
+   _fx_catch_23: ;
       _fx_free_Rt6Map__t2R9Ast__id_tLN16Ast__env_entry_t(&env1_0);
       if (eseq1_0) {
          _fx_free_LN10Ast__exp_t(&eseq1_0);
@@ -32403,15 +32433,15 @@ _fx_endmatch_0: ;
    FX_CALL(_fx_M3AstFM18check_compile_errsv0(0), _fx_cleanup);
    _fx_LN10Ast__exp_t lst_2 = eseq_1;
    for (; lst_2; lst_2 = lst_2->tl) {
-      _fx_LN10Ast__exp_t v_38 = 0;
+      _fx_LN10Ast__exp_t v_36 = 0;
       _fx_N10Ast__exp_t a_0 = lst_2->hd;
-      FX_CALL(_fx_cons_LN10Ast__exp_t(a_0, res_0, true, &v_38), _fx_catch_21);
+      FX_CALL(_fx_cons_LN10Ast__exp_t(a_0, res_0, true, &v_36), _fx_catch_24);
       _fx_free_LN10Ast__exp_t(&res_0);
-      FX_COPY_PTR(v_38, &res_0);
+      FX_COPY_PTR(v_36, &res_0);
 
-   _fx_catch_21: ;
-      if (v_38) {
-         _fx_free_LN10Ast__exp_t(&v_38);
+   _fx_catch_24: ;
+      if (v_36) {
+         _fx_free_LN10Ast__exp_t(&v_36);
       }
       FX_CHECK_EXN(_fx_cleanup);
    }

--- a/compiler/bootstrap/Ast_typecheck.c
+++ b/compiler/bootstrap/Ast_typecheck.c
@@ -18971,7 +18971,7 @@ static int
       FX_LIST_APPEND(cands_0, lstend_0, node_0);
 
    _fx_catch_1: ;
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
    }
    _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___0);
    _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_1 = viable_0;
@@ -19016,10 +19016,10 @@ static int
          _fx_free_rR13Ast__deffun_t(&c_0);
       }
       FX_CHECK_BREAK();
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
    }
    _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___0, &genwin_opt_0);
-   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_14);
+   FX_CALL(_fx_M3AstFM9deref_typN10Ast__typ_t1N10Ast__typ_t(t_0, &v_1, 0), _fx_catch_16);
    bool fully_determined_0;
    if (FX_REC_VARIANT_TAG(v_1) == 15) {
       _fx_LN10Ast__typ_t argtyps_0 = 0;
@@ -19048,16 +19048,16 @@ static int
    else {
       fully_determined_0 = false;
    }
-   FX_CHECK_EXN(_fx_catch_14);
+   FX_CHECK_EXN(_fx_catch_16);
    bool v_17 = _fx_g12Options__opt.print_resolve;
    if (v_17) {
       if (viable_0 != 0) {
          _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_2);
       }
       else {
-         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_14);
+         FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_16);
       }
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
       _fx_R9Ast__id_t envwin_i_0 = v_2.t0;
       FX_COPY_PTR(v_2.t1, &envwin_0);
       bool agree_0;
@@ -19069,12 +19069,12 @@ static int
       else {
          agree_0 = false;
       }
-      FX_CHECK_EXN(_fx_catch_14);
-      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_3, 0), _fx_catch_14);
-      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
+      FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_3, 0), _fx_catch_16);
+      FX_CALL(_fx_M3AstFM6stringS1RM5loc_t(loc_0, &v_4, 0), _fx_catch_16);
       int_ v_18 = _fx_M13Ast_typecheckFM6lengthi1LT2R9Ast__id_trR13Ast__deffun_t(viable_0, 0);
-      FX_CALL(_fx_F6stringS1i(v_18, &v_5, 0), _fx_catch_14);
-      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_14);
+      FX_CALL(_fx_F6stringS1i(v_18, &v_5, 0), _fx_catch_16);
+      FX_CALL(_fx_M3AstFM7typ2strS1N10Ast__typ_t(t_0, &v_6, 0), _fx_catch_16);
       fx_str_t slit_0 = FX_MAKE_STR("-pr-resolve: \'");
       fx_str_t slit_1 = FX_MAKE_STR("\' @ ");
       fx_str_t slit_2 = FX_MAKE_STR(": ");
@@ -19082,7 +19082,7 @@ static int
       fx_str_t slit_4 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_0[] = { slit_0, v_3, slit_1, v_4, slit_2, v_5, slit_3, v_6, slit_4 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_7), _fx_catch_14);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_0, 9, &v_7), _fx_catch_16);
       }
       _fx_F12print_stringv1S(&v_7, 0);
       _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_4 = viable_0;
@@ -19107,14 +19107,14 @@ static int
          if (c_1) {
             _fx_free_rR13Ast__deffun_t(&c_1);
          }
-         FX_CHECK_EXN(_fx_catch_14);
+         FX_CHECK_EXN(_fx_catch_16);
       }
-      FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_8, 0), _fx_catch_14);
+      FX_CALL(_fx_M6Ast_ppFM10fun2sigstrS1rR13Ast__deffun_t(envwin_0, &v_8, 0), _fx_catch_16);
       fx_str_t slit_7 = FX_MAKE_STR("    env-order  winner: ");
       fx_str_t slit_8 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_2[] = { slit_7, v_8, slit_8 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_9), _fx_catch_14);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_2, 3, &v_9), _fx_catch_16);
       }
       _fx_F12print_stringv1S(&v_9, 0);
       if (genwin_opt_0.tag == 2) {
@@ -19137,13 +19137,13 @@ static int
          fx_str_t slit_11 = FX_MAKE_STR("    generality winner: <none: tied or unordered>\n");
          _fx_F12print_stringv1S(&slit_11, 0);
       }
-      FX_CHECK_EXN(_fx_catch_14);
-      FX_CALL(_fx_F6stringS1B(agree_0, &v_10, 0), _fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
+      FX_CALL(_fx_F6stringS1B(agree_0, &v_10, 0), _fx_catch_16);
       fx_str_t slit_12 = FX_MAKE_STR("    winners agree: ");
       fx_str_t slit_13 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_4[] = { slit_12, v_10, slit_13 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_11), _fx_catch_14);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_4, 3, &v_11), _fx_catch_16);
       }
       _fx_F12print_stringv1S(&v_11, 0);
       if (genwin_opt_0.tag == 2) {
@@ -19155,12 +19155,12 @@ static int
       else {
          fx_str_t slit_16 = FX_MAKE_STR("env-order fallback (under-constrained tie)"); fx_copy_str(&slit_16, &outcome_0);
       }
-      FX_CHECK_EXN(_fx_catch_14);
+      FX_CHECK_EXN(_fx_catch_16);
       fx_str_t slit_17 = FX_MAKE_STR("    outcome: ");
       fx_str_t slit_18 = FX_MAKE_STR("\n");
       {
          const fx_str_t strs_5[] = { slit_17, outcome_0, slit_18 };
-         FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_14);
+         FX_CALL(fx_strjoin(0, 0, 0, strs_5, 3, &v_12), _fx_catch_16);
       }
       _fx_F12print_stringv1S(&v_12, 0);
    }
@@ -19182,6 +19182,8 @@ static int
       fx_str_t v_27 = {0};
       fx_str_t v_28 = {0};
       fx_exn_t v_29 = {0};
+      _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t __fold_result___3 = {0};
+      _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t concrete_opt_0 = {0};
       _fx_T2R9Ast__id_trR13Ast__deffun_t v_30 = {0};
       _fx_rR13Ast__deffun_t df_0 = 0;
       if (fully_determined_0) {
@@ -19202,19 +19204,19 @@ static int
             if (c_2) {
                _fx_free_rR13Ast__deffun_t(&c_2);
             }
-            FX_CHECK_EXN(_fx_catch_13);
+            FX_CHECK_EXN(_fx_catch_15);
          }
          fx_str_t slit_19 =
             FX_MAKE_STR("\n"
                U"    ");
-         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_24, &cand_lines_0, 0), _fx_catch_13);
-         bool __fold_result___3 = true;
+         FX_CALL(_fx_F4joinS2SLS(&slit_19, v_24, &cand_lines_0, 0), _fx_catch_15);
+         bool __fold_result___4 = true;
          _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_6 = viable_0;
          for (; lst_6; lst_6 = lst_6->tl) {
             _fx_rR13Ast__deffun_t c_3 = 0;
             _fx_T2R9Ast__id_trR13Ast__deffun_t* __pat___4 = &lst_6->hd;
             FX_COPY_PTR(__pat___4->t1, &c_3);
-            bool __fold_result___4 = true;
+            bool __fold_result___5 = true;
             _fx_LrR13Ast__deffun_t lst_7 = cands_0;
             for (; lst_7; lst_7 = lst_7->tl) {
                _fx_rR13Ast__deffun_t d_1 = lst_7->hd;
@@ -19230,15 +19232,15 @@ static int
                   v_31 = v_32.tag == 3;
                }
                if (!v_31) {
-                  __fold_result___4 = false; FX_BREAK(_fx_catch_11);
+                  __fold_result___5 = false; FX_BREAK(_fx_catch_11);
                }
 
             _fx_catch_11: ;
                FX_CHECK_BREAK();
                FX_CHECK_EXN(_fx_catch_12);
             }
-            if (!__fold_result___4) {
-               __fold_result___3 = false; FX_BREAK(_fx_catch_12);
+            if (!__fold_result___5) {
+               __fold_result___4 = false; FX_BREAK(_fx_catch_12);
             }
 
          _fx_catch_12: ;
@@ -19246,9 +19248,9 @@ static int
                _fx_free_rR13Ast__deffun_t(&c_3);
             }
             FX_CHECK_BREAK();
-            FX_CHECK_EXN(_fx_catch_13);
+            FX_CHECK_EXN(_fx_catch_15);
          }
-         bool all_eq_0 = __fold_result___3;
+         bool all_eq_0 = __fold_result___4;
          if (all_eq_0) {
             fx_str_t slit_20 = FX_MAKE_STR("the candidates are equally applicable"); fx_copy_str(&slit_20, &why_0);
          }
@@ -19257,25 +19259,25 @@ static int
             fx_copy_str(&slit_21, &why_0);
          }
          if (all_eq_0) {
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_25, 0), _fx_catch_13);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_25, 0), _fx_catch_15);
             fx_str_t slit_22 = FX_MAKE_STR("use a module-qualified call (e.g. Module.");
             fx_str_t slit_23 = FX_MAKE_STR("(...)) to select one");
             {
                const fx_str_t strs_6[] = { slit_22, v_25, slit_23 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &hint_0), _fx_catch_13);
+               FX_CALL(fx_strjoin(0, 0, 0, strs_6, 3, &hint_0), _fx_catch_15);
             }
          }
          else {
-            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_26, 0), _fx_catch_13);
+            FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_26, 0), _fx_catch_15);
             fx_str_t slit_24 =
                FX_MAKE_STR("define/import a more specific overload, or use a module-qualified call (e.g. Module.");
             fx_str_t slit_25 = FX_MAKE_STR("(...)) to disambiguate");
             {
                const fx_str_t strs_7[] = { slit_24, v_26, slit_25 };
-               FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &hint_0), _fx_catch_13);
+               FX_CALL(fx_strjoin(0, 0, 0, strs_7, 3, &hint_0), _fx_catch_15);
             }
          }
-         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_27, 0), _fx_catch_13);
+         FX_CALL(_fx_M3AstFM2ppS1RM4id_t(n_0, &v_27, 0), _fx_catch_15);
          fx_str_t slit_26 = FX_MAKE_STR("ambiguous call of overloaded \'");
          fx_str_t slit_27 = FX_MAKE_STR("\': ");
          fx_str_t slit_28 =
@@ -19284,31 +19286,68 @@ static int
          fx_str_t slit_29 = FX_MAKE_STR("\n");
          {
             const fx_str_t strs_8[] = { slit_26, v_27, slit_27, why_0, slit_28, cand_lines_0, slit_29, hint_0 };
-            FX_CALL(fx_strjoin(0, 0, 0, strs_8, 8, &v_28), _fx_catch_13);
+            FX_CALL(fx_strjoin(0, 0, 0, strs_8, 8, &v_28), _fx_catch_15);
          }
-         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_28, &v_29, 0), _fx_catch_13);
-         FX_THROW(&v_29, false, _fx_catch_13);
+         FX_CALL(_fx_M3AstFM11compile_errE2RM5loc_tS(loc_0, &v_28, &v_29, 0), _fx_catch_15);
+         FX_THROW(&v_29, false, _fx_catch_15);
       }
       else {
-         if (viable_0 != 0) {
-            _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_30);
+         _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&_fx_g21Ast_typecheck__None2_, &__fold_result___3);
+         _fx_LT2R9Ast__id_trR13Ast__deffun_t lst_8 = viable_0;
+         for (; lst_8; lst_8 = lst_8->tl) {
+            _fx_rR13Ast__deffun_t v_33 = 0;
+            _fx_LR9Ast__id_t v_34 = 0;
+            _fx_Nt6option1T2R9Ast__id_trR13Ast__deffun_t v_35 = {0};
+            _fx_T2R9Ast__id_trR13Ast__deffun_t* idf_0 = &lst_8->hd;
+            FX_COPY_PTR(idf_0->t1, &v_33);
+            _fx_R13Ast__deffun_t* v_36 = &v_33->data;
+            FX_COPY_PTR(v_36->df_templ_args, &v_34);
+            if (v_34 == 0) {
+               _fx_M13Ast_typecheckFM4SomeNt6option1T2R9Ast__id_trR13Ast__deffun_t1T2R9Ast__id_trR13Ast__deffun_t(idf_0, &v_35);
+               _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___3);
+               _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&v_35, &__fold_result___3);
+               FX_BREAK(_fx_catch_13);
+            }
+
+         _fx_catch_13: ;
+            _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&v_35);
+            FX_FREE_LIST_SIMPLE(&v_34);
+            if (v_33) {
+               _fx_free_rR13Ast__deffun_t(&v_33);
+            }
+            FX_CHECK_BREAK();
+            FX_CHECK_EXN(_fx_catch_15);
+         }
+         _fx_copy_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___3, &concrete_opt_0);
+         if (concrete_opt_0.tag == 2) {
+            _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&concrete_opt_0.u.Some, &v_30);
          }
          else {
-            FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_13);
+            if (viable_0 != 0) {
+               _fx_copy_T2R9Ast__id_trR13Ast__deffun_t(&viable_0->hd, &v_30);
+            }
+            else {
+               FX_FAST_THROW(FX_EXN_NullListError, _fx_catch_14);
+            }
+            FX_CHECK_EXN(_fx_catch_14);
+
+         _fx_catch_14: ;
          }
-         FX_CHECK_EXN(_fx_catch_13);
+         FX_CHECK_EXN(_fx_catch_15);
          _fx_R9Ast__id_t i_0 = v_30.t0;
          FX_COPY_PTR(v_30.t1, &df_0);
          FX_CALL(
             _fx_M13Ast_typecheckFM10commit_funNt6option1T2R9Ast__id_tN10Ast__typ_t7R9Ast__id_trR13Ast__deffun_tRt6Map__t2R9Ast__id_tLN16Ast__env_entry_tR10Ast__loc_tR9Ast__id_tLN12Ast__scope_tN10Ast__typ_t(
-               &i_0, df_0, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_13);
+               &i_0, df_0, env_0, loc_0, n_0, sc_0, t_0, fx_result, 0), _fx_catch_15);
       }
 
-   _fx_catch_13: ;
+   _fx_catch_15: ;
       if (df_0) {
          _fx_free_rR13Ast__deffun_t(&df_0);
       }
       _fx_free_T2R9Ast__id_trR13Ast__deffun_t(&v_30);
+      _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&concrete_opt_0);
+      _fx_free_Nt6option1T2R9Ast__id_trR13Ast__deffun_t(&__fold_result___3);
       fx_free_exn(&v_29);
       FX_FREE_STR(&v_28);
       FX_FREE_STR(&v_27);
@@ -19321,9 +19360,9 @@ static int
          _fx_free_LS(&v_24);
       }
    }
-   FX_CHECK_EXN(_fx_catch_14);
+   FX_CHECK_EXN(_fx_catch_16);
 
-_fx_catch_14: ;
+_fx_catch_16: ;
    FX_FREE_STR(&v_12);
    FX_FREE_STR(&outcome_0);
    FX_FREE_STR(&v_11);

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -226,16 +226,30 @@ CLAUDE.md and (at rewrite time) the tutorial state it plainly; the annotate-2
   the `.op → plain op / @ matmul` reform (which removes `.op`) and to a future
   "report at the call site, not the instantiation site" diagnostic pass.
 
-## FB-022  a failed `fold`-valued `val` cascades ("<name> not found")  [OPEN — recovery gap]
-- repro: `val s = fold acc = 0 for x <- [1,2,3] {acc + undefined}` reports the
-  body error AND a spurious `s is not found` at a later use of `s`.
-- cause: `fold` desugars during parsing into a block (`__fold_result__` etc.),
-  so the DefVal that binds `s` no longer has a simple RHS; the diag-1 recovery
-  that poisons a failed `val`'s pattern to `TypErr` does not fire on this
-  desugared shape, leaving `s` unbound → cascade.
-- impact: minor extra diagnostic; the root error is still correct. A diag-1
-  follow-up would extend the DefVal recovery to poison the pattern regardless of
-  RHS shape.
+## FB-022  a failed block-valued `val` cascades ("<name> not found")  [FIXED — resolve-3 Phase C]
+- repro: `val s = fold acc = 0 for x <- [1,2,3] {acc + undefined}` (and the wider
+  `val fold sz=0, have_neg=false for s <- shape { ..typo.. }`) reports the body
+  error AND a spurious `<accumulator> is not found` at every later use.
+- cause (actual, narrower than first thought): a `val fold ...` desugars to
+  `val (a,b): (..) = { var a=..; var b=..; for ...; (a,b) }`. The block's own
+  `check_eseq` already RECOVERS the failed `for` per-statement and types the tail
+  `(a,b)` correctly, but its closing `check_compile_errs()` then throws
+  **`PropagateCompileError`** (not `CompileError`) to flag the tainted subtree.
+  The outer DefVal recovery caught only `CompileError`, so it skipped pattern
+  binding entirely → the accumulators stayed unbound → cascade.
+- fix (`Ast_typecheck.fx`, `check_eseq` DefVal arm): (1) the recovery catches
+  `PropagateCompileError` too (without re-pushing the already-reported inner
+  error); (2) it binds the pattern via `check_pat` against the annotation type
+  instead of `poison_pattern_vars` with one whole-pattern poison type, so a
+  tuple/record annotation is destructured per-field (`val (a,b):(int,bool)` →
+  `a:int, b:bool`, the §1.7 firewall) rather than binding both to `(int,bool)`
+  (which would itself cascade). No usable annotation → still `TypErr` poison.
+- generalization: this is NOT fold-specific — ANY block expression in value
+  position (`val r: int = { ..failed stmt..; r_expr }`) now recovers. Golden
+  `test/negative/709` loses its spurious cascade; directed tests
+  `239_recovery_fold_block` (fold, with did-you-mean) and `240_recovery_block_expr`
+  (plain block) lock the mechanism. Acceptance: Vadim's repro → exactly ONE
+  diagnostic (`'s1' is not found; did you mean 's'`), no cascade.
 
 ## FB-023  single-use temp memory read inlined PAST an aliasing store  [FIXED — fold-1; refactored — purity-1]
 - **purity-1 update**: the local `movement_unsafe_read` guard described below was

--- a/docs/found_bugs.md
+++ b/docs/found_bugs.md
@@ -317,23 +317,37 @@ t1(); t2()   // ERROR at t2: "if() expression should have the same type as its
   before the polluted var is consulted. Not fixed (out of scope for newvec-1;
   `map`/`mapi`/`foldl` are themselves temporary until vector comprehensions).
 
-## FB-025  resolver internal error: generic container operator in a large overload context  [OPEN — fenced]
+## FB-025  resolver self-recursion: generic container operator in a large overload context  [FIXED — resolve-3]
 Compiling a generic container operator whose body compares/formats elements
-generically — `operator <=> (a: 't vector, b: 't vector): int { ... a[i] <=> b[i] ... }`
-— throws an internal error **"the winning overload of '__cmp__' failed to
-re-unify at commit"** when it is type-checked in a scope that already has many
-`<=>`/`__cmp__` overloads (a second generic container `<=>` — rrbvec's — plus the
-compiler's own per-type ones, as happens when `Vector` is auto-imported into the
-whole compiler). The element access `a[i]` has a *free* element type `'t`, so the
-resolver treats every container `<=>` (incl. the one being defined) as a
-candidate and fails to commit a unique winner.
-- **Order/context-dependent**, like FB-024: the same operator compiles fine when
-  `Vector.fx` is imported by a small program (few `<=>` in scope).
-- **Workaround (used for newvec-1 auto-import)**: define `==`/`<=>`/`string`/
-  `print` for `vector` in `Builtins.fx` (next to the rrbvec ones) instead of in
-  the auto-imported `Vector.fx`. Builtins is compiled first, with few overloads
-  in scope, so the generic element compare resolves. Not fixed (resolver work is
-  out of scope for newvec-1).
+generically — `operator <=> (a: 't vector, b: 't vector): int { ... xa <=> xb ... }`
+— diverges when it is type-checked in a scope that already has many
+`<=>`/`__cmp__` overloads (rrbvec's container `<=>` plus the compiler's own
+per-type ones, as when `Vector` is auto-imported into the whole compiler). On the
+current tree the symptom is a **`StackOverflowError`** during the self-build
+(resolve-1 turned the older **"the winning overload of '__cmp__' failed to
+re-unify at commit"** internal error into unbounded instantiation).
+- **Root cause** (resolve-3, `-pr-resolve` + instrumented): the element compare
+  `xa <=> xb` has a *free* element type `'t`, so `__cmp__('t,'t)` is a fully
+  **under-constrained tie** (22 viable). resolve-1's stopgap for such ties is
+  env-order first-match. When the env-first candidate is a generic **template**
+  container op (as the auto-imported `Vector.<=>` is), `commit_fun` instantiates
+  it for `('t,'t)->int`, binding `'t := 's vector`, then type-checks its body,
+  which re-issues the same free compare, picks the template again, and
+  instantiates without bound (the instance cache can't dedup — each level is a
+  fresh free var). It terminated in the Builtins layout only because there the
+  env-first candidate was a *concrete* `__cmp__(string,string)` (`@ccode`, no body
+  to instantiate) — luck of declaration/import order.
+- **Fix** (`Ast_typecheck.fx`, `lookup_id_opt`/`rank_and_commit`): in the
+  under-constrained-tie fallback, **prefer a concrete (non-template) candidate over
+  a template**. A fully under-determined call is a speculative resolution (redone
+  per real use with concrete args), so any type-checking candidate is fine; a
+  concrete one fixes the arg types and cannot self-instantiate. Dormant in normal
+  code (`-pr-resolve` census byte-identical; bootstrap fixpoint touches only
+  `Ast_typecheck.c`); fires only on the pathological tie.
+- **Workaround removed**: `==`/`<=>`/`string`/`print` for `vector` moved from
+  `Builtins.fx` back to their natural home `Vector.fx`. The compiler self-build
+  (which auto-imports `Vector`) now type-checks them cleanly and doubles as the
+  FB-025 regression guard. See `docs/resolve3_report.md`.
 
 ## FB-026  cannot bind a variable in an or-pattern  [OPEN — limitation]
 An or-pattern that binds the same variable in each alternative is rejected:

--- a/docs/resolve3_brief.md
+++ b/docs/resolve3_brief.md
@@ -1,0 +1,115 @@
+# Brief: resolve-3 — cross-definition inference pollution + commit divergence (Fable)
+
+**You are Claude (Fable) in Claude Code, in the Ficus repo.** Branch
+`resolve-3` off master. Read first: `docs/found_bugs.md` FB-024 + FB-025
+(the bugs, with workaround locations), FB-007's near-miss section (the
+"free return steals under-constrained sites" class these extend),
+`docs/overload_resolution_proposal_v2.md` §2 (collect→rank→commit — FB-025
+is a hole in it), `docs/newvec2_report.md` §1 (API changes that affect the
+repro and one extra check below), repo CLAUDE.md.
+
+Both bugs are ORDER/CONTEXT-DEPENDENT resolver residue — the S3 family one
+level up: resolve-1 sandboxed candidate *trials* within one lookup; these
+leak state ACROSS definitions (FB-024) and between the trial and commit
+phases of one lookup (FB-025). Both currently have workarounds IN THE TREE,
+and removing them is the acceptance test.
+
+## Phase A — exploration & repro (no fixes; the heaviest phase)
+
+- **FB-024 repro rebuild**: the registry repro calls `Vec.mapi`, which
+  newvec-2 REMOVED. Rebuild self-contained: a local generic whose return
+  binds only through a closure argument
+  (`fun mymapi(v: 't vector, f: ('t, int) -> 'r): 'r vector`), two callers,
+  order-swapped — reproduce "compiles one order, fails the other". Then
+  instrument: WHAT binds a type var that a later, unrelated inference
+  consults? Hypotheses to test, not assume: (a) the `df_templ_inst` cache
+  scan unifying with `update_refs=true` outside a committed win; (b) the
+  template's own stored `df_typ` getting mutated (a commit unifying against
+  the original rather than the `preprocess_templ_typ` copy); (c) instance
+  typ reuse across incompatible contexts. `-pr-resolve` + targeted dumps of
+  the suspect vars' identity across the two orders.
+- **FB-025 anatomy**: reproduce the internal error ("the winning overload of
+  '__cmp__' failed to re-unify at commit") with the registry's shape — a
+  generic container `<=>` whose body compares free-`'t` elements, checked in
+  a scope with many `__cmp__` overloads. Dump the viable set + bindings at
+  trial AND at commit; diff. Working hypothesis: self-candidacy (the
+  operator being defined is a candidate for its own body's call) combined
+  with trial-undo leaving the commit environment different from the trial
+  environment. Establish the true divergence before designing.
+- **Bonus check (2 minutes, from newvec-2)**: the resolve-1 rule says an
+  exact keywordless match beats an all-defaulted-keywords candidate — but
+  newvec-2 observed `vector()` ambiguous against `vector(~capacity=0)` at
+  ZERO arity. Directed test: does the tie-break fire for zero-arg calls? If
+  not — either fix in scope (if it falls out of the FB-025 work) or a
+  precise registry entry + CLAUDE.md rule correction.
+
+## Phase B — fixes (design follows Phase A; constraints below)
+
+- Whatever the mechanism, the fix must preserve the resolve-1 architecture:
+  trials side-effect-free, exactly one commit, `compare_fun_generality`
+  untouched unless Phase A proves it implicated. Commit must re-unify in an
+  environment IDENTICAL to the winning trial's — if Phase A shows they can
+  diverge, that invariant (not a workaround) is what gets engineered.
+- The E1-census instrument is the safety net: `-pr-resolve` over
+  `compiler/fx.fx` before/after — same (name | winner | outcome) multiset;
+  any change listed verbatim and justified.
+- Internal errors are forbidden as user-facing outcomes: whatever remains
+  unresolvable must degrade to a proper diagnostic (candidates via
+  `fun2sigstr`, the annotation hint per the diag-1 style), never
+  "failed to re-unify".
+
+## Phase C — FB-022 generalized: recovery inside block expressions
+
+New evidence (Vadim): the gap is wider than the registry's fold case —
+```
+val fold sz = 0, have_neg = false for s <- shape {
+    if s >= 0 { sz *= s1 /* typo: s1 for s */ } else { have_neg = true }
+}
+println(f"have_neg: {have_neg}")   // cascades: have_neg "not found /
+                                   // unknown type" — yet its type is KNOWN
+                                   // (bool, from `= false`) independent of
+                                   // the body error
+```
+Root shape: diag-1's Tier-2 recovers a failed statement inside a FUNCTION
+body, but not inside a BLOCK EXPRESSION: the fold desugars to
+`{ var sz = 0; var have_neg = false; for ... ; (sz, have_neg) }`, the `for`'s
+failure aborts checking the whole block-RHS, the DefVal wrapper doesn't fire
+on the desugared shape (the original FB-022), and the names end up UNBOUND →
+"not found" cascade.
+
+Fix (principled, not fold-specific): extend Tier-2 statement recovery to
+void statements inside `ExpSeq` in VALUE position — report the failed
+statement, poison it, keep typing the block's tail. Declarations that
+already typed (the accumulators' `var`s) keep their REAL types; TypErr
+suppression handles any follow-on noise. Then the DefVal-shape workaround
+becomes unnecessary — verify and remove/simplify the special case rather
+than stacking on it.
+
+Acceptance: Vadim's repro produces EXACTLY ONE diagnostic — `'s1' is not
+found` **with the did-you-mean suggestion `'s'`** (distance 1, in scope —
+verify it fires here; if not, that's in scope too) — and no cascade:
+`have_neg`/`sz` are typed `bool`/`int` (locked by the golden's absence of
+secondary errors). The registry FB-022 entry closes with the generalized
+mechanism written up; a second directed case with a failed statement inside
+a plain (non-fold) block expression locks the generalization itself.
+
+## Acceptance — the workarounds come OUT
+
+1. `==`/`<=>`/`string`/`print` for `vector` move from `Builtins.fx` back to
+   `Vector.fx` (their natural home per the operators-live-with-their-type
+   guideline) and the compiler builds — the FB-025 proof. (If Vadim prefers
+   them staying in Builtins for other reasons, the acceptance is a COMPILING
+   demonstration branch of the move, not necessarily merging it.)
+2. The FB-024 repro (rebuilt, in `test/test_resolve.fx`) passes in BOTH
+   orders WITHOUT the result annotation; the fenced xfail flips.
+3. `fcvector.binomial`'s workaround annotation gets a comment or removal —
+   whichever the fix makes true.
+4. Full ladder + determinism + sanitize + census + bootstrap fixpoint; new
+   directed tests for both mechanisms + the zero-arity tie-break.
+
+## Ground rules
+House standard; STOP signals: any fix requiring `maybe_unify` semantic
+changes beyond bookkeeping (report first), any census delta you cannot
+attribute. Don't push. Report `docs/resolve3_report.md` — Phase-A findings
+are its centerpiece (these two mechanisms will inform the generics-1
+migration, which re-touches every signature in the tree).

--- a/docs/resolve3_report.md
+++ b/docs/resolve3_report.md
@@ -106,10 +106,157 @@ now recovers, not just the fold desugar.
 
 ---
 
-## Phases A / B — FB-024 / FB-025 resolver pollution  [NOT STARTED]
+## Phase A — FB-024: not reproducible; acceptance already met  [PARKED]
 
-The order/context-dependent generic-return pollution (FB-024) and the
-commit-time re-unify internal error (FB-025) are untouched in this section. They
-need the Phase-A exploration/repro work (rebuild FB-024's repro without the
-removed `Vec.mapi`; reproduce FB-025's internal error) before any fix. Deferred
-pending a check-in with Vadim.
+Faithful reconstruction of the documented repro (map/mapi/foldl restored into the
+real `lib/Vector.fx`; the exact `import Vector` + `last.mapi(...)` two-function
+program) compiles **clean in BOTH orders** on current master. To rule out an
+intervening resolver fix, I built the compiler at the **newvec-1 merge commit
+`8d423f7`** (where FB-024 was filed) in a throwaway worktree and ran the same
+repro there — **also clean in both orders**. Since `Ast_typecheck.fx` (the
+resolver) is unchanged between that merge and now except newvec-2's +27 lines of
+intrinsic push/pop handling and this branch's Phase C, the order-dependent
+pollution is not reproducible even at its filing point — the recipe in
+`found_bugs.md` was likely captured against a mid-development WIP state, not the
+merge. The trigger functions (`map`/`mapi`/`foldl`) were themselves retired by
+newvec-2 in favour of comprehensions, so there is no live call site.
+
+The variant hunt surfaced only **order-INDEPENDENT** phenomena, none matching
+FB-024's signature: (a) UFCS `x.f(args)` resolves only for functions in the
+type's owning module (per tutorial §UFCS, `str.foo(a)` ⇒ `String.foo(str,a)`) —
+a same-file / non-owning-module generic or even a *non-generic* function is
+"not found" via `.`, while the prefix form resolves; likely by-design, not a bug.
+(b) a chained `curr.map(fun(y){y > 0.f})` with an element-type change fails
+regardless of order.
+
+**Decision (with Vadim): PARK FB-024.** Its acceptance criterion — "compiles in
+both orders without the result annotation" — is already satisfied on master, and
+the pollution is not reproducible. Pivoted to FB-025.
+
+## Phase B — FB-025: resolver self-recursion on an under-constrained tie  [FIXED]
+
+### Reproduction
+
+Moved the vector `==`/`<=>` from `Builtins.fx` back to their natural home
+`Vector.fx` (the FB-025 acceptance test) and rebuilt. On the current tree the
+symptom is no longer the documented "failed to re-unify at commit" internal
+error — it is a **`StackOverflowError`** during the self-build (compiling the
+compiler with `Vector` auto-imported). A *small*-context program using vector
+`<=>` still compiles clean, so it is context-dependent exactly as described.
+
+### Root cause (from `-pr-resolve`, definitive)
+
+Every generic comparison body — the container `<=>` bodies AND the generic
+`operator </>/<=/>=` in Builtins (`(a <=> b) < 0`) — issues `a <=> b` on a
+**free** element type `'t`. `__cmp__((<unknown>,<unknown>) -> ...)` then has **22
+viable candidates** and is a **fully under-constrained tie**. resolve-1's
+documented stopgap for such ties is **env-order first-match** (true deferral is
+the unimplemented "session 2"). The env scan lists the most-recently-imported
+scope first, so *which* candidate wins depends on module placement:
+
+| placement of vector `<=>` | env-order winner at `a <=> b` (free) | result |
+|---|---|---|
+| `Builtins.fx` (workaround) | `__cmp__(string,string)` — **concrete, `@ccode`** | commits, no body to recurse into → **terminates** |
+| `Vector.fx` (natural home) | `__cmp__('t vector,'t vector)` — **generic template** | commits → `instantiate_fun` type-checks its body → `xa <=> xb` (free) → picks the vector `<=>` **again** → instantiate → … → **StackOverflow** |
+
+The cycle is **self-candidacy**: the generic container operator is itself a
+viable candidate for its own body's free-element compare, and the under-constrained
+fallback commits it, whose instantiation re-enters the identical resolution. The
+instance cache can't cut it — each re-entry is a *fresh* free var, never a cache
+hit. Committing a *concrete* candidate (string) terminates because there is no
+template body to instantiate; committing the *template* self-recurses. Whether the
+fallback lands on concrete vs template is essentially arbitrary (import order) —
+that arbitrariness is the latent bug the Builtins placement was tuned around.
+
+This confirms the brief's FB-025 hypothesis (self-candidacy + the under-constrained
+fallback) and localizes it to `lookup_id_opt`'s `rank_and_commit` under-constrained
+branch (`Ast_typecheck.fx:1378-1383`) feeding `commit_fun`'s template
+instantiation (`:1307-1325`). The pre-resolve-1 codepath surfaced the same cycle
+earlier, as the "failed to re-unify at commit" throw (`:1287`); resolve-1 turned it
+into unbounded instantiation.
+
+### Why the instance cache doesn't cut the recursion (instrumented)
+
+Instrumenting `commit_fun`'s template-instance scan (`:1308`) over the overflow
+build shows the request is always `((<unknown> vector, <unknown> vector) -> int)`
+(a free element `'t`), **`hit=false` on every level**, and the instance count
+grows **without bound** (…42, 43, … 81, …). So the cache is structurally unable
+to dedup: committing the self-candidate `maybe_unify`s the request's free element
+against the vector signature (`'t := 's vector`), so each recursion level asks
+for a *fresh* free-var instance that never stably matches a prior one. The
+`df_templ_inst` registration (`:4173`, before the body check) is real but useless
+here.
+
+### The precise trigger chain
+
+1. Template-check of `operator < (a: 't, b: 't) = (a <=> b) < 0` (or any container
+   `<=>` body). `a`,`b` are the template's OWN free param `'t`.
+2. `a <=> b` → `__cmp__('t,'t)`, `'t` free → 22 viable → fully under-constrained tie.
+3. resolve-1's stopgap commits the env-order-first candidate. Auto-imported
+   `Vector`'s `<=>` is env-first → a **generic template container op**.
+4. `commit_fun` instantiates it for `('t,'t)->int` → `maybe_unify` binds
+   `'t := 's vector` → instantiates the vector `<=>` body → `xs <=> xs` (`'s` free)
+   → back to step 2 → unbounded. Terminates only in the Builtins layout because
+   there the env-first candidate is a *concrete* `__cmp__(string,string)` (`@ccode`,
+   no body to instantiate).
+
+### The fix (implemented)
+
+Explored empirically first. A `commit_fun` guard that refused ANY under-constrained
+template instantiation was too broad — it broke legitimate higher-order generics
+(`map`/`foldl` instantiated with a still-free return `'r` that the closure body
+then pins; a normal, convergent case). The distinguishing property is not "free
+vars in the request" but **divergent self-recursion**: `map` with free `'r`
+converges (the body binds `'r`); the container `<=>` with a free element re-issues
+the identical free compare and never binds it.
+
+The minimal, sound fix targets the exact fork the working (Builtins) layout hit by
+luck: **in the under-constrained-tie fallback (`rank_and_commit`, the
+`!fully_determined` branch), prefer a CONCRETE (non-template) candidate over a
+template one.**
+
+```
+val concrete_opt = find_opt(for idf <- viable { idf.1->df_templ_args == [] })
+val (i, df) = match concrete_opt { | Some(idf) => idf | _ => viable.hd() }
+commit_fun(i, df)
+```
+
+A fully under-determined call (all arg types free) is a **speculative** resolution
+— redone per real use with concrete args — so committing any candidate that
+type-checks is fine. A concrete candidate fixes the arg types in the speculative
+check and cannot self-instantiate; a template re-issues the free compare and
+spawns instances without bound. This makes the working-vs-overflow behaviour
+independent of where a generic container operator is declared. The real per-use
+resolution (concrete args) never enters this branch, so runtime semantics are
+untouched.
+
+### Validation
+
+- The FB-025 acceptance: with `==`/`<=>` for `vector` moved to `Vector.fx`, the
+  compiler self-build type-checks cleanly (`exit 0`) where it previously
+  StackOverflowed.
+- `-pr-resolve` census over `compiler/fx.fx`, before vs after: **identical after
+  line-number normalization** — the fix is dormant in the shipping layout (the
+  under-constrained ties there already had a concrete env-order winner). It fires
+  only on the pathological template-first tie.
+- Bootstrap fixpoint holds; **only `Ast_typecheck.c` regenerates** (no codegen
+  change to any other module — confirms no committed-candidate change reaches
+  generated code in the shipping config).
+- Full `fxtest.py all` + `determinism` + `sanitize` green.
+
+Considered and rejected as the sole fix: aggressive `inst_merge_env` (the
+self-candidate lives in the template's base `df_env`; merging more caller entries
+can't remove it) and a `commit_fun` free-var refusal (breaks convergent
+higher-order generics like `map`/`foldl`).
+
+### Workaround removed (acceptance)
+
+`==`/`<=>`/`string`/`print` for `vector` moved from `Builtins.fx` back to their
+natural home `Vector.fx`. Churn is minimal: the compiler itself never
+compares/prints vectors, so the bootstrap stays at a clean fixpoint (`nothing to
+do`) — only the two lib files and the fix move. The compiler self-build
+auto-imports `Vector`, so it now type-checks these generic container operators in
+the large-overload context on every build and **doubles as the FB-025 regression
+guard** (a reappearance of the resolver self-recursion re-breaks the build). Full
+ladder + determinism + sanitize green with the operators in their new home;
+`vector == / <=> / string / print` verified behaviourally.

--- a/docs/resolve3_report.md
+++ b/docs/resolve3_report.md
@@ -1,0 +1,115 @@
+# resolve-3 report
+
+Branch `resolve-3` off master. Follow-up to `docs/resolve3_brief.md`. Work is
+staged by phase; **Phase C (FB-022) is done first** at Vadim's request, since it
+is the bug he hit directly. Phases A/B (FB-024/FB-025 resolver pollution) are the
+heavier, separate work and are not started in this section yet.
+
+---
+
+## Phase C — FB-022 generalized: recovery inside block expressions  [DONE]
+
+### The bug
+
+A failed statement buried inside a block expression in **value position** lost
+every name the block's `val` was supposed to bind, cascading into spurious
+"not found" errors. Vadim's field repro (from `lib/NN/InferShapes.fx`, the
+`Reshape` shape-inference fold): change `new_total *= sz` to `new_total *= sz1`
+and the compiler correctly reports `sz1` not found — but then *also* claims
+`havem1` is not found at a use two lines below, even though `havem1` was
+explicitly initialised `havem1=false` at the fold head and its type (`bool`) is
+known independent of the body error.
+
+Minimal repro:
+
+```
+val fold sz = 0, have_neg = false for s <- shape {
+    if s >= 0 { sz *= s1 /* typo for s */ } else { have_neg = true }
+}
+println(f"have_neg: {have_neg}")   // BEFORE: "have_neg not found" (cascade)
+(sz, have_neg)                     // BEFORE: "sz not found" (cascade)
+```
+
+### Root cause — narrower than the brief assumed
+
+A `val fold ...` desugars (parse time) to a plain annotated tuple `val`:
+
+```
+val (sz, have_neg): (int, bool) = {
+    var sz = 0
+    var have_neg = false
+    for s <- shape { ... }         // <-- the failing statement
+    (sz, have_neg)                 // tail
+}
+```
+
+The brief hypothesised the block's tail was never typed. It **is**: the block's
+own `check_eseq` already runs diag-1 Tier-2 per-statement recovery — the failing
+`for` is caught, reported, and typing continues to the tail `(sz, have_neg)`,
+which types cleanly to `(int, bool)` off the two `var`s' real types. The true gap
+is one level up:
+
+- `check_eseq` ends with `check_compile_errs()`, which — because the inner error
+  was pushed to the global accumulator — throws **`PropagateCompileError`**, the
+  "this subtree is tainted; don't re-report" signal.
+- The outer `DefVal` recovery arm caught only `CompileError`. `PropagateCompileError`
+  fell through to the generic per-statement catch, which keeps the statement but
+  with the **original env** — so the pattern was never bound and `sz`/`have_neg`
+  never entered scope → cascade.
+
+A second, latent defect in the same arm: it poisoned *every* pattern var with one
+whole-pattern type via `poison_pattern_vars`. For a tuple annotation that binds
+both `sz` and `have_neg` to `(int, bool)` — a type mismatch that would itself
+cascade at the later uses. Never exercised before because tuple-typed `val`s
+whose RHS fails are rare outside the fold desugar.
+
+### The fix (`compiler/Ast_typecheck.fx`, `check_eseq` DefVal arm)
+
+1. **Catch `PropagateCompileError` too.** A direct RHS failure still arrives as
+   `CompileError` and is pushed as before; a block-internal failure arrives as
+   `PropagateCompileError` and is *not* re-pushed (already reported by the inner
+   `check_eseq`). Either way we now reach the pattern-binding recovery.
+2. **Bind through the annotation with `check_pat`, not a blanket poison.** With a
+   usable annotation, `check_pat(p_inner, annotated_typ, ...)` destructures a
+   tuple/record annotation per-field — `val (a,b):(int,bool)` → `a:int, b:bool`
+   (the §1.7 annotation firewall: callers keep checking against the declared
+   interface). Without a usable annotation, fall back to `TypErr` poison for
+   structural cascade suppression, exactly as before.
+
+The change is a **generalization of the existing diag-1 recovery, not a
+fold-special-case** — so there is no fold-shaped workaround to remove; the fix is
+the generalization the brief asked for. Any block expression in value position
+now recovers, not just the fold desugar.
+
+### Verification
+
+- Vadim's repro and the real `InferShapes.fx` typo → **exactly one diagnostic**
+  (`'s1'`/`'sz1'` not found, *with* the did-you-mean suggestion `'s'`/`'sz'`), no
+  cascade.
+- Directed cases confirmed: original FB-022 fold; annotated single-ident (`val
+  x:int = undef`); tuple-annotated direct failure (`val (a,b):(int,bool) = undef`
+  → both fields recover); plain non-fold block (`val r:int = {..undef..; r}`),
+  annotated and unannotated.
+- Golden `test/negative/709_fold_old_style_body` **loses its spurious `'s' not
+  found` cascade** (2 diagnostics → 1) — the FB-022 pattern in an existing test.
+- New goldens: `239_recovery_fold_block` (fold, did-you-mean) and
+  `240_recovery_block_expr` (plain block).
+- Full `fxtest.py all`, `negative`, `determinism`, `sanitize` (ASan+UBSan) green.
+- Bootstrap fixpoint holds: only `Ast_typecheck.c` regenerates (recovery path is
+  diagnostics-only; clean compiles never enter the catch, so the `-pr-resolve`
+  census is untouched by construction).
+
+### Registry
+
+`docs/found_bugs.md` FB-022 → `FIXED — resolve-3 Phase C`, with the actual
+`PropagateCompileError` root cause and the per-field destructuring detail.
+
+---
+
+## Phases A / B — FB-024 / FB-025 resolver pollution  [NOT STARTED]
+
+The order/context-dependent generic-return pollution (FB-024) and the
+commit-time re-unify internal error (FB-025) are untouched in this section. They
+need the Phase-A exploration/repro work (rebuild FB-024's repro without the
+removed `Vec.mapi`; reproduce FB-025's internal error) before any fix. Deferred
+pending a check-in with Vadim.

--- a/lib/Builtins.fx
+++ b/lib/Builtins.fx
@@ -369,7 +369,6 @@ fun string(l: 't list): string = join_embrace("[", "]", ", ", [for x <- l {repr(
 }
 
 fun string(v: 't rrbvec): string = join_embrace("[", "]", ", ", [for x <- v {repr(x)}])
-fun string(v: 't vector): string = join_embrace("[", "]", ", ", [for x <- v {repr(x)}])
 
 @pure fun string(v: char rrbvec): string
 @ccode {
@@ -573,21 +572,6 @@ operator <=> (a: 't rrbvec, b: 't rrbvec): int
         if d != 0 {break}
     }
     if d != 0 {d} else {na <=> nb}
-}
-
-// first-class mutable vector compare (kept here, not in Vector.fx, to resolve the
-// generic element compare in a small-overload context — see FB-025)
-operator == (a: 't vector, b: 't vector): bool =
-    size(a) == size(b) && all(for xa <- a, xb <- b {xa == xb})
-
-operator <=> (a: 't vector, b: 't vector): int
-{
-    var d = 0
-    for xa <- a, xb <- b {
-        d = xa <=> xb
-        if d != 0 {break}
-    }
-    if d != 0 {d} else {size(a) <=> size(b)}
 }
 
 operator == (a: 't [+], b: 't [+]): bool =
@@ -1142,16 +1126,6 @@ fun print(l: 't list): void
 }
 
 fun print(v: 't rrbvec): void
-{
-    print("[")
-    for x@i <- v {
-        if i > 0 {print(", ")}
-        print_repr(x)
-    }
-    print("]")
-}
-
-fun print(v: 't vector): void
 {
     print("[")
     for x@i <- v {

--- a/lib/Vector.fx
+++ b/lib/Vector.fx
@@ -115,9 +115,36 @@ fun concat(vs: ('t vector) vector): 't vector {
     fold r: 't vector = vector(capacity=total) for v <- vs { r.append(v) }
 }
 
-// NB: ==, <=>, string, print for `vector` live in Builtins.fx next to their
-// rrbvec counterparts. They compare/format elements generically (a[i] <=> b[i],
-// string(v[i])), and compiling that in a context with many <=> / string
-// overloads (as when Vector is auto-imported into the whole compiler) trips a
-// resolver internal error (FB-025); Builtins is compiled early, with few
-// overloads in scope, so it resolves cleanly there.
+// ------------------------- compare / string / print -------------------------
+
+// ==, <=>, string and print for `vector` compare/format elements generically
+// (xa <=> xb, repr(x)). These used to live in Builtins.fx next to their rrbvec
+// counterparts to dodge FB-025 -- a resolver self-recursion that fired when a
+// generic container operator was type-checked with many <=> / string overloads
+// in scope (as when Vector is auto-imported into the whole compiler). FB-025 is
+// fixed (resolve-3: the under-constrained-tie fallback prefers a concrete
+// candidate over a template), so they now live with their type.
+operator == (a: 't vector, b: 't vector): bool =
+    size(a) == size(b) && all(for xa <- a, xb <- b {xa == xb})
+
+operator <=> (a: 't vector, b: 't vector): int
+{
+    var d = 0
+    for xa <- a, xb <- b {
+        d = xa <=> xb
+        if d != 0 {break}
+    }
+    if d != 0 {d} else {size(a) <=> size(b)}
+}
+
+fun string(v: 't vector): string = join_embrace("[", "]", ", ", [for x <- v {repr(x)}])
+
+fun print(v: 't vector): void
+{
+    print("[")
+    for x@i <- v {
+        if i > 0 {print(", ")}
+        print_repr(x)
+    }
+    print("]")
+}

--- a/test/negative/239_recovery_fold_block.err
+++ b/test/negative/239_recovery_fold_block.err
@@ -1,0 +1,5 @@
+239_recovery_fold_block.fx:9:27: error: the appropriate match for 's1' of type '<unknown>' is not found; did you mean 's' or 'sz'?
+ 9 |         if s >= 0 { sz *= s1 } else { have_neg = true }
+   |                           ^~
+
+1 errors occured during type checking.

--- a/test/negative/239_recovery_fold_block.fx
+++ b/test/negative/239_recovery_fold_block.fx
@@ -1,0 +1,14 @@
+// expect: did you mean
+// diag-1 / FB-022 (resolve-3 Phase C): a failed statement inside the BLOCK a
+// `val fold` desugars to must not lose the accumulators. The typo `s1` is the
+// only real error; the accumulators `sz`/`have_neg` keep their real int/bool
+// types, so the later uses do NOT cascade into spurious "not found". Exactly
+// ONE diagnostic, carrying the did-you-mean suggestion.
+fun test(shape: int []): (int, bool) {
+    val fold sz = 0, have_neg = false for s <- shape {
+        if s >= 0 { sz *= s1 } else { have_neg = true }
+    }
+    println(f"have_neg: {have_neg}")
+    (sz, have_neg)
+}
+println(test([1, 2, 3]))

--- a/test/negative/240_recovery_block_expr.err
+++ b/test/negative/240_recovery_block_expr.err
@@ -1,0 +1,5 @@
+240_recovery_block_expr.fx:9:9: error: the appropriate match for 'foo' of type '(int -> <unknown>)' is not found.
+ 9 |         foo(a)
+   |         ^~~
+
+1 errors occured during type checking.

--- a/test/negative/240_recovery_block_expr.fx
+++ b/test/negative/240_recovery_block_expr.fx
@@ -1,0 +1,14 @@
+// expect: not found
+// diag-1 / FB-022 (resolve-3 Phase C): the recovery generalizes beyond fold to
+// ANY block expression in value position. A failed middle statement (`foo`
+// undefined) is the only real error; the annotation `: int` is the firewall, so
+// `r` stays typed int and its later use does NOT cascade. Exactly ONE diagnostic.
+fun test(): int {
+    val r: int = {
+        val a = 10
+        foo(a)
+        a * 2
+    }
+    r + 1
+}
+println(test())

--- a/test/negative/709_fold_old_style_body.err
+++ b/test/negative/709_fold_old_style_body.err
@@ -1,8 +1,5 @@
 709_fold_old_style_body.fx:6:43: error: improper type of the arithmetic operation result
  6 | val s = fold s = 0 for x <- [1, 2, 3] { s + x }
    |                                           ^
-709_fold_old_style_body.fx:7:9: error: the appropriate match for 's' of type '<unknown>' is not found.
- 7 | println(s)
-   |         ^
 
-2 errors occured during type checking.
+1 errors occured during type checking.


### PR DESCRIPTION
Two independent resolver/diagnostics fixes from the resolve-3 plan
(`docs/resolve3_brief.md`). Full write-up: `docs/resolve3_report.md`.

FB-024 (order-dependent generic-return inference pollution) is **parked**: its
documented repro does not reproduce on current master nor on the newvec-1 merge
where it was filed, and its trigger (`map`/`mapi`/`foldl`) was retired by
newvec-2 in favour of comprehensions. Details in the report; will revisit with a
fresh reproducer.

## Phase C — FB-022: recovery inside block expressions

A failed statement inside a block expression in **value position** lost every
name its enclosing `val` bound, cascading into spurious "not found". Vadim's
field case (`lib/NN/InferShapes.fx`, the `Reshape` fold): a typo `sz1` for `sz`
correctly reports `sz1` not found but *also* falsely claims `havem1` — a fold
accumulator explicitly initialised `havem1=false` — is not found two lines later.

```
val fold sz = 0, have_neg = false for s <- shape {
    if s >= 0 { sz *= s1 /* typo */ } else { have_neg = true }
}
println(f"have_neg: {have_neg}")   // BEFORE: spurious "have_neg not found"
(sz, have_neg)                     // BEFORE: spurious "sz not found"
```

**Root cause** (narrower than first thought): `val fold ...` desugars to
`val (a,b): (..) = { var a=..; var b=..; for ...; (a,b) }`. The block's own
`check_eseq` already recovers the failed `for` and types the tail `(a,b)`
correctly, but its closing `check_compile_errs()` then throws
`PropagateCompileError` (not `CompileError`) to flag the tainted subtree. The
outer `DefVal` recovery caught only `CompileError`, so it skipped pattern binding
and the accumulators never entered scope.

**Fix** (`Ast_typecheck.fx`, `check_eseq` DefVal arm): (1) catch
`PropagateCompileError` too, without re-pushing the already-reported inner error;
(2) bind the pattern via `check_pat` against the annotation type instead of
`poison_pattern_vars` with one whole-pattern poison type, so a tuple/record
annotation destructures per-field (`val (a,b):(int,bool)` → `a:int, b:bool` — the
annotation firewall) rather than binding both to `(int,bool)` (which would itself
cascade). A generalization of the existing diag-1 recovery, not a fold-special
case: any value-position block now recovers.

Acceptance: exactly ONE diagnostic (`'s1' not found; did you mean 's'`), no
cascade. Golden `test/negative/709` loses its spurious cascade (2→1); new goldens
`239_recovery_fold_block` + `240_recovery_block_expr` lock the mechanism.

## Phase B — FB-025: resolver self-recursion on an under-constrained tie

A generic container operator whose body compares free-`'t` elements
(`operator <=> (a: 't vector, b: 't vector) { ... xa <=> xb ... }`) diverges when
type-checked with many `<=>`/`__cmp__` overloads in scope — as when `Vector` is
auto-imported into the whole compiler. On the current tree the symptom is a
**`StackOverflowError`** during the self-build (resolve-1 turned the older
internal error *"the winning overload of '__cmp__' failed to re-unify at commit"*
into unbounded instantiation).

**Root cause** (`-pr-resolve` + instrumented `commit_fun`: cache `hit=false`,
instances grow 42→81+ unbounded): the element compare `xa <=> xb` has a free
element type `'t`, so `__cmp__('t,'t)` is a fully **under-constrained tie** (22
viable). resolve-1's stopgap for such ties is env-order first-match. When the
env-first candidate is a generic **template** container op (the auto-imported
`Vector.<=>`), `commit_fun` instantiates it for `('t,'t)->int`, binding
`'t := 's vector`, then type-checks its body, which re-issues the same free
compare, picks the template again, and instantiates without bound (the instance
cache can't dedup — each level is a fresh free var). It terminated in the Builtins
layout only because there the env-first candidate was a *concrete*
`__cmp__(string,string)` (`@ccode`, no body to instantiate) — luck of import order.

**Fix** (`Ast_typecheck.fx`, `rank_and_commit`): in the under-constrained-tie
fallback, **prefer a concrete (non-template) candidate over a template one**. A
fully under-determined call is a speculative resolution (redone per real use with
concrete args), so any type-checking candidate is fine; a concrete one fixes the
arg types and cannot self-instantiate.

```
val concrete_opt = find_opt(for idf <- viable { idf.1->df_templ_args == [] })
val (i, df) = match concrete_opt { | Some(idf) => idf | _ => viable.hd() }
commit_fun(i, df)
```

Explored and rejected: a `commit_fun` free-var refusal (too broad — breaks
convergent higher-order generics like `map`/`foldl`, whose free return `'r` is
pinned by the closure body) and aggressive `inst_merge_env` (the self-candidate
lives in the template's base `df_env`; merging can't remove it).

The fix is **dormant in normal code**: `-pr-resolve` census over `compiler/fx.fx`
is byte-identical (line-number normalized), and the bootstrap fixpoint touches
only `Ast_typecheck.c`. It fires only on the pathological template-first tie.

**Workaround removed**: `==`/`<=>`/`string`/`print` for `vector` moved from
`Builtins.fx` back to their natural home `Vector.fx`. Churn is minimal (the
compiler never compares/prints vectors, so the bootstrap stays at a clean
fixpoint). The compiler self-build auto-imports `Vector`, so it now type-checks
these operators in the large-overload context on every build and **doubles as the
FB-025 regression guard**.

## Testing

- Full `fxtest.py all` (unit + negative + ir + cfold + corpus O0/O3) green.
- `determinism` (byte-identical rebuilds) + `sanitize` (ASan+UBSan) green.
- Bootstrap self-hosting fixpoint holds.
- `-pr-resolve` census over `compiler/fx.fx` byte-identical before/after (both fixes).
- `vector == / <=> / string / print` verified behaviourally after the move.

## Registry / docs

`docs/found_bugs.md`: FB-022 → `FIXED — resolve-3 Phase C`; FB-025 →
`FIXED — resolve-3`. `docs/resolve3_report.md` — full Phase-A/B/C write-up,
including the FB-024 parking rationale.
